### PR TITLE
Reshaping IntrusivePtr public APIs

### DIFF
--- a/Tetragrama/Components/DockspaceUIComponent.cpp
+++ b/Tetragrama/Components/DockspaceUIComponent.cpp
@@ -12,6 +12,8 @@
 
 namespace fs = std::filesystem;
 
+using namespace ZEngine::Helpers;
+
 namespace Tetragrama::Components
 {
     ImVec4      DockspaceUIComponent::s_asset_importer_report_msg_color   = {1, 1, 1, 1};
@@ -21,8 +23,7 @@ namespace Tetragrama::Components
     float       DockspaceUIComponent::s_editor_scene_serializer_progress  = 0.0f;
 
     DockspaceUIComponent::DockspaceUIComponent(std::string_view name, bool visibility)
-        : UIComponent(name, visibility, false), m_asset_importer(ZEngine::CreateScope<Importers::AssimpImporter>()),
-          m_editor_serializer(ZEngine::CreateScope<Serializers::EditorSceneSerializer>())
+        : UIComponent(name, visibility, false), m_asset_importer(CreateScope<Importers::AssimpImporter>()), m_editor_serializer(CreateScope<Serializers::EditorSceneSerializer>())
     {
         m_dockspace_node_flag = ImGuiDockNodeFlags_NoWindowMenuButton | ImGuiDockNodeFlags_PassthruCentralNode;
         m_window_flags        = ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |

--- a/Tetragrama/Components/DockspaceUIComponent.h
+++ b/Tetragrama/Components/DockspaceUIComponent.h
@@ -53,16 +53,16 @@ namespace Tetragrama::Components
         static float       s_editor_scene_serializer_progress;
 
     private:
-        bool                                               m_open_asset_importer{false};
-        bool                                               m_open_exit{false};
-        bool                                               m_pending_shutdown{false};
-        bool                                               m_open_save_scene{false};
-        bool                                               m_open_save_scene_as{false};
-        bool                                               m_request_save_scene_ui_close{false};
-        ImGuiDockNodeFlags                                 m_dockspace_node_flag;
-        ImGuiWindowFlags                                   m_window_flags;
-        Importers::ImportConfiguration                     m_default_import_configuration;
-        ZEngine::Scope<Importers::IAssetImporter>          m_asset_importer;
-        ZEngine::Scope<Serializers::EditorSceneSerializer> m_editor_serializer;
+        bool                                                        m_open_asset_importer{false};
+        bool                                                        m_open_exit{false};
+        bool                                                        m_pending_shutdown{false};
+        bool                                                        m_open_save_scene{false};
+        bool                                                        m_open_save_scene_as{false};
+        bool                                                        m_request_save_scene_ui_close{false};
+        ImGuiDockNodeFlags                                          m_dockspace_node_flag;
+        ImGuiWindowFlags                                            m_window_flags;
+        Importers::ImportConfiguration                              m_default_import_configuration;
+        ZEngine::Helpers::Scope<Importers::IAssetImporter>          m_asset_importer;
+        ZEngine::Helpers::Scope<Serializers::EditorSceneSerializer> m_editor_serializer;
     };
 } // namespace Tetragrama::Components

--- a/Tetragrama/Components/HierarchyViewUIComponent.cpp
+++ b/Tetragrama/Components/HierarchyViewUIComponent.cpp
@@ -14,6 +14,7 @@
 #include <imgui.h>
 
 using namespace ZEngine;
+using namespace ZEngine::Helpers;
 using namespace ZEngine::Windows::Inputs;
 using namespace ZEngine::Rendering::Scenes;
 using namespace Tetragrama::Inputs;
@@ -49,7 +50,7 @@ namespace Tetragrama::Components
         }
     }
 
-    std::future<void> HierarchyViewUIComponent::EditorCameraAvailableMessageHandlerAsync(Messengers::GenericMessage<ZEngine::Ref<EditorCameraController>>& message)
+    std::future<void> HierarchyViewUIComponent::EditorCameraAvailableMessageHandlerAsync(Messengers::GenericMessage<Ref<EditorCameraController>>& message)
     {
         {
             std::unique_lock lock(m_mutex);

--- a/Tetragrama/Components/HierarchyViewUIComponent.h
+++ b/Tetragrama/Components/HierarchyViewUIComponent.h
@@ -22,14 +22,14 @@ namespace Tetragrama::Components
         void RenderGuizmo();
         void RenderSceneNodeTree(int node_identifier);
 
-        std::future<void> EditorCameraAvailableMessageHandlerAsync(Messengers::GenericMessage<ZEngine::Ref<Controllers::EditorCameraController>>&);
+        std::future<void> EditorCameraAvailableMessageHandlerAsync(Messengers::GenericMessage<ZEngine::Helpers::Ref<Controllers::EditorCameraController>>&);
 
     private:
-        ImGuiTreeNodeFlags                                    m_node_flag;
-        bool                                                  m_is_node_opened{false};
-        int                                                   m_selected_node_identifier{-1};
-        int                                                   m_gizmo_operation{-1};
-        std::mutex                                            m_mutex;
-        ZEngine::WeakRef<Controllers::EditorCameraController> m_active_editor_camera;
+        ImGuiTreeNodeFlags                                             m_node_flag;
+        bool                                                           m_is_node_opened{false};
+        int                                                            m_selected_node_identifier{-1};
+        int                                                            m_gizmo_operation{-1};
+        std::mutex                                                     m_mutex;
+        ZEngine::Helpers::WeakRef<Controllers::EditorCameraController> m_active_editor_camera;
     };
 } // namespace Tetragrama::Components

--- a/Tetragrama/Components/InspectorViewUIComponent.cpp
+++ b/Tetragrama/Components/InspectorViewUIComponent.cpp
@@ -10,6 +10,7 @@ using namespace ZEngine::Rendering::Materials;
 using namespace ZEngine::Rendering::Components;
 using namespace ZEngine::Rendering::Textures;
 using namespace ZEngine::Rendering::Lights;
+using namespace ZEngine::Helpers;
 
 namespace Tetragrama::Components
 {
@@ -23,7 +24,7 @@ namespace Tetragrama::Components
 
     void InspectorViewUIComponent::Update(ZEngine::Core::TimeStep dt) {}
 
-    std::future<void> InspectorViewUIComponent::SceneAvailableMessageHandlerAsync(Messengers::GenericMessage<ZEngine::Ref<ZEngine::Rendering::Scenes::GraphicScene>>& message)
+    std::future<void> InspectorViewUIComponent::SceneAvailableMessageHandlerAsync(Messengers::GenericMessage<Ref<ZEngine::Rendering::Scenes::GraphicScene>>& message)
     {
         {
             std::lock_guard lock(m_mutex);
@@ -420,11 +421,11 @@ namespace Tetragrama::Components
 
             if (ImGui::MenuItem("Material"))
             {
-                ZEngine::Ref<StandardMaterial> material = ZEngine::CreateRef<StandardMaterial>();
+                Ref<StandardMaterial> material = CreateRef<StandardMaterial>();
                 material->SetTileFactor(20.f);
                 material->SetShininess(10.0f);
-                material->SetDiffuseMap(ZEngine::Ref<Texture>(CreateTexture(1, 1)));
-                material->SetSpecularMap(ZEngine::Ref<Texture>(CreateTexture(1, 1)));
+                material->SetDiffuseMap(Ref<Texture>(CreateTexture(1, 1)));
+                material->SetSpecularMap(Ref<Texture>(CreateTexture(1, 1)));
 
                 // m_scene_entity->AddComponent<MaterialComponent>(std::move(material));
                 ImGui::CloseCurrentPopup();
@@ -434,19 +435,19 @@ namespace Tetragrama::Components
             {
                 if (ImGui::MenuItem("Directional Light"))
                 {
-                    m_scene_entity.AddComponent<LightComponent>(ZEngine::CreateRef<DirectionalLight>());
+                    m_scene_entity.AddComponent<LightComponent>(CreateRef<DirectionalLight>());
                     ImGui::CloseCurrentPopup();
                 }
 
                 if (ImGui::MenuItem("Point Light"))
                 {
-                    m_scene_entity.AddComponent<LightComponent>(ZEngine::CreateRef<PointLight>());
+                    m_scene_entity.AddComponent<LightComponent>(CreateRef<PointLight>());
                     ImGui::CloseCurrentPopup();
                 }
 
                 if (ImGui::MenuItem("Spot Light"))
                 {
-                    m_scene_entity.AddComponent<LightComponent>(ZEngine::CreateRef<Spotlight>());
+                    m_scene_entity.AddComponent<LightComponent>(CreateRef<Spotlight>());
                     ImGui::CloseCurrentPopup();
                 }
 

--- a/Tetragrama/Components/InspectorViewUIComponent.h
+++ b/Tetragrama/Components/InspectorViewUIComponent.h
@@ -21,18 +21,18 @@ namespace Tetragrama::Components
         virtual void Render() override;
 
     public:
-        std::future<void> SceneAvailableMessageHandlerAsync(Messengers::GenericMessage<ZEngine::Ref<ZEngine::Rendering::Scenes::GraphicScene>>&);
+        std::future<void> SceneAvailableMessageHandlerAsync(Messengers::GenericMessage<ZEngine::Helpers::Ref<ZEngine::Rendering::Scenes::GraphicScene>>&);
         std::future<void> SceneEntitySelectedMessageHandlerAsync(Messengers::GenericMessage<ZEngine::Rendering::Scenes::SceneEntity>&);
         std::future<void> SceneEntityUnSelectedMessageHandlerAsync(Messengers::EmptyMessage&);
         std::future<void> SceneEntityDeletedMessageHandlerAsync(Messengers::EmptyMessage&);
         std::future<void> RequestStartOrPauseRenderMessageHandlerAsync(Messengers::GenericMessage<bool>&);
 
     private:
-        ImGuiTreeNodeFlags                                         m_node_flag;
-        bool                                                       m_recieved_unselected_request{false};
-        bool                                                       m_recieved_deleted_request{false};
-        ZEngine::WeakRef<ZEngine::Rendering::Scenes::GraphicScene> m_active_scene;
-        ZEngine::Rendering::Scenes::SceneEntity                    m_scene_entity;
-        std::mutex                                                 m_mutex;
+        ImGuiTreeNodeFlags                                                  m_node_flag;
+        bool                                                                m_recieved_unselected_request{false};
+        bool                                                                m_recieved_deleted_request{false};
+        ZEngine::Helpers::WeakRef<ZEngine::Rendering::Scenes::GraphicScene> m_active_scene;
+        ZEngine::Rendering::Scenes::SceneEntity                             m_scene_entity;
+        std::mutex                                                          m_mutex;
     };
 } // namespace Tetragrama::Components

--- a/Tetragrama/Components/UIComponent.cpp
+++ b/Tetragrama/Components/UIComponent.cpp
@@ -2,6 +2,7 @@
 #include <UIComponent.h>
 
 using namespace ZEngine;
+using namespace ZEngine::Helpers;
 
 namespace Tetragrama::Components
 {

--- a/Tetragrama/Components/UIComponent.h
+++ b/Tetragrama/Components/UIComponent.h
@@ -3,7 +3,7 @@
 #include <ImguiLayer.h>
 #include <ZEngine/Core/IRenderable.h>
 #include <ZEngine/Core/IUpdatable.h>
-#include <ZEngine/ZEngineDef.h>
+#include <ZEngine/Helpers/IntrusivePtr.h>
 #include <string>
 #include <vector>
 
@@ -20,7 +20,7 @@ namespace Tetragrama::Components
     public:
         UIComponent() = default;
         UIComponent(std::string_view name, bool visibility, bool can_be_closed);
-        UIComponent(const ZEngine::Ref<Tetragrama::Layers::ImguiLayer>& layer, std::string_view name, bool visibility, bool can_be_closed);
+        UIComponent(const ZEngine::Helpers::Ref<Tetragrama::Layers::ImguiLayer>& layer, std::string_view name, bool visibility, bool can_be_closed);
         virtual ~UIComponent() = default;
 
         void SetName(std::string_view name);
@@ -29,18 +29,18 @@ namespace Tetragrama::Components
         std::string_view GetName() const;
         bool             GetVisibility() const;
 
-        void SetParentLayer(const ZEngine::Ref<Tetragrama::Layers::ImguiLayer>& layer);
-        void SetParentUI(const ZEngine::Ref<UIComponent>& item);
+        void SetParentLayer(const ZEngine::Helpers::Ref<Tetragrama::Layers::ImguiLayer>& layer);
+        void SetParentUI(const ZEngine::Helpers::Ref<UIComponent>& item);
 
         bool HasParentLayer() const;
         bool HasParentUI() const;
 
     protected:
-        bool                                             m_visibility{false};
-        bool                                             m_can_be_closed{false};
-        bool                                             m_is_allowed_to_render{true};
-        std::string                                      m_name;
-        ZEngine::WeakRef<Tetragrama::Layers::ImguiLayer> m_parent_layer;
-        ZEngine::WeakRef<UIComponent>                    m_parent_ui;
+        bool                                                      m_visibility{false};
+        bool                                                      m_can_be_closed{false};
+        bool                                                      m_is_allowed_to_render{true};
+        std::string                                               m_name;
+        ZEngine::Helpers::WeakRef<Tetragrama::Layers::ImguiLayer> m_parent_layer;
+        ZEngine::Helpers::WeakRef<UIComponent>                    m_parent_ui;
     };
 } // namespace Tetragrama::Components

--- a/Tetragrama/Controllers/EditorCameraController.cpp
+++ b/Tetragrama/Controllers/EditorCameraController.cpp
@@ -1,6 +1,7 @@
 #include <EditorCameraController.h>
 
 using namespace ZEngine::Rendering::Cameras;
+using namespace ZEngine::Helpers;
 
 namespace Tetragrama::Controllers
 {
@@ -9,7 +10,7 @@ namespace Tetragrama::Controllers
         m_process_event   = true;
         m_controller_type = Controllers::CameraControllerType::PERSPECTIVE_CONTROLLER;
         m_perspective_camera =
-            ZEngine::CreateRef<PerspectiveCamera>(m_camera_fov, m_aspect_ratio, m_camera_near, m_camera_far, glm::radians(yaw_angle_degree), glm::radians(pitch_angle_degree));
+            CreateRef<PerspectiveCamera>(m_camera_fov, m_aspect_ratio, m_camera_near, m_camera_far, glm::radians(yaw_angle_degree), glm::radians(pitch_angle_degree));
         m_perspective_camera->SetDistance(distance);
     }
 } // namespace Tetragrama::Controllers

--- a/Tetragrama/Controllers/ICameraController.h
+++ b/Tetragrama/Controllers/ICameraController.h
@@ -14,10 +14,10 @@ namespace Tetragrama::Controllers
 
         virtual ~ICameraController() = default;
 
-        virtual glm::vec3                                               GetPosition() const                    = 0;
-        virtual void                                                    SetPosition(const glm::vec3& position) = 0;
-        virtual const ZEngine::Ref<ZEngine::Rendering::Cameras::Camera> GetCamera() const                      = 0;
-        virtual void                                                    UpdateProjectionMatrix()               = 0;
+        virtual glm::vec3                                                        GetPosition() const                    = 0;
+        virtual void                                                             SetPosition(const glm::vec3& position) = 0;
+        virtual const ZEngine::Helpers::Ref<ZEngine::Rendering::Cameras::Camera> GetCamera() const                      = 0;
+        virtual void                                                             UpdateProjectionMatrix()               = 0;
 
         float GetRotationAngle() const
         {
@@ -76,14 +76,14 @@ namespace Tetragrama::Controllers
         }
 
     protected:
-        glm::vec3                                      m_position{0.0f, 0.0f, 10.0f};
-        float                                          m_rotation_angle{0.0f};
-        float                                          m_zoom_factor{1.0f};
-        float                                          m_move_speed{0.05f};
-        float                                          m_rotation_speed{0.05f};
-        float                                          m_aspect_ratio{0.0f};
-        bool                                           m_can_rotate{false};
-        CameraControllerType                           m_controller_type{CameraControllerType::UNDEFINED};
-        ZEngine::WeakRef<ZEngine::Windows::CoreWindow> m_window;
+        glm::vec3                                               m_position{0.0f, 0.0f, 10.0f};
+        float                                                   m_rotation_angle{0.0f};
+        float                                                   m_zoom_factor{1.0f};
+        float                                                   m_move_speed{0.05f};
+        float                                                   m_rotation_speed{0.05f};
+        float                                                   m_aspect_ratio{0.0f};
+        bool                                                    m_can_rotate{false};
+        CameraControllerType                                    m_controller_type{CameraControllerType::UNDEFINED};
+        ZEngine::Helpers::WeakRef<ZEngine::Windows::CoreWindow> m_window;
     };
 } // namespace Tetragrama::Controllers

--- a/Tetragrama/Controllers/PerspectiveCameraController.cpp
+++ b/Tetragrama/Controllers/PerspectiveCameraController.cpp
@@ -7,6 +7,7 @@
 #include <ZEngine/Core/EventDispatcher.h>
 
 using namespace ZEngine;
+using namespace ZEngine::Helpers;
 using namespace ZEngine::Windows::Inputs;
 using namespace ZEngine::Windows::Events;
 using namespace Tetragrama::Inputs;
@@ -107,7 +108,7 @@ namespace Tetragrama::Controllers
         }
     }
 
-    const ZEngine::Ref<Rendering::Cameras::Camera> PerspectiveCameraController::GetCamera() const
+    const Ref<Rendering::Cameras::Camera> PerspectiveCameraController::GetCamera() const
     {
         return m_perspective_camera;
     }

--- a/Tetragrama/Controllers/PerspectiveCameraController.h
+++ b/Tetragrama/Controllers/PerspectiveCameraController.h
@@ -46,7 +46,7 @@ namespace Tetragrama::Controllers
         void Update(ZEngine::Core::TimeStep) override;
         bool OnEvent(ZEngine::Core::CoreEvent&) override;
 
-        const ZEngine::Ref<ZEngine::Rendering::Cameras::Camera> GetCamera() const override;
+        const ZEngine::Helpers::Ref<ZEngine::Rendering::Cameras::Camera> GetCamera() const override;
 
         void UpdateProjectionMatrix() override;
 
@@ -87,12 +87,12 @@ namespace Tetragrama::Controllers
         bool OnMouseButtonWheelMoved(ZEngine::Windows::Events::MouseButtonWheelEvent&) override;
 
     protected:
-        float                                                        m_camera_fov{90.0f};
-        float                                                        m_camera_near{1.f};
-        float                                                        m_camera_far{1000.0f};
-        std::recursive_mutex                                         m_event_mutex;
-        bool                                                         m_process_event{true};
-        glm::vec3                                                    m_camera_target{0.0f, 0.0f, 0.0f};
-        ZEngine::Ref<ZEngine::Rendering::Cameras::PerspectiveCamera> m_perspective_camera;
+        float                                                                 m_camera_fov{90.0f};
+        float                                                                 m_camera_near{1.f};
+        float                                                                 m_camera_far{1000.0f};
+        std::recursive_mutex                                                  m_event_mutex;
+        bool                                                                  m_process_event{true};
+        glm::vec3                                                             m_camera_target{0.0f, 0.0f, 0.0f};
+        ZEngine::Helpers::Ref<ZEngine::Rendering::Cameras::PerspectiveCamera> m_perspective_camera;
     };
 } // namespace Tetragrama::Controllers

--- a/Tetragrama/Editor.cpp
+++ b/Tetragrama/Editor.cpp
@@ -7,26 +7,27 @@
 
 using namespace Tetragrama::Messengers;
 using namespace ZEngine;
+using namespace ZEngine::Helpers;
 
 namespace Tetragrama
 {
-    EditorConfiguration       Editor::s_editor_configuration;
-    ZEngine::Ref<EditorScene> Editor::s_editor_scene{nullptr};
-    std::recursive_mutex      Editor::s_mutex;
+    EditorConfiguration  Editor::s_editor_configuration;
+    Ref<EditorScene>     Editor::s_editor_scene{nullptr};
+    std::recursive_mutex Editor::s_mutex;
 
     Editor::Editor(const EditorConfiguration& config) : m_engine_configuration()
     {
-        m_ui_layer     = ZEngine::CreateRef<Layers::UILayer>();
-        m_render_layer = ZEngine::CreateRef<Layers::RenderLayer>();
+        m_ui_layer     = CreateRef<Layers::UILayer>();
+        m_render_layer = CreateRef<Layers::RenderLayer>();
 
         s_editor_configuration = config;
         if ((!s_editor_scene) && config.ActiveSceneName.empty())
         {
-            s_editor_scene = ZEngine::CreateRef<EditorScene>("Empty_Scene");
+            s_editor_scene = CreateRef<EditorScene>("Empty_Scene");
         }
         else if (!config.ActiveSceneName.empty())
         {
-            s_editor_scene = ZEngine::CreateRef<EditorScene>(config.ActiveSceneName);
+            s_editor_scene = CreateRef<EditorScene>(config.ActiveSceneName);
         }
 
         auto title = config.ProjectName;
@@ -90,7 +91,7 @@ namespace Tetragrama
         return s_editor_configuration;
     }
 
-    ZEngine::Ref<EditorScene> Editor::GetCurrentEditorScene()
+    Ref<EditorScene> Editor::GetCurrentEditorScene()
     {
         {
             std::unique_lock l(s_mutex);

--- a/Tetragrama/Editor.h
+++ b/Tetragrama/Editor.h
@@ -1,8 +1,8 @@
 #pragma once
 #include <Layers/RenderLayer.h>
 #include <ZEngine/Engine.h>
+#include <ZEngine/Helpers/IntrusivePtr.h>
 #include <ZEngine/Windows/CoreWindow.h>
-#include <ZEngine/ZEngineDef.h>
 
 namespace Tetragrama::Serializers
 {
@@ -65,20 +65,20 @@ namespace Tetragrama
         void Initialize() override;
         void Run();
 
-        static const EditorConfiguration& GetCurrentEditorConfiguration();
-        static ZEngine::Ref<EditorScene>  GetCurrentEditorScene();
-        static void                       SetCurrentEditorScene(EditorScene&&);
+        static const EditorConfiguration&         GetCurrentEditorConfiguration();
+        static ZEngine::Helpers::Ref<EditorScene> GetCurrentEditorScene();
+        static void                               SetCurrentEditorScene(EditorScene&&);
 
     private:
-        ZEngine::Ref<ZEngine::Windows::CoreWindow> m_window;
+        ZEngine::Helpers::Ref<ZEngine::Windows::CoreWindow> m_window;
 
     private:
-        static EditorConfiguration        s_editor_configuration;
-        static ZEngine::Ref<EditorScene>  s_editor_scene;
-        static std::recursive_mutex       s_mutex;
-        ZEngine::EngineConfiguration      m_engine_configuration;
-        ZEngine::Ref<Layers::ImguiLayer>  m_ui_layer;
-        ZEngine::Ref<Layers::RenderLayer> m_render_layer;
+        static EditorConfiguration                 s_editor_configuration;
+        static ZEngine::Helpers::Ref<EditorScene>  s_editor_scene;
+        static std::recursive_mutex                s_mutex;
+        ZEngine::EngineConfiguration               m_engine_configuration;
+        ZEngine::Helpers::Ref<Layers::ImguiLayer>  m_ui_layer;
+        ZEngine::Helpers::Ref<Layers::RenderLayer> m_render_layer;
     };
 
 } // namespace Tetragrama

--- a/Tetragrama/EditorWindow.cpp
+++ b/Tetragrama/EditorWindow.cpp
@@ -14,6 +14,7 @@ using namespace ZEngine;
 using namespace ZEngine::Windows::Events;
 using namespace ZEngine::Windows;
 using namespace ZEngine::Rendering;
+using namespace ZEngine::Helpers;
 
 namespace Tetragrama
 {

--- a/Tetragrama/EditorWindow.h
+++ b/Tetragrama/EditorWindow.h
@@ -34,9 +34,9 @@ namespace Tetragrama
         virtual void  Update(ZEngine::Core::TimeStep delta_time) override;
         virtual void  Render() override;
 
-        virtual bool                                CreateSurface(void* instance, void** out_window_surface) override;
-        virtual std::vector<std::string>            GetRequiredExtensionLayers() override;
-        ZEngine::Ref<ZEngine::Rendering::Swapchain> GetSwapchain() const override;
+        virtual bool                                         CreateSurface(void* instance, void** out_window_surface) override;
+        virtual std::vector<std::string>                     GetRequiredExtensionLayers() override;
+        ZEngine::Helpers::Ref<ZEngine::Rendering::Swapchain> GetSwapchain() const override;
 
     public:
         bool OnEvent(ZEngine::Core::CoreEvent& event) override;
@@ -73,8 +73,8 @@ namespace Tetragrama
         static void __OnGlfwFrameBufferSizeChanged(GLFWwindow*, int width, int height);
 
     private:
-        GLFWwindow*                                 m_native_window{nullptr};
-        ZEngine::Ref<ZEngine::Rendering::Swapchain> m_swapchain;
+        GLFWwindow*                                          m_native_window{nullptr};
+        ZEngine::Helpers::Ref<ZEngine::Rendering::Swapchain> m_swapchain;
     };
 
 } // namespace Tetragrama

--- a/Tetragrama/EntryPoint.cpp
+++ b/Tetragrama/EntryPoint.cpp
@@ -127,7 +127,7 @@ int applicationEntryPoint(int argc, char* argv[])
             break;
         }
 
-        auto editor = ZEngine::CreateRef<Tetragrama::Editor>(editor_config);
+        auto editor = ZEngine::Helpers::CreateRef<Tetragrama::Editor>(editor_config);
         editor->Initialize();
         editor->Run();
     }

--- a/Tetragrama/Inputs/Keyboard.h
+++ b/Tetragrama/Inputs/Keyboard.h
@@ -11,13 +11,13 @@ namespace Tetragrama::Inputs
         Keyboard(const char* name = "keyboard_device") : ZEngine::Windows::Inputs::IDevice(name) {}
         ~Keyboard() = default;
 
-        virtual bool IsKeyPressed(ZENGINE_KEYCODE key, const ZEngine::Ref<ZEngine::Windows::CoreWindow>& window) const override
+        virtual bool IsKeyPressed(ZENGINE_KEYCODE key, const ZEngine::Helpers::Ref<ZEngine::Windows::CoreWindow>& window) const override
         {
             auto state = glfwGetKey(reinterpret_cast<GLFWwindow*>(window->GetNativeWindow()), (int) key);
             return state == GLFW_PRESS;
         }
 
-        virtual bool IsKeyReleased(ZENGINE_KEYCODE key, const ZEngine::Ref<ZEngine::Windows::CoreWindow>& window) const override
+        virtual bool IsKeyReleased(ZENGINE_KEYCODE key, const ZEngine::Helpers::Ref<ZEngine::Windows::CoreWindow>& window) const override
         {
             auto state = glfwGetKey(reinterpret_cast<GLFWwindow*>(window->GetNativeWindow()), (int) key);
             return state == GLFW_RELEASE;

--- a/Tetragrama/Inputs/Mouse.h
+++ b/Tetragrama/Inputs/Mouse.h
@@ -11,19 +11,19 @@ namespace Tetragrama::Inputs
     public:
         Mouse(const char* name = "mouse_device") : ZEngine::Windows::Inputs::IDevice(name) {}
 
-        virtual bool IsKeyPressed(ZENGINE_KEYCODE key, const ZEngine::Ref<ZEngine::Windows::CoreWindow>& window) const override
+        virtual bool IsKeyPressed(ZENGINE_KEYCODE key, const ZEngine::Helpers::Ref<ZEngine::Windows::CoreWindow>& window) const override
         {
 
             auto state = glfwGetMouseButton(reinterpret_cast<GLFWwindow*>(window->GetNativeWindow()), (int) key);
             return state == GLFW_PRESS;
         }
 
-        virtual bool IsKeyReleased(ZENGINE_KEYCODE key, const ZEngine::Ref<ZEngine::Windows::CoreWindow>& window) const override
+        virtual bool IsKeyReleased(ZENGINE_KEYCODE key, const ZEngine::Helpers::Ref<ZEngine::Windows::CoreWindow>& window) const override
         {
             return !IsKeyPressed(key, window);
         }
 
-        std::array<double, 2> GetMousePosition(const ZEngine::Ref<ZEngine::Windows::CoreWindow>& window) const
+        std::array<double, 2> GetMousePosition(const ZEngine::Helpers::Ref<ZEngine::Windows::CoreWindow>& window) const
         {
             double x, y;
             glfwGetCursorPos(reinterpret_cast<GLFWwindow*>(window->GetNativeWindow()), &x, &y);

--- a/Tetragrama/Layers/ImguiLayer.cpp
+++ b/Tetragrama/Layers/ImguiLayer.cpp
@@ -7,6 +7,7 @@
 using namespace ZEngine;
 using namespace ZEngine::Rendering::Renderers;
 using namespace ZEngine::Windows::Events;
+using namespace ZEngine::Helpers;
 
 namespace Tetragrama::Layers
 {

--- a/Tetragrama/Layers/ImguiLayer.h
+++ b/Tetragrama/Layers/ImguiLayer.h
@@ -32,9 +32,9 @@ namespace Tetragrama::Layers
 
         void Render() override;
 
-        virtual void AddUIComponent(const ZEngine::Ref<Components::UIComponent>& component);
-        virtual void AddUIComponent(ZEngine::Ref<Components::UIComponent>&& component);
-        virtual void AddUIComponent(std::vector<ZEngine::Ref<Components::UIComponent>>&& components);
+        virtual void AddUIComponent(const ZEngine::Helpers::Ref<Components::UIComponent>& component);
+        virtual void AddUIComponent(ZEngine::Helpers::Ref<Components::UIComponent>&& component);
+        virtual void AddUIComponent(std::vector<ZEngine::Helpers::Ref<Components::UIComponent>>&& components);
 
     protected:
         bool OnKeyPressed(ZEngine::Windows::Events::KeyPressedEvent&) override;
@@ -53,7 +53,7 @@ namespace Tetragrama::Layers
         bool OnWindowRestored(ZEngine::Windows::Events::WindowRestoredEvent&) override;
 
     private:
-        static bool                                        m_initialized;
-        std::vector<ZEngine::Ref<Components::UIComponent>> m_ui_components;
+        static bool                                                 m_initialized;
+        std::vector<ZEngine::Helpers::Ref<Components::UIComponent>> m_ui_components;
     };
 } // namespace Tetragrama::Layers

--- a/Tetragrama/Layers/RenderLayer.cpp
+++ b/Tetragrama/Layers/RenderLayer.cpp
@@ -10,6 +10,7 @@ using namespace ZEngine::Rendering::Renderers;
 using namespace ZEngine::Windows;
 using namespace ZEngine::Core;
 using namespace ZEngine::Event;
+using namespace ZEngine::Helpers;
 
 namespace Tetragrama::Layers
 {

--- a/Tetragrama/Layers/RenderLayer.h
+++ b/Tetragrama/Layers/RenderLayer.h
@@ -35,12 +35,12 @@ namespace Tetragrama::Layers
         std::future<void> SceneRequestSelectEntityFromPixelMessageHandlerAsync(Messengers::GenericMessage<std::pair<int, int>>&);
 
     private:
-        ZEngine::Ref<ZEngine::Serializers::GraphicSceneSerializer>    m_scene_serializer;
-        ZEngine::Ref<Tetragrama::Controllers::EditorCameraController> m_editor_camera_controller;
-        std::queue<std::function<void(void)>>                         m_deferral_operation;
-        std::mutex                                                    m_message_handler_mutex;
-        std::mutex                                                    m_mutex;
-        std::queue<std::pair<float, float>>                           m_viewport_requested_size_collection;
+        ZEngine::Helpers::Ref<ZEngine::Serializers::GraphicSceneSerializer>    m_scene_serializer;
+        ZEngine::Helpers::Ref<Tetragrama::Controllers::EditorCameraController> m_editor_camera_controller;
+        std::queue<std::function<void(void)>>                                  m_deferral_operation;
+        std::mutex                                                             m_message_handler_mutex;
+        std::mutex                                                             m_mutex;
+        std::queue<std::pair<float, float>>                                    m_viewport_requested_size_collection;
 
     private:
         void HandleNewSceneMessage(const Messengers::EmptyMessage&);

--- a/Tetragrama/Layers/UILayer.cpp
+++ b/Tetragrama/Layers/UILayer.cpp
@@ -4,6 +4,7 @@
 #include <Messenger.h>
 #include <UILayer.h>
 
+using namespace ZEngine::Helpers;
 using namespace Tetragrama::Messengers;
 
 namespace Tetragrama::Layers
@@ -14,13 +15,13 @@ namespace Tetragrama::Layers
     {
         ImguiLayer::Initialize();
 
-        m_dockspace_component      = ZEngine::CreateRef<Components::DockspaceUIComponent>();
-        m_scene_component          = ZEngine::CreateRef<Components::SceneViewportUIComponent>();
-        m_editor_log_component     = ZEngine::CreateRef<Components::LogUIComponent>();
-        m_demo_component           = ZEngine::CreateRef<Components::DemoUIComponent>();
-        m_project_view_component   = ZEngine::CreateRef<Components::ProjectViewUIComponent>();
-        m_inspector_view_component = ZEngine::CreateRef<Components::InspectorViewUIComponent>();
-        m_hierarchy_view_component = ZEngine::CreateRef<Components::HierarchyViewUIComponent>();
+        m_dockspace_component      = CreateRef<Components::DockspaceUIComponent>();
+        m_scene_component          = CreateRef<Components::SceneViewportUIComponent>();
+        m_editor_log_component     = CreateRef<Components::LogUIComponent>();
+        m_demo_component           = CreateRef<Components::DemoUIComponent>();
+        m_project_view_component   = CreateRef<Components::ProjectViewUIComponent>();
+        m_inspector_view_component = CreateRef<Components::InspectorViewUIComponent>();
+        m_hierarchy_view_component = CreateRef<Components::HierarchyViewUIComponent>();
 
         AddUIComponent(m_dockspace_component);
         AddUIComponent(m_demo_component);
@@ -60,7 +61,7 @@ namespace Tetragrama::Layers
          */
         MESSENGER_REGISTER(
             Components::UIComponent,
-            GenericMessage<ZEngine::Ref<Controllers::EditorCameraController>>,
+            GenericMessage<Ref<Controllers::EditorCameraController>>,
             EDITOR_RENDER_LAYER_CAMERA_CONTROLLER_AVAILABLE,
             m_hierarchy_view_component.get(),
             return m_hierarchy_view_component->EditorCameraAvailableMessageHandlerAsync(*message_ptr))
@@ -97,7 +98,7 @@ namespace Tetragrama::Layers
 
         MESSENGER_REGISTER(
             Components::UIComponent,
-            GenericMessage<ZEngine::Ref<ZEngine::Rendering::Scenes::GraphicScene>>,
+            GenericMessage<Ref<ZEngine::Rendering::Scenes::GraphicScene>>,
             EDITOR_RENDER_LAYER_SCENE_AVAILABLE,
             m_inspector_view_component.get(),
             return m_inspector_view_component->SceneAvailableMessageHandlerAsync(*message_ptr));

--- a/Tetragrama/Layers/UILayer.h
+++ b/Tetragrama/Layers/UILayer.h
@@ -20,13 +20,13 @@ namespace Tetragrama::Layers
         void Initialize() override;
 
     private:
-        ZEngine::Ref<Components::DockspaceUIComponent>     m_dockspace_component;
-        ZEngine::Ref<Components::SceneViewportUIComponent> m_scene_component;
-        ZEngine::Ref<Components::LogUIComponent>           m_editor_log_component;
-        ZEngine::Ref<Components::DemoUIComponent>          m_demo_component;
-        ZEngine::Ref<Components::ProjectViewUIComponent>   m_project_view_component;
-        ZEngine::Ref<Components::InspectorViewUIComponent> m_inspector_view_component;
-        ZEngine::Ref<Components::HierarchyViewUIComponent> m_hierarchy_view_component;
+        ZEngine::Helpers::Ref<Components::DockspaceUIComponent>     m_dockspace_component;
+        ZEngine::Helpers::Ref<Components::SceneViewportUIComponent> m_scene_component;
+        ZEngine::Helpers::Ref<Components::LogUIComponent>           m_editor_log_component;
+        ZEngine::Helpers::Ref<Components::DemoUIComponent>          m_demo_component;
+        ZEngine::Helpers::Ref<Components::ProjectViewUIComponent>   m_project_view_component;
+        ZEngine::Helpers::Ref<Components::InspectorViewUIComponent> m_inspector_view_component;
+        ZEngine::Helpers::Ref<Components::HierarchyViewUIComponent> m_hierarchy_view_component;
     };
 
 } // namespace Tetragrama::Layers

--- a/Tetragrama/Messengers/Messenger.h
+++ b/Tetragrama/Messengers/Messenger.h
@@ -195,7 +195,7 @@ namespace Tetragrama::Messengers
         }
 
     private:
-        inline static ZEngine::Ref<Messenger> m_messenger = ZEngine::CreateRef<Messenger>();
+        inline static ZEngine::Helpers::Ref<Messenger> m_messenger = ZEngine::Helpers::CreateRef<Messenger>();
     };
 
 #define MESSENGER_REGISTER(TRecipient, TMessage, token, recipient_ptr, function_body)                                   \

--- a/Tetragrama/Serializers/EditorSceneSerializer.cpp
+++ b/Tetragrama/Serializers/EditorSceneSerializer.cpp
@@ -8,7 +8,7 @@ using namespace ZEngine::Helpers;
 namespace Tetragrama::Serializers
 {
 
-    void EditorSceneSerializer::Serialize(const ZEngine::Ref<EditorScene>& scene)
+    void EditorSceneSerializer::Serialize(const Ref<EditorScene>& scene)
     {
         ThreadPoolHelper::Submit([this, scene] {
             {

--- a/Tetragrama/Serializers/EditorSceneSerializer.h
+++ b/Tetragrama/Serializers/EditorSceneSerializer.h
@@ -8,7 +8,7 @@ namespace Tetragrama::Serializers
     class EditorSceneSerializer : public Serializer<EditorScene>
     {
     public:
-        virtual void Serialize(const ZEngine::Ref<EditorScene>& data) override;
+        virtual void Serialize(const ZEngine::Helpers::Ref<EditorScene>& data) override;
         virtual void Deserialize(std::string_view filename) override;
     };
 } // namespace Tetragrama::Serializers

--- a/Tetragrama/Serializers/Serializer.h
+++ b/Tetragrama/Serializers/Serializer.h
@@ -76,7 +76,7 @@ namespace Tetragrama::Serializers
             return m_is_serializing;
         }
 
-        virtual void Serialize(const ZEngine::Ref<TSerializerData>& data) = 0;
-        virtual void Deserialize(std::string_view filename)               = 0;
+        virtual void Serialize(const ZEngine::Helpers::Ref<TSerializerData>& data) = 0;
+        virtual void Deserialize(std::string_view filename)                        = 0;
     };
 } // namespace Tetragrama::Serializers

--- a/ZEngine/ZEngine/Core/CoroutineScheduler.cpp
+++ b/ZEngine/ZEngine/Core/CoroutineScheduler.cpp
@@ -6,8 +6,8 @@ using namespace ZEngine::Helpers;
 
 namespace ZEngine::Core
 {
-    std::atomic_bool                        CoroutineScheduler::s_running      = false;
-    Ref<CoroutineScheduler::SchedulerQueue> CoroutineScheduler::s_action_queue = CreateRef<CoroutineScheduler::SchedulerQueue>();
+    std::atomic_bool                                 CoroutineScheduler::s_running      = false;
+    Helpers::Ref<CoroutineScheduler::SchedulerQueue> CoroutineScheduler::s_action_queue = Helpers::CreateRef<CoroutineScheduler::SchedulerQueue>();
 
     void CoroutineScheduler::Schedule(CoroutineAction&& action)
     {
@@ -28,7 +28,7 @@ namespace ZEngine::Core
         std::thread(Run, s_action_queue.Weak()).detach();
     }
 
-    void CoroutineScheduler::Run(WeakRef<SchedulerQueue> queue_ref)
+    void CoroutineScheduler::Run(Helpers::WeakRef<SchedulerQueue> queue_ref)
     {
         while (auto queue = queue_ref.lock())
         {

--- a/ZEngine/ZEngine/Core/CoroutineScheduler.h
+++ b/ZEngine/ZEngine/Core/CoroutineScheduler.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <Helpers/IntrusivePtr.h>
 #include <Helpers/ThreadSafeQueue.h>
 #include <ZEngineDef.h>
 #include <atomic>
@@ -27,11 +28,11 @@ namespace ZEngine::Core
         static void Schedule(CoroutineAction&& action);
 
     private:
-        static std::atomic_bool                               s_running;
-        static Ref<Helpers::ThreadSafeQueue<CoroutineAction>> s_action_queue;
+        static std::atomic_bool                                        s_running;
+        static Helpers::Ref<Helpers::ThreadSafeQueue<CoroutineAction>> s_action_queue;
 
         static void Start();
-        static void Run(WeakRef<SchedulerQueue> queue);
+        static void Run(Helpers::WeakRef<SchedulerQueue> queue);
     };
 
 } // namespace ZEngine::Core

--- a/ZEngine/ZEngine/Core/IPipeline.h
+++ b/ZEngine/ZEngine/Core/IPipeline.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <ZEngineDef.h>
+#include <Helpers/IntrusivePtr.h>
 #include <string>
 
 namespace ZEngine::Core
@@ -60,9 +60,9 @@ namespace ZEngine::Core
         }
 
     protected:
-        StageInformation    m_information{};
-        IPipelineContext*   m_context{nullptr};
-        Ref<IPipelineStage> m_next_stage{nullptr};
+        StageInformation             m_information{};
+        IPipelineContext*            m_context{nullptr};
+        Helpers::Ref<IPipelineStage> m_next_stage{nullptr};
     };
 
     struct IPipelineContext
@@ -74,7 +74,7 @@ namespace ZEngine::Core
          * Update the current compiler stage
          * @param stage Compiler stage
          */
-        virtual void UpdateStage(Ref<IPipelineStage> stage);
+        virtual void UpdateStage(Helpers::Ref<IPipelineStage> stage);
 
         /**
          * Update the current compiler stage
@@ -83,7 +83,7 @@ namespace ZEngine::Core
         virtual void UpdateStage(IPipelineStage* const stage);
 
     protected:
-        bool                m_running_stages{true};
-        Ref<IPipelineStage> m_stage{nullptr};
+        bool                         m_running_stages{true};
+        Helpers::Ref<IPipelineStage> m_stage{nullptr};
     };
 } // namespace ZEngine::Core

--- a/ZEngine/ZEngine/Core/IPipelineContext.cpp
+++ b/ZEngine/ZEngine/Core/IPipelineContext.cpp
@@ -1,5 +1,7 @@
 #include <Core/IPipeline.h>
 
+using namespace ZEngine::Helpers;
+
 namespace ZEngine::Core
 {
 

--- a/ZEngine/ZEngine/Engine.cpp
+++ b/ZEngine/ZEngine/Engine.cpp
@@ -8,10 +8,10 @@ using namespace ZEngine::Rendering::Renderers;
 
 namespace ZEngine
 {
-    static bool                         s_request_terminate{false};
-    static WeakRef<Windows::CoreWindow> g_current_window = nullptr;
+    static bool                                  s_request_terminate{false};
+    static Helpers::WeakRef<Windows::CoreWindow> g_current_window = nullptr;
 
-    void Engine::Initialize(const EngineConfiguration& engine_configuration, const Ref<ZEngine::Windows::CoreWindow>& window)
+    void Engine::Initialize(const EngineConfiguration& engine_configuration, const Helpers::Ref<ZEngine::Windows::CoreWindow>& window)
     {
         g_current_window = window;
         Logging::Logger::Initialize(engine_configuration.LoggerConfiguration);
@@ -97,7 +97,7 @@ namespace ZEngine
         }
     }
 
-    Ref<Windows::CoreWindow> Engine::GetWindow()
+    Helpers::Ref<Windows::CoreWindow> Engine::GetWindow()
     {
         return g_current_window.lock();
     }

--- a/ZEngine/ZEngine/Engine.h
+++ b/ZEngine/ZEngine/Engine.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <EngineConfiguration.h>
 #include <Event/EngineClosedEvent.h>
+#include <Helpers/IntrusivePtr.h>
 #include <Windows/CoreWindow.h>
 
 namespace ZEngine
@@ -11,11 +12,11 @@ namespace ZEngine
         Engine(const Engine&) = delete;
         ~Engine()             = delete;
 
-        static void                     Initialize(const EngineConfiguration&, const Ref<ZEngine::Windows::CoreWindow>&);
-        static void                     Run();
-        static Ref<Windows::CoreWindow> GetWindow();
-        static void                     Deinitialize();
-        static void                     Dispose();
-        static bool                     OnEngineClosed(Event::EngineClosedEvent&);
+        static void                              Initialize(const EngineConfiguration&, const Helpers::Ref<ZEngine::Windows::CoreWindow>&);
+        static void                              Run();
+        static Helpers::Ref<Windows::CoreWindow> GetWindow();
+        static void                              Deinitialize();
+        static void                              Dispose();
+        static bool                              OnEngineClosed(Event::EngineClosedEvent&);
     };
 } // namespace ZEngine

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
@@ -14,6 +14,7 @@
 
 using namespace std::chrono_literals;
 using namespace ZEngine::Rendering::Primitives;
+using namespace ZEngine::Helpers;
 
 namespace ZEngine::Hardwares
 {

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.h
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.h
@@ -81,7 +81,7 @@ namespace ZEngine::Hardwares
         VulkanDevice(const VulkanDevice&) = delete;
         ~VulkanDevice()                   = delete;
 
-        static void Initialize(const Ref<Windows::CoreWindow>& window);
+        static void Initialize(const Helpers::Ref<Windows::CoreWindow>& window);
         static void Deinitialize();
         static void Dispose();
 
@@ -163,12 +163,12 @@ namespace ZEngine::Hardwares
             uint32_t                        height,
             uint32_t                        layer_number = 1);
 
-        static Ref<Rendering::Buffers::CommandBuffer> BeginInstantCommandBuffer(Rendering::QueueType type);
-        static void                                   EndInstantCommandBuffer(Ref<Rendering::Buffers::CommandBuffer>& command);
+        static Helpers::Ref<Rendering::Buffers::CommandBuffer> BeginInstantCommandBuffer(Rendering::QueueType type);
+        static void                                            EndInstantCommandBuffer(Helpers::Ref<Rendering::Buffers::CommandBuffer>& command);
 
         static VmaAllocator GetVmaAllocator();
 
-        static std::vector<Ref<Rendering::Pools::CommandPool>> s_command_pool_collection;
+        static std::vector<Helpers::Ref<Rendering::Pools::CommandPool>> s_command_pool_collection;
 
     private:
         static std::string                                                                      s_application_name;
@@ -201,7 +201,7 @@ namespace ZEngine::Hardwares
         static std::mutex                                                                       s_queue_mutex;
         static std::mutex                                                                       s_command_pool_mutex;
         static std::mutex                                                                       s_deletion_queue_mutex;
-        static std::map<Rendering::QueueType, Ref<Rendering::Pools::CommandPool>>               s_in_device_command_pool_map;
+        static std::map<Rendering::QueueType, Helpers::Ref<Rendering::Pools::CommandPool>>      s_in_device_command_pool_map;
         static std::condition_variable                                                          s_cond;
         static std::atomic_bool                                                                 s_is_executing_instant_command;
         static std::mutex                                                                       s_instant_command_mutex;

--- a/ZEngine/ZEngine/Helpers/IntrusivePtr.h
+++ b/ZEngine/ZEngine/Helpers/IntrusivePtr.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <atomic>
-#include <concepts>
+#include <memory>
 
 namespace ZEngine::Helpers
 {
@@ -441,6 +441,26 @@ namespace ZEngine::Helpers
         T* m_ptr = nullptr;
     };
 
+    template <typename T>
+    using Ref = IntrusivePtr<T>;
+
+    template <typename T>
+    using WeakRef = IntrusiveWeakPtr<T>;
+
+    template <typename T>
+    using Scope = std::unique_ptr<T>;
+
+    template <typename T, typename... Args>
+    Ref<T> CreateRef(Args&&... args)
+    {
+        return make_intrusive<T>(std::forward<Args>(args)...);
+    }
+
+    template <typename T, typename... Args>
+    Scope<T> CreateScope(Args&&... args)
+    {
+        return std::make_unique<T>(std::forward<Args>(args)...);
+    }
 } // namespace ZEngine::Helpers
 
 namespace std

--- a/ZEngine/ZEngine/Helpers/IntrusivePtr.h
+++ b/ZEngine/ZEngine/Helpers/IntrusivePtr.h
@@ -92,6 +92,15 @@ namespace ZEngine::Helpers
     class IntrusiveWeakPtr;
 
     template <typename T>
+    using Ref = IntrusivePtr<T>;
+
+    template <typename T>
+    using WeakRef = IntrusiveWeakPtr<T>;
+
+    template <typename T>
+    using Scope = std::unique_ptr<T>;
+
+    template <typename T>
     class IntrusivePtr
     {
     public:
@@ -440,15 +449,6 @@ namespace ZEngine::Helpers
     private:
         T* m_ptr = nullptr;
     };
-
-    template <typename T>
-    using Ref = IntrusivePtr<T>;
-
-    template <typename T>
-    using WeakRef = IntrusiveWeakPtr<T>;
-
-    template <typename T>
-    using Scope = std::unique_ptr<T>;
 
     template <typename T, typename... Args>
     Ref<T> CreateRef(Args&&... args)

--- a/ZEngine/ZEngine/Managers/IAssetManager.h
+++ b/ZEngine/ZEngine/Managers/IAssetManager.h
@@ -1,12 +1,12 @@
 #pragma once
+#include <Helpers/IntrusivePtr.h>
 #include <Managers/IManager.h>
-#include <ZEngineDef.h>
 
 namespace ZEngine::Managers
 {
 
     template <typename T>
-    struct IAssetManager : public IManager<std::string, ZEngine::Ref<T>>
+    struct IAssetManager : public IManager<std::string, Helpers::Ref<T>>
     {
         IAssetManager()          = default;
         virtual ~IAssetManager() = default;
@@ -18,7 +18,7 @@ namespace ZEngine::Managers
          * @param filename Path to find the asset file in the system
          * @return An asset instance
          */
-        virtual Ref<T> Add(const char* name, const char* filename) = 0;
+        virtual Helpers::Ref<T> Add(const char* name, const char* filename) = 0;
 
         /**
          * Add a asset to the Asset manager store
@@ -26,7 +26,7 @@ namespace ZEngine::Managers
          * @param filename Path to find the asset file in the system
          * @return An asset instance
          */
-        virtual Ref<T> Load(const char* filename) = 0;
+        virtual Helpers::Ref<T> Load(const char* filename) = 0;
 
         /**
          * Get an asset instance from the Asset manager store
@@ -35,10 +35,10 @@ namespace ZEngine::Managers
          * @return An asset instance.
          *		  The asset must exists in the store, otherwise an assertion will be raised
          */
-        ZEngine::Ref<T> Obtains(const char* name)
+        Helpers::Ref<T> Obtains(const char* name)
         {
             const auto key    = std::string(name).append(this->m_suffix);
-            const auto result = IManager<std::string, ZEngine::Ref<T>>::Get(key);
+            const auto result = IManager<std::string, Helpers::Ref<T>>::Get(key);
             assert(result.has_value() == true);
 
             return result->get();

--- a/ZEngine/ZEngine/Managers/ShaderManager.cpp
+++ b/ZEngine/ZEngine/Managers/ShaderManager.cpp
@@ -2,6 +2,8 @@
 #include <Managers/ShaderManager.h>
 #include <uuid.h>
 
+using namespace ZEngine::Helpers;
+
 namespace ZEngine::Managers
 {
     std::unordered_map<std::string, Ref<Rendering::Shaders::Shader>> ShaderManager::s_shader_mappings = {};

--- a/ZEngine/ZEngine/Managers/ShaderManager.h
+++ b/ZEngine/ZEngine/Managers/ShaderManager.h
@@ -18,7 +18,7 @@ namespace ZEngine::Managers
          * @param filename Path to find the shader source file in the system
          * @return A shader instance
          */
-        Ref<Rendering::Shaders::Shader> Add(const char* name, const char* filename) override;
+        Helpers::Ref<Rendering::Shaders::Shader> Add(const char* name, const char* filename) override;
 
         /**
          * Add a shader to the Shader manager store
@@ -26,16 +26,16 @@ namespace ZEngine::Managers
          * @param filename Path to find the shader source file in the system
          * @return A shader instance
          */
-        Ref<Rendering::Shaders::Shader> Load(const char* filename) override;
+        Helpers::Ref<Rendering::Shaders::Shader> Load(const char* filename) override;
 
         static const std::string GetFragmentFilename(std::string_view key);
         static const std::string GetVertexFilename(std::string_view key);
 
-        static Ref<Rendering::Shaders::Shader> Get(ZEngine::Rendering::Specifications::ShaderSpecification& spec);
+        static Helpers::Ref<Rendering::Shaders::Shader> Get(ZEngine::Rendering::Specifications::ShaderSpecification& spec);
 
     private:
         static const std::string_view                                                     s_base_dir;
         static const std::unordered_map<std::string, std::pair<std::string, std::string>> s_shader_path;
-        static std::unordered_map<std::string, Ref<Rendering::Shaders::Shader>>           s_shader_mappings;
+        static std::unordered_map<std::string, Helpers::Ref<Rendering::Shaders::Shader>>  s_shader_mappings;
     };
 } // namespace ZEngine::Managers

--- a/ZEngine/ZEngine/Managers/TextureManager.cpp
+++ b/ZEngine/ZEngine/Managers/TextureManager.cpp
@@ -2,6 +2,8 @@
 #include <Core/Coroutine.h>
 #include <Managers/TextureManager.h>
 
+using namespace ZEngine::Helpers;
+
 namespace ZEngine::Managers
 {
 
@@ -38,7 +40,7 @@ namespace ZEngine::Managers
             return found.second->second;
         }
 
-        ZEngine::Ref<Rendering::Textures::Texture> texture;
+        Ref<Rendering::Textures::Texture> texture;
         texture.reset(Rendering::Textures::CreateTexture(width, height));
         auto result = IManager::Add(key, texture);
 
@@ -53,7 +55,7 @@ namespace ZEngine::Managers
         return Add(reinterpret_cast<const char*>(name.u8string().c_str()), filename);
     }
 
-    ZEngine::Scope<CoreTextureManager> TextureManager::m_texture_manager = CreateScope<CoreTextureManager>();
+    Scope<CoreTextureManager> TextureManager::m_texture_manager = CreateScope<CoreTextureManager>();
 
     Ref<Rendering::Textures::Texture> TextureManager::Add(std::string_view name, std::string_view filename)
     {

--- a/ZEngine/ZEngine/Managers/TextureManager.h
+++ b/ZEngine/ZEngine/Managers/TextureManager.h
@@ -1,7 +1,7 @@
 #pragma once
+#include <Helpers/IntrusivePtr.h>
 #include <Managers/IAssetManager.h>
 #include <Rendering/Textures/Texture.h>
-#include <ZEngineDef.h>
 #include <assert.h>
 #include <filesystem>
 #include <future>
@@ -22,7 +22,7 @@ namespace ZEngine::Managers
          * @param filename Path to find the texture
          * @return A texture instance
          */
-        Ref<Rendering::Textures::Texture> Add(const char* name, const char* filename) override;
+        Helpers::Ref<Rendering::Textures::Texture> Add(const char* name, const char* filename) override;
 
         /**
          * Add a texture to the Texture manager store
@@ -32,7 +32,7 @@ namespace ZEngine::Managers
          * @param height Texture height
          * @return A texture instance
          */
-        Ref<Rendering::Textures::Texture> Add(const char* name, unsigned int width, unsigned int height);
+        Helpers::Ref<Rendering::Textures::Texture> Add(const char* name, unsigned int width, unsigned int height);
 
         /**
          * Add a texture to the Texture manager store
@@ -40,7 +40,7 @@ namespace ZEngine::Managers
          * @param filename Path to find the texture file in the system
          * @return A texture instance
          */
-        Ref<Rendering::Textures::Texture> Load(const char* filename) override;
+        Helpers::Ref<Rendering::Textures::Texture> Load(const char* filename) override;
     };
 
     struct TextureManager
@@ -59,7 +59,7 @@ namespace ZEngine::Managers
          * @param filename Path to find the texture
          * @return A texture instance
          */
-        static Ref<Rendering::Textures::Texture> Add(std::string_view name, std::string_view filename);
+        static Helpers::Ref<Rendering::Textures::Texture> Add(std::string_view name, std::string_view filename);
 
         /**
          * Add a texture to the Texture manager store
@@ -69,7 +69,7 @@ namespace ZEngine::Managers
          * @param height Texture height
          * @return A texture instance
          */
-        static Ref<Rendering::Textures::Texture> Add(std::string_view name, unsigned int width, unsigned int height);
+        static Helpers::Ref<Rendering::Textures::Texture> Add(std::string_view name, unsigned int width, unsigned int height);
 
         /**
          * Add a texture to the Texture manager store
@@ -77,10 +77,10 @@ namespace ZEngine::Managers
          * @param filename Path to find the texture file in the system
          * @return A texture instance
          */
-        static Ref<Rendering::Textures::Texture> Load(std::string_view filename);
+        static Helpers::Ref<Rendering::Textures::Texture> Load(std::string_view filename);
 
     private:
-        static ZEngine::Scope<ZEngine::Managers::CoreTextureManager> m_texture_manager;
+        static Helpers::Scope<ZEngine::Managers::CoreTextureManager> m_texture_manager;
     };
 
 } // namespace ZEngine::Managers

--- a/ZEngine/ZEngine/Rendering/Buffers/CommandBuffer.cpp
+++ b/ZEngine/ZEngine/Rendering/Buffers/CommandBuffer.cpp
@@ -8,6 +8,8 @@
 #include <Rendering/Renderers/RenderPasses/RenderPass.h>
 #include <Rendering/ResourceTypes.h>
 
+using namespace ZEngine::Helpers;
+
 namespace ZEngine::Rendering::Buffers
 {
     CommandBuffer::CommandBuffer(VkCommandPool command_pool, Rendering::QueueType type, bool one_time)

--- a/ZEngine/ZEngine/Rendering/Buffers/CommandBuffer.h
+++ b/ZEngine/ZEngine/Rendering/Buffers/CommandBuffer.h
@@ -50,15 +50,15 @@ namespace ZEngine::Rendering::Buffers
         void              ResetState();
         void              SetState(const CommanBufferState& state);
 
-        void                   SetSignalFence(const Ref<Primitives::Fence>& semaphore);
-        void                   SetSignalSemaphore(const Ref<Primitives::Semaphore>& semaphore);
+        void                   SetSignalFence(const Helpers::Ref<Primitives::Fence>& semaphore);
+        void                   SetSignalSemaphore(const Helpers::Ref<Primitives::Semaphore>& semaphore);
         Primitives::Semaphore* GetSignalSemaphore() const;
         Primitives::Fence*     GetSignalFence();
 
         void ClearColor(float r, float g, float b, float a);
         void ClearDepth(float depth_color, uint32_t stencil);
 
-        void BeginRenderPass(const Ref<Renderers::RenderPasses::RenderPass>&);
+        void BeginRenderPass(const Helpers::Ref<Renderers::RenderPasses::RenderPass>&);
         void EndRenderPass();
         void BindDescriptorSets(uint32_t frame_index = 0);
         void BindDescriptorSet(const VkDescriptorSet& descriptor);
@@ -83,14 +83,14 @@ namespace ZEngine::Rendering::Buffers
         void PushConstants(VkShaderStageFlags stage_flags, uint32_t offset, uint32_t size, const void* data);
 
     private:
-        bool                                         m_one_time_usage{false};
-        std::atomic_uint8_t                          m_command_buffer_state{CommanBufferState::Idle};
-        VkCommandBuffer                              m_command_buffer{VK_NULL_HANDLE};
-        VkCommandPool                                m_command_pool{VK_NULL_HANDLE};
-        std::array<VkClearValue, 2>                  m_clear_value{};
-        Rendering::QueueType                         m_queue_type;
-        Ref<Primitives::Fence>                       m_signal_fence;
-        Ref<Primitives::Semaphore>                   m_signal_semaphore;
-        WeakRef<Renderers::RenderPasses::RenderPass> m_active_render_pass;
+        bool                                                  m_one_time_usage{false};
+        std::atomic_uint8_t                                   m_command_buffer_state{CommanBufferState::Idle};
+        VkCommandBuffer                                       m_command_buffer{VK_NULL_HANDLE};
+        VkCommandPool                                         m_command_pool{VK_NULL_HANDLE};
+        std::array<VkClearValue, 2>                           m_clear_value{};
+        Rendering::QueueType                                  m_queue_type;
+        Helpers::Ref<Primitives::Fence>                       m_signal_fence;
+        Helpers::Ref<Primitives::Semaphore>                   m_signal_semaphore;
+        Helpers::WeakRef<Renderers::RenderPasses::RenderPass> m_active_render_pass;
     };
 } // namespace ZEngine::Rendering::Buffers

--- a/ZEngine/ZEngine/Rendering/Buffers/FrameBuffer.cpp
+++ b/ZEngine/ZEngine/Rendering/Buffers/FrameBuffer.cpp
@@ -1,6 +1,7 @@
 #include <pch.h>
 #include <Rendering/Buffers/Framebuffer.h>
 
+using namespace ZEngine::Helpers;
 using namespace ZEngine::Rendering::Specifications;
 
 namespace ZEngine::Rendering::Buffers

--- a/ZEngine/ZEngine/Rendering/Buffers/Framebuffer.h
+++ b/ZEngine/ZEngine/Rendering/Buffers/Framebuffer.h
@@ -21,8 +21,8 @@ namespace ZEngine::Rendering::Buffers
         Specifications::FrameBufferSpecificationVNext&       GetSpecification();
         const Specifications::FrameBufferSpecificationVNext& GetSpecification() const;
 
-        static Ref<FramebufferVNext> Create(const Specifications::FrameBufferSpecificationVNext&);
-        static Ref<FramebufferVNext> Create(Specifications::FrameBufferSpecificationVNext&&);
+        static Helpers::Ref<FramebufferVNext> Create(const Specifications::FrameBufferSpecificationVNext&);
+        static Helpers::Ref<FramebufferVNext> Create(Specifications::FrameBufferSpecificationVNext&&);
 
     private:
         VkFramebuffer                                 m_handle{VK_NULL_HANDLE};

--- a/ZEngine/ZEngine/Rendering/Components/LightComponent.h
+++ b/ZEngine/ZEngine/Rendering/Components/LightComponent.h
@@ -5,18 +5,18 @@ namespace ZEngine::Rendering::Components
 {
     struct LightComponent
     {
-        LightComponent(const Ref<Lights::LightVNext>& light) : m_light(light) {}
-        LightComponent(Ref<Lights::LightVNext>&& light) : m_light(std::move(light)) {}
+        LightComponent(const Helpers::Ref<Lights::LightVNext>& light) : m_light(light) {}
+        LightComponent(Helpers::Ref<Lights::LightVNext>&& light) : m_light(std::move(light)) {}
 
         ~LightComponent() = default;
 
-        Ref<Lights::LightVNext> GetLight() const
+        Helpers::Ref<Lights::LightVNext> GetLight() const
         {
             return m_light;
         }
 
     private:
-        Ref<Lights::LightVNext> m_light;
+        Helpers::Ref<Lights::LightVNext> m_light;
     };
 
 } // namespace ZEngine::Rendering::Components

--- a/ZEngine/ZEngine/Rendering/Components/MaterialComponent.h
+++ b/ZEngine/ZEngine/Rendering/Components/MaterialComponent.h
@@ -5,43 +5,43 @@ namespace ZEngine::Rendering::Components
 {
     struct MaterialComponent
     {
-        MaterialComponent(const Ref<Materials::ShaderMaterial>& shader_material)
+        MaterialComponent(const Helpers::Ref<Materials::ShaderMaterial>& shader_material)
         {
             m_shader_material_collection.push_back(shader_material);
         }
 
-        MaterialComponent(Ref<Materials::ShaderMaterial>&& shader_material)
+        MaterialComponent(Helpers::Ref<Materials::ShaderMaterial>&& shader_material)
         {
             m_shader_material_collection.push_back(std::move(shader_material));
         }
 
-        MaterialComponent(const std::vector<Ref<Materials::ShaderMaterial>>& shader_materials)
+        MaterialComponent(const std::vector<Helpers::Ref<Materials::ShaderMaterial>>& shader_materials)
         {
             m_shader_material_collection = shader_materials;
         }
 
-        MaterialComponent(std::vector<Ref<Materials::ShaderMaterial>>&& shader_materials)
+        MaterialComponent(std::vector<Helpers::Ref<Materials::ShaderMaterial>>&& shader_materials)
         {
             m_shader_material_collection = std::move(shader_materials);
         }
 
-        void AddMaterial(const Ref<Materials::ShaderMaterial>& material)
+        void AddMaterial(const Helpers::Ref<Materials::ShaderMaterial>& material)
         {
             m_shader_material_collection.push_back(material);
         }
 
-        void AddMaterial(Ref<Materials::ShaderMaterial>&& material)
+        void AddMaterial(Helpers::Ref<Materials::ShaderMaterial>&& material)
         {
             m_shader_material_collection.push_back(std::move(material));
         }
 
-        const std::vector<Ref<Materials::ShaderMaterial>>& GetMaterials() const
+        const std::vector<Helpers::Ref<Materials::ShaderMaterial>>& GetMaterials() const
         {
             return m_shader_material_collection;
         }
 
     private:
-        std::vector<Ref<Materials::ShaderMaterial>> m_shader_material_collection;
+        std::vector<Helpers::Ref<Materials::ShaderMaterial>> m_shader_material_collection;
     };
 
 } // namespace ZEngine::Rendering::Components

--- a/ZEngine/ZEngine/Rendering/Materials/BasicMaterial.cpp
+++ b/ZEngine/ZEngine/Rendering/Materials/BasicMaterial.cpp
@@ -1,6 +1,8 @@
 #include <pch.h>
 #include <Rendering/Materials/BasicMaterial.h>
 
+using namespace ZEngine::Helpers;
+
 namespace ZEngine::Rendering::Materials
 {
 

--- a/ZEngine/ZEngine/Rendering/Materials/BasicMaterial.h
+++ b/ZEngine/ZEngine/Rendering/Materials/BasicMaterial.h
@@ -10,12 +10,12 @@ namespace ZEngine::Rendering::Materials
         explicit BasicMaterial();
         virtual ~BasicMaterial() = default;
 
-        void                   SetTexture(const Ref<Textures::Texture>&);
-        Ref<Textures::Texture> GetTexture() const;
+        void                            SetTexture(const Helpers::Ref<Textures::Texture>&);
+        Helpers::Ref<Textures::Texture> GetTexture() const;
 
-        void Apply(const Ref<Shaders::Shader>&) override;
+        void Apply(const Helpers::Ref<Shaders::Shader>&) override;
 
     private:
-        Ref<Textures::Texture> m_texture;
+        Helpers::Ref<Textures::Texture> m_texture;
     };
 } // namespace ZEngine::Rendering::Materials

--- a/ZEngine/ZEngine/Rendering/Materials/IMaterial.h
+++ b/ZEngine/ZEngine/Rendering/Materials/IMaterial.h
@@ -16,12 +16,12 @@ namespace ZEngine::Rendering::Materials
             m_material_name = typeid(*this).name();
         }
 
-        explicit IMaterial(const Ref<Textures::Texture>& texture)
+        explicit IMaterial(const Helpers::Ref<Textures::Texture>& texture)
         {
             m_material_name = typeid(*this).name();
         }
 
-        explicit IMaterial(Ref<Textures::Texture>&& texture)
+        explicit IMaterial(Helpers::Ref<Textures::Texture>&& texture)
         {
             m_material_name = typeid(*this).name();
         }

--- a/ZEngine/ZEngine/Rendering/Materials/ShaderMaterial.cpp
+++ b/ZEngine/ZEngine/Rendering/Materials/ShaderMaterial.cpp
@@ -1,6 +1,8 @@
 #include <pch.h>
 #include <Rendering/Materials/ShaderMaterial.h>
 
+using namespace ZEngine::Helpers;
+
 namespace ZEngine::Rendering::Materials
 {
 

--- a/ZEngine/ZEngine/Rendering/Materials/ShaderMaterial.h
+++ b/ZEngine/ZEngine/Rendering/Materials/ShaderMaterial.h
@@ -12,6 +12,6 @@ namespace ZEngine::Rendering::Materials
 
         virtual ~ShaderMaterial() = default;
 
-        virtual void Apply(const Ref<Shaders::Shader>&);
+        virtual void Apply(const Helpers::Ref<Shaders::Shader>&);
     };
 } // namespace ZEngine::Rendering::Materials

--- a/ZEngine/ZEngine/Rendering/Materials/StandardMaterial.cpp
+++ b/ZEngine/ZEngine/Rendering/Materials/StandardMaterial.cpp
@@ -1,6 +1,8 @@
 #include <pch.h>
 #include <Rendering/Materials/StandardMaterial.h>
 
+using namespace ZEngine::Helpers;
+
 namespace ZEngine::Rendering::Materials
 {
 

--- a/ZEngine/ZEngine/Rendering/Materials/StandardMaterial.h
+++ b/ZEngine/ZEngine/Rendering/Materials/StandardMaterial.h
@@ -18,25 +18,25 @@ namespace ZEngine::Rendering::Materials
 
         void SetShininess(float value);
 
-        void Apply(const Ref<Shaders::Shader>&) override;
+        void Apply(const Helpers::Ref<Shaders::Shader>&) override;
 
-        void SetSpecularMap(const Ref<Textures::Texture>& texture);
-        void SetDiffuseMap(const Ref<Textures::Texture>& texture);
+        void SetSpecularMap(const Helpers::Ref<Textures::Texture>& texture);
+        void SetDiffuseMap(const Helpers::Ref<Textures::Texture>& texture);
 
         float                 GetTileFactor() const;
         float                 GetShininess() const;
         const Maths::Vector4& GetDiffuseTintColor() const;
         const Maths::Vector4& GetSpecularTintColor() const;
 
-        Ref<Textures::Texture> GetSpecularMap() const;
-        Ref<Textures::Texture> GetDiffuseMap() const;
+        Helpers::Ref<Textures::Texture> GetSpecularMap() const;
+        Helpers::Ref<Textures::Texture> GetDiffuseMap() const;
 
     private:
-        float                  m_shininess;
-        float                  m_tile_factor;
-        Maths::Vector4         m_diffuse_tint_color;
-        Maths::Vector4         m_specular_tint_color;
-        Ref<Textures::Texture> m_diffuse_map;
-        Ref<Textures::Texture> m_specular_map;
+        float                           m_shininess;
+        float                           m_tile_factor;
+        Maths::Vector4                  m_diffuse_tint_color;
+        Maths::Vector4                  m_specular_tint_color;
+        Helpers::Ref<Textures::Texture> m_diffuse_map;
+        Helpers::Ref<Textures::Texture> m_specular_map;
     };
 } // namespace ZEngine::Rendering::Materials

--- a/ZEngine/ZEngine/Rendering/Meshes/MeshLight.h
+++ b/ZEngine/ZEngine/Rendering/Meshes/MeshLight.h
@@ -13,8 +13,8 @@ namespace ZEngine::Rendering::Mesh
             m_is_MeshLight_mesh_object = true;
         }
 
-        explicit MeshLight(Ref<Geometries::IGeometry>&& geometry, Ref<Materials::ShaderMaterial>&& material) : Mesh(geometry, material) {}
-        explicit MeshLight(Ref<Geometries::IGeometry>& geometry, Ref<Materials::ShaderMaterial>& material) : Mesh(geometry, material) {}
+        explicit MeshLight(Helpers::Ref<Geometries::IGeometry>&& geometry, Helpers::Ref<Materials::ShaderMaterial>&& material) : Mesh(geometry, material) {}
+        explicit MeshLight(Helpers::Ref<Geometries::IGeometry>& geometry, Helpers::Ref<Materials::ShaderMaterial>& material) : Mesh(geometry, material) {}
         explicit MeshLight(Geometries::IGeometry* const geometry, Materials::ShaderMaterial* const material) : Mesh(geometry, material) {}
 
         virtual ~MeshLight() = default;

--- a/ZEngine/ZEngine/Rendering/Pools/CommandPool.cpp
+++ b/ZEngine/ZEngine/Rendering/Pools/CommandPool.cpp
@@ -3,6 +3,7 @@
 #include <Rendering/Pools/CommandPool.h>
 #include <ZEngineDef.h>
 
+using namespace ZEngine::Helpers;
 namespace ZEngine::Rendering::Pools
 {
     CommandPool::CommandPool(Rendering::QueueType type, uint64_t swapchain_identifier, bool present_on_swapchain)

--- a/ZEngine/ZEngine/Rendering/Pools/CommandPool.h
+++ b/ZEngine/ZEngine/Rendering/Pools/CommandPool.h
@@ -12,13 +12,13 @@ namespace ZEngine::Rendering::Pools
         CommandPool(Rendering::QueueType type, uint64_t swapchain_identifier = 0, bool present_on_swapchain = true);
         ~CommandPool();
 
-        Buffers::CommandBuffer*     GetCommmandBuffer();
-        Ref<Buffers::CommandBuffer> GetOneTimeCommmandBuffer();
+        Buffers::CommandBuffer*              GetCommmandBuffer();
+        Helpers::Ref<Buffers::CommandBuffer> GetOneTimeCommmandBuffer();
 
     private:
-        uint32_t                                m_max_command_buffer_count{UINT32_MAX};
-        std::deque<Ref<Buffers::CommandBuffer>> m_allocated_command_buffers;
-        VkCommandPool                           m_handle{VK_NULL_HANDLE};
-        Rendering::QueueType                    m_queue_type;
+        uint32_t                                         m_max_command_buffer_count{UINT32_MAX};
+        std::deque<Helpers::Ref<Buffers::CommandBuffer>> m_allocated_command_buffers;
+        VkCommandPool                                    m_handle{VK_NULL_HANDLE};
+        Rendering::QueueType                             m_queue_type;
     };
 } // namespace ZEngine::Rendering::Pools

--- a/ZEngine/ZEngine/Rendering/Renderers/GraphicRenderer.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/GraphicRenderer.cpp
@@ -4,6 +4,7 @@
 
 using namespace ZEngine::Rendering::Specifications;
 using namespace ZEngine::Rendering::Renderers::Contracts;
+using namespace ZEngine::Helpers;
 
 namespace ZEngine::Rendering::Renderers
 {

--- a/ZEngine/ZEngine/Rendering/Renderers/GraphicRenderer.h
+++ b/ZEngine/ZEngine/Rendering/Renderers/GraphicRenderer.h
@@ -27,17 +27,17 @@ namespace ZEngine::Rendering::Renderers
         static void                       Initialize();
         static void                       Deinitialize();
         static void                       SetViewportSize(uint32_t width, uint32_t height);
-        static void                       SetMainSwapchain(const Ref<Rendering::Swapchain>& swapchain);
+        static void                       SetMainSwapchain(const Helpers::Ref<Rendering::Swapchain>& swapchain);
         static const RendererInformation& GetRendererInformation();
 
         static void            Update();
-        static void            DrawScene(const Ref<Rendering::Cameras::Camera>& camera, const Ref<Rendering::Scenes::SceneRawData>& data);
+        static void            DrawScene(const Helpers::Ref<Rendering::Cameras::Camera>& camera, const Helpers::Ref<Rendering::Scenes::SceneRawData>& data);
         static void            BeginImguiFrame();
         static void            DrawUIFrame();
         static void            EndImguiFrame();
         static VkDescriptorSet GetImguiFrameOutput();
 
-        static Ref<Textures::TextureArray> GlobalTextures;
+        static Helpers::Ref<Textures::TextureArray> GlobalTextures;
 
         static void BindGlobalTextures(RenderPasses::RenderPass* pass);
 
@@ -47,14 +47,14 @@ namespace ZEngine::Rendering::Renderers
         ~GraphicRenderer()                      = delete;
 
     private:
-        static RendererInformation            s_renderer_information;
-        static WeakRef<Rendering::Swapchain>  s_main_window_swapchain;
-        static Ref<Buffers::UniformBufferSet> s_UBCamera;
-        static Pools::CommandPool*            s_command_pool;
-        static Buffers::CommandBuffer*        s_current_command_buffer;
-        static Buffers::CommandBuffer*        s_current_command_buffer_ui;
-        static Ref<SceneRenderer>             s_scene_renderer;
-        static Ref<ImGUIRenderer>             s_imgui_renderer;
-        static Scope<RenderGraph>             s_render_graph;
+        static RendererInformation                     s_renderer_information;
+        static Helpers::WeakRef<Rendering::Swapchain>  s_main_window_swapchain;
+        static Helpers::Ref<Buffers::UniformBufferSet> s_UBCamera;
+        static Pools::CommandPool*                     s_command_pool;
+        static Buffers::CommandBuffer*                 s_current_command_buffer;
+        static Buffers::CommandBuffer*                 s_current_command_buffer_ui;
+        static Helpers::Ref<SceneRenderer>             s_scene_renderer;
+        static Helpers::Ref<ImGUIRenderer>             s_imgui_renderer;
+        static Helpers::Scope<RenderGraph>             s_render_graph;
     };
 } // namespace ZEngine::Rendering::Renderers

--- a/ZEngine/ZEngine/Rendering/Renderers/ImGUIRenderer.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/ImGUIRenderer.cpp
@@ -11,6 +11,7 @@
 using namespace ZEngine::Hardwares;
 using namespace ZEngine::Rendering;
 using namespace ZEngine::Rendering::Textures;
+using namespace ZEngine::Helpers;
 
 namespace ZEngine::Rendering::Renderers
 {

--- a/ZEngine/ZEngine/Rendering/Renderers/ImGUIRenderer.h
+++ b/ZEngine/ZEngine/Rendering/Renderers/ImGUIRenderer.h
@@ -22,11 +22,11 @@ namespace ZEngine::Rendering::Renderers
         VkDescriptorSet UpdateFrameOutput(const Hardwares::BufferImage& buffer);
 
     private:
-        VkDescriptorSet               m_frame_output{VK_NULL_HANDLE};
-        VkDescriptorSet               m_font_descriptor_set{VK_NULL_HANDLE};
-        Ref<Buffers::VertexBufferSet> m_vertex_buffer;
-        Ref<Buffers::IndexBufferSet>  m_index_buffer;
-        Ref<RenderPasses::RenderPass> m_ui_pass;
+        VkDescriptorSet                        m_frame_output{VK_NULL_HANDLE};
+        VkDescriptorSet                        m_font_descriptor_set{VK_NULL_HANDLE};
+        Helpers::Ref<Buffers::VertexBufferSet> m_vertex_buffer;
+        Helpers::Ref<Buffers::IndexBufferSet>  m_index_buffer;
+        Helpers::Ref<RenderPasses::RenderPass> m_ui_pass;
     };
 
 } // namespace ZEngine::Rendering::Renderers

--- a/ZEngine/ZEngine/Rendering/Renderers/Pipelines/GraphicRendererPipelineInformation.h
+++ b/ZEngine/ZEngine/Rendering/Renderers/Pipelines/GraphicRendererPipelineInformation.h
@@ -27,9 +27,9 @@ namespace ZEngine::Rendering::Renderers
         uint32_t GeometryCollectionCount{0};
         uint32_t MaterialCollectionCount{0};
 
-        std::vector<Rendering::Meshes::Mesh>          MeshCollection;
-        std::vector<Ref<Geometries::IGeometry>>       GeometryCollection;
-        std::vector<Ref<Materials::ShaderMaterial>>   MaterialCollection;
-        std::vector<GraphicRendererInformationRecord> RecordCollection;
+        std::vector<Rendering::Meshes::Mesh>                 MeshCollection;
+        std::vector<Helpers::Ref<Geometries::IGeometry>>     GeometryCollection;
+        std::vector<Helpers::Ref<Materials::ShaderMaterial>> MaterialCollection;
+        std::vector<GraphicRendererInformationRecord>        RecordCollection;
     };
 } // namespace ZEngine::Rendering::Renderers

--- a/ZEngine/ZEngine/Rendering/Renderers/Pipelines/RendererPipeline.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/Pipelines/RendererPipeline.cpp
@@ -3,6 +3,8 @@
 #include <Managers/ShaderManager.h>
 #include <Rendering/Renderers/Pipelines/RendererPipeline.h>
 
+using namespace ZEngine::Helpers;
+
 namespace ZEngine::Rendering::Renderers::Pipelines
 {
     GraphicPipeline::GraphicPipeline(Specifications::GraphicRendererPipelineSpecification&& spec) : m_pipeline_specification(std::move(spec))

--- a/ZEngine/ZEngine/Rendering/Renderers/Pipelines/RendererPipeline.h
+++ b/ZEngine/ZEngine/Rendering/Renderers/Pipelines/RendererPipeline.h
@@ -19,15 +19,15 @@ namespace ZEngine::Rendering::Renderers::Pipelines
         void                                                  Dispose();
         VkPipeline                                            GetHandle() const;
         VkPipelineLayout                                      GetPipelineLayout() const;
-        Ref<Shaders::Shader>                                  GetShader() const;
+        Helpers::Ref<Shaders::Shader>                         GetShader() const;
 
     public:
-        static Ref<GraphicPipeline> Create(Specifications::GraphicRendererPipelineSpecification& spec);
+        static Helpers::Ref<GraphicPipeline> Create(Specifications::GraphicRendererPipelineSpecification& spec);
 
     protected:
         VkPipeline                                           m_pipeline_handle{VK_NULL_HANDLE};
         VkPipelineLayout                                     m_pipeline_layout{VK_NULL_HANDLE};
         Specifications::GraphicRendererPipelineSpecification m_pipeline_specification;
-        Ref<Shaders::Shader>                                 m_shader;
+        Helpers::Ref<Shaders::Shader>                        m_shader;
     };
 } // namespace ZEngine::Rendering::Renderers::Pipelines

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.cpp
@@ -2,6 +2,8 @@
 #include <Rendering/Renderers/RenderGraph.h>
 #include <Rendering/Textures/Texture2D.h>
 
+using namespace ZEngine::Helpers;
+
 namespace ZEngine::Rendering::Renderers
 {
     RenderGraphResource& RenderGraphBuilder::AttachBuffer(std::string_view name, const Ref<Buffers::StorageBufferSet>& buffer)

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.h
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.h
@@ -32,12 +32,12 @@ namespace ZEngine::Rendering::Renderers
 
     struct RenderGraphResourceInfo
     {
-        bool                                 External = false;
-        Specifications::TextureSpecification TextureSpec;
-        Ref<Textures::Texture>               TextureHandle;
-        Ref<Buffers::UniformBufferSet>       UniformBufferSetHandle;
-        Ref<Buffers::StorageBufferSet>       BufferSetHandle;
-        Ref<Buffers::IndirectBufferSet>      IndirectBufferSetHandle;
+        bool                                     External = false;
+        Specifications::TextureSpecification     TextureSpec;
+        Helpers::Ref<Textures::Texture>          TextureHandle;
+        Helpers::Ref<Buffers::UniformBufferSet>  UniformBufferSetHandle;
+        Helpers::Ref<Buffers::StorageBufferSet>  BufferSetHandle;
+        Helpers::Ref<Buffers::IndirectBufferSet> IndirectBufferSetHandle;
     };
 
     struct RenderGraphResource
@@ -68,8 +68,8 @@ namespace ZEngine::Rendering::Renderers
 
     struct IRenderGraphCallbackPass : public Helpers::RefCounted
     {
-        virtual void Setup(std::string_view name, RenderGraphBuilder* const builder)                                              = 0;
-        virtual void Compile(Ref<RenderPasses::RenderPass>& handle, RenderPasses::RenderPassBuilder& builder, RenderGraph& graph) = 0;
+        virtual void Setup(std::string_view name, RenderGraphBuilder* const builder)                                                       = 0;
+        virtual void Compile(Helpers::Ref<RenderPasses::RenderPass>& handle, RenderPasses::RenderPassBuilder& builder, RenderGraph& graph) = 0;
         virtual void Execute(
             uint32_t                               frame_index,
             Rendering::Scenes::SceneRawData* const scene_data,
@@ -80,16 +80,16 @@ namespace ZEngine::Rendering::Renderers
 
     struct RenderGraphNode
     {
-        RenderGraphRenderPassCreation   Creation;
-        std::unordered_set<std::string> EdgeNodes;
-        Ref<RenderPasses::RenderPass>   Handle;
-        Ref<IRenderGraphCallbackPass>   CallbackPass;
+        RenderGraphRenderPassCreation          Creation;
+        std::unordered_set<std::string>        EdgeNodes;
+        Helpers::Ref<RenderPasses::RenderPass> Handle;
+        Helpers::Ref<IRenderGraphCallbackPass> CallbackPass;
     };
 
     class RenderGraph : public Helpers::RefCounted
     {
     public:
-        RenderGraph() : m_builder(CreateRef<RenderGraphBuilder>(*this)), m_render_pass_builder(new RenderPasses::RenderPassBuilder{}) {}
+        RenderGraph() : m_builder(Helpers::CreateRef<RenderGraphBuilder>(*this)), m_render_pass_builder(new RenderPasses::RenderPassBuilder{}) {}
         ~RenderGraph() = default;
 
         void Setup();
@@ -100,23 +100,23 @@ namespace ZEngine::Rendering::Renderers
 
         void Dispose();
 
-        RenderGraphResource&            GetResource(std::string_view);
-        Ref<Textures::Texture>          GetRenderTarget(std::string_view);
-        Ref<Textures::Texture>          GetTexture(std::string_view);
-        Ref<Buffers::StorageBufferSet>  GetBufferSet(std::string_view);
-        Ref<Buffers::UniformBufferSet>  GetBufferUniformSet(std::string_view);
-        Ref<Buffers::IndirectBufferSet> GetIndirectBufferSet(std::string_view);
+        RenderGraphResource&                     GetResource(std::string_view);
+        Helpers::Ref<Textures::Texture>          GetRenderTarget(std::string_view);
+        Helpers::Ref<Textures::Texture>          GetTexture(std::string_view);
+        Helpers::Ref<Buffers::StorageBufferSet>  GetBufferSet(std::string_view);
+        Helpers::Ref<Buffers::UniformBufferSet>  GetBufferUniformSet(std::string_view);
+        Helpers::Ref<Buffers::IndirectBufferSet> GetIndirectBufferSet(std::string_view);
 
-        Ref<RenderGraphBuilder> GetBuilder() const;
-        RenderGraphNode&        GetNode(std::string_view);
-        void                    AddCallbackPass(std::string_view pass_name, const Ref<IRenderGraphCallbackPass>& pass_callback);
+        Helpers::Ref<RenderGraphBuilder> GetBuilder() const;
+        RenderGraphNode&                 GetNode(std::string_view);
+        void                             AddCallbackPass(std::string_view pass_name, const Helpers::Ref<IRenderGraphCallbackPass>& pass_callback);
 
     private:
-        std::map<std::string, RenderGraphNode>     m_node;
-        std::vector<std::string>                   m_sorted_nodes;
-        std::map<std::string, RenderGraphResource> m_resource_map;
-        Ref<RenderGraphBuilder>                    m_builder;
-        Ref<RenderPasses::RenderPassBuilder>       m_render_pass_builder;
+        std::map<std::string, RenderGraphNode>        m_node;
+        std::vector<std::string>                      m_sorted_nodes;
+        std::map<std::string, RenderGraphResource>    m_resource_map;
+        Helpers::Ref<RenderGraphBuilder>              m_builder;
+        Helpers::Ref<RenderPasses::RenderPassBuilder> m_render_pass_builder;
 
         friend struct RenderGraphBuilder;
     };
@@ -127,9 +127,9 @@ namespace ZEngine::Rendering::Renderers
 
         RenderGraphResource& CreateTexture(std::string_view name, const Specifications::TextureSpecification& spec);
         RenderGraphResource& CreateRenderTarget(std::string_view name, const Specifications::TextureSpecification& spec);
-        RenderGraphResource& AttachBuffer(std::string_view name, const Ref<Buffers::StorageBufferSet>& buffer);
-        RenderGraphResource& AttachBuffer(std::string_view name, const Ref<Buffers::UniformBufferSet>& buffer);
-        RenderGraphResource& AttachTexture(std::string_view name, const Ref<Textures::Texture>& texture);
+        RenderGraphResource& AttachBuffer(std::string_view name, const Helpers::Ref<Buffers::StorageBufferSet>& buffer);
+        RenderGraphResource& AttachBuffer(std::string_view name, const Helpers::Ref<Buffers::UniformBufferSet>& buffer);
+        RenderGraphResource& AttachTexture(std::string_view name, const Helpers::Ref<Textures::Texture>& texture);
         void                 CreateRenderPassNode(const RenderGraphRenderPassCreation&);
 
         RenderGraphResource& CreateBuffer(std::string_view name) = delete;

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/Attachment.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/Attachment.cpp
@@ -3,6 +3,7 @@
 
 using namespace ZEngine::Hardwares;
 using namespace ZEngine::Rendering::Specifications;
+using namespace ZEngine::Helpers;
 
 namespace ZEngine::Rendering::Renderers::RenderPasses
 {

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/Attachment.h
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/Attachment.h
@@ -1,6 +1,6 @@
 #pragma once
+#include <Helpers/IntrusivePtr.h>
 #include <Rendering/Specifications/AttachmentSpecification.h>
-#include <ZEngineDef.h>
 #include <vulkan/vulkan.h>
 
 namespace ZEngine::Rendering::Renderers::RenderPasses
@@ -17,7 +17,7 @@ namespace ZEngine::Rendering::Renderers::RenderPasses
         uint32_t GetColorAttachmentCount() const;
         uint32_t GetDepthAttachmentCount() const;
 
-        static Ref<Attachment> Create(const Specifications::AttachmentSpecification&);
+        static Helpers::Ref<Attachment> Create(const Specifications::AttachmentSpecification&);
 
     private:
         uint32_t                                m_color_attachment_count{0};

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/RenderPass.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/RenderPass.cpp
@@ -7,6 +7,7 @@
 
 using namespace ZEngine::Rendering::Buffers;
 using namespace ZEngine::Rendering::Specifications;
+using namespace ZEngine::Helpers;
 
 namespace ZEngine::Rendering::Renderers::RenderPasses
 {

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/RenderPass.h
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/RenderPass.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <Helpers/IntrusivePtr.h>
 #include <Rendering/Buffers/Framebuffer.h>
 #include <Rendering/Buffers/GraphicBuffer.h>
 #include <Rendering/Buffers/StorageBuffer.h>
@@ -6,7 +7,6 @@
 #include <Rendering/Renderers/Pipelines/RendererPipeline.h>
 #include <Rendering/Specifications/RenderPassSpecification.h>
 #include <Rendering/Textures/Texture.h>
-#include <ZEngineDef.h>
 #include <vulkan/vulkan.h>
 #include <vector>
 
@@ -44,43 +44,43 @@ namespace ZEngine::Rendering::Renderers::RenderPasses
 
         void Dispose();
 
-        Ref<Pipelines::GraphicPipeline> GetPipeline() const;
-        void                            Bake();
-        bool                            Verify();
-        void                            Update();
-        void                            MarkDirty();
-        void                            SetInput(std::string_view key_name, const Ref<Rendering::Buffers::UniformBufferSet>& buffer);
-        void                            SetInput(std::string_view key_name, const Ref<Rendering::Buffers::StorageBufferSet>& buffer);
-        void                            SetInput(std::string_view key_name, const Ref<Textures::TextureArray>& textures);
-        void                            SetInput(std::string_view key_name, const Ref<Rendering::Buffers::UniformBuffer>& buffer);
-        void                            SetInput(std::string_view key_name, const Ref<Rendering::Buffers::StorageBuffer>& buffer);
-        void                            SetInput(std::string_view key_name, const Ref<Textures::Texture>& buffer);
-        void                            UpdateInputBinding();
-        Ref<Textures::Texture>          GetOutputColor(uint32_t color_index);
-        Ref<Textures::Texture>          GetOutputDepth();
+        Helpers::Ref<Pipelines::GraphicPipeline> GetPipeline() const;
+        void                                     Bake();
+        bool                                     Verify();
+        void                                     Update();
+        void                                     MarkDirty();
+        void                                     SetInput(std::string_view key_name, const Helpers::Ref<Rendering::Buffers::UniformBufferSet>& buffer);
+        void                                     SetInput(std::string_view key_name, const Helpers::Ref<Rendering::Buffers::StorageBufferSet>& buffer);
+        void                                     SetInput(std::string_view key_name, const Helpers::Ref<Textures::TextureArray>& textures);
+        void                                     SetInput(std::string_view key_name, const Helpers::Ref<Rendering::Buffers::UniformBuffer>& buffer);
+        void                                     SetInput(std::string_view key_name, const Helpers::Ref<Rendering::Buffers::StorageBuffer>& buffer);
+        void                                     SetInput(std::string_view key_name, const Helpers::Ref<Textures::Texture>& buffer);
+        void                                     UpdateInputBinding();
+        Helpers::Ref<Textures::Texture>          GetOutputColor(uint32_t color_index);
+        Helpers::Ref<Textures::Texture>          GetOutputDepth();
 
         const Specifications::RenderPassSpecification& GetSpecification() const;
         Specifications::RenderPassSpecification&       GetSpecification();
 
-        Ref<Renderers::RenderPasses::Attachment> GetAttachment() const;
+        Helpers::Ref<Renderers::RenderPasses::Attachment> GetAttachment() const;
 
         void          ResizeFramebuffer();
         VkFramebuffer GetFramebuffer() const;
         uint32_t      GetRenderAreaWidth() const;
         uint32_t      GetRenderAreaHeight() const;
 
-        static Ref<RenderPass> Create(const Specifications::RenderPassSpecification& specification);
+        static Helpers::Ref<RenderPass> Create(const Specifications::RenderPassSpecification& specification);
 
     private:
         std::pair<bool, Specifications::LayoutBindingSpecification> ValidateInput(std::string_view key);
 
     private:
-        bool                                     m_perform_update{false};
-        Specifications::RenderPassSpecification  m_specification;
-        std::vector<PassInput>                   m_input_collection;
-        Ref<Pipelines::GraphicPipeline>          m_pipeline;
-        Ref<Renderers::RenderPasses::Attachment> m_attachment;
-        Ref<Buffers::FramebufferVNext>           m_framebuffer;
+        bool                                              m_perform_update{false};
+        Specifications::RenderPassSpecification           m_specification;
+        std::vector<PassInput>                            m_input_collection;
+        Helpers::Ref<Pipelines::GraphicPipeline>          m_pipeline;
+        Helpers::Ref<Renderers::RenderPasses::Attachment> m_attachment;
+        Helpers::Ref<Buffers::FramebufferVNext>           m_framebuffer;
     };
 
     struct RenderPassBuilder : public Helpers::RefCounted
@@ -104,13 +104,13 @@ namespace ZEngine::Rendering::Renderers::RenderPasses
         RenderPassBuilder& SetOffset(uint32_t input_attribute_index, uint32_t offset);
 
         RenderPassBuilder& UseShader(std::string_view name);
-        RenderPassBuilder& UseRenderTarget(const Ref<Rendering::Textures::Texture>& target);
+        RenderPassBuilder& UseRenderTarget(const Helpers::Ref<Rendering::Textures::Texture>& target);
         RenderPassBuilder& AddRenderTarget(const Specifications::TextureSpecification& target_spec);
-        RenderPassBuilder& AddInputAttachment(const Ref<Rendering::Textures::Texture>& target);
-        RenderPassBuilder& AddInputTexture(std::string_view key, const Ref<Rendering::Textures::Texture>& input);
+        RenderPassBuilder& AddInputAttachment(const Helpers::Ref<Rendering::Textures::Texture>& target);
+        RenderPassBuilder& AddInputTexture(std::string_view key, const Helpers::Ref<Rendering::Textures::Texture>& input);
         RenderPassBuilder& UseSwapchainAsRenderTarget();
 
-        Ref<RenderPass> Create();
+        Helpers::Ref<RenderPass> Create();
 
     private:
         Specifications::RenderPassSpecification m_spec{};

--- a/ZEngine/ZEngine/Rendering/Renderers/SceneRenderer.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/SceneRenderer.cpp
@@ -4,6 +4,8 @@
 #include <Rendering/Renderers/SceneRenderer.h>
 #include <Rendering/Textures/Texture2D.h>
 
+using namespace ZEngine::Helpers;
+
 #define WRITE_BUFFERS_ONCE(frame_index, body)          \
     if (!m_write_once_control.contains(frame_index))   \
     {                                                  \

--- a/ZEngine/ZEngine/Rendering/Renderers/SceneRenderer.h
+++ b/ZEngine/ZEngine/Rendering/Renderers/SceneRenderer.h
@@ -26,14 +26,14 @@ namespace ZEngine::Rendering::Renderers
         virtual void Dispose();
 
     protected:
-        std::map<uint32_t, bool>        m_write_once_control;
-        std::map<uint32_t, uint32_t>    m_cached_vertices_count;
-        std::map<uint32_t, uint32_t>    m_cached_indices_count;
-        Ref<Buffers::StorageBufferSet>  m_vertex_buffer;
-        Ref<Buffers::StorageBufferSet>  m_index_buffer;
-        Ref<Buffers::StorageBufferSet>  m_draw_buffer;
-        Ref<Buffers::StorageBufferSet>  m_transform_buffer;
-        Ref<Buffers::IndirectBufferSet> m_indirect_buffer;
+        std::map<uint32_t, bool>                 m_write_once_control;
+        std::map<uint32_t, uint32_t>             m_cached_vertices_count;
+        std::map<uint32_t, uint32_t>             m_cached_indices_count;
+        Helpers::Ref<Buffers::StorageBufferSet>  m_vertex_buffer;
+        Helpers::Ref<Buffers::StorageBufferSet>  m_index_buffer;
+        Helpers::Ref<Buffers::StorageBufferSet>  m_draw_buffer;
+        Helpers::Ref<Buffers::StorageBufferSet>  m_transform_buffer;
+        Helpers::Ref<Buffers::IndirectBufferSet> m_indirect_buffer;
     };
 
     /*
@@ -42,7 +42,7 @@ namespace ZEngine::Rendering::Renderers
     struct SceneDepthPrePass : public IRenderGraphCallbackPass, public IndirectRenderingStorage
     {
         virtual void Setup(std::string_view name, RenderGraphBuilder* const builder) override;
-        virtual void Compile(Ref<RenderPasses::RenderPass>& handle, RenderPasses::RenderPassBuilder& builder, RenderGraph& graph) override;
+        virtual void Compile(Helpers::Ref<RenderPasses::RenderPass>& handle, RenderPasses::RenderPassBuilder& builder, RenderGraph& graph) override;
         virtual void Execute(
             uint32_t                               frame_index,
             Rendering::Scenes::SceneRawData* const scene_data,
@@ -61,7 +61,7 @@ namespace ZEngine::Rendering::Renderers
         }
 
         virtual void Setup(std::string_view name, RenderGraphBuilder* const builder) override;
-        virtual void Compile(Ref<RenderPasses::RenderPass>& handle, RenderPasses::RenderPassBuilder& builder, RenderGraph& graph) override;
+        virtual void Compile(Helpers::Ref<RenderPasses::RenderPass>& handle, RenderPasses::RenderPassBuilder& builder, RenderGraph& graph) override;
         virtual void Execute(
             uint32_t                               frame_index,
             Rendering::Scenes::SceneRawData* const scene_data,
@@ -77,13 +77,13 @@ namespace ZEngine::Rendering::Renderers
         const std::vector<uint32_t>              m_index_data        = {0, 1, 2, 2, 3, 0, 1, 5, 6, 6, 2, 1, 7, 6, 5, 5, 4, 7, 4, 0, 3, 3, 7, 4, 4, 5, 1, 1, 0, 4, 3, 2, 6, 6, 7, 3};
         const std::vector<DrawData>              m_draw_data         = {DrawData{.VertexOffset = 0, .IndexOffset = 0, .VertexCount = 8, .IndexCount = 36}};
         const std::vector<VkDrawIndirectCommand> m_indirect_commmand = {VkDrawIndirectCommand{.vertexCount = 36, .instanceCount = 1, .firstVertex = 0, .firstInstance = 0}};
-        Ref<Textures::Texture>                   m_environment_map;
+        Helpers::Ref<Textures::Texture>          m_environment_map;
     };
 
     struct GridPass : public IRenderGraphCallbackPass, public IndirectRenderingStorage
     {
         virtual void Setup(std::string_view name, RenderGraphBuilder* const builder) override;
-        virtual void Compile(Ref<RenderPasses::RenderPass>& handle, RenderPasses::RenderPassBuilder& builder, RenderGraph& graph) override;
+        virtual void Compile(Helpers::Ref<RenderPasses::RenderPass>& handle, RenderPasses::RenderPassBuilder& builder, RenderGraph& graph) override;
         virtual void Execute(
             uint32_t                               frame_index,
             Rendering::Scenes::SceneRawData* const scene_data,
@@ -102,7 +102,7 @@ namespace ZEngine::Rendering::Renderers
     struct GbufferPass : public IRenderGraphCallbackPass, public IndirectRenderingStorage
     {
         virtual void Setup(std::string_view name, RenderGraphBuilder* const builder) override;
-        virtual void Compile(Ref<RenderPasses::RenderPass>& handle, RenderPasses::RenderPassBuilder& builder, RenderGraph& graph) override;
+        virtual void Compile(Helpers::Ref<RenderPasses::RenderPass>& handle, RenderPasses::RenderPassBuilder& builder, RenderGraph& graph) override;
         virtual void Execute(
             uint32_t                               frame_index,
             Rendering::Scenes::SceneRawData* const scene_data,
@@ -114,7 +114,7 @@ namespace ZEngine::Rendering::Renderers
     struct LightingPass : public IRenderGraphCallbackPass, public IndirectRenderingStorage
     {
         virtual void Setup(std::string_view name, RenderGraphBuilder* const builder) override;
-        virtual void Compile(Ref<RenderPasses::RenderPass>& handle, RenderPasses::RenderPassBuilder& builder, RenderGraph& graph) override;
+        virtual void Compile(Helpers::Ref<RenderPasses::RenderPass>& handle, RenderPasses::RenderPassBuilder& builder, RenderGraph& graph) override;
         virtual void Execute(
             uint32_t                               frame_index,
             Rendering::Scenes::SceneRawData* const scene_data,
@@ -132,10 +132,10 @@ namespace ZEngine::Rendering::Renderers
         void Deinitialize();
 
     private:
-        Ref<SceneDepthPrePass> m_scene_depth_prepass;
-        Ref<SkyboxPass>        m_skybox_pass;
-        Ref<GridPass>          m_grid_pass;
-        Ref<GbufferPass>       m_gbuffer_pass;
-        Ref<LightingPass>      m_lighting_pass;
+        Helpers::Ref<SceneDepthPrePass> m_scene_depth_prepass;
+        Helpers::Ref<SkyboxPass>        m_skybox_pass;
+        Helpers::Ref<GridPass>          m_grid_pass;
+        Helpers::Ref<GbufferPass>       m_gbuffer_pass;
+        Helpers::Ref<LightingPass>      m_lighting_pass;
     };
 } // namespace ZEngine::Rendering::Renderers

--- a/ZEngine/ZEngine/Rendering/Scenes/GraphicScene.cpp
+++ b/ZEngine/ZEngine/Rendering/Scenes/GraphicScene.cpp
@@ -11,6 +11,7 @@
 #define INVALID_NODE_ID -1
 
 using namespace ZEngine::Rendering::Components;
+using namespace ZEngine::Helpers;
 
 namespace ZEngine::Rendering::Scenes
 {

--- a/ZEngine/ZEngine/Rendering/Scenes/GraphicScene.h
+++ b/ZEngine/ZEngine/Rendering/Scenes/GraphicScene.h
@@ -74,7 +74,7 @@ namespace ZEngine::Rendering::Scenes
     struct SceneEntity : public Helpers::RefCounted
     {
         SceneEntity() = default;
-        SceneEntity(int node, WeakRef<Scenes::SceneRawData> scene) : m_node(node), m_weak_scene(scene) {}
+        SceneEntity(int node, Helpers::WeakRef<Scenes::SceneRawData> scene) : m_node(node), m_weak_scene(scene) {}
         ~SceneEntity() = default;
 
         void             SetName(std::string_view name);
@@ -134,8 +134,8 @@ namespace ZEngine::Rendering::Scenes
         }
 
     private:
-        int                           m_node{-1};
-        WeakRef<Scenes::SceneRawData> m_weak_scene;
+        int                                    m_node{-1};
+        Helpers::WeakRef<Scenes::SceneRawData> m_weak_scene;
     };
 
     struct GraphicScene : public Helpers::RefCounted
@@ -175,17 +175,17 @@ namespace ZEngine::Rendering::Scenes
         /*
          * Scene Graph operations
          */
-        static bool              HasSceneNodes();
-        static uint32_t          GetSceneNodeCount() = delete;
-        static std::vector<int>  GetRootSceneNodes();
-        static Ref<SceneRawData> GetRawData();
-        static void              SetRawData(Ref<SceneRawData>&& data);
-        static void              ComputeAllTransforms();
+        static bool                       HasSceneNodes();
+        static uint32_t                   GetSceneNodeCount() = delete;
+        static std::vector<int>           GetRootSceneNodes();
+        static Helpers::Ref<SceneRawData> GetRawData();
+        static void                       SetRawData(Helpers::Ref<SceneRawData>&& data);
+        static void                       ComputeAllTransforms();
 
     private:
-        static Ref<SceneRawData>    s_raw_data;
-        static Ref<entt::registry>  s_entities;
-        static std::recursive_mutex s_scene_node_mutex;
+        static Helpers::Ref<SceneRawData>   s_raw_data;
+        static Helpers::Ref<entt::registry> s_entities;
+        static std::recursive_mutex         s_scene_node_mutex;
         friend class ZEngine::Serializers::GraphicScene3DSerializer;
 
     private:

--- a/ZEngine/ZEngine/Rendering/Shaders/Compilers/CompilationStage.cpp
+++ b/ZEngine/ZEngine/Rendering/Shaders/Compilers/CompilationStage.cpp
@@ -5,6 +5,8 @@
 #include <Rendering/Shaders/Compilers/CompilationStage.h>
 #include <Rendering/Shaders/Compilers/ValidationStage.h>
 
+using namespace ZEngine::Helpers;
+
 namespace ZEngine::Rendering::Shaders::Compilers
 {
     const TBuiltInResource DefaultTBuiltInResource = {

--- a/ZEngine/ZEngine/Rendering/Shaders/Compilers/ShaderCompiler.cpp
+++ b/ZEngine/ZEngine/Rendering/Shaders/Compilers/ShaderCompiler.cpp
@@ -4,6 +4,8 @@
 #include <Rendering/Shaders/Compilers/CompilationStage.h>
 #include <Rendering/Shaders/Compilers/ShaderCompiler.h>
 
+using namespace ZEngine::Helpers;
+
 namespace ZEngine::Rendering::Shaders::Compilers
 {
 

--- a/ZEngine/ZEngine/Rendering/Shaders/Compilers/ShaderCompiler.h
+++ b/ZEngine/ZEngine/Rendering/Shaders/Compilers/ShaderCompiler.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <Core/IPipeline.h>
+#include <Helpers/IntrusivePtr.h>
 #include <Rendering/Shaders/ShaderReader.h>
-#include <ZEngineDef.h>
 #include <future>
 #include <mutex>
 
@@ -38,8 +38,8 @@ namespace ZEngine::Rendering::Shaders::Compilers
         std::future<ShaderCompilerResult> CompileAsync();
 
     private:
-        std::string          m_source_file;
-        Scope<ShaderReader>  m_reader{nullptr};
-        std::recursive_mutex m_mutex;
+        std::string                  m_source_file;
+        Helpers::Scope<ShaderReader> m_reader{nullptr};
+        std::recursive_mutex         m_mutex;
     };
 } // namespace ZEngine::Rendering::Shaders::Compilers

--- a/ZEngine/ZEngine/Rendering/Shaders/Compilers/ValidationStage.cpp
+++ b/ZEngine/ZEngine/Rendering/Shaders/Compilers/ValidationStage.cpp
@@ -4,6 +4,8 @@
 #include <Rendering/Shaders/Compilers/ShaderFileGenerator.h>
 #include <Rendering/Shaders/Compilers/ValidationStage.h>
 
+using namespace ZEngine::Helpers;
+
 namespace ZEngine::Rendering::Shaders::Compilers
 {
 

--- a/ZEngine/ZEngine/Rendering/Shaders/Shader.cpp
+++ b/ZEngine/ZEngine/Rendering/Shaders/Shader.cpp
@@ -8,6 +8,7 @@
 #include <vulkan/vulkan.h>
 
 using namespace ZEngine::Rendering::Specifications;
+using namespace ZEngine::Helpers;
 
 namespace ZEngine::Rendering::Shaders
 {

--- a/ZEngine/ZEngine/Rendering/Shaders/Shader.h
+++ b/ZEngine/ZEngine/Rendering/Shaders/Shader.h
@@ -26,8 +26,8 @@ namespace ZEngine::Rendering::Shaders
         const std::vector<VkPushConstantRange>&                                            GetPushConstants() const;
         void                                                                               Dispose();
 
-        static Ref<Shader> Create(Specifications::ShaderSpecification&& spec);
-        static Ref<Shader> Create(const Specifications::ShaderSpecification& spec);
+        static Helpers::Ref<Shader> Create(Specifications::ShaderSpecification&& spec);
+        static Helpers::Ref<Shader> Create(const Specifications::ShaderSpecification& spec);
 
     private:
         void CreateModule();

--- a/ZEngine/ZEngine/Rendering/Specifications/FrameBufferSpecification.h
+++ b/ZEngine/ZEngine/Rendering/Specifications/FrameBufferSpecification.h
@@ -7,13 +7,13 @@ namespace ZEngine::Rendering::Specifications
 {
     struct FrameBufferSpecificationVNext
     {
-        float                                    ClearColorValue[4] = {0.1f, 0.1f, 0.1f, 1.0f};
-        float                                    ClearDepthValue[2] = {1.0f, 0.0f};
-        uint32_t                                 Width              = 1;
-        uint32_t                                 Height             = 1;
-        uint32_t                                 Layers             = 1;
-        std::vector<VkImageView>                 RenderTargetViews  = {};
-        Ref<Renderers::RenderPasses::Attachment> Attachment         = {};
+        float                                             ClearColorValue[4] = {0.1f, 0.1f, 0.1f, 1.0f};
+        float                                             ClearDepthValue[2] = {1.0f, 0.0f};
+        uint32_t                                          Width              = 1;
+        uint32_t                                          Height             = 1;
+        uint32_t                                          Layers             = 1;
+        std::vector<VkImageView>                          RenderTargetViews  = {};
+        Helpers::Ref<Renderers::RenderPasses::Attachment> Attachment         = {};
     };
 
 } // namespace ZEngine::Rendering::Specifications

--- a/ZEngine/ZEngine/Rendering/Specifications/GraphicRendererPipelineSpecification.h
+++ b/ZEngine/ZEngine/Rendering/Specifications/GraphicRendererPipelineSpecification.h
@@ -1,9 +1,9 @@
 #pragma once
+#include <Helpers/IntrusivePtr.h>
 #include <Rendering/Buffers/Framebuffer.h>
 #include <Rendering/Renderers/RenderPasses/Attachment.h>
 #include <Rendering/Specifications/ShaderSpecification.h>
 #include <Rendering/Swapchain.h>
-#include <ZEngineDef.h>
 
 namespace ZEngine::Rendering::Specifications
 {
@@ -24,16 +24,16 @@ namespace ZEngine::Rendering::Specifications
 
     struct GraphicRendererPipelineSpecification
     {
-        bool                                           EnableBlending                     = false;
-        bool                                           EnableDepthTest                    = false;
-        bool                                           EnableDepthWrite                   = true;
-        bool                                           EnableStencilTest                  = false;
-        const char*                                    DebugName                          = {};
-        ShaderSpecification                            ShaderSpecification                = {};
-        Ref<Rendering::Buffers::FramebufferVNext>      TargetFrameBuffer                  = {};
-        Ref<Rendering::Swapchain>                      SwapchainRenderTarget              = {};
-        Ref<Renderers::RenderPasses::Attachment>       Attachment                         = {};
-        std::vector<VertexInputBindingSpecification>   VertexInputBindingSpecifications   = {};
-        std::vector<VertexInputAttributeSpecification> VertexInputAttributeSpecifications = {};
+        bool                                               EnableBlending                     = false;
+        bool                                               EnableDepthTest                    = false;
+        bool                                               EnableDepthWrite                   = true;
+        bool                                               EnableStencilTest                  = false;
+        const char*                                        DebugName                          = {};
+        ShaderSpecification                                ShaderSpecification                = {};
+        Helpers::Ref<Rendering::Buffers::FramebufferVNext> TargetFrameBuffer                  = {};
+        Helpers::Ref<Rendering::Swapchain>                 SwapchainRenderTarget              = {};
+        Helpers::Ref<Renderers::RenderPasses::Attachment>  Attachment                         = {};
+        std::vector<VertexInputBindingSpecification>       VertexInputBindingSpecifications   = {};
+        std::vector<VertexInputAttributeSpecification>     VertexInputAttributeSpecifications = {};
     };
 } // namespace ZEngine::Rendering::Specifications

--- a/ZEngine/ZEngine/Rendering/Specifications/RenderPassSpecification.h
+++ b/ZEngine/ZEngine/Rendering/Specifications/RenderPassSpecification.h
@@ -1,8 +1,8 @@
 #pragma once
+#include <Helpers/IntrusivePtr.h>
 #include <Rendering/Specifications/GraphicRendererPipelineSpecification.h>
 #include <Rendering/Specifications/TextureSpecification.h>
 #include <Rendering/Textures/Texture.h>
-#include <ZEngineDef.h>
 #include <unordered_map>
 #include <vector>
 
@@ -10,12 +10,12 @@ namespace ZEngine::Rendering::Specifications
 {
     struct RenderPassSpecification
     {
-        const char*                                             DebugName               = {};
-        bool                                                    SwapchainAsRenderTarget = false;
-        Specifications::GraphicRendererPipelineSpecification    PipelineSpecification   = {};
-        std::vector<Ref<Textures::Texture>>                     Inputs                  = {};
-        std::unordered_map<std::string, Ref<Textures::Texture>> InputTextures           = {};
-        std::vector<Specifications::TextureSpecification>       Outputs                 = {};
-        std::vector<Ref<Textures::Texture>>                     ExternalOutputs         = {};
+        const char*                                                      DebugName               = {};
+        bool                                                             SwapchainAsRenderTarget = false;
+        Specifications::GraphicRendererPipelineSpecification             PipelineSpecification   = {};
+        std::vector<Helpers::Ref<Textures::Texture>>                     Inputs                  = {};
+        std::unordered_map<std::string, Helpers::Ref<Textures::Texture>> InputTextures           = {};
+        std::vector<Specifications::TextureSpecification>                Outputs                 = {};
+        std::vector<Helpers::Ref<Textures::Texture>>                     ExternalOutputs         = {};
     };
 } // namespace ZEngine::Rendering::Specifications

--- a/ZEngine/ZEngine/Rendering/Swapchain.cpp
+++ b/ZEngine/ZEngine/Rendering/Swapchain.cpp
@@ -6,6 +6,7 @@
 #include <random>
 
 using namespace ZEngine::Rendering::Specifications;
+using namespace ZEngine::Helpers;
 
 namespace ZEngine::Rendering
 {

--- a/ZEngine/ZEngine/Rendering/Swapchain.h
+++ b/ZEngine/ZEngine/Rendering/Swapchain.h
@@ -24,29 +24,29 @@ namespace ZEngine::Rendering
         VkSwapchainKHR GetHandle() const;
         uint64_t       GetIdentifier() const;
 
-        Ref<Renderers::RenderPasses::Attachment> GetAttachment() const;
+        Helpers::Ref<Renderers::RenderPasses::Attachment> GetAttachment() const;
 
     private:
         void Create();
         void Dispose();
 
-        uint32_t                                 m_current_frame_index{0};
-        uint32_t                                 m_last_frame_image_index{0};
-        VkSwapchainKHR                           m_handle{VK_NULL_HANDLE};
-        uint32_t                                 m_image_width{0};
-        uint32_t                                 m_image_height{0};
-        uint32_t                                 m_min_image_count{0};
-        uint32_t                                 m_image_count{0};
-        Ref<Renderers::RenderPasses::Attachment> m_attachment;
-        std::vector<uint32_t>                    m_queue_family_index_collection;
-        std::vector<VkImage>                     m_image_collection;
-        std::vector<VkImageView>                 m_image_view_collection;
-        std::vector<VkFramebuffer>               m_framebuffer_collection;
-        std::vector<Ref<Primitives::Semaphore>>  m_acquired_semaphore_collection;
-        std::vector<Ref<Primitives::Semaphore>>  m_render_complete_semaphore_collection;
-        std::vector<Ref<Primitives::Fence>>      m_frame_signal_fence_collection;
-        std::vector<Primitives::Semaphore*>      m_wait_semaphore_collection;
-        std::mutex                               m_image_mutex;
-        uint64_t                                 m_identifier{0};
+        uint32_t                                          m_current_frame_index{0};
+        uint32_t                                          m_last_frame_image_index{0};
+        VkSwapchainKHR                                    m_handle{VK_NULL_HANDLE};
+        uint32_t                                          m_image_width{0};
+        uint32_t                                          m_image_height{0};
+        uint32_t                                          m_min_image_count{0};
+        uint32_t                                          m_image_count{0};
+        Helpers::Ref<Renderers::RenderPasses::Attachment> m_attachment;
+        std::vector<uint32_t>                             m_queue_family_index_collection;
+        std::vector<VkImage>                              m_image_collection;
+        std::vector<VkImageView>                          m_image_view_collection;
+        std::vector<VkFramebuffer>                        m_framebuffer_collection;
+        std::vector<Helpers::Ref<Primitives::Semaphore>>  m_acquired_semaphore_collection;
+        std::vector<Helpers::Ref<Primitives::Semaphore>>  m_render_complete_semaphore_collection;
+        std::vector<Helpers::Ref<Primitives::Fence>>      m_frame_signal_fence_collection;
+        std::vector<Primitives::Semaphore*>               m_wait_semaphore_collection;
+        std::mutex                                        m_image_mutex;
+        uint64_t                                          m_identifier{0};
     };
 } // namespace ZEngine::Rendering

--- a/ZEngine/ZEngine/Rendering/Textures/Texture.h
+++ b/ZEngine/ZEngine/Rendering/Textures/Texture.h
@@ -73,23 +73,23 @@ namespace ZEngine::Rendering::Textures
     {
         TextureArray(uint32_t count = 0) : m_texture_array(count), m_count(count) {}
 
-        Ref<Texture>& operator[](uint32_t index)
+        Helpers::Ref<Texture>& operator[](uint32_t index)
         {
             assert(index < m_texture_array.size());
             return m_texture_array[index];
         }
 
-        const std::vector<Ref<Texture>>& Data() const
+        const std::vector<Helpers::Ref<Texture>>& Data() const
         {
             return m_texture_array;
         }
 
-        std::vector<Ref<Texture>>& Data()
+        std::vector<Helpers::Ref<Texture>>& Data()
         {
             return m_texture_array;
         }
 
-        int Add(const Ref<Texture>& texture)
+        int Add(const Helpers::Ref<Texture>& texture)
         {
             int output_index = -1;
 
@@ -102,7 +102,7 @@ namespace ZEngine::Rendering::Textures
             return output_index;
         }
 
-        int Add(Ref<Texture>&& texture)
+        int Add(Helpers::Ref<Texture>&& texture)
         {
             int output_index = -1;
 
@@ -134,9 +134,9 @@ namespace ZEngine::Rendering::Textures
         }
 
     private:
-        uint32_t                  m_count{0};
-        uint32_t                  m_free_slot_index{0};
-        std::vector<Ref<Texture>> m_texture_array;
+        uint32_t                           m_count{0};
+        uint32_t                           m_free_slot_index{0};
+        std::vector<Helpers::Ref<Texture>> m_texture_array;
     };
 
     /*

--- a/ZEngine/ZEngine/Rendering/Textures/Texture2D.cpp
+++ b/ZEngine/ZEngine/Rendering/Textures/Texture2D.cpp
@@ -16,6 +16,8 @@
 #include <stb/stb_image_resize.h>
 #include <stb/stb_image_write.h>
 
+using namespace ZEngine::Helpers;
+
 namespace ZEngine::Rendering::Textures
 {
 

--- a/ZEngine/ZEngine/Rendering/Textures/Texture2D.h
+++ b/ZEngine/ZEngine/Rendering/Textures/Texture2D.h
@@ -12,22 +12,22 @@ namespace ZEngine::Rendering::Textures
         Texture2D() = default;
         virtual ~Texture2D();
 
-        static Ref<Texture2D>              Create(const Specifications::TextureSpecification& spec);
-        static Ref<Texture2D>              Create(uint32_t width = 1, uint32_t height = 1);
-        static Ref<Texture2D>              Create(uint32_t width, uint32_t height, float r, float g, float b, float a);
-        static Ref<Texture2D>              Read(std::string_view filename);
-        static Ref<Texture2D>              ReadCubemap(std::string_view filename);
-        static std::future<Ref<Texture2D>> ReadAsync(std::string_view filename);
+        static Helpers::Ref<Texture2D>              Create(const Specifications::TextureSpecification& spec);
+        static Helpers::Ref<Texture2D>              Create(uint32_t width = 1, uint32_t height = 1);
+        static Helpers::Ref<Texture2D>              Create(uint32_t width, uint32_t height, float r, float g, float b, float a);
+        static Helpers::Ref<Texture2D>              Read(std::string_view filename);
+        static Helpers::Ref<Texture2D>              ReadCubemap(std::string_view filename);
+        static std::future<Helpers::Ref<Texture2D>> ReadAsync(std::string_view filename);
 
         virtual Hardwares::BufferImage&       GetBuffer() override;
         virtual const Hardwares::BufferImage& GetBuffer() const override;
-        Ref<Buffers::Image2DBuffer>           GetImage2DBuffer() const;
+        Helpers::Ref<Buffers::Image2DBuffer>  GetImage2DBuffer() const;
         virtual void                          Dispose() override;
 
     protected:
-        static void FillAsVulkanImage(Ref<Texture2D>& texture, const Specifications::TextureSpecification& specification);
+        static void FillAsVulkanImage(Helpers::Ref<Texture2D>& texture, const Specifications::TextureSpecification& specification);
 
     private:
-        Ref<Buffers::Image2DBuffer> m_image_2d_buffer;
+        Helpers::Ref<Buffers::Image2DBuffer> m_image_2d_buffer;
     };
 } // namespace ZEngine::Rendering::Textures

--- a/ZEngine/ZEngine/Serializers/GraphicScene3DSerializer.cpp
+++ b/ZEngine/ZEngine/Serializers/GraphicScene3DSerializer.cpp
@@ -78,7 +78,7 @@ namespace YAML
 
 namespace ZEngine::Serializers
 {
-    GraphicScene3DSerializer::GraphicScene3DSerializer(const Ref<GraphicScene>& scene) : GraphicSceneSerializer()
+    GraphicScene3DSerializer::GraphicScene3DSerializer(const Helpers::Ref<GraphicScene>& scene) : GraphicSceneSerializer()
     {
         m_scene                        = scene;
         auto directory                 = fmt::format("{0}/{1}", std::filesystem::current_path().string(), "Scenes");

--- a/ZEngine/ZEngine/Serializers/GraphicScene3DSerializer.h
+++ b/ZEngine/ZEngine/Serializers/GraphicScene3DSerializer.h
@@ -32,7 +32,7 @@ namespace ZEngine::Serializers
     class GraphicScene3DSerializer : public GraphicSceneSerializer
     {
     public:
-        GraphicScene3DSerializer(const Ref<ZEngine::Rendering::Scenes::GraphicScene>& scene);
+        GraphicScene3DSerializer(const Helpers::Ref<ZEngine::Rendering::Scenes::GraphicScene>& scene);
         virtual ~GraphicScene3DSerializer() = default;
 
         Core::SerializeInformation Serialize(std::string_view filename) override;

--- a/ZEngine/ZEngine/Serializers/GraphicSceneSerializer.h
+++ b/ZEngine/ZEngine/Serializers/GraphicSceneSerializer.h
@@ -12,7 +12,7 @@ namespace ZEngine::Serializers
         virtual ~GraphicSceneSerializer() = default;
 
     protected:
-        std::filesystem::path                             m_default_scene_directory_path;
-        WeakRef<ZEngine::Rendering::Scenes::GraphicScene> m_scene;
+        std::filesystem::path                                      m_default_scene_directory_path;
+        Helpers::WeakRef<ZEngine::Rendering::Scenes::GraphicScene> m_scene;
     };
 } // namespace ZEngine::Serializers

--- a/ZEngine/ZEngine/Windows/CoreWindow.cpp
+++ b/ZEngine/ZEngine/Windows/CoreWindow.cpp
@@ -2,6 +2,7 @@
 #include <CoreWindow.h>
 
 using namespace ZEngine::Windows::Layers;
+using namespace ZEngine::Helpers;
 
 namespace ZEngine::Windows
 {

--- a/ZEngine/ZEngine/Windows/CoreWindow.h
+++ b/ZEngine/ZEngine/Windows/CoreWindow.h
@@ -7,6 +7,7 @@
 #include <Core/IRenderable.h>
 #include <Core/IUpdatable.h>
 #include <Core/TimeStep.h>
+#include <Helpers/IntrusivePtr.h>
 #include <Inputs/IInputEventCallback.h>
 #include <Layers/Layer.h>
 #include <Layers/LayerStack.h>
@@ -52,10 +53,10 @@ namespace ZEngine::Windows
         virtual void                  SetCallbackFunction(const EventCallbackFn& callback) = 0;
         virtual const WindowProperty& GetWindowProperty() const                            = 0;
 
-        virtual bool                      CreateSurface(void* instance, void** out_window_surface) = 0;
-        virtual std::vector<std::string>  GetRequiredExtensionLayers()                             = 0;
-        virtual void*                     GetNativeWindow() const                                  = 0;
-        virtual Ref<Rendering::Swapchain> GetSwapchain() const                                     = 0;
+        virtual bool                               CreateSurface(void* instance, void** out_window_surface) = 0;
+        virtual std::vector<std::string>           GetRequiredExtensionLayers()                             = 0;
+        virtual void*                              GetNativeWindow() const                                  = 0;
+        virtual Helpers::Ref<Rendering::Swapchain> GetSwapchain() const                                     = 0;
 
         virtual void  PollEvent()    = 0;
         virtual float GetTime()      = 0;
@@ -63,15 +64,15 @@ namespace ZEngine::Windows
 
         virtual void ForwardEventToLayers(Core::CoreEvent& event);
 
-        virtual void PushOverlayLayer(const Ref<Layers::Layer>& layer);
-        virtual void PushOverlayLayer(Ref<Layers::Layer>&& layer);
-        virtual void PushLayer(const Ref<Layers::Layer>& layer);
-        virtual void PushLayer(Ref<Layers::Layer>&& layer);
+        virtual void PushOverlayLayer(const Helpers::Ref<Layers::Layer>& layer);
+        virtual void PushOverlayLayer(Helpers::Ref<Layers::Layer>&& layer);
+        virtual void PushLayer(const Helpers::Ref<Layers::Layer>& layer);
+        virtual void PushLayer(Helpers::Ref<Layers::Layer>&& layer);
 
     protected:
         Core::TimeStep                     m_delta_time;
         WindowProperty                     m_property;
-        ZEngine::Scope<Layers::LayerStack> m_layer_stack_ptr{nullptr};
+        Helpers::Scope<Layers::LayerStack> m_layer_stack_ptr{nullptr};
     };
 
     CoreWindow* Create(const WindowConfiguration&);

--- a/ZEngine/ZEngine/Windows/Inputs/IDevice.cpp
+++ b/ZEngine/ZEngine/Windows/Inputs/IDevice.cpp
@@ -3,5 +3,5 @@
 
 namespace ZEngine::Windows::Inputs
 {
-    std::unordered_map<std::string, Ref<IDevice>> IDevice::m_devices;
+    std::unordered_map<std::string, Helpers::Ref<IDevice>> IDevice::m_devices;
 }

--- a/ZEngine/ZEngine/Windows/Inputs/IDevice.h
+++ b/ZEngine/ZEngine/Windows/Inputs/IDevice.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <CoreWindow.h>
 #include <KeyCode.h>
-#include <ZEngineDef.h>
 #include <algorithm>
 #include <memory>
 #include <string>
@@ -28,14 +27,14 @@ namespace ZEngine::Windows::Inputs
                 return reinterpret_cast<T*>(it->second.get());
             }
 
-            Ref<IDevice> device_ptr = CreateRef<T>();
+            Helpers::Ref<IDevice> device_ptr = CreateRef<T>();
 
             auto pair = m_devices.emplace(std::make_pair(std::string(type.name()), std::move(device_ptr)));
             return reinterpret_cast<T*>(pair.first->second.get());
         }
 
-        virtual bool IsKeyPressed(ZENGINE_KEYCODE key, const Ref<Windows::CoreWindow>& window) const  = 0;
-        virtual bool IsKeyReleased(ZENGINE_KEYCODE key, const Ref<Windows::CoreWindow>& window) const = 0;
+        virtual bool IsKeyPressed(ZENGINE_KEYCODE key, const Helpers::Ref<Windows::CoreWindow>& window) const  = 0;
+        virtual bool IsKeyReleased(ZENGINE_KEYCODE key, const Helpers::Ref<Windows::CoreWindow>& window) const = 0;
 
         virtual std::string_view GetName() const
         {
@@ -44,7 +43,7 @@ namespace ZEngine::Windows::Inputs
 
     protected:
         IDevice(std::string_view name = "abstract_device") : m_name(name) {}
-        static std::unordered_map<std::string, Ref<IDevice>> m_devices;
-        std::string                                          m_name;
+        static std::unordered_map<std::string, Helpers::Ref<IDevice>> m_devices;
+        std::string                                                   m_name;
     };
 } // namespace ZEngine::Windows::Inputs

--- a/ZEngine/ZEngine/Windows/Inputs/IDevice.h
+++ b/ZEngine/ZEngine/Windows/Inputs/IDevice.h
@@ -27,7 +27,7 @@ namespace ZEngine::Windows::Inputs
                 return reinterpret_cast<T*>(it->second.get());
             }
 
-            Helpers::Ref<IDevice> device_ptr = CreateRef<T>();
+            Helpers::Ref<IDevice> device_ptr = Helpers::CreateRef<T>();
 
             auto pair = m_devices.emplace(std::make_pair(std::string(type.name()), std::move(device_ptr)));
             return reinterpret_cast<T*>(pair.first->second.get());

--- a/ZEngine/ZEngine/Windows/Layers/Layer.h
+++ b/ZEngine/ZEngine/Windows/Layers/Layer.h
@@ -27,12 +27,12 @@ namespace ZEngine::Windows::Layers
             return m_name;
         }
 
-        void SetAttachedWindow(const ZEngine::Ref<Windows::CoreWindow>& window)
+        void SetAttachedWindow(const Helpers::Ref<Windows::CoreWindow>& window)
         {
             m_window = window;
         }
 
-        ZEngine::Ref<ZEngine::Windows::CoreWindow> GetAttachedWindow() const
+        Helpers::Ref<ZEngine::Windows::CoreWindow> GetAttachedWindow() const
         {
             if (!m_window.expired())
                 return m_window.lock();
@@ -42,6 +42,6 @@ namespace ZEngine::Windows::Layers
 
     protected:
         std::string                                    m_name;
-        ZEngine::WeakRef<ZEngine::Windows::CoreWindow> m_window;
+        Helpers::WeakRef<ZEngine::Windows::CoreWindow> m_window;
     };
 } // namespace ZEngine::Windows::Layers

--- a/ZEngine/ZEngine/Windows/Layers/LayerStack.cpp
+++ b/ZEngine/ZEngine/Windows/Layers/LayerStack.cpp
@@ -1,6 +1,8 @@
 #include <pch.h>
 #include <LayerStack.h>
 
+using namespace ZEngine::Helpers;
+
 namespace ZEngine::Windows::Layers
 {
 

--- a/ZEngine/ZEngine/Windows/Layers/LayerStack.h
+++ b/ZEngine/ZEngine/Windows/Layers/LayerStack.h
@@ -1,6 +1,6 @@
 #pragma once
+#include <Helpers/IntrusivePtr.h>
 #include <Layers/Layer.h>
-#include <ZEngineDef.h>
 #include <vector>
 
 namespace ZEngine::Windows::Layers
@@ -13,43 +13,43 @@ namespace ZEngine::Windows::Layers
         LayerStack() = default;
         ~LayerStack();
 
-        void PushLayer(const Ref<Layer>& layer);
-        void PushLayer(Ref<Layer>&& layer);
+        void PushLayer(const Helpers::Ref<Layer>& layer);
+        void PushLayer(Helpers::Ref<Layer>&& layer);
 
-        void PushOverlayLayer(const Ref<Layer>& layer);
-        void PushOverlayLayer(Ref<Layer>&& layer);
+        void PushOverlayLayer(const Helpers::Ref<Layer>& layer);
+        void PushOverlayLayer(Helpers::Ref<Layer>&& layer);
 
-        void PopLayer(const Ref<Layer>& layer);
-        void PopLayer(Ref<Layer>&& layer);
+        void PopLayer(const Helpers::Ref<Layer>& layer);
+        void PopLayer(Helpers::Ref<Layer>&& layer);
 
         void PopLayer();
 
         void PopOverlayLayer();
 
-        void PopOverlayLayer(const Ref<Layer>& layer);
-        void PopOverlayLayer(Ref<Layer>&& layer);
+        void PopOverlayLayer(const Helpers::Ref<Layer>& layer);
+        void PopOverlayLayer(Helpers::Ref<Layer>&& layer);
 
     public:
-        std::vector<Ref<Layer>>::iterator begin()
+        std::vector<Helpers::Ref<Layer>>::iterator begin()
         {
             return std::begin(m_layers);
         }
-        std::vector<Ref<Layer>>::iterator end()
+        std::vector<Helpers::Ref<Layer>>::iterator end()
         {
             return std::end(m_layers);
         }
 
-        std::vector<Ref<Layer>>::reverse_iterator rbegin()
+        std::vector<Helpers::Ref<Layer>>::reverse_iterator rbegin()
         {
             return std::rbegin(m_layers);
         }
-        std::vector<Ref<Layer>>::reverse_iterator rend()
+        std::vector<Helpers::Ref<Layer>>::reverse_iterator rend()
         {
             return std::rend(m_layers);
         }
 
     private:
-        std::vector<Ref<Layer>>           m_layers;
-        std::vector<Ref<Layer>>::iterator current_it;
+        std::vector<Helpers::Ref<Layer>>           m_layers;
+        std::vector<Helpers::Ref<Layer>>::iterator current_it;
     };
 } // namespace ZEngine::Windows::Layers

--- a/ZEngine/ZEngine/Windows/WindowConfiguration.h
+++ b/ZEngine/ZEngine/Windows/WindowConfiguration.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <ZEngineDef.h>
+#include <Helpers/IntrusivePtr.h>
 #include <string>
 #include <vector>
 
@@ -16,8 +16,8 @@ namespace ZEngine::Windows
         uint32_t                                                   Height{800};
         bool                                                       EnableVsync{true};
         std::string                                                Title;
-        std::vector<ZEngine::Ref<ZEngine::Windows::Layers::Layer>> RenderingLayerCollection;
-        std::vector<ZEngine::Ref<ZEngine::Windows::Layers::Layer>> OverlayLayerCollection;
+        std::vector<Helpers::Ref<ZEngine::Windows::Layers::Layer>> RenderingLayerCollection;
+        std::vector<Helpers::Ref<ZEngine::Windows::Layers::Layer>> OverlayLayerCollection;
     };
 
 } // namespace ZEngine::Windows

--- a/ZEngine/ZEngine/ZEngineDef.h
+++ b/ZEngine/ZEngine/ZEngineDef.h
@@ -1,38 +1,10 @@
 #pragma once
-#include <Helpers/IntrusivePtr.h>
-#include <stdlib.h>
-#include <memory>
+#include <Logging/LoggerDefinition.h>
 
 #define BIT(x)                 (1 << (x))
 #define ZENGINE_EXIT_FAILURE() exit(EXIT_FAILURE);
 
 #define ZENGINE_KEYCODE ZEngine::Windows::Inputs::GlfwKeyCode
-
-namespace ZEngine
-{
-    template <typename T>
-    using Ref = Helpers::IntrusivePtr<T>;
-
-    template <typename T>
-    using WeakRef = Helpers::IntrusiveWeakPtr<T>;
-
-    template <typename T>
-    using Scope = std::unique_ptr<T>;
-
-    template <typename T, typename... Args>
-    Ref<T> CreateRef(Args&&... args)
-    {
-        return Helpers::make_intrusive<T>(std::forward<Args>(args)...);
-    }
-
-    template <typename T, typename... Args>
-    Scope<T> CreateScope(Args&&... args)
-    {
-        return std::make_unique<T>(std::forward<Args>(args)...);
-    }
-} // namespace ZEngine
-
-#include "Logging/LoggerDefinition.h"
 
 #ifdef _MSC_VER
 #define ZENGINE_DEBUG_BREAK() __debugbreak();


### PR DESCRIPTION
In this PR we are reshaping the intrusive Ptr public api.
we moved the defined namespace aliases (Ref, Scope) into Helpers/IntrusivePtr header, and this has the consequences of updating all the codebase to consume the new namespace.