### PR TITLE
added support of build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ bld/
 [Oo]bj/
 [Ll]og/
 [Bb]in-int/
+[Rr]esult.[Ww]indows.[Xx]64.[Mm]ulti[Cc]onfig/
+[Rr]esult.[Ll]inux.[Xx]64.[Dd]ebug/
+[Rr]esult.[Ll]inux.[Xx]64.[Rr]elease/
 
 # Submodules folder
 __externals/fmt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,9 @@ set (CMAKE_C_STANDARD 11)
 #
 get_filename_component (ENLISTMENT_ROOT "." ABSOLUTE CACHE)
 get_filename_component (EXTERNAL_DIR "${ENLISTMENT_ROOT}/__externals" ABSOLUTE CACHE)
-get_filename_component (OUTPUT_BUILD_DIR "${ENLISTMENT_ROOT}/out/build" ABSOLUTE CACHE)
 get_filename_component (EXAMPLE_DIR "${ENLISTMENT_ROOT}/Examples" ABSOLUTE CACHE)
 
-option (BUILD_SANDBOX "build example projects that show how to use core engine" ON)
+option (BUILD_SANDBOX_PROJECTS "build example projects that show how to use core engine" ON)
 
 # Externals dependencies
 #
@@ -40,18 +39,14 @@ add_subdirectory(ZEngine)
 
 # Examples
 #
-if (BUILD_SANDBOX)
+if (BUILD_SANDBOX_PROJECTS)
 	add_subdirectory(${EXAMPLE_DIR}/Sandbox)
 	add_subdirectory(${EXAMPLE_DIR}/Sandbox3D)
 endif ()
 
 # Post build operation
 #
-if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
-	set(SYSTEM_NAME "Windows")
-elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-	set(SYSTEM_NAME "Linux")
-endif ()
+set(SYSTEM_NAME ${CMAKE_SYSTEM_NAME})
 
 add_custom_target(AssembleContent ALL
 	COMMENT "Copying assets and resources contents"

--- a/Scripts/BuildEngine.ps1
+++ b/Scripts/BuildEngine.ps1
@@ -29,14 +29,109 @@ param (
     [string[]] $SystemNames = @('Windows', 'Linux'),
 
     [Parameter(HelpMessage="Architecture type to build, default to x64")]
+    [ValidateSet('x64')]
     [string] $Architectures = 'x64',
 
-    [Parameter(HelpMessage="Configuration type to build, default to Debug")]
+    [Parameter(HelpMessage="Configuration type to build")]
     [ValidateSet('Debug', 'Release')]
-    [string[]] $Configurations = 'Debug',
+    [string[]] $Configurations = @('Debug', 'Release'),
 
     [Parameter(HelpMessage="Whether to run build, default to True")]
-    [bool] $RunBuild = $True
+    [bool] $RunBuilds = $True
 )
 
 $ErrorActionPreference = "Stop"
+[string]$RepoRoot = [IO.Path]::Combine($PSScriptRoot, "..")
+
+. (Join-Path $PSScriptRoot shared.ps1)
+
+$CMakeProgram  =  Find-CMake
+if($CMakeProgram) {
+    Write-Host "CMake program found..."
+}
+
+function Build([string]$systemName, [string]$architecture, [string]$configuration, [bool]$runBuild) {
+    $IsMultipleConfig = ($systemName -ne 'Linux')
+
+    Write-Host "Building $systemName $architecture $configuration"
+
+    [string]$BuildDirectoryNameExtension = If($IsMultipleConfig) { "MultiConfig" } Else { $configuration }
+    [string]$BuildDirectoryName = "Result." + $systemName + "." + $architecture + "." + $BuildDirectoryNameExtension
+    [string]$BuildDirectoryPath = [IO.Path]::Combine($RepoRoot, $BuildDirectoryName)
+    [string]$CMakeCacheVariableOverride = ""
+    [string]$CMakeGenerator = ""
+
+    # Create build directory
+    #
+    if(-Not (Test-Path $BuildDirectoryPath)) {
+        $createDir = mkdir $BuildDirectoryPath
+    }
+
+    # Define CMake build arguments
+    #
+    if($systemName -eq "Windows") {
+        $CMakeGenerator = "-G `"Visual Studio 16 2019`" -A $architecture"
+    }
+    else {
+        $CMakeGenerator = "-G `"Unix Makefiles`""
+    }
+
+    $CMakeCacheVariableOverride += " -DCMAKE_SYSTEM_NAME=$systemName"
+    $CMakeCacheVariableOverride += " -DCMAKE_BUILD_TYPE=$configuration"
+    $CMakeCacheVariableOverride += " -DBUILD_SANDBOX_PROJECTS=ON"
+    $CMakeCacheVariableOverride += " -DSDL_STATIC=ON"
+    $CMakeCacheVariableOverride += " -DSDL_SHARED=OFF"
+    $CMakeCacheVariableOverride += " -DSPDLOG_BUILD_SHARED=OFF"
+    $CMakeCacheVariableOverride += " -DBUILD_STATIC_LIBS=ON"
+    $CMakeCacheVariableOverride += " -DSPDLOG_FMT_EXTERNAL=ON"
+    $CMakeCacheVariableOverride += " -DSPDLOG_FMT_EXTERNAL_HO=OFF"
+
+    $CMakeArguments = " -S $RepoRoot -B $BuildDirectoryPath $CMakeGenerator $CMakeCacheVariableOverride"
+
+    # Set Clang as Compiler 
+    #
+    if($systemName -eq 'Linux') {
+        $env:CC= '/usr/bin/clang-7'
+        $env:CXX= '/usr/bin/clang++-7'
+    }
+
+    # CMake Generation process
+    #
+    Write-Host $CMakeArguments
+    $process = Start-Process $CMakeProgram -ArgumentList $CMakeArguments -NoNewWindow -Wait -PassThru
+    if($process.ExitCode -ne 0) {
+        throw "cmake failed generation for '$argumentList' with exit code '$p.ExitCode'"        
+    }
+
+    # CMake Build Process
+    #
+    if($runBuild) {
+        if ($CMakeGenerator -like "Visual Studio*") {
+            # With a Visual Studio Generator, `msbuild.exe` is used to run the build. By default, `msbuild.exe` will
+            # launch worker processes to opportunistically re-use for subsequent builds. To cause the worker processes
+            # to exit at the end of the main process, pass `-nodeReuse:false`.
+            $buildToolOptions = '-nodeReuse:false'
+        }
+
+        $buildArguments = "--build $BuildDirectoryPath --config $configuration"
+        if($buildToolOptions) {
+            $buildArguments += " -- $buildToolOptions"
+        }
+
+        $process = Start-Process $CMakeProgram -ArgumentList $buildArguments -NoNewWindow -Wait -PassThru
+        $process.WaitForExit();
+        $exitCode = $process.ExitCode
+        if ($exitCode -ne 0) {
+            throw "cmake failed build for '$buildArguments' with exit code '$exitCode'"
+        }
+    }
+
+}
+
+foreach ($system in $SystemNames) {
+    foreach ($arch in $Architectures) {
+        foreach ($config in $Configurations) {
+            Build $system $arch $config $RunBuilds
+        }
+    }
+}

--- a/Scripts/PostBuild.ps1
+++ b/Scripts/PostBuild.ps1
@@ -34,7 +34,11 @@ param (
 
 $ErrorActionPreference = "Stop"
 [string]$RepoRoot = [IO.Path]::Combine($PSScriptRoot, "..")
-[string]$OuputBuildDirectory = [IO.Path]::Combine($RepoRoot, "out\build")
+[string]$OuputBuildDirectory = If($SystemNames -eq 'Windows') { 
+    [IO.Path]::Combine($RepoRoot, "Result.Windows.x64.MultiConfig") 
+}  Else { 
+    [IO.Path]::Combine($RepoRoot, "Result.Linux.x64.$Configurations")
+}
 
 $ContentsToProcess = @(
     @{
@@ -75,7 +79,9 @@ foreach ($item in $ContentsToProcess) {
         else {
             Copy-Item -Path $content.From -Destination $content.To -Force
         }
+
+        [string]$name = $item.Name
+        [string]$ToDirectory = $content.To
+        Write-Host "Copied $name --> $ToDirectory"
     }
-    $name = $item.Name
-    Write-Host "Copied $name"
 }

--- a/Scripts/Shared.ps1
+++ b/Scripts/Shared.ps1
@@ -1,0 +1,57 @@
+# MIT License
+
+# Copyright (c) 2020 Jean Philippe
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+#Requires -PSEdition Core
+
+function CompareVersion([System.Version] $Version, [string] $ExpectedVersion) {
+    $Version.CompareTo([System.Version]::new($ExpectedVersion)) -ge 0
+}
+
+function Find-CMake () {
+
+    [string]$CMakeMinimumVersion = "3.20"
+
+    $InstalledCMakeProgram = @(
+        'cmake'
+        if($IsWindows){
+            Join-Path -Path $env:ProgramFiles -ChildPath 'CMake\bin\cmake.exe'
+        }
+    )
+
+    foreach ($CMakeProgram in $InstalledCMakeProgram) {
+        $Command = Get-Command $CMakeProgram -ErrorAction SilentlyContinue
+        if($Command) {
+            if($IsWindows -and (CompareVersion $Command.Version $CMakeMinimumVersion )){
+                return $Command.Source
+            }
+
+            if ((& $Command --version | Out-String) -match "cmake version ([\d\.]*)") {
+                [Version] $CMakeVersion = $Matches[1]
+                if (CompareVersion $CMakeVersion $CMakeMinimumVersion) {
+                    return $Command.Source
+                }
+            }
+        }
+    }
+
+    throw "Failed to find cmake. Tried: " + ($CMakeCandidates -join ', ')
+}


### PR DESCRIPTION
This PR adds a PSCore build script to control how the engine and other projects are generated and built.
Since the aim is to support Windows and Linux, the script provides the ability to build on both platforms.

The interface offered by this script is like this: 
`.\Scripts\BuildEngine.ps1 -SystemNames Linux -Architectures x64 -Configurations Release`

Extra features
+ Added detection of CMake program
