### PR TITLE
Fixing Engine running on Integrated GPU device

### DIFF
--- a/ZEngine/include/ZEngine/Hardwares/VulkanDevice.h
+++ b/ZEngine/include/ZEngine/Hardwares/VulkanDevice.h
@@ -10,6 +10,12 @@
 #include <GLFW/glfw3.h>
 #include <vk_mem_alloc.h>
 
+
+namespace ZEngine::Window
+{
+    class CoreWindow;
+}
+
 namespace ZEngine::Hardwares
 {
 
@@ -73,7 +79,7 @@ namespace ZEngine::Hardwares
         VulkanDevice(const VulkanDevice&) = delete;
         ~VulkanDevice()                   = delete;
 
-        static void Initialize(GLFWwindow* const native_window, const std::vector<const char*>& additional_extension_layer_name_collection);
+        static void Initialize(const Ref<Window::CoreWindow>& window, const std::vector<const char*>& additional_extension_layer_name_collection);
         static void Deinitialize();
         static void Dispose();
 

--- a/ZEngine/include/ZEngine/Rendering/Specifications/ShaderSpecification.h
+++ b/ZEngine/include/ZEngine/Rendering/Specifications/ShaderSpecification.h
@@ -72,6 +72,7 @@ namespace ZEngine::Rendering::Specifications
     struct ShaderSpecification
     {
         uint32_t    OverloadMaxSet   = 1;
+        uint32_t    OverloadPoolSize = 0;
         std::string VertexFilename   = {};
         std::string FragmentFilename = {};
     };

--- a/ZEngine/src/Engine.cpp
+++ b/ZEngine/src/Engine.cpp
@@ -25,7 +25,7 @@ namespace ZEngine
         std::vector<const char*> window_additional_extension_layer_name_collection(
             glfw_extensions_layer_name_collection, glfw_extensions_layer_name_collection + glfw_extensions_layer_name_count);
 
-        Hardwares::VulkanDevice::Initialize(reinterpret_cast<GLFWwindow*>(m_window->GetNativeWindow()), window_additional_extension_layer_name_collection);
+        Hardwares::VulkanDevice::Initialize(m_window, window_additional_extension_layer_name_collection);
 
         m_window->Initialize();
         GraphicRenderer::SetMainSwapchain(m_window->GetSwapchain());

--- a/ZEngine/src/ImGUIRenderer.cpp
+++ b/ZEngine/src/ImGUIRenderer.cpp
@@ -65,6 +65,7 @@ namespace ZEngine::Rendering::Renderers
         ui_pipeline_spec.ShaderSpecification.VertexFilename                   = "Shaders/Cache/imgui_vertex.spv";
         ui_pipeline_spec.ShaderSpecification.FragmentFilename                 = "Shaders/Cache/imgui_fragment.spv";
         ui_pipeline_spec.ShaderSpecification.OverloadMaxSet                   = 2000;
+        ui_pipeline_spec.ShaderSpecification.OverloadPoolSize                 = 2;
 
         ui_pipeline_spec.VertexInputBindingSpecifications.resize(1);
         ui_pipeline_spec.VertexInputBindingSpecifications[0].Stride = sizeof(ImDrawVert);
@@ -108,8 +109,7 @@ namespace ZEngine::Rendering::Renderers
         font_tex_spec.Height                               = height;
         font_tex_spec.Data                                 = pixels;
         font_tex_spec.Format                               = Specifications::ImageFormat::R8G8B8A8_UNORM;
-
-        Ref<Textures::Texture> font_texture = Textures::Texture2D::Create(font_tex_spec);
+        Ref<Textures::Texture> font_texture                = Textures::Texture2D::Create(font_tex_spec);
 
         VkDescriptorSetAllocateInfo font_alloc_info = {};
         font_alloc_info.sType                       = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;

--- a/ZEngine/src/Shader.cpp
+++ b/ZEngine/src/Shader.cpp
@@ -353,6 +353,14 @@ namespace ZEngine::Rendering::Shaders
                  */
                 find_pool_size_it->descriptorCount++;
             }
+            /*
+             * Ensure correctness with number of frame count
+             */
+            for (auto& pool_size : pool_size_collection)
+            {
+                pool_size.descriptorCount *= renderer_info.FrameCount;
+                pool_size.descriptorCount += m_specification.OverloadPoolSize;
+            }
         }
         /*
          * Create DescriptorPool

--- a/ZEngine/src/Swapchain.cpp
+++ b/ZEngine/src/Swapchain.cpp
@@ -213,29 +213,22 @@ namespace ZEngine::Rendering
         swapchain_create_info.imageFormat              = m_surface_format.format;
         swapchain_create_info.imageColorSpace          = m_surface_format.colorSpace;
         swapchain_create_info.imageExtent              = extent;
-        swapchain_create_info.imageArrayLayers         = m_capabilities.maxImageArrayLayers;
+        swapchain_create_info.imageArrayLayers         = 1;
         swapchain_create_info.preTransform             = m_capabilities.currentTransform;
+        swapchain_create_info.presentMode              = Hardwares::VulkanDevice::GetPresentMode();
 
-        std::unordered_set<uint32_t> device_family_indices = {
+        std::set<uint32_t> device_family_indices = {
             Hardwares::VulkanDevice::GetQueue(QueueType::GRAPHIC_QUEUE).FamilyIndex, Hardwares::VulkanDevice::GetQueue(QueueType::TRANSFER_QUEUE).FamilyIndex};
 
         m_queue_family_index_collection = std::vector<uint32_t>{device_family_indices.begin(), device_family_indices.end()};
 
-        if (m_queue_family_index_collection.size() > 1)
-        {
-            swapchain_create_info.imageSharingMode      = VK_SHARING_MODE_CONCURRENT;
-            swapchain_create_info.queueFamilyIndexCount = m_queue_family_index_collection.size();
-            swapchain_create_info.pQueueFamilyIndices   = m_queue_family_index_collection.data();
-        }
-        else
-        {
-            swapchain_create_info.imageSharingMode      = VK_SHARING_MODE_EXCLUSIVE;
-            swapchain_create_info.queueFamilyIndexCount = 0;
-            swapchain_create_info.pQueueFamilyIndices   = nullptr;
-        }
-        swapchain_create_info.imageUsage     = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-        swapchain_create_info.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
-        swapchain_create_info.clipped        = VK_TRUE;
+        swapchain_create_info.imageSharingMode = (m_queue_family_index_collection.size() > 1) ? VK_SHARING_MODE_CONCURRENT : VK_SHARING_MODE_EXCLUSIVE;
+
+        swapchain_create_info.queueFamilyIndexCount = m_queue_family_index_collection.size();
+        swapchain_create_info.pQueueFamilyIndices   = m_queue_family_index_collection.data();
+        swapchain_create_info.imageUsage            = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+        swapchain_create_info.compositeAlpha        = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+        swapchain_create_info.clipped               = VK_TRUE;
 
         ZENGINE_VALIDATE_ASSERT(vkCreateSwapchainKHR(native_device, &swapchain_create_info, nullptr, &m_handle) == VK_SUCCESS, "Failed to create Swapchain")
 


### PR DESCRIPTION
For a while now, we have been seeing failure to run the engine on the computer with Integrated GPU.

This PR comes as fix to this issue by ensuring the proper GPU device selection, proper presentation mode and selection of minimal but required config needed by the engine to run.