### PR TITLE
add the python installation in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Before building, make sure your setup is correct :
 - Install Visual Studio 2022 Community or Professional, make sure to add "Desktop development with C++".
 - Install [PowerShell Core](https://github.com/PowerShell/PowerShell/releases)
 - Install [Vulkan SDK](https://sdk.lunarg.com/sdk/download/1.3.250.1/windows/VulkanSDK-1.3.250.1-Installer.exe) (uncheck the GLM headers component when installing)
+- Install [Python](https://www.python.org/ftp/python/3.12.4/python-3.12.4-amd64.exe)
 
 ## Building 
 


### PR DESCRIPTION
Unable to run .\Scripts\BuildEngine.ps1 -Configurations Debug -RunBuilds $True -VsVersion 2022 when python is not installed on the machine, so it must appear in the readme.