### PR TITLE
Adding new build option to compile Panzerfaust only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,39 +18,42 @@ include(${ENLISTMENT_ROOT}/Scripts/CMake/NuGet.cmake)
 
 
 option (COPY_EXAMPLE_PROJECT "Copy example projects that show how to use Launcher" ON)
+option (LAUNCHER_ONLY "Build Launcher only" OFF)
 
-# Externals dependencies
-#
-add_subdirectory (${EXTERNAL_DIR}/fmt)
-add_subdirectory (${EXTERNAL_DIR}/imgui)
-add_subdirectory (${EXTERNAL_DIR}/glfw)
-add_subdirectory (${EXTERNAL_DIR}/spdlog)
-add_subdirectory (${EXTERNAL_DIR}/glm)
-add_subdirectory (${EXTERNAL_DIR}/entt)
-add_subdirectory (${EXTERNAL_DIR}/assimp)
-add_subdirectory (${EXTERNAL_DIR}/stduuid)
-add_subdirectory (${EXTERNAL_DIR}/yaml-cpp)
-add_subdirectory (${EXTERNAL_DIR}/SPIRV-headers)
-add_subdirectory (${EXTERNAL_DIR}/SPIRV-Tools)
-add_subdirectory (${EXTERNAL_DIR}/glslang)
-add_subdirectory (${EXTERNAL_DIR}/SPIRV-Cross)
-add_subdirectory (${EXTERNAL_DIR}/gtest)
-add_subdirectory (${EXTERNAL_DIR}/VulkanMemoryAllocator)
 
-set (CMAKE_PREFIX_PATH
-	${CMAKE_PREFIX_PATH}
-	${EXTERNAL_DIR}/Vulkan-Headers/build/install/share/cmake
-)
-add_subdirectory (${EXTERNAL_DIR}/Vulkan-Loader)
+if(NOT LAUNCHER_ONLY)
+	# Externals dependencies
+	#
+	add_subdirectory (${EXTERNAL_DIR}/fmt)
+	add_subdirectory (${EXTERNAL_DIR}/imgui)
+	add_subdirectory (${EXTERNAL_DIR}/glfw)
+	add_subdirectory (${EXTERNAL_DIR}/spdlog)
+	add_subdirectory (${EXTERNAL_DIR}/glm)
+	add_subdirectory (${EXTERNAL_DIR}/entt)
+	add_subdirectory (${EXTERNAL_DIR}/assimp)
+	add_subdirectory (${EXTERNAL_DIR}/stduuid)
+	add_subdirectory (${EXTERNAL_DIR}/yaml-cpp)
+	add_subdirectory (${EXTERNAL_DIR}/SPIRV-headers)
+	add_subdirectory (${EXTERNAL_DIR}/SPIRV-Tools)
+	add_subdirectory (${EXTERNAL_DIR}/glslang)
+	add_subdirectory (${EXTERNAL_DIR}/SPIRV-Cross)
+	add_subdirectory (${EXTERNAL_DIR}/gtest)
+	add_subdirectory (${EXTERNAL_DIR}/VulkanMemoryAllocator)
 
-# Core engine lib is here
-#
-add_subdirectory(ZEngine)
+	set (CMAKE_PREFIX_PATH
+		${CMAKE_PREFIX_PATH}
+		${EXTERNAL_DIR}/Vulkan-Headers/build/install/share/cmake
+	)
+	add_subdirectory (${EXTERNAL_DIR}/Vulkan-Loader)
 
-# Editor is here
-#
-add_subdirectory(Tetragrama)
+	# Core engine lib is here
+	#
+	add_subdirectory(ZEngine)
 
+	# Editor is here
+	#
+	add_subdirectory(Tetragrama)
+endif ()
 # Launcher is here
 #
 add_subdirectory(Panzerfaust)
@@ -65,12 +68,18 @@ endif ()
 #
 set(SYSTEM_NAME ${CMAKE_SYSTEM_NAME})
 
-add_custom_target(BuildLauncher ALL
+if(NOT LAUNCHER_ONLY)
+	add_custom_target(BuildLauncher ALL
 	COMMENT "Building Panzerfaust"
 	DEPENDS
 		zEngineLib
 		tetragrama
-)
+	)
+else ()
+	add_custom_target(BuildLauncher ALL
+	COMMENT "Building Panzerfaust"
+	)
+endif ()
 
 add_custom_command(TARGET BuildLauncher
 	POST_BUILD
@@ -83,10 +92,17 @@ add_custom_target(AssembleContent ALL
 		BuildLauncher
 )
 
-add_custom_command(TARGET AssembleContent
+if(NOT LAUNCHER_ONLY)
+	add_custom_command(TARGET AssembleContent
+		POST_BUILD
+		COMMAND pwsh ${CMAKE_CURRENT_SOURCE_DIR}/Scripts/PostBuild.ps1 -Configurations $<IF:$<CONFIG:Debug>,Debug,Release>
+	)
+else ()
+	add_custom_command(TARGET AssembleContent
 	POST_BUILD
-	COMMAND pwsh ${CMAKE_CURRENT_SOURCE_DIR}/Scripts/PostBuild.ps1 -Configurations $<IF:$<CONFIG:Debug>,Debug,Release>
-)
+	COMMAND pwsh ${CMAKE_CURRENT_SOURCE_DIR}/Scripts/PostBuild.ps1 -Configurations $<IF:$<CONFIG:Debug>,Debug,Release> -LauncherOnly
+	)
+endif ()
 
 # Copying Examples dir
 #

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Before building, make sure your setup is correct :
 	- `RunBuilds` can be omitted as its default value is: `$True`.
 	- You can build `Debug` and `Release` versions at once by omitting the `Configuration` parameter
 	- On Windows, you can specify the Visual Studio version with `VsVersion`, it can be omitted as its default value is: `2022`
+	- If you want to work on the launcher only, you can specify the Launcher only parameter with `LauncherOnly` then only the launcher will be build.
 
 ## Dependencies
 

--- a/Scripts/BuildEngine.ps1
+++ b/Scripts/BuildEngine.ps1
@@ -36,7 +36,10 @@ param (
 
     [Parameter(HelpMessage = "VS version use to build, default to 2022")]
     [ValidateSet(2022)]
-    [int] $VsVersion = 2022
+    [int] $VsVersion = 2022,
+
+    [Parameter(HelpMessage = "Build Launcher only")]
+    [switch] $LauncherOnly
 )
 
 $ErrorActionPreference = "Stop"
@@ -73,7 +76,7 @@ if ($IsWindows) {
     $installPath = Split-Path -Path $nugetProgram -Parent
     if ($env:PATH -notlike "*$installPath*") {
         $env:PATH = "$installPath;$env:PATH"
-    }
+    } 
 }
 
 
@@ -143,6 +146,7 @@ function Build([string]$configuration, [int]$VsVersion , [bool]$runBuild) {
         'VULKAN_LOADER' = @("-DVULKAN_HEADERS_INSTALL_DIR=$ExternalVulkanHeadersInstallDir", "-DUSE_MASM=OFF", "-DUSE_GAS=OFF")
         'SPIRV_TOOLS' = @("-DSPIRV_SKIP_EXECUTABLES=ON", "-DSPIRV_SKIP_TESTS=ON")
         'SPIRV_CROSS' = @("-DSPIRV_CROSS_ENABLE_TESTS=OFF")
+        'LAUNCHER_ONLY' = @("-DLAUNCHER_ONLY=ON")
     }  
 
     $cMakeCacheVariableOverride = $cMakeOptions -join ' ' 
@@ -184,6 +188,11 @@ function Build([string]$configuration, [int]$VsVersion , [bool]$runBuild) {
     $cMakeCacheVariableOverride += ' ' + $submoduleCMakeOptions.VULKAN_LOADER -join ' '
     $cMakeCacheVariableOverride += ' ' + $submoduleCMakeOptions.SPIRV_CROSS -join ' '
     $cMakeCacheVariableOverride += ' ' + $submoduleCMakeOptions.SPIRV_TOOLS -join ' '
+
+    if($LauncherOnly)
+    {
+        $cMakeCacheVariableOverride += ' ' + $submoduleCMakeOptions.LAUNCHER_ONLY -join ' '
+    }
 
     if (-not $IsLinux) {
         $cMakeCacheVariableOverride += ' ' + $submoduleCMakeOptions.GLFW -join ' '

--- a/Scripts/PostBuild.ps1
+++ b/Scripts/PostBuild.ps1
@@ -25,7 +25,10 @@
 param (
     [Parameter(HelpMessage="Configuration type to build, default to Debug")]
     [ValidateSet('Debug', 'Release')]
-    [string[]] $Configurations = 'Debug'
+    [string[]] $Configurations = 'Debug',
+
+    [Parameter(HelpMessage = "Build Launcher only")]
+    [switch] $LauncherOnly
 )
 
 $ErrorActionPreference = "Stop"
@@ -50,52 +53,56 @@ elseif ($IsWindows) {
     [IO.Path]::Combine($RepoRoot, "Result.$SystemName.x64.$Configurations")
 }
 
-$ContentsToProcess = @(
-    @{
-        Name = "Resources"
-        IsDirectory = $true
-        Contents = @(
-            if ($IsWindows) {
-                @{ From = "$RepoRoot\Resources\Shaders";            To = "$OuputBuildDirectory\Tetragrama\src\$Configurations\Shaders"}
-                @{ From = "$RepoRoot\Resources\Editor\Settings";    To = "$OuputBuildDirectory\Tetragrama\src\$Configurations\Settings"}
-            }
-            elseif ($IsMacOS) {
-                @{ From = "$RepoRoot\Resources\Shaders";            To = "$OuputBuildDirectory\Tetragrama\src\$Configurations\Shaders"}
-                @{ From = "$RepoRoot\Resources\Editor\Settings";    To = "$OuputBuildDirectory\Tetragrama\src\$Configurations\Settings"}
+if(-not $LauncherOnly)
+{ 
+    $ContentsToProcess = @(
+        @{
+            Name = "Resources"
+            IsDirectory = $true
+            Contents = @(
+            
+                if ($IsWindows) {
+                    @{ From = "$RepoRoot\Resources\Shaders";            To = "$OuputBuildDirectory\Tetragrama\src\$Configurations\Shaders"}
+                    @{ From = "$RepoRoot\Resources\Editor\Settings";    To = "$OuputBuildDirectory\Tetragrama\src\$Configurations\Settings"}
+                }
+                elseif ($IsMacOS) {
+                    @{ From = "$RepoRoot\Resources\Shaders";            To = "$OuputBuildDirectory\Tetragrama\src\$Configurations\Shaders"}
+                    @{ From = "$RepoRoot\Resources\Editor\Settings";    To = "$OuputBuildDirectory\Tetragrama\src\$Configurations\Settings"}
+                }
+                else {
+                    @{ From = "$RepoRoot\Resources\Shaders";            To = "$OuputBuildDirectory\Tetragrama\src\Shaders"}
+                    @{ From = "$RepoRoot\Resources\Editor\Settings";    To = "$OuputBuildDirectory\Tetragrama\src\Settings"}
+                }
+            )
+        },
+        @{
+            Name = "Tetragrama"
+            IsDirectory = $true
+            Contents = @(
+                @{ From = "$OuputBuildDirectory\Tetragrama\src\$Configurations"; To = "$OuputBuildDirectory\Panzerfaust\$Configurations\net6.0\Editor"}
+            )
+        }
+    )
+
+    foreach ($item in $ContentsToProcess) {
+        foreach($content in $item.Contents) {
+
+            if($item.IsDirectory -eq $true) {
+
+                # Delete if directories or files already exist
+                #
+                if(Test-Path $content.To) {
+                    Remove-Item $content.To -Recurse -Force
+                }
+                Copy-Item -Path $content.From -Destination $content.To -Recurse -Force
             }
             else {
-                @{ From = "$RepoRoot\Resources\Shaders";            To = "$OuputBuildDirectory\Tetragrama\src\Shaders"}
-                @{ From = "$RepoRoot\Resources\Editor\Settings";    To = "$OuputBuildDirectory\Tetragrama\src\Settings"}
+                Copy-Item -Path $content.From -Destination $content.To -Force
             }
-        )
-    },
-    @{
-        Name = "Tetragrama"
-        IsDirectory = $true
-        Contents = @(
-            @{ From = "$OuputBuildDirectory\Tetragrama\src\$Configurations"; To = "$OuputBuildDirectory\Panzerfaust\$Configurations\net6.0\Editor"}
-        )
-    }
-)
 
-foreach ($item in $ContentsToProcess) {
-    foreach($content in $item.Contents) {
-
-        if($item.IsDirectory -eq $true) {
-
-            # Delete if directories or files already exist
-            #
-            if(Test-Path $content.To) {
-                Remove-Item $content.To -Recurse -Force
-            }
-            Copy-Item -Path $content.From -Destination $content.To -Recurse -Force
+            [string]$name = $item.Name
+            [string]$ToDirectory = $content.To
+            Write-Host "Copied $name --> $ToDirectory"
         }
-        else {
-            Copy-Item -Path $content.From -Destination $content.To -Force
-        }
-
-        [string]$name = $item.Name
-        [string]$ToDirectory = $content.To
-        Write-Host "Copied $name --> $ToDirectory"
     }
 }


### PR DESCRIPTION
- Adding $LauncherOnly parameter to BuildEngine.ps1 that avoid building renderer engine when dev want to work on launcher only
- Adding new cmake option in cmakelist to that is used to avoid building renderer engine when $LauncherOnly is set as parameter in build command.
- Add $LauncherOnly related to build command parameter to avoid Postbuild operation
