### PR TITLE
Fixing import model and serialization logic

### DIFF
--- a/Tetragrama/Components/DockspaceUIComponent.cpp
+++ b/Tetragrama/Components/DockspaceUIComponent.cpp
@@ -53,18 +53,7 @@ namespace Tetragrama::Components
         m_default_import_configuration.OutputMaterialsPath.init(&(parent->LayerArena), editor_config.SceneDataPath.c_str());
         m_default_import_configuration.OutputTextureFilesPath.init(&(parent->LayerArena), editor_config.DefaultImportTexturePath.c_str());
 
-#ifdef _WIN32
-        std::replace(m_default_import_configuration.OutputModelFilePath.begin(), m_default_import_configuration.OutputModelFilePath.end(), '/', '\\');
-        std::replace(m_default_import_configuration.OutputMeshFilePath.begin(), m_default_import_configuration.OutputMeshFilePath.end(), '/', '\\');
-        std::replace(m_default_import_configuration.OutputTextureFilesPath.begin(), m_default_import_configuration.OutputTextureFilesPath.end(), '/', '\\');
-        std::replace(m_default_import_configuration.OutputMaterialsPath.begin(), m_default_import_configuration.OutputMaterialsPath.end(), '/', '\\');
-#endif // _WIN32
-
-        auto editor_serializer_default_output = fmt::format("{0}/{1}", editor_config.WorkingSpacePath.c_str(), editor_config.ScenePath.c_str());
-
-#ifdef _WIN32
-        std::replace(editor_serializer_default_output.begin(), editor_serializer_default_output.end(), '/', '\\');
-#endif // _WIN32
+        auto editor_serializer_default_output = fmt::format("{0}{1}{2}", editor_config.WorkingSpacePath.c_str(), PLATFORM_OS_BACKSLASH, editor_config.ScenePath.c_str());
 
         m_editor_serializer->SetDefaultOutput(editor_serializer_default_output);
         m_editor_serializer->SetOnProgressCallback(OnEditorSceneSerializerProgress);
@@ -539,9 +528,6 @@ namespace Tetragrama::Components
 
             if (!scene_filename.empty())
             {
-#ifdef _WIN32
-                std::replace(scene_filename.begin(), scene_filename.end(), '/', '\\'); // Todo : Move this replace into an helper function....
-#endif
                 m_editor_serializer->Deserialize(scene_filename);
             }
         }

--- a/Tetragrama/Components/DockspaceUIComponent.cpp
+++ b/Tetragrama/Components/DockspaceUIComponent.cpp
@@ -46,16 +46,12 @@ namespace Tetragrama::Components
 
         const auto& editor_config          = *context->ConfigurationPtr;
 
-        auto        o_model_fpath          = fmt::format("{0}/{1}", editor_config.WorkingSpacePath, editor_config.SceneDataPath);
-        auto        o_mesh_fpath           = fmt::format("{0}/{1}", editor_config.WorkingSpacePath, editor_config.SceneDataPath);
-        auto        o_texture_fpath        = fmt::format("{0}/{1}", editor_config.WorkingSpacePath, editor_config.DefaultImportTexturePath);
-        auto        o_material_fpath       = fmt::format("{0}/{1}", editor_config.WorkingSpacePath, editor_config.SceneDataPath);
-
         m_default_import_configuration     = {};
-        m_default_import_configuration.OutputModelFilePath.init(&(parent->LayerArena), o_model_fpath.c_str());
-        m_default_import_configuration.OutputMeshFilePath.init(&(parent->LayerArena), o_mesh_fpath.c_str());
-        m_default_import_configuration.OutputTextureFilesPath.init(&(parent->LayerArena), o_texture_fpath.c_str());
-        m_default_import_configuration.OutputMaterialsPath.init(&(parent->LayerArena), o_material_fpath.c_str());
+        m_default_import_configuration.OutputWorkingSpacePath.init(&(parent->LayerArena), editor_config.WorkingSpacePath.c_str());
+        m_default_import_configuration.OutputModelFilePath.init(&(parent->LayerArena), editor_config.SceneDataPath.c_str());
+        m_default_import_configuration.OutputMeshFilePath.init(&(parent->LayerArena), editor_config.SceneDataPath.c_str());
+        m_default_import_configuration.OutputMaterialsPath.init(&(parent->LayerArena), editor_config.SceneDataPath.c_str());
+        m_default_import_configuration.OutputTextureFilesPath.init(&(parent->LayerArena), editor_config.DefaultImportTexturePath.c_str());
 
 #ifdef _WIN32
         std::replace(m_default_import_configuration.OutputModelFilePath.begin(), m_default_import_configuration.OutputModelFilePath.end(), '/', '\\');
@@ -64,7 +60,7 @@ namespace Tetragrama::Components
         std::replace(m_default_import_configuration.OutputMaterialsPath.begin(), m_default_import_configuration.OutputMaterialsPath.end(), '/', '\\');
 #endif // _WIN32
 
-        auto editor_serializer_default_output = fmt::format("{0}/{1}", editor_config.WorkingSpacePath, editor_config.ScenePath);
+        auto editor_serializer_default_output = fmt::format("{0}/{1}", editor_config.WorkingSpacePath.c_str(), editor_config.ScenePath.c_str());
 
 #ifdef _WIN32
         std::replace(editor_serializer_default_output.begin(), editor_serializer_default_output.end(), '/', '\\');
@@ -424,23 +420,7 @@ namespace Tetragrama::Components
         /*
          * Removing the WorkingSpace Path
          */
-        // auto ws                           = context_ptr->ConfigurationPtr->WorkingSpacePath + "\\";
-        //  if (data.SerializedMeshesPath.find(ws) != std::string::npos)
-        //{
-        //      data.SerializedMeshesPath.replace(data.SerializedMeshesPath.find(ws), ws.size(), "");
-        //  }
-
-        // if (data.SerializedMaterialsPath.find(ws) != std::string::npos)
-        //{
-        //     data.SerializedMaterialsPath.replace(data.SerializedMaterialsPath.find(ws), ws.size(), "");
-        // }
-
-        // if (data.SerializedModelPath.find(ws) != std::string::npos)
-        //{
-        //     data.SerializedModelPath.replace(data.SerializedModelPath.find(ws), ws.size(), "");
-        // }
-        //
-        // context_ptr->CurrentScenePtr->Push(data.SerializedMeshesPath, data.SerializedModelPath, data.SerializedMaterialsPath);
+        context_ptr->CurrentScenePtr->Push(&(context_ptr->Arena), data.SerializedMeshesPath.c_str(), data.SerializedModelPath.c_str(), data.SerializedMaterialsPath.c_str());
     }
 
     void DockspaceUIComponent::OnAssetImporterProgress(void* const context, float value)
@@ -530,9 +510,11 @@ namespace Tetragrama::Components
         auto ctx = reinterpret_cast<EditorContext*>(context);
 
         // Todo : Ensure no data race on CurrentScenePtr
-        ZEngine::Helpers::secure_strcpy(ctx->ConfigurationPtr->ActiveSceneName, ZEngine::Helpers::secure_strlen(scene.Name), scene.Name);
+        ctx->ConfigurationPtr->ActiveSceneName.reserve(ZEngine::Helpers::secure_strlen(scene.Name));
+        ctx->ConfigurationPtr->ActiveSceneName.clear();
+        ctx->ConfigurationPtr->ActiveSceneName.append(scene.Name);
 
-        ctx->CurrentScenePtr->Name          = ctx->ConfigurationPtr->ActiveSceneName;
+        ctx->CurrentScenePtr->Name          = ctx->ConfigurationPtr->ActiveSceneName.c_str();
         ctx->CurrentScenePtr->Data          = scene.Data;
         ctx->CurrentScenePtr->MeshFiles     = scene.MeshFiles;
         ctx->CurrentScenePtr->ModelFiles    = scene.ModelFiles;

--- a/Tetragrama/Components/ProjectViewUIComponent.cpp
+++ b/Tetragrama/Components/ProjectViewUIComponent.cpp
@@ -16,7 +16,7 @@ namespace Tetragrama::Components
     {
         UIComponent::Initialize(parent, name, visibility, closed);
         auto context        = reinterpret_cast<EditorContext*>(ParentLayer->ParentContext);
-        m_assets_directory  = context->ConfigurationPtr->WorkingSpacePath;
+        m_assets_directory  = context->ConfigurationPtr->WorkingSpacePath.c_str();
         m_current_directory = m_assets_directory;
     }
 

--- a/Tetragrama/Editor.cpp
+++ b/Tetragrama/Editor.cpp
@@ -30,18 +30,18 @@ namespace Tetragrama
 
         if (Helpers::secure_strlen(file))
         {
-            Context->ConfigurationPtr->ReadConfig(file);
+            Context->ConfigurationPtr->ReadConfig(arena, file);
 
-            if (Helpers::secure_strlen(Context->ConfigurationPtr->ActiveSceneName))
+            if (!Context->ConfigurationPtr->ActiveSceneName.empty())
             {
-                Context->CurrentScenePtr->Initialize(&(Context->Arena), Context->ConfigurationPtr->ActiveSceneName);
+                Context->CurrentScenePtr->Initialize(&(Context->Arena), Context->ConfigurationPtr->ActiveSceneName.c_str());
             }
         }
 
         UILayer->ParentContext                   = reinterpret_cast<void*>(Context);
         CanvasLayer->ParentContext               = reinterpret_cast<void*>(Context);
 
-        std::string                  title       = fmt::format("{0} - Active Scene : {1}", Context->ConfigurationPtr->ProjectName, Context->CurrentScenePtr->Name);
+        std::string                  title       = fmt::format("{0} - Active Scene : {1}", Context->ConfigurationPtr->ProjectName.c_str(), Context->CurrentScenePtr->Name);
         Windows::WindowConfiguration window_conf = {.EnableVsync = true};
         window_conf.Title.init(&(Context->Arena), title.c_str());
         window_conf.RenderingLayerCollection.init(&(Context->Arena), 1);
@@ -116,9 +116,9 @@ namespace Tetragrama
         return m_has_pending_change;
     }
 
-    void EditorConfiguration::ReadConfig(std::string_view file)
+    void EditorConfiguration::ReadConfig(ZEngine::Core::Memory::ArenaAllocator* arena, const char* file)
     {
-        std::ifstream  f(file.data());
+        std::ifstream  f(file);
         nlohmann::json config             = nlohmann::json::parse(f);
         std::string    root_project_dir   = std::filesystem::path(file).parent_path().string();
 
@@ -156,13 +156,12 @@ namespace Tetragrama
             config["workingSpace"] = root_project_dir;
         }
 
-        Helpers::secure_strcpy(ProjectName, 50, config["projectName"].get<std::string>().c_str());
-
-        Helpers::secure_strcpy(WorkingSpacePath, MAX_FILE_PATH_COUNT, config["workingSpace"].get<std::string>().c_str());
-        Helpers::secure_strcpy(DefaultImportTexturePath, MAX_FILE_PATH_COUNT, config["defaultImportDir"]["textureDir"].get<std::string>().c_str());
-        Helpers::secure_strcpy(DefaultImportSoundPath, MAX_FILE_PATH_COUNT, config["defaultImportDir"]["soundDir"].get<std::string>().c_str());
-        Helpers::secure_strcpy(ScenePath, MAX_FILE_PATH_COUNT, config["sceneDir"].get<std::string>().c_str());
-        Helpers::secure_strcpy(SceneDataPath, MAX_FILE_PATH_COUNT, config["sceneDataDir"].get<std::string>().c_str());
+        ProjectName.init(arena, config["projectName"].get<std::string>().c_str());
+        WorkingSpacePath.init(arena, config["workingSpace"].get<std::string>().c_str());
+        DefaultImportTexturePath.init(arena, config["defaultImportDir"]["textureDir"].get<std::string>().c_str());
+        DefaultImportSoundPath.init(arena, config["defaultImportDir"]["soundDir"].get<std::string>().c_str());
+        ScenePath.init(arena, config["sceneDir"].get<std::string>().c_str());
+        SceneDataPath.init(arena, config["sceneDataDir"].get<std::string>().c_str());
 
         /*
          * Retreiving the Active Scene
@@ -174,7 +173,7 @@ namespace Tetragrama
             {
                 continue;
             }
-            Helpers::secure_strcpy(ActiveSceneName, 50, scene["name"].get<std::string>().c_str());
+            ActiveSceneName.init(arena, scene["name"].get<std::string>().c_str());
             break;
         }
     }

--- a/Tetragrama/Editor.h
+++ b/Tetragrama/Editor.h
@@ -51,15 +51,15 @@ namespace Tetragrama
 
     struct EditorConfiguration
     {
-        char WorkingSpacePath[MAX_FILE_PATH_COUNT]         = {0};
-        char DefaultImportTexturePath[MAX_FILE_PATH_COUNT] = {0};
-        char DefaultImportSoundPath[MAX_FILE_PATH_COUNT]   = {0};
-        char ScenePath[MAX_FILE_PATH_COUNT]                = {0};
-        char SceneDataPath[MAX_FILE_PATH_COUNT]            = {0};
-        char ProjectName[50]                               = {0};
-        char ActiveSceneName[50]                           = {0};
+        ZEngine::Core::Containers::String WorkingSpacePath         = {};
+        ZEngine::Core::Containers::String DefaultImportTexturePath = {};
+        ZEngine::Core::Containers::String DefaultImportSoundPath   = {};
+        ZEngine::Core::Containers::String ScenePath                = {};
+        ZEngine::Core::Containers::String SceneDataPath            = {};
+        ZEngine::Core::Containers::String ProjectName              = {};
+        ZEngine::Core::Containers::String ActiveSceneName          = {};
 
-        void ReadConfig(std::string_view file);
+        void                              ReadConfig(ZEngine::Core::Memory::ArenaAllocator* arena, const char* file);
     };
 
     struct EditorContext

--- a/Tetragrama/Helpers/SerializerCommonHelper.cpp
+++ b/Tetragrama/Helpers/SerializerCommonHelper.cpp
@@ -2,6 +2,8 @@
 #include <SerializerCommonHelper.h>
 #include <ZEngine/Helpers/MemoryOperations.h>
 
+#define DEFAULT_STR_BUFFER 256
+
 using namespace ZEngine::Core::Containers;
 
 namespace Tetragrama::Helpers
@@ -16,10 +18,11 @@ namespace Tetragrama::Helpers
     void DeserializeStringData(ZEngine::Core::Memory::ArenaAllocator* Arena, std::istream& in, ZEngine::Core::Containers::String& d)
     {
         size_t v_count;
+        char   buf[DEFAULT_STR_BUFFER] = {0};
         in.read(reinterpret_cast<char*>(&v_count), sizeof(size_t));
+        in.read(buf, v_count + 1);
 
-        d.init(Arena, v_count + 2);
-        in.read(d.data(), v_count + 1);
+        d.init(Arena, buf);
     }
 
     void SerializeStringArrayData(std::ostream& os, ZEngine::Core::Containers::ArrayView<ZEngine::Core::Containers::String> str_view)
@@ -58,11 +61,12 @@ namespace Tetragrama::Helpers
         for (int i = 0; i < data_count; ++i)
         {
             size_t v_count;
+            char   buf[DEFAULT_STR_BUFFER] = {0};
             in.read(reinterpret_cast<char*>(&v_count), sizeof(size_t));
+            in.read(buf, v_count + 1);
 
             String v;
-            v.init(Arena, v_count + 2);
-            in.read(v.data(), v_count + 1);
+            v.init(Arena, buf);
             data.push(v);
         }
     }

--- a/Tetragrama/Importers/AssimpImporter.cpp
+++ b/Tetragrama/Importers/AssimpImporter.cpp
@@ -320,7 +320,7 @@ namespace Tetragrama::Importers
         if (!config.OutputMeshFilePath.empty())
         {
             std::string   output_mesh_file = fmt::format("{}.zemeshes", config.AssetFilename.c_str());
-            std::string   fullname_path    = fmt::format("{0}/{1}/{2}", config.OutputWorkingSpacePath.c_str(), config.OutputMeshFilePath.c_str(), output_mesh_file.c_str());
+            std::string   fullname_path    = fmt::format("{0}{1}{2}{3}{4}", config.OutputWorkingSpacePath.c_str(), PLATFORM_OS_BACKSLASH, config.OutputMeshFilePath.c_str(), PLATFORM_OS_BACKSLASH, output_mesh_file.c_str());
             std::ofstream out(fullname_path, std::ios::binary | std::ios::trunc);
 
             if (out.is_open())
@@ -349,7 +349,7 @@ namespace Tetragrama::Importers
             /*
              * Normalize file naming
              */
-            auto dst_dir            = fmt::format("{0}/{1}/{2}", config.OutputWorkingSpacePath.c_str(), config.OutputTextureFilesPath.c_str(), config.AssetFilename.c_str());
+            auto dst_dir            = fmt::format("{0}{1}{2}{3}{4}", config.OutputWorkingSpacePath.c_str(), PLATFORM_OS_BACKSLASH, config.OutputTextureFilesPath.c_str(), PLATFORM_OS_BACKSLASH, config.AssetFilename.c_str());
 
             auto create_base_dir_fn = [](std::string_view filename) -> void {
                 auto            base_dir = fs::absolute(filename).parent_path();
@@ -361,71 +361,90 @@ namespace Tetragrama::Importers
                 }
             };
 
-            std::vector<std::string> src_tex_files = {};
-            std::vector<std::string> dst_tex_files = {};
+            auto          scratch       = ZGetScratch(arena);
+            Array<String> src_tex_files = {};
+            Array<String> dst_tex_files = {};
+            src_tex_files.init(scratch.Arena, 10);
+            dst_tex_files.init(scratch.Arena, 10);
+
             for (auto& mat_file : importer_data.Scene.MaterialFiles)
             {
                 if (!std::string_view(mat_file.AlbedoTexture).empty())
                 {
-                    auto src_file = fmt::format("{0}/{1}", config.InputBaseAssetFilePath.c_str(), mat_file.AlbedoTexture);
-                    auto dst_file = fmt::format("{0}/{1}", dst_dir, mat_file.AlbedoTexture);
+                    auto src_file = fmt::format("{0}{1}{2}", config.InputBaseAssetFilePath.c_str(), PLATFORM_OS_BACKSLASH, mat_file.AlbedoTexture);
+                    auto dst_file = fmt::format("{0}{1}{2}", dst_dir, PLATFORM_OS_BACKSLASH, mat_file.AlbedoTexture);
                     create_base_dir_fn(dst_file);
 
                     ZEngine::Helpers::secure_strcpy(mat_file.AlbedoTexture, MAX_FILE_PATH_COUNT, dst_file.c_str());
 
-                    src_tex_files.emplace_back(src_file);
-                    dst_tex_files.emplace_back(dst_file);
+                    auto& sf = src_tex_files.push_use({});
+                    auto& df = dst_tex_files.push_use({});
+
+                    sf.init(scratch.Arena, src_file.c_str());
+                    df.init(scratch.Arena, dst_file.c_str());
                 }
 
                 if (!std::string_view(mat_file.EmissiveTexture).empty())
                 {
-                    auto src_file = fmt::format("{0}/{1}", config.InputBaseAssetFilePath.c_str(), mat_file.EmissiveTexture);
-                    auto dst_file = fmt::format("{0}/{1}", dst_dir, mat_file.EmissiveTexture);
+                    auto src_file = fmt::format("{0}{1}{2}", config.InputBaseAssetFilePath.c_str(), PLATFORM_OS_BACKSLASH, mat_file.EmissiveTexture);
+                    auto dst_file = fmt::format("{0}{1}{2}", dst_dir, PLATFORM_OS_BACKSLASH, mat_file.EmissiveTexture);
 
                     create_base_dir_fn(dst_file);
 
                     ZEngine::Helpers::secure_strcpy(mat_file.EmissiveTexture, MAX_FILE_PATH_COUNT, dst_file.c_str());
 
-                    src_tex_files.emplace_back(src_file);
-                    dst_tex_files.emplace_back(dst_file);
+                    auto& sf = src_tex_files.push_use({});
+                    auto& df = dst_tex_files.push_use({});
+
+                    sf.init(scratch.Arena, src_file.c_str());
+                    df.init(scratch.Arena, dst_file.c_str());
                 }
 
                 if (!std::string_view(mat_file.NormalTexture).empty())
                 {
-                    auto src_file = fmt::format("{0}/{1}", config.InputBaseAssetFilePath.c_str(), mat_file.NormalTexture);
-                    auto dst_file = fmt::format("{0}/{1}", dst_dir, mat_file.NormalTexture);
+                    auto src_file = fmt::format("{0}{1}{2}", config.InputBaseAssetFilePath.c_str(), PLATFORM_OS_BACKSLASH, mat_file.NormalTexture);
+                    auto dst_file = fmt::format("{0}{1}{2}", dst_dir, PLATFORM_OS_BACKSLASH, mat_file.NormalTexture);
 
                     create_base_dir_fn(dst_file);
                     ZEngine::Helpers::secure_strcpy(mat_file.NormalTexture, MAX_FILE_PATH_COUNT, dst_file.c_str());
 
-                    src_tex_files.emplace_back(src_file);
-                    dst_tex_files.emplace_back(dst_file);
+                    auto& sf = src_tex_files.push_use({});
+                    auto& df = dst_tex_files.push_use({});
+
+                    sf.init(scratch.Arena, src_file.c_str());
+                    df.init(scratch.Arena, dst_file.c_str());
                 }
 
                 if (!std::string_view(mat_file.OpacityTexture).empty())
                 {
-                    auto src_file = fmt::format("{0}/{1}", config.InputBaseAssetFilePath.c_str(), mat_file.OpacityTexture);
-                    auto dst_file = fmt::format("{0}/{1}", dst_dir, mat_file.OpacityTexture);
+                    auto src_file = fmt::format("{0}{1}{2}", config.InputBaseAssetFilePath.c_str(), PLATFORM_OS_BACKSLASH, mat_file.OpacityTexture);
+                    auto dst_file = fmt::format("{0}{1}{2}", dst_dir, PLATFORM_OS_BACKSLASH, mat_file.OpacityTexture);
 
                     create_base_dir_fn(dst_file);
 
                     ZEngine::Helpers::secure_strcpy(mat_file.OpacityTexture, MAX_FILE_PATH_COUNT, dst_file.c_str());
 
-                    src_tex_files.emplace_back(src_file);
-                    dst_tex_files.emplace_back(dst_file);
+                    auto& sf = src_tex_files.push_use({});
+                    auto& df = dst_tex_files.push_use({});
+
+                    sf.init(scratch.Arena, src_file.c_str());
+                    df.init(scratch.Arena, dst_file.c_str());
                 }
 
                 if (!std::string_view(mat_file.SpecularTexture).empty())
                 {
-                    auto src_file = fmt::format("{0}/{1}", config.InputBaseAssetFilePath.c_str(), mat_file.SpecularTexture);
-                    auto dst_file = fmt::format("{0}/{1}", dst_dir, mat_file.SpecularTexture);
+                    auto src_file = fmt::format("{0}{1}{2}", config.InputBaseAssetFilePath.c_str(), PLATFORM_OS_BACKSLASH, mat_file.SpecularTexture);
+                    auto dst_file = fmt::format("{0}{1}{2}", dst_dir, PLATFORM_OS_BACKSLASH, mat_file.SpecularTexture);
 
                     create_base_dir_fn(dst_file);
 
                     ZEngine::Helpers::secure_strcpy(mat_file.SpecularTexture, MAX_FILE_PATH_COUNT, dst_file.c_str());
 
-                    src_tex_files.emplace_back(src_file);
-                    dst_tex_files.emplace_back(dst_file);
+                    auto& sf = src_tex_files.push_use({});
+                    auto& df = dst_tex_files.push_use({});
+
+                    sf.init(scratch.Arena, src_file.c_str());
+                    df.init(scratch.Arena, dst_file.c_str());
                 }
             }
             /*
@@ -437,8 +456,8 @@ namespace Tetragrama::Importers
             ZENGINE_VALIDATE_ASSERT(src_tex_files.size() == dst_tex_files.size(), "source files count can't be diff of destination files count")
             for (int i = 0; i < src_tex_files.size(); ++i)
             {
-                auto          src = fs::absolute(src_tex_files[i]);
-                auto          dst = fs::absolute(dst_tex_files[i]);
+                auto          src = fs::absolute(src_tex_files[i].c_str());
+                auto          dst = fs::absolute(dst_tex_files[i].c_str());
 
                 std::ifstream in(src.c_str(), std::ios::binary);
                 std::ofstream out(dst.c_str(), std::ios::binary);
@@ -456,8 +475,10 @@ namespace Tetragrama::Importers
                 out.close();
             }
 
+            ZReleaseScratch(scratch);
+
             std::string   output_material_file = fmt::format("{}.zematerials", config.AssetFilename.c_str());
-            std::string   fullname_path        = fmt::format("{0}/{1}/{2}", config.OutputWorkingSpacePath.c_str(), config.OutputMaterialsPath.c_str(), output_material_file.c_str());
+            std::string   fullname_path        = fmt::format("{0}{1}{2}{3}{4}", config.OutputWorkingSpacePath.c_str(), PLATFORM_OS_BACKSLASH, config.OutputMaterialsPath.c_str(), PLATFORM_OS_BACKSLASH, output_material_file.c_str());
             std::ofstream out(fullname_path, std::ios::binary | std::ios::trunc);
 
             if (out.is_open())
@@ -487,7 +508,7 @@ namespace Tetragrama::Importers
         if (!config.OutputModelFilePath.empty())
         {
             std::string   output_model_file = fmt::format("{}.zemodel", config.AssetFilename.c_str());
-            std::string   fullname_path     = fmt::format("{0}/{1}/{2}", config.OutputWorkingSpacePath.c_str(), config.OutputModelFilePath.c_str(), output_model_file.c_str());
+            std::string   fullname_path     = fmt::format("{0}{1}{2}{3}{4}", config.OutputWorkingSpacePath.c_str(), PLATFORM_OS_BACKSLASH, config.OutputModelFilePath.c_str(), PLATFORM_OS_BACKSLASH, output_model_file.c_str());
             std::ofstream out(fullname_path, std::ios::binary | std::ios::trunc);
 
             if (out.is_open())

--- a/Tetragrama/Importers/AssimpImporter.cpp
+++ b/Tetragrama/Importers/AssimpImporter.cpp
@@ -319,7 +319,8 @@ namespace Tetragrama::Importers
 
         if (!config.OutputMeshFilePath.empty())
         {
-            std::string   fullname_path = fmt::format("{0}/{1}.zemeshes", config.OutputMeshFilePath.c_str(), config.AssetFilename.c_str());
+            std::string   output_mesh_file = fmt::format("{}.zemeshes", config.AssetFilename.c_str());
+            std::string   fullname_path    = fmt::format("{0}/{1}/{2}", config.OutputWorkingSpacePath.c_str(), config.OutputMeshFilePath.c_str(), output_mesh_file.c_str());
             std::ofstream out(fullname_path, std::ios::binary | std::ios::trunc);
 
             if (out.is_open())
@@ -340,7 +341,7 @@ namespace Tetragrama::Importers
             }
             out.close();
 
-            importer_data.SerializedMeshesPath.init(arena, fullname_path.c_str());
+            importer_data.SerializedMeshesPath.init(arena, output_mesh_file.c_str());
         }
 
         if (!config.OutputMaterialsPath.empty() && !config.OutputTextureFilesPath.empty())
@@ -348,7 +349,7 @@ namespace Tetragrama::Importers
             /*
              * Normalize file naming
              */
-            auto dst_dir            = fmt::format("{0}/{1}", config.OutputTextureFilesPath.c_str(), config.AssetFilename.c_str());
+            auto dst_dir            = fmt::format("{0}/{1}/{2}", config.OutputWorkingSpacePath.c_str(), config.OutputTextureFilesPath.c_str(), config.AssetFilename.c_str());
 
             auto create_base_dir_fn = [](std::string_view filename) -> void {
                 auto            base_dir = fs::absolute(filename).parent_path();
@@ -455,7 +456,8 @@ namespace Tetragrama::Importers
                 out.close();
             }
 
-            std::string   fullname_path = fmt::format("{0}/{1}.zematerials", config.OutputMaterialsPath.c_str(), config.AssetFilename.c_str());
+            std::string   output_material_file = fmt::format("{}.zematerials", config.AssetFilename.c_str());
+            std::string   fullname_path        = fmt::format("{0}/{1}/{2}", config.OutputWorkingSpacePath.c_str(), config.OutputMaterialsPath.c_str(), output_material_file.c_str());
             std::ofstream out(fullname_path, std::ios::binary | std::ios::trunc);
 
             if (out.is_open())
@@ -479,12 +481,13 @@ namespace Tetragrama::Importers
             }
             out.close();
 
-            importer_data.SerializedMaterialsPath.init(arena, fullname_path.c_str());
+            importer_data.SerializedMaterialsPath.init(arena, output_material_file.c_str());
         }
 
         if (!config.OutputModelFilePath.empty())
         {
-            std::string   fullname_path = fmt::format("{0}/{1}.zemodel", config.OutputModelFilePath.c_str(), config.AssetFilename.c_str());
+            std::string   output_model_file = fmt::format("{}.zemodel", config.AssetFilename.c_str());
+            std::string   fullname_path     = fmt::format("{0}/{1}/{2}", config.OutputWorkingSpacePath.c_str(), config.OutputModelFilePath.c_str(), output_model_file.c_str());
             std::ofstream out(fullname_path, std::ios::binary | std::ios::trunc);
 
             if (out.is_open())
@@ -514,7 +517,7 @@ namespace Tetragrama::Importers
 
             out.close();
 
-            importer_data.SerializedModelPath.init(arena, fullname_path.c_str());
+            importer_data.SerializedModelPath.init(arena, output_model_file.c_str());
         }
     }
 
@@ -566,7 +569,7 @@ namespace Tetragrama::Importers
                 deserialized_data.Scene.MaterialFiles.resize(mat_file_count);
 
                 Array<String> textures = {};
-                textures.init(arena, 5);
+                textures.init(arena, 5, 5);
                 for (auto& mat_file : deserialized_data.Scene.MaterialFiles)
                 {
                     Tetragrama::Helpers::DeserializeStringData(arena, in, textures[0]);

--- a/Tetragrama/Importers/IAssetImporter.h
+++ b/Tetragrama/Importers/IAssetImporter.h
@@ -35,6 +35,7 @@ namespace Tetragrama::Importers
     {
         ZEngine::Core::Containers::String AssetFilename;
         ZEngine::Core::Containers::String InputBaseAssetFilePath;
+        ZEngine::Core::Containers::String OutputWorkingSpacePath;
         ZEngine::Core::Containers::String OutputModelFilePath;
         ZEngine::Core::Containers::String OutputMeshFilePath;
         ZEngine::Core::Containers::String OutputTextureFilesPath;

--- a/Tetragrama/Serializers/EditorSceneSerializer.cpp
+++ b/Tetragrama/Serializers/EditorSceneSerializer.cpp
@@ -143,21 +143,21 @@ namespace Tetragrama::Serializers
 
                 int      i          = 0;
 
-                while (hash[i] != ':' && hash[i] != '\0')
+                while (i < hash.size() && hash[i] != ':')
                 {
                     indices[0] = indices[0] * 10 + (hash[i] - '0');
                     i++;
                 }
                 i++; // Skip the colon
 
-                while (hash[i] != ':' && hash[i] != '\0')
+                while (i < hash.size() && hash[i] != ':')
                 {
                     indices[1] = indices[1] * 10 + (hash[i] - '0');
                     i++;
                 }
                 i++;
 
-                while (hash[i] != '\0')
+                while (i < hash.size() && hash[i] != '\0')
                 {
                     indices[2] = indices[2] * 10 + (hash[i] - '0');
                     i++;
@@ -176,9 +176,9 @@ namespace Tetragrama::Serializers
             std::vector<ZEngine::Rendering::Scenes::SceneRawData> scene_data;
             for (auto& [_, model] : scene.Data)
             {
-                auto mesh_path     = fmt::format("{0}/{1}", config.WorkingSpacePath, scene.MeshFiles[model.MeshFileIndex].c_str());
-                auto model_path    = fmt::format("{0}/{1}", config.WorkingSpacePath, scene.ModelFiles[model.ModelPathIndex].c_str());
-                auto material_path = fmt::format("{0}/{1}", config.WorkingSpacePath, scene.MaterialFiles[model.MaterialPathIndex].c_str());
+                auto mesh_path     = fmt::format("{0}/{1}/{2}", config.WorkingSpacePath.c_str(), config.SceneDataPath.c_str(), scene.MeshFiles[model.MeshFileIndex].c_str());
+                auto model_path    = fmt::format("{0}/{1}/{2}", config.WorkingSpacePath.c_str(), config.SceneDataPath.c_str(), scene.ModelFiles[model.ModelPathIndex].c_str());
+                auto material_path = fmt::format("{0}/{1}/{2}", config.WorkingSpacePath.c_str(), config.SceneDataPath.c_str(), scene.MaterialFiles[model.MaterialPathIndex].c_str());
 
 #ifdef _WIN32
                 std::replace(model_path.begin(), model_path.end(), '/', '\\');

--- a/Tetragrama/Serializers/EditorSceneSerializer.cpp
+++ b/Tetragrama/Serializers/EditorSceneSerializer.cpp
@@ -31,7 +31,7 @@ namespace Tetragrama::Serializers
                 return;
             }
 
-            auto          full_scenename = fmt::format("{0}/{1}.zescene", m_default_output, scene->Name);
+            auto          full_scenename = fmt::format("{0}{1}{2}.zescene", m_default_output, PLATFORM_OS_BACKSLASH, scene->Name);
             std::ofstream out(full_scenename, std::ios::binary | std::ios::trunc | std::ios::out);
             if (!out.is_open())
             {
@@ -176,17 +176,11 @@ namespace Tetragrama::Serializers
             std::vector<ZEngine::Rendering::Scenes::SceneRawData> scene_data;
             for (auto& [_, model] : scene.Data)
             {
-                auto mesh_path     = fmt::format("{0}/{1}/{2}", config.WorkingSpacePath.c_str(), config.SceneDataPath.c_str(), scene.MeshFiles[model.MeshFileIndex].c_str());
-                auto model_path    = fmt::format("{0}/{1}/{2}", config.WorkingSpacePath.c_str(), config.SceneDataPath.c_str(), scene.ModelFiles[model.ModelPathIndex].c_str());
-                auto material_path = fmt::format("{0}/{1}/{2}", config.WorkingSpacePath.c_str(), config.SceneDataPath.c_str(), scene.MaterialFiles[model.MaterialPathIndex].c_str());
+                auto mesh_path     = fmt::format("{0}{1}{2}{3}{4}", config.WorkingSpacePath.c_str(), PLATFORM_OS_BACKSLASH, config.SceneDataPath.c_str(), PLATFORM_OS_BACKSLASH, scene.MeshFiles[model.MeshFileIndex].c_str());
+                auto model_path    = fmt::format("{0}{1}{2}{3}{4}", config.WorkingSpacePath.c_str(), PLATFORM_OS_BACKSLASH, config.SceneDataPath.c_str(), PLATFORM_OS_BACKSLASH, scene.ModelFiles[model.ModelPathIndex].c_str());
+                auto material_path = fmt::format("{0}{1}{2}{3}{4}", config.WorkingSpacePath.c_str(), PLATFORM_OS_BACKSLASH, config.SceneDataPath.c_str(), PLATFORM_OS_BACKSLASH, scene.MaterialFiles[model.MaterialPathIndex].c_str());
 
-#ifdef _WIN32
-                std::replace(model_path.begin(), model_path.end(), '/', '\\');
-                std::replace(mesh_path.begin(), mesh_path.end(), '/', '\\');
-                std::replace(material_path.begin(), material_path.end(), '/', '\\');
-#endif // _WIN32
-
-                auto import_data = AssetImporter->DeserializeImporterData(&Arena, model_path, mesh_path, material_path);
+                auto import_data   = AssetImporter->DeserializeImporterData(&Arena, model_path, mesh_path, material_path);
                 scene_data.push_back(import_data.Scene);
             }
 

--- a/ZEngine/ZEngine/ZEngineDef.h
+++ b/ZEngine/ZEngine/ZEngineDef.h
@@ -15,6 +15,14 @@
 #error "Platform not supported!"
 #endif
 
+#ifdef _MSC_VER
+#define PLATFORM_OS_BACKSLASH '\\'
+#elif defined(__APPLE__) || defined(__linux__)
+#define PLATFORM_OS_BACKSLASH '/'
+#else
+#define PLATFORM_OS_BACKSLASH
+#endif
+
 #define ZENGINE_VALIDATE_ASSERT(condition, message) \
     {                                               \
         if (!(condition))                           \


### PR DESCRIPTION
This PR does some cleanup around file path handling and provides proper backslash usage depending on the platform.
This has the benefit of removing the usage of std::replace(...)  we use to format a file/dir path