### PR TITLE
feat: Add CMakePresets.json support for cross-platform builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -422,6 +422,7 @@ out/
 !.vscode/launch.json
 # Visual Studio CMake settings files
 CMakeSettings.json
+CMakeUserPresets.json
 
 # MacOS files
 .DS_Store

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,425 @@
+{
+    "version": 3,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 17,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "base",
+            "description": "Base configuration for all platforms",
+            "hidden": true,
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+            }
+        },
+        {
+            "name": "windows-base",
+            "inherits": "base",
+            "hidden": true,
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            },
+            "generator": "Visual Studio 17 2022",
+            "architecture": {
+                "value": "x64",
+                "strategy": "external"
+            },
+            "toolset": {
+                "value": "host=x64",
+                "strategy": "external"
+            },
+            "cacheVariables": {
+                "CMAKE_CONFIGURATION_TYPES": "Debug;Release"
+            },
+            "vendor": {
+                "microsoft.com/VisualStudioSettings/CMake/1.0": {
+                    "hostOS": ["Windows"]
+                }
+            }
+        },
+        {
+            "name": "linux-base",
+            "inherits": "base",
+            "hidden": true,
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            },
+            "generator": "Unix Makefiles",
+            "environment": {
+                "CC": "/usr/bin/gcc-11",
+                "CXX": "/usr/bin/g++-11"
+            },
+            "vendor": {
+                "microsoft.com/VisualStudioSettings/CMake/1.0": {
+                    "hostOS": ["Linux"]
+                }
+            }
+        },
+        {
+            "name": "macos-base",
+            "inherits": "base",
+            "hidden": true,
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Darwin"
+            },
+            "generator": "Xcode",
+            "cacheVariables": {
+                "BUILD_FRAMEWORK": "ON"
+            },
+            "vendor": {
+                "microsoft.com/VisualStudioSettings/CMake/1.0": {
+                    "hostOS": ["macOS"]
+                }
+            }
+        },
+        {
+            "name": "windows-debug",
+            "displayName": "Windows Debug",
+            "description": "Debug build for Windows using MSVC",
+            "inherits": "windows-base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "ENTT_INCLUDE_HEADERS": "ON",
+                "SPDLOG_BUILD_SHARED": "OFF",
+                "BUILD_STATIC_LIBS": "ON",
+                "SPDLOG_FMT_EXTERNAL": "ON",
+                "SPDLOG_FMT_EXTERNAL_HO": "OFF",
+                "GLFW_BUILD_DOCS": "OFF",
+                "GLFW_BUILD_EXAMPLES": "OFF",
+                "GLFW_INSTALL": "OFF",
+                "ASSIMP_BUILD_TESTS": "OFF",
+                "ASSIMP_INSTALL": "OFF",
+                "ASSIMP_BUILD_SAMPLES": "OFF",
+                "ASSIMP_BUILD_ASSIMP_TOOLS": "OFF",
+                "ASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT": "OFF",
+                "ASSIMP_BUILD_OBJ_IMPORTER": "ON",
+                "ASSIMP_BUILD_ALL_EXPORTERS_BY_DEFAULT": "OFF",
+                "ASSIMP_BUILD_OBJ_EXPORTER": "ON",
+                "UUID_BUILD_TESTS": "OFF",
+                "UUID_USING_CXX20_SPAN": "ON",
+                "UUID_SYSTEM_GENERATOR": "OFF",
+                "YAML_CPP_BUILD_TOOLS": "OFF",
+                "YAML_CPP_BUILD_TESTS": "OFF",
+                "YAML_CPP_FORMAT_SOURCE": "OFF",
+                "YAML_BUILD_SHARED_LIBS": "OFF",
+                "USE_MASM": "OFF",
+                "USE_GAS": "OFF",
+                "SPIRV_SKIP_EXECUTABLES": "ON",
+                "SPIRV_SKIP_TESTS": "ON",
+                "SPIRV_CROSS_ENABLE_TESTS": "OFF",
+                "CMAKE_POLICY_VERSION_MINIMUM": "3.5"
+            }
+        },
+        {
+            "name": "windows-release",
+            "displayName": "Windows Release",
+            "description": "Release build for Windows using MSVC",
+            "inherits": "windows-base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "ENTT_INCLUDE_HEADERS": "ON",
+                "SPDLOG_BUILD_SHARED": "OFF",
+                "BUILD_STATIC_LIBS": "ON",
+                "SPDLOG_FMT_EXTERNAL": "ON",
+                "SPDLOG_FMT_EXTERNAL_HO": "OFF",
+                "GLFW_BUILD_DOCS": "OFF",
+                "GLFW_BUILD_EXAMPLES": "OFF",
+                "GLFW_INSTALL": "OFF",
+                "ASSIMP_BUILD_TESTS": "OFF",
+                "ASSIMP_INSTALL": "OFF",
+                "ASSIMP_BUILD_SAMPLES": "OFF",
+                "ASSIMP_BUILD_ASSIMP_TOOLS": "OFF",
+                "ASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT": "OFF",
+                "ASSIMP_BUILD_OBJ_IMPORTER": "ON",
+                "ASSIMP_BUILD_ALL_EXPORTERS_BY_DEFAULT": "OFF",
+                "ASSIMP_BUILD_OBJ_EXPORTER": "ON",
+                "UUID_BUILD_TESTS": "OFF",
+                "UUID_USING_CXX20_SPAN": "ON",
+                "UUID_SYSTEM_GENERATOR": "OFF",
+                "YAML_CPP_BUILD_TOOLS": "OFF",
+                "YAML_CPP_BUILD_TESTS": "OFF",
+                "YAML_CPP_FORMAT_SOURCE": "OFF",
+                "YAML_BUILD_SHARED_LIBS": "OFF",
+                "USE_MASM": "OFF",
+                "USE_GAS": "OFF",
+                "SPIRV_SKIP_EXECUTABLES": "ON",
+                "SPIRV_SKIP_TESTS": "ON",
+                "SPIRV_CROSS_ENABLE_TESTS": "OFF",
+                "CMAKE_POLICY_VERSION_MINIMUM": "3.5"
+            }
+        },
+        {
+            "name": "linux-debug",
+            "displayName": "Linux Debug",
+            "description": "Debug build for Linux using GCC",
+            "inherits": "linux-base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "ENTT_INCLUDE_HEADERS": "ON",
+                "SPDLOG_BUILD_SHARED": "OFF",
+                "BUILD_STATIC_LIBS": "ON",
+                "SPDLOG_FMT_EXTERNAL": "ON",
+                "SPDLOG_FMT_EXTERNAL_HO": "OFF",
+                "GLFW_BUILD_DOCS": "OFF",
+                "GLFW_BUILD_EXAMPLES": "OFF",
+                "GLFW_INSTALL": "OFF",
+                "ASSIMP_BUILD_TESTS": "OFF",
+                "ASSIMP_INSTALL": "OFF",
+                "ASSIMP_BUILD_SAMPLES": "OFF",
+                "ASSIMP_BUILD_ASSIMP_TOOLS": "OFF",
+                "ASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT": "OFF",
+                "ASSIMP_BUILD_OBJ_IMPORTER": "ON",
+                "ASSIMP_BUILD_ALL_EXPORTERS_BY_DEFAULT": "OFF",
+                "ASSIMP_BUILD_OBJ_EXPORTER": "ON",
+                "UUID_BUILD_TESTS": "OFF",
+                "UUID_USING_CXX20_SPAN": "ON",
+                "UUID_SYSTEM_GENERATOR": "OFF",
+                "YAML_CPP_BUILD_TOOLS": "OFF",
+                "YAML_CPP_BUILD_TESTS": "OFF",
+                "YAML_CPP_FORMAT_SOURCE": "OFF",
+                "YAML_BUILD_SHARED_LIBS": "OFF",
+                "USE_MASM": "OFF",
+                "USE_GAS": "OFF",
+                "SPIRV_SKIP_EXECUTABLES": "ON",
+                "SPIRV_SKIP_TESTS": "ON",
+                "SPIRV_CROSS_ENABLE_TESTS": "OFF",
+                "CMAKE_POLICY_VERSION_MINIMUM": "3.5"
+            }
+        },
+        {
+            "name": "linux-release",
+            "displayName": "Linux Release",
+            "description": "Release build for Linux using GCC",
+            "inherits": "linux-base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "ENTT_INCLUDE_HEADERS": "ON",
+                "SPDLOG_BUILD_SHARED": "OFF",
+                "BUILD_STATIC_LIBS": "ON",
+                "SPDLOG_FMT_EXTERNAL": "ON",
+                "SPDLOG_FMT_EXTERNAL_HO": "OFF",
+                "GLFW_BUILD_DOCS": "OFF",
+                "GLFW_BUILD_EXAMPLES": "OFF",
+                "GLFW_INSTALL": "OFF",
+                "ASSIMP_BUILD_TESTS": "OFF",
+                "ASSIMP_INSTALL": "OFF",
+                "ASSIMP_BUILD_SAMPLES": "OFF",
+                "ASSIMP_BUILD_ASSIMP_TOOLS": "OFF",
+                "ASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT": "OFF",
+                "ASSIMP_BUILD_OBJ_IMPORTER": "ON",
+                "ASSIMP_BUILD_ALL_EXPORTERS_BY_DEFAULT": "OFF",
+                "ASSIMP_BUILD_OBJ_EXPORTER": "ON",
+                "UUID_BUILD_TESTS": "OFF",
+                "UUID_USING_CXX20_SPAN": "ON",
+                "UUID_SYSTEM_GENERATOR": "OFF",
+                "YAML_CPP_BUILD_TOOLS": "OFF",
+                "YAML_CPP_BUILD_TESTS": "OFF",
+                "YAML_CPP_FORMAT_SOURCE": "OFF",
+                "YAML_BUILD_SHARED_LIBS": "OFF",
+                "USE_MASM": "OFF",
+                "USE_GAS": "OFF",
+                "SPIRV_SKIP_EXECUTABLES": "ON",
+                "SPIRV_SKIP_TESTS": "ON",
+                "SPIRV_CROSS_ENABLE_TESTS": "OFF",
+                "CMAKE_POLICY_VERSION_MINIMUM": "3.5"
+            }
+        },
+        {
+            "name": "macos-debug",
+            "displayName": "macOS Debug",
+            "description": "Debug build for macOS using Clang",
+            "inherits": "macos-base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "ENTT_INCLUDE_HEADERS": "ON",
+                "SPDLOG_BUILD_SHARED": "OFF",
+                "BUILD_STATIC_LIBS": "ON",
+                "SPDLOG_FMT_EXTERNAL": "ON",
+                "SPDLOG_FMT_EXTERNAL_HO": "OFF",
+                "GLFW_BUILD_DOCS": "OFF",
+                "GLFW_BUILD_EXAMPLES": "OFF",
+                "GLFW_INSTALL": "OFF",
+                "ASSIMP_BUILD_TESTS": "OFF",
+                "ASSIMP_INSTALL": "OFF",
+                "ASSIMP_BUILD_SAMPLES": "OFF",
+                "ASSIMP_BUILD_ASSIMP_TOOLS": "OFF",
+                "ASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT": "OFF",
+                "ASSIMP_BUILD_OBJ_IMPORTER": "ON",
+                "ASSIMP_BUILD_ALL_EXPORTERS_BY_DEFAULT": "OFF",
+                "ASSIMP_BUILD_OBJ_EXPORTER": "ON",
+                "UUID_BUILD_TESTS": "OFF",
+                "UUID_USING_CXX20_SPAN": "ON",
+                "UUID_SYSTEM_GENERATOR": "OFF",
+                "YAML_CPP_BUILD_TOOLS": "OFF",
+                "YAML_CPP_BUILD_TESTS": "OFF",
+                "YAML_CPP_FORMAT_SOURCE": "OFF",
+                "YAML_BUILD_SHARED_LIBS": "OFF",
+                "USE_MASM": "OFF",
+                "USE_GAS": "OFF",
+                "SPIRV_SKIP_EXECUTABLES": "ON",
+                "SPIRV_SKIP_TESTS": "ON",
+                "SPIRV_CROSS_ENABLE_TESTS": "OFF",
+                "CMAKE_POLICY_VERSION_MINIMUM": "3.5"
+            }
+        },
+        {
+            "name": "macos-release",
+            "displayName": "macOS Release", 
+            "description": "Release build for macOS using Clang",
+            "inherits": "macos-base",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "ENTT_INCLUDE_HEADERS": "ON",
+                "SPDLOG_BUILD_SHARED": "OFF",
+                "BUILD_STATIC_LIBS": "ON",
+                "SPDLOG_FMT_EXTERNAL": "ON",
+                "SPDLOG_FMT_EXTERNAL_HO": "OFF",
+                "GLFW_BUILD_DOCS": "OFF",
+                "GLFW_BUILD_EXAMPLES": "OFF",
+                "GLFW_INSTALL": "OFF",
+                "ASSIMP_BUILD_TESTS": "OFF",
+                "ASSIMP_INSTALL": "OFF",
+                "ASSIMP_BUILD_SAMPLES": "OFF",
+                "ASSIMP_BUILD_ASSIMP_TOOLS": "OFF",
+                "ASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT": "OFF",
+                "ASSIMP_BUILD_OBJ_IMPORTER": "ON",
+                "ASSIMP_BUILD_ALL_EXPORTERS_BY_DEFAULT": "OFF",
+                "ASSIMP_BUILD_OBJ_EXPORTER": "ON",
+                "UUID_BUILD_TESTS": "OFF",
+                "UUID_USING_CXX20_SPAN": "ON",
+                "UUID_SYSTEM_GENERATOR": "OFF",
+                "YAML_CPP_BUILD_TOOLS": "OFF",
+                "YAML_CPP_BUILD_TESTS": "OFF",
+                "YAML_CPP_FORMAT_SOURCE": "OFF",
+                "YAML_BUILD_SHARED_LIBS": "OFF",
+                "USE_MASM": "OFF",
+                "USE_GAS": "OFF",
+                "SPIRV_SKIP_EXECUTABLES": "ON",
+                "SPIRV_SKIP_TESTS": "ON",
+                "SPIRV_CROSS_ENABLE_TESTS": "OFF",
+                "CMAKE_POLICY_VERSION_MINIMUM": "3.5"
+            }
+        },
+        {
+            "name": "launcher-only-debug",
+            "displayName": "Launcher Only Debug",
+            "description": "Debug build for Panzerfaust launcher only",
+            "inherits": "base",
+            "generator": "Ninja",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "LAUNCHER_ONLY": "ON"
+            }
+        },
+        {
+            "name": "launcher-only-release",
+            "displayName": "Launcher Only Release",
+            "description": "Release build for Panzerfaust launcher only",
+            "inherits": "base",
+            "generator": "Ninja",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "LAUNCHER_ONLY": "ON"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "windows-debug",
+            "displayName": "Build Windows Debug",
+            "configurePreset": "windows-debug",
+            "configuration": "Debug",
+            "targets": ["ALL_BUILD"]
+        },
+        {
+            "name": "windows-release",
+            "displayName": "Build Windows Release", 
+            "configurePreset": "windows-release",
+            "configuration": "Release",
+            "targets": ["ALL_BUILD"]
+        },
+        {
+            "name": "linux-debug",
+            "displayName": "Build Linux Debug",
+            "configurePreset": "linux-debug",
+            "configuration": "Debug"
+        },
+        {
+            "name": "linux-release",
+            "displayName": "Build Linux Release",
+            "configurePreset": "linux-release", 
+            "configuration": "Release"
+        },
+        {
+            "name": "macos-debug",
+            "displayName": "Build macOS Debug",
+            "configurePreset": "macos-debug",
+            "configuration": "Debug"
+        },
+        {
+            "name": "macos-release",
+            "displayName": "Build macOS Release",
+            "configurePreset": "macos-release",
+            "configuration": "Release"
+        },
+        {
+            "name": "launcher-only-debug",
+            "displayName": "Build Launcher Only Debug",
+            "configurePreset": "launcher-only-debug",
+            "configuration": "Debug"
+        },
+        {
+            "name": "launcher-only-release", 
+            "displayName": "Build Launcher Only Release",
+            "configurePreset": "launcher-only-release",
+            "configuration": "Release"
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "windows-debug-test",
+            "displayName": "Test Windows Debug",
+            "configurePreset": "windows-debug",
+            "configuration": "Debug"
+        },
+        {
+            "name": "windows-release-test",
+            "displayName": "Test Windows Release",
+            "configurePreset": "windows-release", 
+            "configuration": "Release"
+        },
+        {
+            "name": "linux-debug-test",
+            "displayName": "Test Linux Debug",
+            "configurePreset": "linux-debug",
+            "configuration": "Debug"
+        },
+        {
+            "name": "linux-release-test",
+            "displayName": "Test Linux Release",
+            "configurePreset": "linux-release",
+            "configuration": "Release"
+        },
+        {
+            "name": "macos-debug-test",
+            "displayName": "Test macOS Debug",
+            "configurePreset": "macos-debug",
+            "configuration": "Debug"
+        },
+        {
+            "name": "macos-release-test",
+            "displayName": "Test macOS Release",
+            "configurePreset": "macos-release",
+            "configuration": "Release"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -62,7 +62,80 @@ Before building, make sure your setup is correct :
     brew install llvm@20
 ```
 
-## Building the engine & launcher
+## Building with CMake Presets (Recommended)
+
+ZEngine now supports CMake Presets for simplified building. This is the modern, cross-platform way to build the project.
+
+### Prerequisites
+- CMake 3.17 or later
+- Platform-specific build tools (Visual Studio on Windows, Xcode on macOS, GCC on Linux)
+
+### Configure and Build
+
+**Debug Build:**
+```bash
+# Configure
+cmake --preset linux-debug      # On Linux
+cmake --preset windows-debug    # On Windows
+cmake --preset macos-debug      # On macOS
+
+# Build
+cmake --build --preset linux-debug      # On Linux
+cmake --build --preset windows-debug    # On Windows
+cmake --build --preset macos-debug      # On macOS
+```
+
+**Release Build:**
+```bash
+# Configure
+cmake --preset linux-release    # On Linux
+cmake --preset windows-release  # On Windows
+cmake --preset macos-release    # On macOS
+
+# Build
+cmake --build --preset linux-release    # On Linux
+cmake --build --preset windows-release  # On Windows
+cmake --build --preset macos-release    # On macOS
+```
+
+**Launcher Only Build:**
+```bash
+# For building only the Panzerfaust launcher
+cmake --preset launcher-only-debug
+cmake --build --preset launcher-only-debug
+
+# Or release version
+cmake --preset launcher-only-release
+cmake --build --preset launcher-only-release
+```
+
+**Running Tests:**
+```bash
+ctest --preset linux-debug-test      # On Linux
+ctest --preset windows-debug-test    # On Windows
+ctest --preset macos-debug-test      # On macOS
+```
+
+### Available Presets
+
+List all available presets:
+```bash
+cmake --list-presets=configure
+cmake --list-presets=build
+cmake --list-presets=test
+```
+
+### IDE Integration
+
+CMakePresets.json is supported by:
+- Visual Studio 2019 16.10+ and Visual Studio 2022
+- Visual Studio Code with CMake Tools extension
+- CLion 2021.3+
+- Qt Creator 6.0+
+
+Simply open the project folder in your IDE and select the desired preset from the configuration dropdown.
+
+## Building the engine & launcher (Legacy PowerShell Method)
 
 1. Start `Powershell Core` and make sure that you can run CMake, You can type `cmake --version` to simply output the current CMake version installed.
 2. Change directories to the location where you've cloned the repository.
@@ -70,7 +143,7 @@ Before building, make sure your setup is correct :
 	- Debug version :	`.\Scripts\BuildEngine.ps1 -Configurations Debug -RunBuilds $True`
 	- Release version :	`.\Scripts\BuildEngine.ps1 -Configurations Release -RunBuilds $True`
 
-## Building the launcher only
+## Building the launcher only (Legacy PowerShell Method)
 
 To only build the Launcher only, you can specify `-LauncherOnly` which will skip building the engine :
 - Debug version :	`.\Scripts\BuildEngine.ps1 -Configurations Debug -RunBuilds $True -LauncherOnly`


### PR DESCRIPTION
- Add comprehensive CMakePresets.json with platform-specific presets
- Support for Windows (Visual Studio), Linux (GCC), and macOS (Xcode)
- Include launcher-only build presets for simplified builds
- Add build and test presets for all configurations
- Update README.md with CMakePresets usage documentation
- Add CMakeUserPresets.json to .gitignore for user-specific settings

Resolves #76