### PR TITLE
Moved layer stack to CoreWindow

### DIFF
--- a/Examples/Sandbox/src/Sandbox.cpp
+++ b/Examples/Sandbox/src/Sandbox.cpp
@@ -12,18 +12,19 @@ namespace Sandbox {
 
 	class Sandbox_One : public ZEngine::Engine {
 	public:																																			  
-		Sandbox_One() {
-			PushLayer(new ExampleLayer());
+		Sandbox_One() : ZEngine::Engine() {
+			auto window = this->GetWindow();
+			window->PushLayer(new ExampleLayer());
+			
 
-			ImguiLayer* gui_layer(new GUILayer{});
+			ZEngine::Layers::ImguiLayer* gui_layer(new GUILayer{});
 			std::vector<ZEngine::Ref<ZEngine::Components::UI::UIComponent>> ui_components {
 				ZEngine::Ref<ZEngine::Components::UI::UIComponent> (new AboutUIComponent()),
 				ZEngine::Ref<ZEngine::Components::UI::UIComponent> (new DemoUIComponent())
 			};
 			gui_layer->AddUIComponent(std::move(ui_components));
-			PushOverlayLayer(gui_layer);			
+			window->PushOverlayLayer(gui_layer);			
 		}
-		
 		~Sandbox_One() = default;
 	};
 

--- a/Examples/Sandbox3D/src/Sandbox.cpp
+++ b/Examples/Sandbox3D/src/Sandbox.cpp
@@ -13,15 +13,17 @@ namespace Sandbox3D {
 	class Sandbox : public ZEngine::Engine {
 	public:
 		Sandbox() {
-			PushLayer(new ExampleLayer());
+			auto window = this->GetWindow();
+			window->PushLayer(new ExampleLayer());
 
-			ImguiLayer* gui_layer(new GUILayer{});
-			std::vector<ZEngine::Ref<ZEngine::Components::UI::UIComponent>> ui_components {
-				ZEngine::Ref<ZEngine::Components::UI::UIComponent> (new AboutUIComponent()),
-				ZEngine::Ref<ZEngine::Components::UI::UIComponent> (new DemoUIComponent())
+
+			ZEngine::Layers::ImguiLayer* gui_layer(new GUILayer{});
+			std::vector<ZEngine::Ref<ZEngine::Components::UI::UIComponent>> ui_components{
+				ZEngine::Ref<ZEngine::Components::UI::UIComponent>(new AboutUIComponent()),
+				ZEngine::Ref<ZEngine::Components::UI::UIComponent>(new DemoUIComponent())
 			};
 			gui_layer->AddUIComponent(std::move(ui_components));
-			PushOverlayLayer(gui_layer);			
+			window->PushOverlayLayer(gui_layer);
 		}		
 
 		~Sandbox() = default;

--- a/ZEngine/include/ZEngine/Engine.h
+++ b/ZEngine/include/ZEngine/Engine.h
@@ -7,7 +7,6 @@
 #include <Event/KeyPressedEvent.h>
 #include <Event/KeyReleasedEvent.h>
 
-#include <LayerStack.h>
 #include <Core/TimeStep.h>
 
 #include <Core/IUpdatable.h>
@@ -21,8 +20,7 @@ namespace ZEngine {
 	class Engine : 
 		public Core::IInitializable,
 		public Core::IUpdatable, 
-		public Core::IRenderable, 
-		public Core::IEventable {
+		public Core::IRenderable {
 
 	public:
 		Engine();
@@ -32,26 +30,18 @@ namespace ZEngine {
 		virtual void Initialize() override;
 		virtual void Update(Core::TimeStep delta_time) override;
 		virtual void Render() override;
-		virtual bool OnEvent(Event::CoreEvent&) override;
 		
 	public:
 		void Run();
 
 		const Ref<ZEngine::Window::CoreWindow>& GetWindow() const { return m_window; }
-		void PushOverlayLayer(Layer* const layer) { m_layer_stack.PushOverlayLayer(layer); }
-		void PushLayer(Layer* const layer) { m_layer_stack.PushLayer(layer); }
-
 		static Core::TimeStep GetDeltaTime() { return m_delta_time; }
 
 	protected:
 		virtual void ProcessEvent();
 
-
 	public:
 		bool OnEngineClosed(Event::EngineClosedEvent&);
-	
-	protected:
-		LayerStack m_layer_stack;
 	
 	private:
 		static Core::TimeStep m_delta_time;
@@ -61,7 +51,6 @@ namespace ZEngine {
 		Ref<ZEngine::Window::CoreWindow> m_window;
 
 	};
-
 
 	Engine* CreateEngine();
 }

--- a/ZEngine/include/ZEngine/Event/EventDispatcher.h
+++ b/ZEngine/include/ZEngine/Event/EventDispatcher.h
@@ -10,6 +10,9 @@ namespace ZEngine::Event {
 		template<typename T, typename = std::enable_if_t<std::is_base_of_v<CoreEvent, T>>>
 		using EventFn = std::function<bool(T&)>;
 
+		template<typename T, typename = std::enable_if_t<std::is_base_of_v<CoreEvent, T>>>
+		using ForwardEventFn = std::function<void(T&)>;
+
 	public:
 		EventDispatcher(CoreEvent& event)
 			:m_event(event)
@@ -24,6 +27,11 @@ namespace ZEngine::Event {
 			}
 
 			return false;
+		}
+
+		template<typename K>
+		void ForwardTo(const ForwardEventFn<K>& func) {
+			func(dynamic_cast<K&>(m_event));
 		}
 
 	private:

--- a/ZEngine/include/ZEngine/Layers/ImguiLayer.h
+++ b/ZEngine/include/ZEngine/Layers/ImguiLayer.h
@@ -36,7 +36,7 @@ namespace ZEngine::Layers {
 		void Initialize() override;
 
 		bool OnEvent(Event::CoreEvent& event) override {
-			EventDispatcher event_dispatcher(event);
+			Event::EventDispatcher event_dispatcher(event);
 
 			event_dispatcher.Dispatch<Event::KeyPressedEvent>(std::bind(&ImguiLayer::OnKeyPressed, this, std::placeholders::_1));
 			event_dispatcher.Dispatch<Event::KeyReleasedEvent>(std::bind(&ImguiLayer::OnKeyReleased, this, std::placeholders::_1));

--- a/ZEngine/include/ZEngine/Layers/Layer.h
+++ b/ZEngine/include/ZEngine/Layers/Layer.h
@@ -10,7 +10,7 @@
 #include <Core/IRenderable.h>
 #include <Core/IUpdatable.h>
 
-
+namespace ZEngine::Window { class CoreWindow; }
 
 namespace ZEngine::Layers {
 	class Layer : 

--- a/ZEngine/include/ZEngine/Layers/LayerStack.h
+++ b/ZEngine/include/ZEngine/Layers/LayerStack.h
@@ -1,12 +1,11 @@
 #pragma once
 #include <vector>
-#include "ZEngineDef.h"
-#include "Layers/Layer.h"
+#include <ZEngineDef.h>
+#include <Layers/Layer.h>
 
-using namespace ZEngine::Layers;
+namespace ZEngine::Layers {
+	class Layer;
 
-namespace ZEngine {
-	
 	class LayerStack {
 	public:
 		LayerStack() = default;

--- a/ZEngine/include/ZEngine/Window/SDLWin/OpenGLWindow.h
+++ b/ZEngine/include/ZEngine/Window/SDLWin/OpenGLWindow.h
@@ -7,7 +7,6 @@
 #include <Window/CoreWindow.h>
 #include <Rendering/Graphics/GraphicContext.h>
 
-
 namespace ZEngine::Window::SDLWin {
 
 	class OpenGLWindow : public CoreWindow {
@@ -35,10 +34,9 @@ namespace ZEngine::Window::SDLWin {
 		void* GetNativeWindow() const override { return m_native_window; }
 		void* GetNativeContext() const override { return m_context->GetNativeContext(); }
 
-
 		virtual const WindowProperty& GetWindowProperty() const override { return m_property; }
 
-
+		virtual void Initialize() override;
 		virtual void PollEvent() override;
 		virtual void Update(Core::TimeStep delta_time) override;
 		virtual void Render() override;
@@ -47,51 +45,48 @@ namespace ZEngine::Window::SDLWin {
 		bool OnEvent(Event::CoreEvent& event) override {
 
 			Event::EventDispatcher event_dispatcher(event);
-			event_dispatcher.Dispatch<WindowClosedEvent>(std::bind(&OpenGLWindow::OnWindowClosed, this, std::placeholders::_1));
-			event_dispatcher.Dispatch<WindowResizedEvent>(std::bind(&OpenGLWindow::OnWindowResized, this, std::placeholders::_1));
+			event_dispatcher.Dispatch<Event::WindowClosedEvent>(std::bind(&OpenGLWindow::OnWindowClosed, this, std::placeholders::_1));
+			event_dispatcher.Dispatch<Event::WindowResizedEvent>(std::bind(&OpenGLWindow::OnWindowResized, this, std::placeholders::_1));
 
-			event_dispatcher.Dispatch<KeyPressedEvent>(std::bind(&OpenGLWindow::OnKeyPressed, this, std::placeholders::_1));
-			event_dispatcher.Dispatch<KeyReleasedEvent>(std::bind(&OpenGLWindow::OnKeyReleased, this, std::placeholders::_1));
+			event_dispatcher.Dispatch<Event::KeyPressedEvent>(std::bind(&OpenGLWindow::OnKeyPressed, this, std::placeholders::_1));
+			event_dispatcher.Dispatch<Event::KeyReleasedEvent>(std::bind(&OpenGLWindow::OnKeyReleased, this, std::placeholders::_1));
 
-			event_dispatcher.Dispatch<MouseButtonPressedEvent>(std::bind(&OpenGLWindow::OnMouseButtonPressed, this, std::placeholders::_1));
-			event_dispatcher.Dispatch<MouseButtonReleasedEvent>(std::bind(&OpenGLWindow::OnMouseButtonReleased, this, std::placeholders::_1));
-			event_dispatcher.Dispatch<MouseButtonMovedEvent>(std::bind(&OpenGLWindow::OnMouseButtonMoved, this, std::placeholders::_1));
-			event_dispatcher.Dispatch<MouseButtonWheelEvent>(std::bind(&OpenGLWindow::OnMouseButtonWheelMoved, this, std::placeholders::_1));
+			event_dispatcher.Dispatch<Event::MouseButtonPressedEvent>(std::bind(&OpenGLWindow::OnMouseButtonPressed, this, std::placeholders::_1));
+			event_dispatcher.Dispatch<Event::MouseButtonReleasedEvent>(std::bind(&OpenGLWindow::OnMouseButtonReleased, this, std::placeholders::_1));
+			event_dispatcher.Dispatch<Event::MouseButtonMovedEvent>(std::bind(&OpenGLWindow::OnMouseButtonMoved, this, std::placeholders::_1));
+			event_dispatcher.Dispatch<Event::MouseButtonWheelEvent>(std::bind(&OpenGLWindow::OnMouseButtonWheelMoved, this, std::placeholders::_1));
 			
-			event_dispatcher.Dispatch<TextInputEvent>(std::bind(&OpenGLWindow::OnTextInputRaised, this, std::placeholders::_1));
+			event_dispatcher.Dispatch<Event::TextInputEvent>(std::bind(&OpenGLWindow::OnTextInputRaised, this, std::placeholders::_1));
 
-			event_dispatcher.Dispatch<WindowMinimizedEvent>(std::bind(&OpenGLWindow::OnWindowMinimized, this, std::placeholders::_1));
-			event_dispatcher.Dispatch<WindowMaximizedEvent>(std::bind(&OpenGLWindow::OnWindowMaximized, this, std::placeholders::_1));
-			event_dispatcher.Dispatch<WindowRestoredEvent>(std::bind(&OpenGLWindow::OnWindowRestored, this, std::placeholders::_1));
-
+			event_dispatcher.Dispatch<Event::WindowMinimizedEvent>(std::bind(&OpenGLWindow::OnWindowMinimized, this, std::placeholders::_1));
+			event_dispatcher.Dispatch<Event::WindowMaximizedEvent>(std::bind(&OpenGLWindow::OnWindowMaximized, this, std::placeholders::_1));
+			event_dispatcher.Dispatch<Event::WindowRestoredEvent>(std::bind(&OpenGLWindow::OnWindowRestored, this, std::placeholders::_1));
 
 			 return true;
 		}
 
 	protected:
-		virtual bool OnWindowClosed(WindowClosedEvent&)						override;
-		virtual bool OnWindowResized(WindowResizedEvent&)					override;
+		virtual bool OnWindowClosed(Event::WindowClosedEvent&)						override;
+		virtual bool OnWindowResized(Event::WindowResizedEvent&)					override;
 
-		
-		virtual bool OnKeyPressed(KeyPressedEvent&)							override;
-		virtual bool OnKeyReleased(KeyReleasedEvent&)						override;
+		virtual bool OnKeyPressed(Event::KeyPressedEvent&)							override;
+		virtual bool OnKeyReleased(Event::KeyReleasedEvent&)						override;
 
-		virtual bool OnMouseButtonPressed(MouseButtonPressedEvent&)			override;
-		virtual bool OnMouseButtonReleased(MouseButtonReleasedEvent&)		override;
-		virtual bool OnMouseButtonMoved(MouseButtonMovedEvent&)				override;
-		virtual bool OnMouseButtonWheelMoved(MouseButtonWheelEvent&)		override;
+		virtual bool OnMouseButtonPressed(Event::MouseButtonPressedEvent&)			override;
+		virtual bool OnMouseButtonReleased(Event::MouseButtonReleasedEvent&)		override;
+		virtual bool OnMouseButtonMoved(Event::MouseButtonMovedEvent&)				override;
+		virtual bool OnMouseButtonWheelMoved(Event::MouseButtonWheelEvent&)			override;
 
-		virtual bool OnTextInputRaised(TextInputEvent&)						override;
+		virtual bool OnTextInputRaised(Event::TextInputEvent&)						override;
 
-		virtual bool OnWindowMinimized(Event::WindowMinimizedEvent&)		override;
-		virtual bool OnWindowMaximized(Event::WindowMaximizedEvent&)		override;
-		virtual bool OnWindowRestored(Event::WindowRestoredEvent&)			override;
+		virtual bool OnWindowMinimized(Event::WindowMinimizedEvent&)				override;
+		virtual bool OnWindowMaximized(Event::WindowMaximizedEvent&)				override;
+		virtual bool OnWindowRestored(Event::WindowRestoredEvent&)					override;
 
 	private:
 		SDL_Window* m_native_window{ nullptr };
 		Rendering::Graphics::GraphicContext* m_context{ nullptr };
 		std::unique_ptr<SDL_Event, std::function<void(SDL_Event*)>> m_event;
-
 	};
 		
 }

--- a/ZEngine/include/ZEngine/ZEngine.h
+++ b/ZEngine/include/ZEngine/ZEngine.h
@@ -3,12 +3,10 @@
 
 #include "Engine.h"
 
-
 #include "Rendering/Shaders/Shader.h"
 #include "Rendering/Buffers/VertexBuffer.h"
 #include "Rendering/Buffers/IndexBuffer.h"
 #include "Rendering/Buffers/VertexArray.h"
-
 
 #include "Rendering/Scenes/GraphicScene.h"
 #include "Rendering/Scenes/GraphicScene2D.h"
@@ -24,7 +22,6 @@
 #include "Rendering/Cameras/OrbitCamera.h"
 #include "Rendering/Cameras/FirstPersonShooterCamera.h"
 
-
 #include "Rendering/Geometries/IGeometry.h"
 #include "Rendering/Geometries/CubeGeometry.h"
 #include "Rendering/Geometries/QuadGeometry.h"
@@ -34,17 +31,14 @@
 #include "Rendering/Materials/StandardMaterial.h"
 #include "Rendering/Materials/MixedTextureMaterial.h"
 
-
 #include "Rendering/Meshes/Mesh.h"
-#include "Rendering/Meshes/MeshBuilder.h"
-										
+#include "Rendering/Meshes/MeshBuilder.h"							
 #include "Rendering/Textures/Texture.h"
 
 #include "Inputs/IDevice.h"
 #include "Inputs/Keyboard.h"
 #include "Inputs/KeyCode.h"
 #include "Inputs/Mouse.h"
-
 
 #include "Managers/IManager.h"
 #include "Managers/ShaderManager.h"
@@ -57,10 +51,7 @@
 #include "Controllers/OrbitCameraController.h"
 #include "Controllers/FirstPersonShooterCameraController.h"
 
-
 #include "Maths/Math.h"
-
-
 
 #include "Core/TimeStep.h"
 #include "Core/Utility.h"

--- a/ZEngine/src/CoreWindow.cpp
+++ b/ZEngine/src/CoreWindow.cpp
@@ -1,5 +1,37 @@
 #include <Window/CoreWindow.h>
 
+using namespace ZEngine;
+using namespace ZEngine::Event;
+using namespace ZEngine::Layers;
+
 namespace ZEngine::Window {
 	const char* CoreWindow::ATTACHED_PROPERTY = "WINDOW_ATTACHED_PROPERTY";
+
+	CoreWindow::CoreWindow() 
+		: m_layer_stack_ptr(new LayerStack())
+	{
+	} 
+
+	void CoreWindow::SetAttachedEngine(Engine* const engine) {
+		m_engine = engine;
+	}
+
+	void CoreWindow::PushOverlayLayer(Layer* const layer) { 
+		m_layer_stack_ptr->PushOverlayLayer(layer); 
+	}
+		
+	void CoreWindow::PushLayer(Layer* const layer) { 
+		m_layer_stack_ptr->PushLayer(layer); 
+	}	
+
+	void CoreWindow::ForwardEventToLayers(CoreEvent& event) {
+		auto index = std::distance(m_layer_stack_ptr->begin(), m_layer_stack_ptr->end());
+		for (auto it = m_layer_stack_ptr->end(); it >= m_layer_stack_ptr->begin();) {
+
+			if(index == 0) break;
+
+			(*(--it))->OnEvent(event);
+			--index;
+		}
+	}	
 }

--- a/ZEngine/src/Engine.cpp
+++ b/ZEngine/src/Engine.cpp
@@ -7,7 +7,6 @@ namespace ZEngine {
 	
 	Core::TimeStep Engine::m_delta_time = { 0.0f };
 
-
 	Engine::Engine() 
 		:m_running(true)
 	{
@@ -20,10 +19,7 @@ namespace ZEngine {
 	}
 
 	void Engine::Initialize() {
-		for(auto layer : m_layer_stack) {
-			layer->SetAttachedWindow(m_window);
-			layer->Initialize();
-		}
+		m_window->Initialize();
 	}
 
 	void Engine::ProcessEvent() {
@@ -32,35 +28,10 @@ namespace ZEngine {
 	
 	void Engine::Update(Core::TimeStep delta_time) {
 		m_window->Update(delta_time);
-		for (auto* const layer : m_layer_stack)
-			layer->Update(delta_time);
 	}
 	
 	void Engine::Render() {
-		for (auto* const layer : m_layer_stack) {
-			layer->Render();
-		}
-
 		m_window->Render();
-	}
-
-
-	bool Engine::OnEvent(Event::CoreEvent& event) {
-
-		auto index = std::distance(m_layer_stack.begin(), m_layer_stack.end());
-		for (auto it = m_layer_stack.end(); it >= m_layer_stack.begin();) {
-			
-			if(index == 0) break;
-			
-			(*(--it))->OnEvent(event);
-			--index;
-		}
-
-		if (!event.IsHandled()) {
-			Event::EventDispatcher event_dispatcher(event);
-			event_dispatcher.Dispatch<Event::EngineClosedEvent>(std::bind(&Engine::OnEngineClosed, this, std::placeholders::_1));
-		}
-		return true;
 	}
 
 	bool Engine::OnEngineClosed(Event::EngineClosedEvent& event) {
@@ -68,8 +39,6 @@ namespace ZEngine {
 		return true;
 	}
 
-
-	
 	void Engine::Run() {
 		
 		while (m_running) {

--- a/ZEngine/src/ImguiLayer.cpp
+++ b/ZEngine/src/ImguiLayer.cpp
@@ -66,14 +66,14 @@ namespace ZEngine::Layers {
 		return false;
 	}
 
-	bool ImguiLayer::OnMouseButtonPressed(MouseButtonPressedEvent& e) {
+	bool ImguiLayer::OnMouseButtonPressed(Event::MouseButtonPressedEvent& e) {
 		ImGuiIO& io = ImGui::GetIO();
 		for (int x = 0; x < (int)ImGuiMouseButton_COUNT; ++x)
 			io.MouseDown[x] = true;
 		return false;
 	}
 
-	bool ImguiLayer::OnMouseButtonReleased(MouseButtonReleasedEvent& e) {
+	bool ImguiLayer::OnMouseButtonReleased(Event::MouseButtonReleasedEvent& e) {
 		ImGuiIO& io = ImGui::GetIO();
 		for (int x = 0; x < (int)ImGuiMouseButton_COUNT; ++x)
 			io.MouseDown[x] = false;
@@ -81,14 +81,14 @@ namespace ZEngine::Layers {
 		return false;
 	}
 
-	bool ImguiLayer::OnMouseButtonMoved(MouseButtonMovedEvent& e) {
+	bool ImguiLayer::OnMouseButtonMoved(Event::MouseButtonMovedEvent& e) {
 		ImGuiIO& io = ImGui::GetIO();
 		io.MousePos = ImVec2(float(e.GetPosX()), float(e.GetPosY()));
 
 		return false;
 	}
 
-	bool ImguiLayer::OnMouseButtonWheelMoved(MouseButtonWheelEvent& e) {
+	bool ImguiLayer::OnMouseButtonWheelMoved(Event::MouseButtonWheelEvent& e) {
 		ImGuiIO& io = ImGui::GetIO();
 		if (e.GetOffetX() > 0) io.MouseWheelH += 1;
 		if (e.GetOffetX() < 0) io.MouseWheelH -= 1;
@@ -97,7 +97,7 @@ namespace ZEngine::Layers {
 		return false;
 	}
 
-	bool ImguiLayer::OnTextInputRaised(TextInputEvent& event) {
+	bool ImguiLayer::OnTextInputRaised(Event::TextInputEvent& event) {
 		ImGuiIO& io = ImGui::GetIO();
 		for (unsigned char c : event.GetText()) io.AddInputCharacter(c);
 		return false;

--- a/ZEngine/src/LayerStack.cpp
+++ b/ZEngine/src/LayerStack.cpp
@@ -1,13 +1,11 @@
-#include <LayerStack.h>
+#include <Layers/LayerStack.h>
 
-
-namespace ZEngine {
+namespace ZEngine::Layers {
 	
 	LayerStack::~LayerStack() {
 		for(auto layer : m_layers)
 			delete layer;
 	}
-
 
 	void LayerStack::PushLayer(Layer* const layer) {
 		if (m_layers.empty()) {


### PR DESCRIPTION
This PR :
- Moves LayerStack from Engine to CoreWindow 
- Introduces `ForwardTo(...)` in EventDispatcher 