### PR TITLE
Write out log content to file

### DIFF
--- a/ZEngine/include/ZEngine/Logging/Logger.h
+++ b/ZEngine/include/ZEngine/Logging/Logger.h
@@ -1,6 +1,8 @@
 #pragma once
+#include <mutex>
 #include <ZEngineDef.h>
 #include <spdlog/spdlog.h>
+#include <spdlog/sinks/base_sink.h>
 
 namespace ZEngine::Logging {
 
@@ -10,11 +12,16 @@ namespace ZEngine::Logging {
         Logger(const Logger&) = delete;
 
         static void                 Initialize();
+        static void                 Flush();
         static Ref<spdlog::logger>& GetEngineLogger();
         static Ref<spdlog::logger>& GetEditorLogger();
 
     private:
-        static Ref<spdlog::logger> m_logger;
-        static Ref<spdlog::logger> m_editor_logger;
+        static std::string                   m_logger_output_directory;
+        static std::string                   m_engine_logger_output_file;
+        static std::string                   m_editor_logger_output_file;
+        static Ref<spdlog::logger>           m_engine_logger;
+        static Ref<spdlog::logger>           m_editor_logger;
+        static std::vector<spdlog::sink_ptr> m_sink_collection;
     };
 } // namespace ZEngine::Logging

--- a/ZEngine/include/ZEngine/pch.h
+++ b/ZEngine/include/ZEngine/pch.h
@@ -11,3 +11,4 @@
 #include <cstdint>
 #include <queue>
 #include <functional>
+#include <filesystem>

--- a/ZEngine/src/Engine.cpp
+++ b/ZEngine/src/Engine.cpp
@@ -17,6 +17,7 @@ namespace ZEngine {
 
     Engine::~Engine() {
         m_request_terminate = false;
+        Logging::Logger::Flush();
         ZENGINE_CORE_INFO("Engine stopped");
     }
 

--- a/ZEngine/src/Logger.cpp
+++ b/ZEngine/src/Logger.cpp
@@ -1,22 +1,57 @@
 #include <pch.h>
+#include <fmt/format.h>
+#include <Logging/LoggerDefinition.h>
 #include <Logging/Logger.h>
+#include <spdlog/async_logger.h>
+#include <spdlog/async.h>
+#include <spdlog/sinks/daily_file_sink.h>
+#include <spdlog/details/thread_pool.h>
 
 namespace ZEngine::Logging {
 
-    Ref<spdlog::logger> Logger::m_logger;
-    Ref<spdlog::logger> Logger::m_editor_logger;
+    std::string Logger::m_logger_output_directory   = "Logs";
+    std::string Logger::m_engine_logger_output_file = "engine_dump.log";
+    std::string Logger::m_editor_logger_output_file = "editor_dump.log";
+
+    Ref<spdlog::logger>           Logger::m_engine_logger;
+    Ref<spdlog::logger>           Logger::m_editor_logger;
+    std::vector<spdlog::sink_ptr> Logger::m_sink_collection;
 
     void Logger::Initialize() {
-        auto sink       = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-        m_logger        = std::make_shared<spdlog::logger>("ENGINE", sink);
-        m_editor_logger = std::make_shared<spdlog::logger>("EDITOR", sink);
+        const auto current_directoy   = std::filesystem::current_path();
+        const auto log_directory      = fmt::format("{0}/{1}", current_directoy.string(), m_logger_output_directory);
+        auto       log_directory_path = std::filesystem::path(log_directory);
+        if (!std::filesystem::exists(log_directory_path)) {
+            auto dir_created = std::filesystem::create_directory(log_directory_path);
+            if (!dir_created) {
+                ZENGINE_CORE_ERROR("failed to create Logs directory");
+            }
+        }
 
-        spdlog::log(spdlog::level::info, "Engine logger initialized");
-        spdlog::log(spdlog::level::info, "Editor logger initialized");
+        spdlog::init_thread_pool(8192, 1);
+        m_sink_collection.push_back(
+            std::make_shared<spdlog::sinks::daily_file_sink_mt>(std::format("{0}/{1}", m_logger_output_directory, m_engine_logger_output_file), 0, 0, true, 0));
+        m_sink_collection.push_back(
+            std::make_shared<spdlog::sinks::daily_file_sink_mt>(std::format("{0}/{1}", m_logger_output_directory, m_editor_logger_output_file), 0, 0, true, 0));
+
+        m_engine_logger = std::make_shared<spdlog::async_logger>("ENGINE", m_sink_collection[0], spdlog::thread_pool());
+        m_editor_logger = std::make_shared<spdlog::async_logger>("EDITOR", m_sink_collection[1], spdlog::thread_pool());
+
+        m_engine_logger->info("Engine logger initialized");
+        m_editor_logger->info("Editor logger initialized");
+        spdlog::register_logger(m_engine_logger);
+        spdlog::register_logger(m_editor_logger);
+
+        spdlog::flush_every(std::chrono::seconds(1));
+    }
+
+    void Logger::Flush() {
+        m_engine_logger->flush();
+        m_editor_logger->flush();
     }
 
     Ref<spdlog::logger>& Logger::GetEngineLogger() {
-        return m_logger;
+        return m_engine_logger;
     }
 
     Ref<spdlog::logger>& Logger::GetEditorLogger() {

--- a/ZEngine/src/Logger.cpp
+++ b/ZEngine/src/Logger.cpp
@@ -30,9 +30,9 @@ namespace ZEngine::Logging {
 
         spdlog::init_thread_pool(8192, 1);
         m_sink_collection.push_back(
-            std::make_shared<spdlog::sinks::daily_file_sink_mt>(std::format("{0}/{1}", m_logger_output_directory, m_engine_logger_output_file), 0, 0, true, 0));
+            std::make_shared<spdlog::sinks::daily_file_sink_mt>(fmt::format("{0}/{1}", m_logger_output_directory, m_engine_logger_output_file), 0, 0, true, 0));
         m_sink_collection.push_back(
-            std::make_shared<spdlog::sinks::daily_file_sink_mt>(std::format("{0}/{1}", m_logger_output_directory, m_editor_logger_output_file), 0, 0, true, 0));
+            std::make_shared<spdlog::sinks::daily_file_sink_mt>(fmt::format("{0}/{1}", m_logger_output_directory, m_editor_logger_output_file), 0, 0, true, 0));
 
         m_engine_logger = std::make_shared<spdlog::async_logger>("ENGINE", m_sink_collection[0], spdlog::thread_pool());
         m_editor_logger = std::make_shared<spdlog::async_logger>("EDITOR", m_sink_collection[1], spdlog::thread_pool());


### PR DESCRIPTION
This PR refactors the Logger implementation to write log content in files (dump file): 
-  a log file for the editor: `editor_dump`
- a log file for the core engine: `engine_dump`

it also creates a Log directory if it doesn't exist
