### PR TITLE
Refactored Arena  memory splitting

### DIFF
--- a/Tetragrama/Components/DockspaceUIComponent.cpp
+++ b/Tetragrama/Components/DockspaceUIComponent.cpp
@@ -33,13 +33,13 @@ namespace Tetragrama::Components
     {
         UIComponent::Initialize(parent, name, visibility, closed);
 
-        parent->LayerArena.CreateSubArena(ZMega(10), &LocalArena);
+        parent->LocalArena.CreateSubArena(ZKilo(100), &LocalArena);
 
-        m_asset_importer    = ZPushStructCtor(&(parent->LayerArena), Importers::AssimpImporter);
-        m_editor_serializer = ZPushStructCtor(&(parent->LayerArena), Serializers::EditorSceneSerializer);
+        m_asset_importer    = ZPushStructCtor(parent->Arena, Importers::AssimpImporter);
+        m_editor_serializer = ZPushStructCtor(parent->Arena, Serializers::EditorSceneSerializer);
 
-        m_editor_serializer->Initialize(&(parent->LayerArena));
-        m_asset_importer->Initialize(&(parent->LayerArena));
+        m_editor_serializer->Initialize(parent->Arena);
+        m_asset_importer->Initialize(parent->Arena);
 
         m_dockspace_node_flag                        = ImGuiDockNodeFlags_NoWindowMenuButton | ImGuiDockNodeFlags_PassthruCentralNode;
         m_window_flags                               = ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavFocus;

--- a/Tetragrama/Components/HierarchyViewUIComponent.cpp
+++ b/Tetragrama/Components/HierarchyViewUIComponent.cpp
@@ -275,7 +275,7 @@ namespace Tetragrama::Components
                 stack.push({-1, 0}); // Marker for TreePop
 
                 // Push children in reverse order
-                auto                                  scratch = ZGetScratch(&ParentLayer->LayerArena);
+                auto                                  scratch = ZGetScratch(&ParentLayer->LocalArena);
                 ZEngine::Core::Containers::Array<int> children;
                 children.init(scratch.Arena, 5);
 

--- a/Tetragrama/Components/LogUIComponent.cpp
+++ b/Tetragrama/Components/LogUIComponent.cpp
@@ -22,7 +22,7 @@ namespace Tetragrama::Components
     {
         UIComponent::Initialize(parent, name, visibility, closed);
 
-        parent->LayerArena.CreateSubArena(ZMega(1), &m_local_arena);
+        parent->LocalArena.CreateSubArena(ZMega(1), &m_local_arena);
         m_log_queue.init(&(m_local_arena), m_maxCount, m_maxCount);
         m_handler_cookie = Logger::AddEventHandler(std::bind(&LogUIComponent::OnLog, this, std::placeholders::_1));
     }

--- a/Tetragrama/Components/ProjectViewUIComponent.cpp
+++ b/Tetragrama/Components/ProjectViewUIComponent.cpp
@@ -16,7 +16,7 @@ namespace Tetragrama::Components
     void ProjectViewUIComponent::Initialize(Layers::ImguiLayer* parent, const char* name, bool visibility, bool closed)
     {
         UIComponent::Initialize(parent, name, visibility, closed);
-        parent->LayerArena.CreateSubArena(ZMega(1), &m_local_arena);
+        parent->LocalArena.CreateSubArena(ZMega(1), &m_local_arena);
         auto context        = reinterpret_cast<EditorContext*>(ParentLayer->ParentContext);
         m_assets_directory  = context->ConfigurationPtr->WorkingSpacePath.c_str();
         m_current_directory = m_assets_directory;

--- a/Tetragrama/Editor.cpp
+++ b/Tetragrama/Editor.cpp
@@ -20,17 +20,16 @@ namespace Tetragrama
     {
         AssetManager::Initialize(arena);
 
-        Context = ZPushStruct(arena, EditorContext);
-
-        arena->CreateSubArena(ZMega(800), &(Context->Arena));
+        Context                      = ZPushStruct(arena, EditorContext);
+        Context->Arena               = arena;
 
         Context->AssetManagerPtr     = AssetManager::Instance();
-        Context->ConfigurationPtr    = ZPushStructCtor(&(Context->Arena), EditorConfiguration);
-        Context->CameraControllerPtr = ZPushStructCtor(&(Context->Arena), EditorCameraController);
-        UILayer                      = ZPushStructCtor(&(Context->Arena), ImguiLayer);
-        CanvasLayer                  = ZPushStructCtor(&(Context->Arena), RenderLayer);
+        Context->ConfigurationPtr    = ZPushStructCtor(Context->Arena, EditorConfiguration);
+        Context->CameraControllerPtr = ZPushStructCtor(Context->Arena, EditorCameraController);
+        UILayer                      = ZPushStructCtor(Context->Arena, ImguiLayer);
+        CanvasLayer                  = ZPushStructCtor(Context->Arena, RenderLayer);
 
-        Context->CurrentScenePtr     = ZPushStructCtor(&(Context->Arena), EditorScene);
+        Context->CurrentScenePtr     = ZPushStructCtor(Context->Arena, EditorScene);
 
         if (ZEngine::Helpers::secure_strlen(file))
         {
@@ -38,7 +37,7 @@ namespace Tetragrama
 
             if (!Context->ConfigurationPtr->ActiveSceneName.empty())
             {
-                Context->CurrentScenePtr->Initialize(&(Context->Arena), Context->ConfigurationPtr->ActiveSceneName.c_str());
+                Context->CurrentScenePtr->Initialize(Context->Arena, Context->ConfigurationPtr->ActiveSceneName.c_str());
             }
         }
 
@@ -47,16 +46,16 @@ namespace Tetragrama
 
         std::string                  title       = fmt::format("{0} - Active Scene : {1}", Context->ConfigurationPtr->ProjectName.c_str(), Context->CurrentScenePtr->Name);
         Windows::WindowConfiguration window_conf = {.EnableVsync = true};
-        window_conf.Title.init(&(Context->Arena), title.c_str());
-        window_conf.RenderingLayerCollection.init(&(Context->Arena), 1);
-        window_conf.OverlayLayerCollection.init(&(Context->Arena), 1);
+        window_conf.Title.init(Context->Arena, title.c_str());
+        window_conf.RenderingLayerCollection.init(Context->Arena, 1);
+        window_conf.OverlayLayerCollection.init(Context->Arena, 1);
 
         window_conf.RenderingLayerCollection.push(CanvasLayer);
         window_conf.OverlayLayerCollection.push(UILayer);
 
-        Window = ZEngine::Windows::Create(&(Context->Arena), window_conf);
+        Window = ZEngine::Windows::Create(Context->Arena, window_conf);
 
-        Context->CameraControllerPtr->Initialize(&(Context->Arena), Window, 150.0, 0.f, 45.f);
+        Context->CameraControllerPtr->Initialize(Context->Arena, Window, 150.0, 0.f, 45.f);
 
         ZEngine::Engine::Initialize(arena, Window);
     }

--- a/Tetragrama/Editor.h
+++ b/Tetragrama/Editor.h
@@ -35,8 +35,8 @@ namespace Tetragrama
 
     struct EditorContext
     {
-        ZEngine::Core::Memory::ArenaAllocator Arena                      = {};
-        std::atomic_int                       SelectedSceneNode          = -1;
+        ZEngine::Core::Memory::ArenaAllocator* Arena                     = nullptr;
+        std::atomic_int                        SelectedSceneNode         = -1;
         ZRawPtr(EditorConfiguration) ConfigurationPtr                    = nullptr;
         ZRawPtr(EditorScene) CurrentScenePtr                             = nullptr;
         ZRawPtr(Controllers::EditorCameraController) CameraControllerPtr = nullptr;

--- a/Tetragrama/EntryPoint.cpp
+++ b/Tetragrama/EntryPoint.cpp
@@ -22,7 +22,7 @@ int applicationEntryPoint(int argc, char* argv[])
     CLI11_PARSE(app, argc, argv);
 
     MemoryManager       manager = {};
-    MemoryConfiguration config  = {.DefaultSize = ZGiga(3u)};
+    MemoryConfiguration config  = {.DefaultSize = ZGiga(1u)};
     manager.Initialize(config);
     auto                arena      = &(manager.ArenaAllocator);
 

--- a/Tetragrama/Importers/IAssetImporter.cpp
+++ b/Tetragrama/Importers/IAssetImporter.cpp
@@ -57,7 +57,7 @@ namespace Tetragrama::Importers
 
     void IAssetImporter::Initialize(ZEngine::Core::Memory::ArenaAllocator* arena)
     {
-        arena->CreateSubArena(ZMega(150), &Arena);
+        arena->CreateSubArena(ZMega(100), &Arena);
     }
 
     void IAssetImporter::SetOnCompleteCallback(on_import_complete_fn callback)

--- a/Tetragrama/Layers/ImguiLayer.cpp
+++ b/Tetragrama/Layers/ImguiLayer.cpp
@@ -28,12 +28,13 @@ namespace Tetragrama::Layers
 
     void ImguiLayer::Initialize(ZEngine::Core::Memory::ArenaAllocator* arena)
     {
-        arena->CreateSubArena(ZMega(200), &LayerArena);
+        Arena = arena;
+        arena->CreateSubArena(ZMega(10), &LocalArena);
 
-        NodeHierarchies.init(&LayerArena, 10, 0);
-        NodeUIComponents.init(&LayerArena, 10, 0);
-        NodeToRender.init(&LayerArena, 10);
-        KeyEntries.init(&LayerArena, 10, 0);
+        NodeHierarchies.init(arena, 10, 0);
+        NodeUIComponents.init(arena, 10, 0);
+        NodeToRender.init(arena, 10);
+        KeyEntries.init(arena, 10, 0);
 
         KeyEntries[ZENGINE_KEY_SPACE]        = ImGuiKey_Space;
         KeyEntries[ZENGINE_KEY_BACKSPACE]    = ImGuiKey_Backspace;
@@ -47,14 +48,14 @@ namespace Tetragrama::Layers
         KeyEntries[ZENGINE_KEY_MOUSE_RIGHT]  = ImGuiKey_MouseRight;
         KeyEntries[ZENGINE_KEY_MOUSE_MIDDLE] = ImGuiKey_MouseMiddle;
 
-        auto dockspace_cmp                   = ZPushStructCtor(&LayerArena, Components::DockspaceUIComponent);
-        auto scene_cmp                       = ZPushStructCtor(&LayerArena, Components::SceneViewportUIComponent);
-        auto editor_log_cmp                  = ZPushStructCtor(&LayerArena, Components::LogUIComponent);
-        auto project_view_cmp                = ZPushStructCtor(&LayerArena, Components::ProjectViewUIComponent);
-        auto inspector_view_cmp              = ZPushStructCtor(&LayerArena, Components::InspectorViewUIComponent);
-        auto hierarchy_view_cmp              = ZPushStructCtor(&LayerArena, Components::HierarchyViewUIComponent);
+        auto dockspace_cmp                   = ZPushStructCtor(arena, Components::DockspaceUIComponent);
+        auto scene_cmp                       = ZPushStructCtor(arena, Components::SceneViewportUIComponent);
+        auto editor_log_cmp                  = ZPushStructCtor(arena, Components::LogUIComponent);
+        auto project_view_cmp                = ZPushStructCtor(arena, Components::ProjectViewUIComponent);
+        auto inspector_view_cmp              = ZPushStructCtor(arena, Components::InspectorViewUIComponent);
+        auto hierarchy_view_cmp              = ZPushStructCtor(arena, Components::HierarchyViewUIComponent);
 
-        auto demo_cmp                        = ZPushStructCtor(&LayerArena, Components::DemoUIComponent);
+        auto demo_cmp                        = ZPushStructCtor(arena, Components::DemoUIComponent);
 
         dockspace_cmp->Initialize(this);
         scene_cmp->Initialize(this);
@@ -64,7 +65,7 @@ namespace Tetragrama::Layers
         hierarchy_view_cmp->Initialize(this);
         demo_cmp->Initialize(this);
 
-        dockspace_cmp->Children.init(&LayerArena, 8);
+        dockspace_cmp->Children.init(arena, 8);
         dockspace_cmp->Children.push(scene_cmp);
         dockspace_cmp->Children.push(editor_log_cmp);
         dockspace_cmp->Children.push(demo_cmp);
@@ -131,7 +132,7 @@ namespace Tetragrama::Layers
             NodeToRender.clear();
         }
 
-        auto       temp_arena = ZGetScratch(&LayerArena);
+        auto       temp_arena = ZGetScratch(&LocalArena);
 
         Array<int> roots      = {};
         Array<int> children   = {};

--- a/Tetragrama/Layers/RenderLayer.cpp
+++ b/Tetragrama/Layers/RenderLayer.cpp
@@ -23,7 +23,7 @@ namespace Tetragrama::Layers
 
     void RenderLayer::Initialize(ZEngine::Core::Memory::ArenaAllocator* arena)
     {
-        arena->CreateSubArena(ZMega(1), &LayerArena);
+        arena->CreateSubArena(ZMega(1), &LocalArena);
     }
 
     void RenderLayer::Deinitialize() {}

--- a/ZEngine/ZEngine/Engine.cpp
+++ b/ZEngine/ZEngine/Engine.cpp
@@ -11,18 +11,14 @@ namespace ZEngine
     static ZRawPtr(Windows::CoreWindow) g_current_window             = nullptr;
     static ZRawPtr(Rendering::Renderers::GraphicRenderer) g_renderer = nullptr;
     static ZRawPtr(Hardwares::VulkanDevice) g_device                 = nullptr;
-    static ZEngine::Core::Memory::ArenaAllocator g_engine_arena      = {};
 
-    void                                         Engine::Initialize(ZEngine::Core::Memory::ArenaAllocator* arena, ZRawPtr(ZEngine::Windows::CoreWindow) const window)
+    void Engine::Initialize(ZEngine::Core::Memory::ArenaAllocator* arena, ZRawPtr(ZEngine::Windows::CoreWindow) const window)
     {
         g_current_window = window;
+        g_device         = ZPushStructCtor(arena, Hardwares::VulkanDevice);
+        g_renderer       = ZPushStructCtor(arena, Rendering::Renderers::GraphicRenderer);
 
-        arena->CreateSubArena(ZGiga(1), &g_engine_arena);
-
-        g_device   = ZPushStructCtor(&g_engine_arena, Hardwares::VulkanDevice);
-        g_renderer = ZPushStructCtor(&g_engine_arena, Rendering::Renderers::GraphicRenderer);
-
-        g_device->Initialize(&g_engine_arena, window);
+        g_device->Initialize(arena, window);
         g_renderer->Initialize(g_device);
 
         ZENGINE_CORE_INFO("Engine initialized")

--- a/ZEngine/ZEngine/Windows/Layers/Layer.h
+++ b/ZEngine/ZEngine/Windows/Layers/Layer.h
@@ -20,14 +20,15 @@ namespace ZEngine::Windows::Layers
             Name = name;
         }
 
-        virtual ~Layer()                                                                      = default;
+        virtual ~Layer()                                                                       = default;
 
-        virtual void                          Initialize(Core::Memory::ArenaAllocator* arena) = 0;
-        virtual void                          Deinitialize() {};
+        virtual void                           Initialize(Core::Memory::ArenaAllocator* arena) = 0;
+        virtual void                           Deinitialize() {};
 
-        ZEngine::Core::Memory::ArenaAllocator LayerArena    = {};
-        const char*                           Name          = nullptr;
-        void*                                 ParentContext = nullptr;
-        ZRawPtr(ZEngine::Windows::CoreWindow) ParentWindow  = nullptr;
+        ZEngine::Core::Memory::ArenaAllocator  LocalArena    = {};
+        ZEngine::Core::Memory::ArenaAllocator* Arena         = nullptr;
+        const char*                            Name          = nullptr;
+        void*                                  ParentContext = nullptr;
+        ZRawPtr(ZEngine::Windows::CoreWindow) ParentWindow   = nullptr;
     };
 } // namespace ZEngine::Windows::Layers


### PR DESCRIPTION
This PR revisits the splitting of the main Arena memory to provide a better partitioning and efficiency among engine subcomponents