### PR TITLE
Marking Methods with Async and Completed the MessengerRegister Macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Before building, make sure your setup is correct :
 
 - Install Visual Studio 2019 or 2022 Community or Professional, make sure to add "Desktop development with C++".
 - Install [PowerShell Core](https://github.com/PowerShell/PowerShell/releases)
-- Install [Vulkan SDK](https://sdk.lunarg.com/sdk/download/1.3.250.1/windows/VulkanSDK-1.3.250.1-Installer.exe)
+- Install [Vulkan SDK](https://sdk.lunarg.com/sdk/download/1.3.250.1/windows/VulkanSDK-1.3.250.1-Installer.exe) (uncheck the GLM headers component when installing)
 
 ## Building 
 

--- a/Tetragrama/src/Components/InspectorViewUIComponent.cpp
+++ b/Tetragrama/src/Components/InspectorViewUIComponent.cpp
@@ -25,7 +25,7 @@ namespace Tetragrama::Components
         return false;
     }
 
-    std::future<void> InspectorViewUIComponent::SceneAvailableMessageHandler(Messengers::GenericMessage<ZEngine::Ref<ZEngine::Rendering::Scenes::GraphicScene>>& message)
+    std::future<void> InspectorViewUIComponent::SceneAvailableMessageHandlerAsync(Messengers::GenericMessage<ZEngine::Ref<ZEngine::Rendering::Scenes::GraphicScene>>& message)
     {
         {
             std::unique_lock lock(m_mutex);
@@ -34,7 +34,7 @@ namespace Tetragrama::Components
         co_return;
     }
 
-    std::future<void> InspectorViewUIComponent::SceneEntitySelectedMessageHandler(Messengers::PointerValueMessage<ZEngine::Rendering::Entities::GraphicSceneEntity>& message)
+    std::future<void> InspectorViewUIComponent::SceneEntitySelectedMessageHandlerAsync(Messengers::PointerValueMessage<ZEngine::Rendering::Entities::GraphicSceneEntity>& message)
     {
         {
             std::unique_lock lock(m_mutex);
@@ -43,7 +43,7 @@ namespace Tetragrama::Components
         co_return;
     }
 
-    std::future<void> InspectorViewUIComponent::SceneEntityUnSelectedMessageHandler(Messengers::EmptyMessage& message)
+    std::future<void> InspectorViewUIComponent::SceneEntityUnSelectedMessageHandlerAsync(Messengers::EmptyMessage& message)
     {
         {
             std::unique_lock lock(m_mutex);
@@ -52,7 +52,7 @@ namespace Tetragrama::Components
         co_return;
     }
 
-    std::future<void> InspectorViewUIComponent::SceneEntityDeletedMessageHandler(Messengers::EmptyMessage&)
+    std::future<void> InspectorViewUIComponent::SceneEntityDeletedMessageHandlerAsync(Messengers::EmptyMessage&)
     {
         {
             std::unique_lock lock(m_mutex);
@@ -61,7 +61,7 @@ namespace Tetragrama::Components
         co_return;
     }
 
-    std::future<void> InspectorViewUIComponent::RequestStartOrPauseRenderMessageHandler(Messengers::GenericMessage<bool>& message)
+    std::future<void> InspectorViewUIComponent::RequestStartOrPauseRenderMessageHandlerAsync(Messengers::GenericMessage<bool>& message)
     {
         {
             std::unique_lock lock(m_mutex);

--- a/Tetragrama/src/Components/InspectorViewUIComponent.h
+++ b/Tetragrama/src/Components/InspectorViewUIComponent.h
@@ -17,11 +17,11 @@ namespace Tetragrama::Components
         virtual void Render() override;
 
     public:
-        std::future<void> SceneAvailableMessageHandler(Messengers::GenericMessage<ZEngine::Ref<ZEngine::Rendering::Scenes::GraphicScene>>&);
-        std::future<void> SceneEntitySelectedMessageHandler(Messengers::PointerValueMessage<ZEngine::Rendering::Entities::GraphicSceneEntity>&);
-        std::future<void> SceneEntityUnSelectedMessageHandler(Messengers::EmptyMessage&);
-        std::future<void> SceneEntityDeletedMessageHandler(Messengers::EmptyMessage&);
-        std::future<void> RequestStartOrPauseRenderMessageHandler(Messengers::GenericMessage<bool>&);
+        std::future<void> SceneAvailableMessageHandlerAsync(Messengers::GenericMessage<ZEngine::Ref<ZEngine::Rendering::Scenes::GraphicScene>>&);
+        std::future<void> SceneEntitySelectedMessageHandlerAsync(Messengers::PointerValueMessage<ZEngine::Rendering::Entities::GraphicSceneEntity>&);
+        std::future<void> SceneEntityUnSelectedMessageHandlerAsync(Messengers::EmptyMessage&);
+        std::future<void> SceneEntityDeletedMessageHandlerAsync(Messengers::EmptyMessage&);
+        std::future<void> RequestStartOrPauseRenderMessageHandlerAsync(Messengers::GenericMessage<bool>&);
 
     protected:
         virtual bool OnUIComponentRaised(ZEngine::Components::UI::Event::UIComponentEvent&) override;

--- a/Tetragrama/src/Components/SceneViewportUIComponent.cpp
+++ b/Tetragrama/src/Components/SceneViewportUIComponent.cpp
@@ -117,20 +117,20 @@ namespace Tetragrama::Components
         ImGui::PopStyleVar();
     }
 
-    std::future<void> SceneViewportUIComponent::SceneViewportClickedMessageHandler(Messengers::ArrayValueMessage<int, 2>& e)
+    std::future<void> SceneViewportUIComponent::SceneViewportClickedMessageHandlerAsync(Messengers::ArrayValueMessage<int, 2>& e)
     {
         // Messengers::IMessenger::Send<ZEngine::Layers::Layer, Messengers::GenericMessage<std::pair<int, int>>>(
         //     EDITOR_RENDER_LAYER_SCENE_REQUEST_SELECT_ENTITY_FROM_PIXEL, Messengers::GenericMessage<std::pair<int, int>>{e});
         co_return;
     }
 
-    std::future<void> SceneViewportUIComponent::SceneViewportFocusedMessageHandler(Messengers::GenericMessage<bool>& e)
+    std::future<void> SceneViewportUIComponent::SceneViewportFocusedMessageHandlerAsync(Messengers::GenericMessage<bool>& e)
     {
         co_await Messengers::IMessenger::SendAsync<ZEngine::Layers::Layer, Messengers::GenericMessage<bool>>(
             EDITOR_RENDER_LAYER_SCENE_REQUEST_FOCUS, Messengers::GenericMessage<bool>{e});
     }
 
-    std::future<void> SceneViewportUIComponent::SceneViewportUnfocusedMessageHandler(Messengers::GenericMessage<bool>& e)
+    std::future<void> SceneViewportUIComponent::SceneViewportUnfocusedMessageHandlerAsync(Messengers::GenericMessage<bool>& e)
     {
         co_await Messengers::IMessenger::SendAsync<ZEngine::Layers::Layer, Messengers::GenericMessage<bool>>(
             EDITOR_RENDER_LAYER_SCENE_REQUEST_UNFOCUS, Messengers::GenericMessage<bool>{e});

--- a/Tetragrama/src/Components/SceneViewportUIComponent.h
+++ b/Tetragrama/src/Components/SceneViewportUIComponent.h
@@ -24,9 +24,9 @@ namespace Tetragrama::Components
         }
 
     public:
-        std::future<void> SceneViewportClickedMessageHandler(Messengers::ArrayValueMessage<int, 2>&);
-        std::future<void> SceneViewportFocusedMessageHandler(Messengers::GenericMessage<bool>&);
-        std::future<void> SceneViewportUnfocusedMessageHandler(Messengers::GenericMessage<bool>&);
+        std::future<void> SceneViewportClickedMessageHandlerAsync(Messengers::ArrayValueMessage<int, 2>&);
+        std::future<void> SceneViewportFocusedMessageHandlerAsync(Messengers::GenericMessage<bool>&);
+        std::future<void> SceneViewportUnfocusedMessageHandlerAsync(Messengers::GenericMessage<bool>&);
 
     private:
         bool                  m_is_window_focused{false};

--- a/Tetragrama/src/Editor.cpp
+++ b/Tetragrama/src/Editor.cpp
@@ -35,55 +35,64 @@ namespace Tetragrama
     {
         ZEngine::Engine::Initialize(m_engine_configuration);
 
-        // Register components
-        IMessenger::Register<ZEngine::Layers::Layer, GenericMessage<std::pair<float, float>>>(
-            m_render_layer.get(), EDITOR_RENDER_LAYER_SCENE_REQUEST_RESIZE, [this](void* const message) -> std::future<void> {
-                auto message_ptr = reinterpret_cast<GenericMessage<std::pair<float, float>>*>(message);
-                return m_render_layer->SceneRequestResizeMessageHandler(*message_ptr);
-            });
+        using PairFloat = std::pair<float, float>;
+        MESSENGER_REGISTER(
+            ZEngine::Layers::Layer,
+            GenericMessage<PairFloat>,
+            EDITOR_RENDER_LAYER_SCENE_REQUEST_RESIZE,
+            m_render_layer.get(),
+            return m_render_layer->SceneRequestResizeMessageHandlerAsync(*message_ptr))
 
-        IMessenger::Register<ZEngine::Layers::Layer, GenericMessage<bool>>(
-            m_render_layer.get(), EDITOR_RENDER_LAYER_SCENE_REQUEST_FOCUS, [this](void* const message) -> std::future<void> {
-                auto message_ptr = reinterpret_cast<GenericMessage<bool>*>(message);
-                return m_render_layer->SceneRequestFocusMessageHandler(*message_ptr);
-            });
+        MESSENGER_REGISTER(
+            ZEngine::Layers::Layer,
+            GenericMessage<bool>,
+            EDITOR_RENDER_LAYER_SCENE_REQUEST_FOCUS,
+            m_render_layer.get(),
+            return m_render_layer->SceneRequestFocusMessageHandlerAsync(*message_ptr))
 
-        IMessenger::Register<ZEngine::Layers::Layer, GenericMessage<bool>>(
-            m_render_layer.get(), EDITOR_RENDER_LAYER_SCENE_REQUEST_UNFOCUS, [this](void* const message) -> std::future<void> {
-                auto message_ptr = reinterpret_cast<GenericMessage<bool>*>(message);
-                return m_render_layer->SceneRequestUnfocusMessageHandler(*message_ptr);
-            });
+        MESSENGER_REGISTER(
+            ZEngine::Layers::Layer,
+            GenericMessage<bool>,
+            EDITOR_RENDER_LAYER_SCENE_REQUEST_UNFOCUS,
+            m_render_layer.get(),
+            return m_render_layer->SceneRequestUnfocusMessageHandlerAsync(*message_ptr))
 
-        IMessenger::Register<ZEngine::Layers::Layer, GenericMessage<std::string>>(
-            m_render_layer.get(), EDITOR_RENDER_LAYER_SCENE_REQUEST_SERIALIZATION, [this](void* const message) -> std::future<void> {
-                auto message_ptr = reinterpret_cast<GenericMessage<std::string>*>(message);
-                return m_render_layer->SceneRequestSerializationMessageHandler(*message_ptr);
-            });
+        MESSENGER_REGISTER(
+            ZEngine::Layers::Layer,
+            GenericMessage<std::string>,
+            EDITOR_RENDER_LAYER_SCENE_REQUEST_SERIALIZATION,
+            m_render_layer.get(),
+            return m_render_layer->SceneRequestSerializationMessageHandlerAsync(*message_ptr))
+     
+        MESSENGER_REGISTER(
+            ZEngine::Layers::Layer,
+            GenericMessage<std::string>,
+            EDITOR_RENDER_LAYER_SCENE_REQUEST_DESERIALIZATION,
+            m_render_layer.get(),
+            return m_render_layer->SceneRequestDeserializationMessageHandlerAsync(*message_ptr))
 
-        IMessenger::Register<ZEngine::Layers::Layer, Messengers::GenericMessage<std::string>>(
-            m_render_layer.get(), EDITOR_RENDER_LAYER_SCENE_REQUEST_DESERIALIZATION, [this](void* const message) -> std::future<void> {
-                auto message_ptr = reinterpret_cast<GenericMessage<std::string>*>(message);
-                return m_render_layer->SceneRequestDeserializationMessageHandler(*message_ptr);
-            });
+        MESSENGER_REGISTER(
+            ZEngine::Layers::Layer,
+            EmptyMessage,
+            EDITOR_RENDER_LAYER_SCENE_REQUEST_NEWSCENE,
+            m_render_layer.get(),
+            return m_render_layer->SceneRequestNewSceneMessageHandlerAsync(*message_ptr))
 
-        IMessenger::Register<ZEngine::Layers::Layer, EmptyMessage>(
-            m_render_layer.get(), EDITOR_RENDER_LAYER_SCENE_REQUEST_NEWSCENE, [this](void* const message) -> std::future<void> {
-                auto message_ptr = reinterpret_cast<EmptyMessage*>(message);
-                return m_render_layer->SceneRequestNewSceneMessageHandler(*message_ptr);
-            });
-
-        IMessenger::Register<ZEngine::Layers::Layer, GenericMessage<std::string>>(
-            m_render_layer.get(), EDITOR_RENDER_LAYER_SCENE_REQUEST_OPENSCENE, [this](void* const message) -> std::future<void> {
-                auto message_ptr = reinterpret_cast<GenericMessage<std::string>*>(message);
-                return m_render_layer->SceneRequestOpenSceneMessageHandler(*message_ptr);
-            });
-
-        IMessenger::Register<ZEngine::Layers::Layer, GenericMessage<std::pair<int, int>>>(
-            m_render_layer.get(), EDITOR_RENDER_LAYER_SCENE_REQUEST_SELECT_ENTITY_FROM_PIXEL, [this](void* const message) -> std::future<void> {
-                auto message_ptr = reinterpret_cast<GenericMessage<std::pair<int, int>>*>(message);
-                return m_render_layer->SceneRequestSelectEntityFromPixelMessageHandler(*message_ptr);
-            });
-
+        MESSENGER_REGISTER(
+            ZEngine::Layers::Layer,
+            GenericMessage<std::string>,
+            EDITOR_RENDER_LAYER_SCENE_REQUEST_OPENSCENE,
+            m_render_layer.get(),
+            return m_render_layer->SceneRequestOpenSceneMessageHandlerAsync(*message_ptr))
+        
+        using PairInt = std::pair<int, int>;
+        MESSENGER_REGISTER(
+            ZEngine::Layers::Layer,
+            GenericMessage<PairInt>,
+            EDITOR_RENDER_LAYER_SCENE_REQUEST_SELECT_ENTITY_FROM_PIXEL,
+            m_render_layer.get(),
+            return m_render_layer->SceneRequestSelectEntityFromPixelMessageHandlerAsync(*message_ptr))
+        
         MESSENGER_REGISTER(
             ZEngine::Layers::Layer,
             GenericMessage<std::string>,

--- a/Tetragrama/src/Layers/RenderLayer.cpp
+++ b/Tetragrama/src/Layers/RenderLayer.cpp
@@ -53,7 +53,7 @@ namespace Tetragrama::Layers
 
     }
 
-    std::future<void> RenderLayer::SceneRequestResizeMessageHandler(Messengers::GenericMessage<std::pair<float, float>>& message)
+    std::future<void> RenderLayer::SceneRequestResizeMessageHandlerAsync(Messengers::GenericMessage<std::pair<float, float>>& message)
     {
         std::unique_lock lock(m_message_handler_mutex);
 
@@ -62,21 +62,21 @@ namespace Tetragrama::Layers
         co_return;
     }
 
-    std::future<void> RenderLayer::SceneRequestFocusMessageHandler(Messengers::GenericMessage<bool>& message)
+    std::future<void> RenderLayer::SceneRequestFocusMessageHandlerAsync(Messengers::GenericMessage<bool>& message)
     {
         // std::unique_lock lock(m_message_handler_mutex);
         // GraphicScene::SetShouldReactToEvent(message.GetValue());
         co_return;
     }
 
-    std::future<void> RenderLayer::SceneRequestUnfocusMessageHandler(Messengers::GenericMessage<bool>& message)
+    std::future<void> RenderLayer::SceneRequestUnfocusMessageHandlerAsync(Messengers::GenericMessage<bool>& message)
     {
         // std::unique_lock lock(m_message_handler_mutex);
         // GraphicScene::SetShouldReactToEvent(message.GetValue());
         co_return;
     }
 
-    std::future<void> RenderLayer::SceneRequestSerializationMessageHandler(Messengers::GenericMessage<std::string>& message)
+    std::future<void> RenderLayer::SceneRequestSerializationMessageHandlerAsync(Messengers::GenericMessage<std::string>& message)
     {
         // std::unique_lock lock(m_message_handler_mutex);
         //// Todo: We need to replace this whole part by using system FileDialog API
@@ -103,7 +103,7 @@ namespace Tetragrama::Layers
         co_return;
     }
 
-    std::future<void> RenderLayer::SceneRequestDeserializationMessageHandler(Messengers::GenericMessage<std::string>& message)
+    std::future<void> RenderLayer::SceneRequestDeserializationMessageHandlerAsync(Messengers::GenericMessage<std::string>& message)
     {
         //{
         //    std::unique_lock lock(m_message_handler_mutex);
@@ -124,7 +124,7 @@ namespace Tetragrama::Layers
         co_return;
     }
 
-    std::future<void> RenderLayer::SceneRequestNewSceneMessageHandler(Messengers::EmptyMessage& message)
+    std::future<void> RenderLayer::SceneRequestNewSceneMessageHandlerAsync(Messengers::EmptyMessage& message)
     {
         //{
         //    std::unique_lock lock(m_message_handler_mutex);
@@ -140,7 +140,7 @@ namespace Tetragrama::Layers
         co_return;
     }
 
-    std::future<void> RenderLayer::SceneRequestOpenSceneMessageHandler(Messengers::GenericMessage<std::string>& message)
+    std::future<void> RenderLayer::SceneRequestOpenSceneMessageHandlerAsync(Messengers::GenericMessage<std::string>& message)
     {
         //{
         //    std::unique_lock lock(m_message_handler_mutex);
@@ -162,7 +162,7 @@ namespace Tetragrama::Layers
         co_return co_await GraphicScene::ImportAssetAsync(value);
     }
 
-    std::future<void> RenderLayer::SceneRequestSelectEntityFromPixelMessageHandler(Messengers::GenericMessage<std::pair<int, int>>& mouse_position)
+    std::future<void> RenderLayer::SceneRequestSelectEntityFromPixelMessageHandlerAsync(Messengers::GenericMessage<std::pair<int, int>>& mouse_position)
     {
         // const auto& value  = mouse_position.GetValue();
         // auto        entity = m_scene->GetEntity(value.first, value.second);

--- a/Tetragrama/src/Layers/RenderLayer.h
+++ b/Tetragrama/src/Layers/RenderLayer.h
@@ -28,17 +28,17 @@ namespace Tetragrama::Layers
         virtual bool OnEvent(ZEngine::Event::CoreEvent& e) override;
 
     public:
-        std::future<void> SceneRequestResizeMessageHandler(Messengers::GenericMessage<std::pair<float, float>>&);
-        std::future<void> SceneRequestFocusMessageHandler(Messengers::GenericMessage<bool>&);
-        std::future<void> SceneRequestUnfocusMessageHandler(Messengers::GenericMessage<bool>&);
-        std::future<void> SceneRequestSerializationMessageHandler(Messengers::GenericMessage<std::string>&);
-        std::future<void> SceneRequestDeserializationMessageHandler(Messengers::GenericMessage<std::string>&);
+        std::future<void> SceneRequestResizeMessageHandlerAsync(Messengers::GenericMessage<std::pair<float, float>>&);
+        std::future<void> SceneRequestFocusMessageHandlerAsync(Messengers::GenericMessage<bool>&);
+        std::future<void> SceneRequestUnfocusMessageHandlerAsync(Messengers::GenericMessage<bool>&);
+        std::future<void> SceneRequestSerializationMessageHandlerAsync(Messengers::GenericMessage<std::string>&);
+        std::future<void> SceneRequestDeserializationMessageHandlerAsync(Messengers::GenericMessage<std::string>&);
 
-        std::future<void> SceneRequestNewSceneMessageHandler(Messengers::EmptyMessage&);
-        std::future<void> SceneRequestOpenSceneMessageHandler(Messengers::GenericMessage<std::string>&);
+        std::future<void> SceneRequestNewSceneMessageHandlerAsync(Messengers::EmptyMessage&);
+        std::future<void> SceneRequestOpenSceneMessageHandlerAsync(Messengers::GenericMessage<std::string>&);
         std::future<void> SceneRequestImportAssetModelAsync(Messengers::GenericMessage<std::string>&);
 
-        std::future<void> SceneRequestSelectEntityFromPixelMessageHandler(Messengers::GenericMessage<std::pair<int, int>>&);
+        std::future<void> SceneRequestSelectEntityFromPixelMessageHandlerAsync(Messengers::GenericMessage<std::pair<int, int>>&);
 
     private:
         ZEngine::Ref<ZEngine::Serializers::GraphicSceneSerializer> m_scene_serializer;

--- a/Tetragrama/src/Layers/UILayer.cpp
+++ b/Tetragrama/src/Layers/UILayer.cpp
@@ -45,21 +45,21 @@ namespace Tetragrama::Layers
             GenericMessage<bool>,
             EDITOR_COMPONENT_SCENEVIEWPORT_FOCUSED,
             m_scene_component.get(),
-            return m_scene_component->SceneViewportFocusedMessageHandler(*message_ptr))
+            return m_scene_component->SceneViewportFocusedMessageHandlerAsync(*message_ptr))
 
         MESSENGER_REGISTER(
             ZEngine::Components::UI::UIComponent,
             GenericMessage<bool>,
             EDITOR_COMPONENT_SCENEVIEWPORT_UNFOCUSED,
             m_scene_component.get(),
-            return m_scene_component->SceneViewportUnfocusedMessageHandler(*message_ptr))
+            return m_scene_component->SceneViewportUnfocusedMessageHandlerAsync(*message_ptr))
 
         MESSENGER_REGISTER(
             ZEngine::Components::UI::UIComponent,
             SINGLE_ARG(ArrayValueMessage<int, 2>),
             EDITOR_COMPONENT_SCENEVIEWPORT_CLICKED,
             m_scene_component.get(),
-            return m_scene_component->SceneViewportClickedMessageHandler(*message_ptr))
+            return m_scene_component->SceneViewportClickedMessageHandlerAsync(*message_ptr))
         /*
          *  Register Hierarchy Component
          */
@@ -77,34 +77,34 @@ namespace Tetragrama::Layers
             GenericMessage<bool>,
             EDITOR_COMPONENT_INSPECTORVIEW_REQUEST_RESUME_OR_PAUSE_RENDER,
             m_inspector_view_component.get(),
-            return m_inspector_view_component->RequestStartOrPauseRenderMessageHandler(*message_ptr))
+            return m_inspector_view_component->RequestStartOrPauseRenderMessageHandlerAsync(*message_ptr))
 
         MESSENGER_REGISTER(
             ZEngine::Components::UI::UIComponent,
             PointerValueMessage<ZEngine::Rendering::Entities::GraphicSceneEntity>,
             EDITOR_COMPONENT_HIERARCHYVIEW_NODE_SELECTED,
             m_inspector_view_component.get(),
-            return m_inspector_view_component->SceneEntitySelectedMessageHandler(*message_ptr));
+            return m_inspector_view_component->SceneEntitySelectedMessageHandlerAsync(*message_ptr));
 
         MESSENGER_REGISTER(
             ZEngine::Components::UI::UIComponent,
             EmptyMessage,
             EDITOR_COMPONENT_HIERARCHYVIEW_NODE_UNSELECTED,
             m_inspector_view_component.get(),
-            return m_inspector_view_component->SceneEntityUnSelectedMessageHandler(*message_ptr));
+            return m_inspector_view_component->SceneEntityUnSelectedMessageHandlerAsync(*message_ptr));
 
         MESSENGER_REGISTER(
             ZEngine::Components::UI::UIComponent,
             EmptyMessage,
             EDITOR_COMPONENT_HIERARCHYVIEW_NODE_DELETED,
             m_inspector_view_component.get(),
-            return m_inspector_view_component->SceneEntityDeletedMessageHandler(*message_ptr));
+            return m_inspector_view_component->SceneEntityDeletedMessageHandlerAsync(*message_ptr));
 
         MESSENGER_REGISTER(
             ZEngine::Components::UI::UIComponent,
             GenericMessage<ZEngine::Ref<ZEngine::Rendering::Scenes::GraphicScene>>,
             EDITOR_RENDER_LAYER_SCENE_AVAILABLE,
             m_inspector_view_component.get(),
-            return m_inspector_view_component->SceneAvailableMessageHandler(*message_ptr));
+            return m_inspector_view_component->SceneAvailableMessageHandlerAsync(*message_ptr));
     }
 } // namespace Tetragrama::Layers


### PR DESCRIPTION
- #236 
-  #248 
- updated the readme to let users know they should uncheck GLM headers when installing to avoid redefinition errors 
