### PR TITLE
fix(buildengine): update `glm`'s cmake minimum version to 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Before building, make sure your setup is correct :
 ### Setup Window machine
 
 - Install Visual Studio 2022 Community or Professional, make sure to add "Desktop development with C++".
+    - Install MSVC v143 - VS 2022 C++ x64/x86 build tools and Windows 10/11 SDK.
 - Install [PowerShell Core](https://github.com/PowerShell/PowerShell/releases)
 - Install [Python](https://www.python.org/ftp/python/3.12.4/python-3.12.4-amd64.exe)
 - Install [CMake](https://cmake.org/download/) 3.20 or later.
 - Install [DOTNET SDK 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) as a VS Build Tool component (if using a standalone implementation, you might need to create a symlink between your custom installation location and the expected location: `C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Sdks\Microsoft.NET.Sdk\Sdk`)
 - Install [LLVM](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/LLVM-18.1.8-win64.exe)
-- Install MSVC v143 - VS 2022 C++ x64/x86 build tools and Windows 10/11 SDK as a VS Build Tool component.
 
 
 ### Setup macOS machine

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ Before building, make sure your setup is correct :
 - Install [PowerShell Core](https://github.com/PowerShell/PowerShell/releases)
 - Install [Python](https://www.python.org/ftp/python/3.12.4/python-3.12.4-amd64.exe)
 - Install [CMake](https://cmake.org/download/) 3.20 or later.
-- Install [DOTNET SDK 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
+- Install [DOTNET SDK 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) as a VS Build Tool component (if using a standalone implementation, you might need to create a symlink between your custom installation location and the expected location: `C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Sdks\Microsoft.NET.Sdk\Sdk`)
 - Install [LLVM](https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/LLVM-18.1.8-win64.exe)
+- Install MSVC v143 - VS 2022 C++ x64/x86 build tools and Windows 10/11 SDK as a VS Build Tool component.
+
 
 ### Setup macOS machine
 

--- a/Scripts/BuildEngine.ps1
+++ b/Scripts/BuildEngine.ps1
@@ -152,6 +152,7 @@ function Build([string]$configuration, [int]$VsVersion , [bool]$runBuild) {
         'SPIRV_TOOLS' = @("-DSPIRV_SKIP_EXECUTABLES=ON", "-DSPIRV_SKIP_TESTS=ON")
         'SPIRV_CROSS' = @("-DSPIRV_CROSS_ENABLE_TESTS=OFF")
         'LAUNCHER_ONLY' = @("-DLAUNCHER_ONLY=ON")
+        'GLM'       = @("-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
     }
 
     $cMakeCacheVariableOverride = $cMakeOptions -join ' '
@@ -197,6 +198,7 @@ function Build([string]$configuration, [int]$VsVersion , [bool]$runBuild) {
         $cMakeCacheVariableOverride += ' ' + $submoduleCMakeOptions.SPIRV_CROSS -join ' '
         $cMakeCacheVariableOverride += ' ' + $submoduleCMakeOptions.SPIRV_TOOLS -join ' '
         $cMakeCacheVariableOverride += ' ' + $submoduleCMakeOptions.GLFW -join ' '
+        $cMakeCacheVariableOverride += ' ' + $submoduleCMakeOptions.GLM -join ' '
     }
 
     $cMakeArguments = " -S $repositoryRootPath -B $buildDirectoryPath $cMakeGenerator $cMakeCacheVariableOverride"


### PR DESCRIPTION
The error was occuring due to GLM’s CMakeLists.txt which was specifying an outdated minimum CMake version. Solved with the flag `-DCMAKE_POLICY_VERSION_MINIMUM=3.5`.
We might need to update other dependencies too even though there is no error caused by deprecated version yet. For instance, `stduuid`, `yaml-cpp` and `SPIRV-Cross` minimum version should be set to 3.10.
