### PR TITLE
Updating post build for macOS Intel / Silicon architecture

### DIFF
--- a/.github/workflows/macOS-build.yml
+++ b/.github/workflows/macOS-build.yml
@@ -7,13 +7,27 @@ on:
     branches: [ master, develop ]
 
 jobs:
-  macOS-Build:
+  macOS-Intel-Build:
     runs-on: macos-13
     strategy:
       matrix:
           buildConfiguration: [Debug, Release]
 
-    steps:      
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: CMake Build
+      run: .\Scripts\BuildEngine.ps1 -Configurations ${{matrix.buildConfiguration}}
+      shell: pwsh
+
+  macOS-Silicon-Build:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+          buildConfiguration: [Debug, Release]
+
+    steps:
     - name: Checkout repository
       uses: actions/checkout@v2
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
 endif ()
 add_custom_command (TARGET AssembleContent
 	POST_BUILD
-	COMMAND pwsh ${CMAKE_CURRENT_SOURCE_DIR}/Scripts/PostBuild.ps1 -SystemName ${SYSTEM_NAME} -Architecture ${SYSTEM_ARCHITECTURE} -Configurations $<IF:$<CONFIG:Debug>,Debug,Release> $<$<BOOL:${LAUNCHER_ONLY}>:-LauncherOnly>
+	COMMAND pwsh ${CMAKE_CURRENT_SOURCE_DIR}/Scripts/PostBuild.ps1 -SystemName ${SYSTEM_NAME} -Architectures ${SYSTEM_ARCHITECTURE} -Configurations $<IF:$<CONFIG:Debug>,Debug,Release> $<$<BOOL:${LAUNCHER_ONLY}>:-LauncherOnly>
 )
 
 # Copying Examples dir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
 endif ()
 add_custom_command (TARGET AssembleContent
 	POST_BUILD
-	COMMAND pwsh ${CMAKE_CURRENT_SOURCE_DIR}/Scripts/PostBuild.ps1 -SystemName ${SYSTEM_NAME} -Archtectures ${SYSTEM_ARCHITECTURE} -Configurations $<IF:$<CONFIG:Debug>,Debug,Release> $<$<BOOL:${LAUNCHER_ONLY}>:-LauncherOnly>
+	COMMAND pwsh ${CMAKE_CURRENT_SOURCE_DIR}/Scripts/PostBuild.ps1 -SystemName ${SYSTEM_NAME} -Architecture ${SYSTEM_ARCHITECTURE} -Configurations $<IF:$<CONFIG:Debug>,Debug,Release> $<$<BOOL:${LAUNCHER_ONLY}>:-LauncherOnly>
 )
 
 # Copying Examples dir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,9 +107,20 @@ add_custom_target (AssembleContent ALL
 	DEPENDS BuildLauncher
 )
 
+
+set (SYSTEM_NAME ${CMAKE_SYSTEM_NAME})
+if ((${CMAKE_SYSTEM_NAME} STREQUAL "Windows") OR (${CMAKE_SYSTEM_NAME} STREQUAL "Linux"))
+	set (SYSTEM_ARCHITECTURE "x64")
+elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+	if (MACOSX_ARCHITECTURE_ARM64)
+		set (SYSTEM_ARCHITECTURE "osx-arm64")
+	else ()
+		set (SYSTEM_ARCHITECTURE "osx-x64")
+	endif ()
+endif ()
 add_custom_command (TARGET AssembleContent
 	POST_BUILD
-	COMMAND pwsh ${CMAKE_CURRENT_SOURCE_DIR}/Scripts/PostBuild.ps1 -Configurations $<IF:$<CONFIG:Debug>,Debug,Release> $<$<BOOL:${LAUNCHER_ONLY}>:-LauncherOnly>
+	COMMAND pwsh ${CMAKE_CURRENT_SOURCE_DIR}/Scripts/PostBuild.ps1 -SystemName ${SYSTEM_NAME} -Archtectures ${SYSTEM_ARCHITECTURE} -Configurations $<IF:$<CONFIG:Debug>,Debug,Release> $<$<BOOL:${LAUNCHER_ONLY}>:-LauncherOnly>
 )
 
 # Copying Examples dir
@@ -117,5 +128,3 @@ add_custom_command (TARGET AssembleContent
 if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/Examples/projectConfig.json)
 	file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/Examples/projectConfig.json DESTINATION ${CMAKE_BINARY_DIR}/Examples)
 endif ()
-
-


### PR DESCRIPTION
During the recent configuration and local dev machine setup, 
we found that some contributors have latest Macbook device which are Silicon meaning arm64 architecture.
That means we have to update existing script to onboard that architecture.

This PR updates the post build script to integrate that architecture and also update the pipeline CI to add macos silicon 