### PR TITLE
Enable CrossPlatform Builds and CI

### DIFF
--- a/.github/workflows/Engine-CI.yml
+++ b/.github/workflows/Engine-CI.yml
@@ -24,3 +24,9 @@ jobs:
     uses: ./.github/workflows/macOS-build.yml
     with:
       targetFramework: net8.0
+
+  linux:
+    needs: clang-format
+    uses: ./.github/workflows/linux-build.yml
+    with:
+      targetFramework: net8.0

--- a/.github/workflows/job-cmakebuild-linux.yml
+++ b/.github/workflows/job-cmakebuild-linux.yml
@@ -1,0 +1,55 @@
+name: ZEngine Cmake Linux Workflow
+
+on:
+  workflow_call:
+    inputs:
+      configuration:
+        type: string
+        default: 'Debug'
+      targetFramework:
+        type: string
+        default: 'net8.0'
+
+jobs:
+  Linux-Build:
+    name: cmake-build-linux-${{ inputs.configuration }}
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      
+    - name: Download the Microsoft repository GPG keys
+      run: wget -q https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb
+
+    - name: Register the Microsoft repository GPG keys
+      run: sudo dpkg -i packages-microsoft-prod.deb
+
+    - name: Install LLVM-20
+      run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 20
+
+    - name: Update the list of packages
+      run: sudo apt-get update
+
+    - name: Install Dependencies
+      run: sudo apt-get install libasound2-dev libgl1-mesa-dev libpulse-dev libdbus-1-dev libx11-dev libxcursor-dev libxext-dev libxi-dev libxinerama-dev libxrandr-dev libxss-dev libxt-dev libxxf86vm-dev cmake apt-transport-https software-properties-common gcc g++ powershell clang-format-20 glslang-tools libwayland-dev libxkbcommon-dev
+
+    - name: CMake Build
+      run: .\Scripts\BuildEngine.ps1 -Configurations ${{inputs.configuration}}
+      shell: pwsh
+
+    - name: Publish Build Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: Build-linux-${{inputs.configuration}}
+        path: |
+          Result.Linux.x64.${{inputs.configuration}}/Panzerfaust/${{inputs.configuration}}/${{inputs.targetFramework}}/publish/
+          Result.Linux.x64.${{inputs.configuration}}/__externals/Vulkan-Loader/loader/
+          Result.Linux.x64.${{inputs.configuration}}/ZEngine/tests/ZEngineTests
+          Result.Linux.x64.${{inputs.configuration}}/Panzerfaust/${{inputs.configuration}}/${{inputs.targetFramework}}/**/Microsoft.CodeAnalysis.CSharp.resources.dll
+          !Result.Linux.x64.${{inputs.configuration}}/Panzerfaust/${{inputs.configuration}}/${{inputs.targetFramework}}/**/Microsoft.CodeAnalysis.CSharp.Scripting.resources.dll
+          !Result.Linux.x64.${{inputs.configuration}}/Panzerfaust/${{inputs.configuration}}/${{inputs.targetFramework}}/**/Microsoft.CodeAnalysis.resources.dll
+          !Result.Linux.x64.${{inputs.configuration}}/Panzerfaust/${{inputs.configuration}}/${{inputs.targetFramework}}/**/Microsoft.CodeAnalysis.Scripting.resources.dll

--- a/.github/workflows/job-deploy-linux.yml
+++ b/.github/workflows/job-deploy-linux.yml
@@ -1,0 +1,29 @@
+# Deploy for linux
+#
+name: linux Deploy Workflow
+
+on:
+  workflow_call:
+    inputs:
+      targetFramework:
+        type: string
+        required: true
+      configuration:
+        type: string
+        default: 'Release'
+
+jobs:
+  deploy:
+    name: deploy-linux-${{ inputs.configuration }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: Result.Linux.x64.${{ inputs.configuration }}
+          name: Build-linux-Release
+
+      - name: Publish Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-${{ inputs.configuration }}
+          path: Result.Linux.x64.${{inputs.configuration}}/Panzerfaust/${{ inputs.configuration }}/${{inputs.targetFramework}}/publish/

--- a/.github/workflows/job-test-linux.yml
+++ b/.github/workflows/job-test-linux.yml
@@ -1,0 +1,31 @@
+# Run tests for linux
+#
+name: linux Test Workflow
+
+on:
+  workflow_call:
+    inputs:
+      configuration:
+        type: string
+        default: 'Debug'
+
+jobs:
+  test:
+    name: test-linux-${{ inputs.configuration }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: Build-linux-${{ inputs.configuration }}
+          path: Result.Linux.x64.${{ inputs.configuration }}
+
+      - name: Update access permission of ZEngineTests
+        run: chmod +x ./Result.Linux.x64.${{ inputs.configuration }}/ZEngine/tests/ZEngineTests
+
+      - name: Run Tests
+        run: .\Scripts\RunTests.ps1 -Configurations ${{ inputs.configuration }}
+        shell: pwsh

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,59 +1,35 @@
-# @JeanPhilippeKernel : Disabled because we only support Windows as platform for now
-#
 name: ZEngine Linux Build
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  workflow_call:
+    inputs:
+      targetFramework:
+        required: true
+        type: string
 
 jobs:
-  Linux-Build:
-    runs-on: ubuntu-latest
+  cmake-build:
     strategy:
       matrix:
-          buildConfiguration: [Debug, Release]
+        buildConfiguration: [Debug, Release]
+    uses: ./.github/workflows/job-cmakebuild-linux.yml
+    with:
+      configuration: ${{matrix.buildConfiguration}}
+      targetframework: ${{inputs.targetFramework}}
 
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+  test:
+    needs: cmake-build
+    strategy:
+      matrix:
+        testConfiguration: [Debug, Release]
+    uses: ./.github/workflows/job-test-linux.yml
+    with:
+      configuration: ${{matrix.testConfiguration}}
 
-#     - name: Checkout submodules
-#       run: git submodule update --init --recursive
+  deploy:
+    needs: test
+    uses: ./.github/workflows/job-deploy-linux.yml
+    with:
+      configuration: Release
+      targetframework: ${{inputs.targetFramework}}
 
-#     - name: Install development library
-#       run: sudo apt-get install libasound2-dev libgl1-mesa-dev libpulse-dev libdbus-1-dev libx11-dev libxcursor-dev libxext-dev libxi-dev libxinerama-dev libxrandr-dev libxss-dev libxt-dev libxxf86vm-dev
-
-#     - name: Install CMake
-#       uses: jwlawson/actions-setup-cmake@v1.9
-#       with:
-#         cmake-version: '3.20.x'
-
-#     - name: Install pre-requisite packages.
-#       run: sudo apt-get install -y wget apt-transport-https software-properties-common
-
-#     - name: Download the Microsoft repository GPG keys
-#       run: wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb
-
-#     - name: Register the Microsoft repository GPG keys
-#       run: sudo dpkg -i packages-microsoft-prod.deb
-
-#     - name: Update the list of packages after we added packages.microsoft.com
-#       run: sudo apt-get update
-
-#     - name: Install PowerShell
-#       run: sudo apt-get install -y powershell
-
-#     - name: Add GCC Toolchain repository
-#       run: sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-
-#     - name: Install GCC compiler
-#       run: sudo apt install -y gcc-11
-
-#     - name: Install G++ compiler
-#       run: sudo apt install -y g++-11
-
-#     - name: CMake Build
-#       run: .\Scripts\BuildEngine.ps1 -Configurations ${{matrix.buildConfiguration}}
-#       shell: pwsh

--- a/Obelisk/EntryPoint.cpp
+++ b/Obelisk/EntryPoint.cpp
@@ -18,7 +18,7 @@ int applicationEntryPoint(int argc, char* argv[])
     MemoryManager       manager = {};
     MemoryConfiguration config  = {.DefaultSize = ZGiga(3u)};
     manager.Initialize(config);
-    auto                arena      = &(manager.ArenaAllocator);
+    auto                arena      = &(manager.Allocator);
 
     LoggerConfiguration logger_cfg = {};
     Logger::Initialize(arena, logger_cfg);

--- a/Panzerfaust/Panzerfaust.csproj
+++ b/Panzerfaust/Panzerfaust.csproj
@@ -9,6 +9,7 @@
 		<ApplicationIcon>./Assets/avalonia-logo.ico</ApplicationIcon>
 		<BaseOutputPath Condition="$([MSBuild]::IsOSPlatform('Windows')) == 'true'">..\Result.Windows.x64.MultiConfig</BaseOutputPath>
 		<BaseOutputPath Condition="$([MSBuild]::IsOSPlatform('OSX')) == 'true'">..\Result.Darwin.x64.$(Configuration)</BaseOutputPath>
+		<BaseOutputPath Condition="$([MSBuild]::IsOSPlatform('Linux')) == 'true'">..\Result.Linux.x64.$(Configuration)</BaseOutputPath>
 		<Platforms>x64;arm64</Platforms>
 	</PropertyGroup>
 	<PropertyGroup Condition=" $([MSBuild]::IsOSPlatform('Windows')) == 'true' AND '$(Configuration)' == 'Debug' ">
@@ -55,6 +56,21 @@
 		<Optimize>true</Optimize>
 		<OutputPath>$(BaseOutputPath)\Panzerfaust\$(Configuration)</OutputPath>
 		<DefineConstants>TRACE;__MACOS__</DefineConstants>
+	</PropertyGroup>
+	<PropertyGroup Condition=" $([MSBuild]::IsOSPlatform('Linux')) == 'true' AND '$(Configuration)' == 'Debug' ">
+		<PlatformTarget>x64</PlatformTarget>
+		<DebugSymbols>true</DebugSymbols>
+		<DebugType>full</DebugType>
+		<Optimize>false</Optimize>
+		<OutputPath>$(BaseOutputPath)\Panzerfaust\$(Configuration)</OutputPath>
+		<DefineConstants>TRACE;DEBUG</DefineConstants>
+	</PropertyGroup>
+	<PropertyGroup Condition=" $([MSBuild]::IsOSPlatform('Linux')) == 'true' AND '$(Configuration)' == 'Release' ">
+		<PlatformTarget>x64</PlatformTarget>
+		<DebugType>pdbonly</DebugType>
+		<Optimize>true</Optimize>
+		<OutputPath>$(BaseOutputPath)\Panzerfaust\$(Configuration)</OutputPath>
+		<DefineConstants>TRACE</DefineConstants>
 	</PropertyGroup>
 	<PropertyGroup>
 	  <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/Scripts/BuildEngine.ps1
+++ b/Scripts/BuildEngine.ps1
@@ -113,7 +113,6 @@ function Build([string]$configuration, [int]$VsVersion , [bool]$runBuild) {
     # Check the system name
     if ($IsLinux) {
         $systemName = "Linux"
-        $cMakeGenerator
     }
     elseif ($IsMacOS) {
         $systemName = "Darwin"
@@ -131,7 +130,6 @@ function Build([string]$configuration, [int]$VsVersion , [bool]$runBuild) {
     [string]$BuildDirectoryName = "Result." + $systemName + "." + $architecture + "." + $BuildDirectoryNameExtension
     [string]$buildDirectoryPath = [IO.Path]::Combine($RepoRoot, $BuildDirectoryName)
     [string]$cMakeCacheVariableOverride = ""
-    [string]$cMakeGenerator = ""
 
     # Create build directory
     if (-Not (Test-Path $buildDirectoryPath)) {
@@ -171,11 +169,7 @@ function Build([string]$configuration, [int]$VsVersion , [bool]$runBuild) {
             $cMakeCacheVariableOverride += ' -DCMAKE_CONFIGURATION_TYPES=Debug;Release '
         }
         "Linux" {
-            $cMakeGenerator = "-G `"Unix Makefiles`""
-
-            # Set Linux build compiler
-            $env:CC = '/usr/bin/gcc-11'
-            $env:CXX = '/usr/bin/g++-11'
+            $cMakeGenerator = "-G `"Ninja`""
         }
         "Darwin" {
             $cMakeGenerator = "-G `"Xcode`""

--- a/Scripts/PostBuild.ps1
+++ b/Scripts/PostBuild.ps1
@@ -28,7 +28,7 @@ param (
     [string[]] $SystemName = 'Windows',
 
     [Parameter(HelpMessage="Architecture type to build, default to x64")]
-    [ValidateSet('win-x64', 'arm64', 'osx-x64', 'osx-arm64')]
+    [ValidateSet('win-x64', 'arm64', 'osx-x64', 'osx-arm64', 'linux-x64')]
     [string[]] $Architectures = 'win-x64',
 
     [Parameter(HelpMessage="Configuration type to build, default to Debug")]
@@ -103,7 +103,8 @@ $ContentsToProcess = @(
                     }
                 }
                 "Linux" {
-                    @{ From = "$OuputBuildDirectory\Obelisk\$Configurations"; To = "$OuputBuildDirectory\Panzerfaust\$Configurations\$TargetFramework\Editor"}
+                    @{ From = "$OuputBuildDirectory\Obelisk"; To = "$OuputBuildDirectory\Panzerfaust\$Configurations\$TargetFramework\Editor"}
+                    @{ From = "$OuputBuildDirectory\Obelisk"; To = "$OuputBuildDirectory\Panzerfaust\$Configurations\$TargetFramework\publish\Editor"}
                 }
                 Default {
                     throw 'This system is not supported'

--- a/Scripts/RunTests.ps1
+++ b/Scripts/RunTests.ps1
@@ -67,7 +67,9 @@ function RunTests {
         "Darwin" {
             $testExecutablePath = Join-Path $OutputBuildDirectory -ChildPath "ZEngine/tests/$Configuration/ZEngineTests"
         }
-        "Linux" {}
+        "Linux" {
+            $testExecutablePath = Join-Path $OutputBuildDirectory -ChildPath "ZEngine/tests/ZEngineTests"
+            }
         Default {
             throw 'This system is not supported'
         }
@@ -79,7 +81,7 @@ function RunTests {
         & $testExecutablePath
     }
     else {
-        Write-Warning "Test executable does not exist: $testExecutablePath"
+        Write-Error "Test executable does not exist: $testExecutablePath"
     }
 }
 

--- a/Scripts/Shared.ps1
+++ b/Scripts/Shared.ps1
@@ -189,7 +189,6 @@ function Find-ClangFormat () {
     $LLVMMaximumVersion = $repoConfiguration.Requirements.LLVM.MaximumVersion
 
     $candidates = @(
-        'clang-format'
         if ($IsMacOS) {
             $brewPrefixPath = Invoke-Expression -Command "& brew --prefix"
             Join-Path $brewPrefixPath -ChildPath 'opt/llvm/bin/clang-format'
@@ -197,6 +196,11 @@ function Find-ClangFormat () {
         if ($IsWindows) {
             Join-Path -Path $env:ProgramFiles -ChildPath 'LLVM\bin\clang-format.exe'
         }
+        if ($IsLinux) {
+            '/usr/bin/clang-format'
+            '/usr/bin/clang-format-20'
+        }
+        'clang-format'
     )
 
     foreach ($candidate in $candidates) {
@@ -225,7 +229,7 @@ function Setup-ShaderCCompilerTool () {
         $outputFile = Join-Path -Path $repositoryToolPath -ChildPath "ShaderCCompiler$outputFileExtension"
         Write-Host "Downloading Shader Compiler Tools..."
 
-        $shaderCToolUrl = IF($IsWindows) {$repoConfiguration.Requirements.ShaderC.Windows.Url} Elseif($IsMacOS) {$repoConfiguration.Requirements.ShaderC.macOS.Url}
+        $shaderCToolUrl = IF($IsWindows) {$repoConfiguration.Requirements.ShaderC.Windows.Url} Elseif($IsMacOS) {$repoConfiguration.Requirements.ShaderC.macOS.Url} Elseif($IsLinux){$repoConfiguration.Requirements.ShaderC.Linux.Url}
         Invoke-WebRequest -Uri $shaderCToolUrl -OutFile $outputFile
 
         # Extract contents

--- a/Scripts/Shared.ps1
+++ b/Scripts/Shared.ps1
@@ -166,6 +166,9 @@ function Find-GlslangValidator () {
         if ($IsMacOS) {
             Join-Path -Path $shaderCCompilerPath -ChildPath "\bin\glslangValidator" # On macOS, the pipeline build might pick up this option...
         }
+        if ($IsLinux) {
+       Join-Path -Path $shaderCCompilerPath -ChildPath "\bin\glslangValidator"
+        }
     )
 
     foreach ($GlslangValidatorProgram in $GlslangValidatorCandidates) {

--- a/Tetragrama/Components/HierarchyViewUIComponent.cpp
+++ b/Tetragrama/Components/HierarchyViewUIComponent.cpp
@@ -8,7 +8,7 @@
 #include <ZEngine/Windows/Inputs/Keyboard.h>
 #include <ZEngine/Windows/Inputs/Mouse.h>
 #include <glm/glm.hpp>
-#include <gtc/type_ptr.hpp>
+#include <glm/gtc/type_ptr.hpp>
 
 using namespace ZEngine;
 using namespace ZEngine::Helpers;

--- a/ZEngine/CMakeLists.txt
+++ b/ZEngine/CMakeLists.txt
@@ -6,16 +6,6 @@ project (ZEngine
 	LANGUAGES CXX C
 )
 
-# Compiler verification in Linux
-#
-if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-	if ((NOT ${CMAKE_CXX_COMPILER_VERSION} MATCHES "11.*.*") AND (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang"))
-		message(FATAL_ERROR "CLANG compiler version should be 11.*.* !")
-	elseif ((NOT ${CMAKE_CXX_COMPILER_VERSION} MATCHES "11.*.*") AND (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU"))
-		message(FATAL_ERROR "GNU compiler version should be 11.*.* !")
-	endif ()
-endif ()
-
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 set	(CMAKE_CXX_STANDARD 20)
 

--- a/ZEngine/ZEngine/Core/Memory/MemoryManager.h
+++ b/ZEngine/ZEngine/Core/Memory/MemoryManager.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <Allocator.h>
+#include <Core/Memory/Allocator.h>
 
 namespace ZEngine::Core::Memory
 {
@@ -12,14 +12,14 @@ namespace ZEngine::Core::Memory
     {
         void Initialize(const MemoryConfiguration& config)
         {
-            this->ArenaAllocator.Initialize(config.DefaultSize);
+            this->Allocator.Initialize(config.DefaultSize);
         }
 
         void Shutdowm()
         {
-            ArenaAllocator.Shutdown();
+            Allocator.Shutdown();
         }
 
-        ArenaAllocator ArenaAllocator = {};
+        ArenaAllocator Allocator = {};
     };
 } // namespace ZEngine::Core::Memory

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
@@ -372,7 +372,7 @@ namespace ZEngine::Hardwares
          * Creating VMA Allocators
          */
         VmaAllocatorCreateInfo vma_allocator_create_info = {.physicalDevice = PhysicalDevice, .device = LogicalDevice, .instance = Instance, .vulkanApiVersion = VK_API_VERSION_1_3};
-        ZENGINE_VALIDATE_ASSERT(vmaCreateAllocator(&vma_allocator_create_info, &VmaAllocator) == VK_SUCCESS, "Failed to create VMA Allocator")
+        ZENGINE_VALIDATE_ASSERT(vmaCreateAllocator(&vma_allocator_create_info, &VmaAllocatorValue) == VK_SUCCESS, "Failed to create VMA Allocator")
 
         m_buffer_manager.Initialize(this);
         EnqueuedCommandbuffers.init(Arena, m_buffer_manager.TotalCommandBufferCount, m_buffer_manager.TotalCommandBufferCount);
@@ -456,7 +456,7 @@ namespace ZEngine::Hardwares
 
     void VulkanDevice::Dispose()
     {
-        vmaDestroyAllocator(VmaAllocator);
+        vmaDestroyAllocator(VmaAllocatorValue);
 
         if (__destroyDebugMessengerPtr)
         {
@@ -651,8 +651,9 @@ namespace ZEngine::Hardwares
                 {
                     auto ds = reinterpret_cast<VkDescriptorSet>(res_handle.Handle);
                     vkFreeDescriptorSets(LogicalDevice, reinterpret_cast<VkDescriptorPool>(res_handle.Data1), 1, &ds);
-                    break;
                 }
+                case DeviceResourceType::RESOURCE_COUNT:
+                    break;
             }
 
             DirtyResources.Remove(handle);
@@ -672,7 +673,7 @@ namespace ZEngine::Hardwares
             }
 
             BufferView& buffer = DirtyBuffers[handle];
-            vmaDestroyBuffer(VmaAllocator, buffer.Handle, buffer.Allocation);
+            vmaDestroyBuffer(VmaAllocatorValue, buffer.Handle, buffer.Allocation);
             DirtyBuffers.Remove(handle);
         }
     }
@@ -693,7 +694,7 @@ namespace ZEngine::Hardwares
 
             vkDestroyImageView(LogicalDevice, buffer.ViewHandle, nullptr);
             vkDestroySampler(LogicalDevice, buffer.Sampler, nullptr);
-            vmaDestroyImage(VmaAllocator, buffer.Handle, buffer.Allocation);
+            vmaDestroyImage(VmaAllocatorValue, buffer.Handle, buffer.Allocation);
 
             DirtyBufferImages.Remove(handle);
         }
@@ -704,9 +705,9 @@ namespace ZEngine::Hardwares
         void* mapped_memory;
         if (data)
         {
-            ZENGINE_VALIDATE_ASSERT(vmaMapMemory(VmaAllocator, buffer.Allocation, &mapped_memory) == VK_SUCCESS, "Failed to map memory")
+            ZENGINE_VALIDATE_ASSERT(vmaMapMemory(VmaAllocatorValue, buffer.Allocation, &mapped_memory) == VK_SUCCESS, "Failed to map memory")
             ZENGINE_VALIDATE_ASSERT(Helpers::secure_memcpy(mapped_memory, data_size, data, data_size) == Helpers::MEMORY_OP_SUCCESS, "Failed to perform memory copy operation")
-            vmaUnmapMemory(VmaAllocator, buffer.Allocation);
+            vmaUnmapMemory(VmaAllocatorValue, buffer.Allocation);
         }
     }
 
@@ -723,13 +724,13 @@ namespace ZEngine::Hardwares
         allocation_create_info.usage                   = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
         allocation_create_info.flags                   = vma_create_flags;
 
-        ZENGINE_VALIDATE_ASSERT(vmaCreateBuffer(VmaAllocator, &buffer_create_info, &allocation_create_info, &(buffer_view.Handle), &(buffer_view.Allocation), nullptr) == VK_SUCCESS, "Failed to create buffer");
+        ZENGINE_VALIDATE_ASSERT(vmaCreateBuffer(VmaAllocatorValue, &buffer_create_info, &allocation_create_info, &(buffer_view.Handle), &(buffer_view.Allocation), nullptr) == VK_SUCCESS, "Failed to create buffer");
 
         /*
          * Zeroing the buffer
          */
         VmaAllocationInfo allocation_info = {};
-        vmaGetAllocationInfo(VmaAllocator, buffer_view.Allocation, &allocation_info);
+        vmaGetAllocationInfo(VmaAllocatorValue, buffer_view.Allocation, &allocation_info);
         Helpers::secure_memset(allocation_info.pMappedData, 0, byte_size, byte_size);
 
         // Metadata info
@@ -849,7 +850,7 @@ namespace ZEngine::Hardwares
         allocation_create_info.usage                   = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
         allocation_create_info.flags                   = VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT;
 
-        ZENGINE_VALIDATE_ASSERT(vmaCreateImage(VmaAllocator, &image_create_info, &allocation_create_info, &(buffer_image.Handle), &(buffer_image.Allocation), nullptr) == VK_SUCCESS, "Failed to create buffer");
+        ZENGINE_VALIDATE_ASSERT(vmaCreateImage(VmaAllocatorValue, &image_create_info, &allocation_create_info, &(buffer_image.Handle), &(buffer_image.Allocation), nullptr) == VK_SUCCESS, "Failed to create buffer");
 
         buffer_image.ViewHandle = CreateImageView(buffer_image.Handle, image_format, image_view_type, image_aspect_flag, layer_count);
         buffer_image.Sampler    = CreateImageSampler();
@@ -1409,7 +1410,7 @@ namespace ZEngine::Hardwares
                     BufferView& buffer = DirtyBuffers[handle];
                     if (buffer && buffer.FrameIndex == CurrentFrameIndex)
                     {
-                        vmaDestroyBuffer(VmaAllocator, buffer.Handle, buffer.Allocation);
+                        vmaDestroyBuffer(VmaAllocatorValue, buffer.Handle, buffer.Allocation);
                         buffer.Handle     = VK_NULL_HANDLE;
                         buffer.Allocation = VK_NULL_HANDLE;
                         DirtyBuffers.Remove(handle);
@@ -1435,7 +1436,7 @@ namespace ZEngine::Hardwares
                     {
                         vkDestroyImageView(LogicalDevice, buffer.ViewHandle, nullptr);
                         vkDestroySampler(LogicalDevice, buffer.Sampler, nullptr);
-                        vmaDestroyImage(VmaAllocator, buffer.Handle, buffer.Allocation);
+                        vmaDestroyImage(VmaAllocatorValue, buffer.Handle, buffer.Allocation);
                         buffer.Handle     = VK_NULL_HANDLE;
                         buffer.Allocation = VK_NULL_HANDLE;
                         DirtyBufferImages.Remove(handle);
@@ -2097,7 +2098,7 @@ namespace ZEngine::Hardwares
             m_current_offset = 0;
             m_total_size     = size;
             Buffer           = CreateBuffer();
-            vmaSetAllocationName(m_device->VmaAllocator, Buffer.Allocation, debug_name);
+            vmaSetAllocationName(m_device->VmaAllocatorValue, Buffer.Allocation, debug_name);
         }
     }
 
@@ -2122,12 +2123,12 @@ namespace ZEngine::Hardwares
         }
 
         VkMemoryPropertyFlags mem_prop_flags;
-        vmaGetAllocationMemoryProperties(m_device->VmaAllocator, Buffer.Allocation, &mem_prop_flags);
+        vmaGetAllocationMemoryProperties(m_device->VmaAllocatorValue, Buffer.Allocation, &mem_prop_flags);
 
         if (mem_prop_flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
         {
             VmaAllocationInfo allocation_info = {};
-            vmaGetAllocationInfo(m_device->VmaAllocator, Buffer.Allocation, &allocation_info);
+            vmaGetAllocationInfo(m_device->VmaAllocatorValue, Buffer.Allocation, &allocation_info);
             if (allocation_info.pMappedData)
             {
                 auto mapped_buf = reinterpret_cast<uint8_t*>(allocation_info.pMappedData);
@@ -2139,12 +2140,12 @@ namespace ZEngine::Hardwares
             BufferView        staging_buffer  = m_device->CreateBuffer(static_cast<VkDeviceSize>(byte_size), VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT);
 
             VmaAllocationInfo allocation_info = {};
-            vmaGetAllocationInfo(m_device->VmaAllocator, staging_buffer.Allocation, &allocation_info);
+            vmaGetAllocationInfo(m_device->VmaAllocatorValue, staging_buffer.Allocation, &allocation_info);
 
             if (allocation_info.pMappedData)
             {
                 ZENGINE_VALIDATE_ASSERT(Helpers::secure_memset(allocation_info.pMappedData, value, allocation_info.size, byte_size) == Helpers::MEMORY_OP_SUCCESS, "Failed to perform memory copy operation")
-                ZENGINE_VALIDATE_ASSERT(vmaFlushAllocation(m_device->VmaAllocator, staging_buffer.Allocation, 0, byte_size) == VK_SUCCESS, "Failed to flush allocation")
+                ZENGINE_VALIDATE_ASSERT(vmaFlushAllocation(m_device->VmaAllocatorValue, staging_buffer.Allocation, 0, byte_size) == VK_SUCCESS, "Failed to flush allocation")
                 m_device->CopyBuffer(staging_buffer, Buffer, byte_size, 0u, offset);
             }
 
@@ -2168,11 +2169,11 @@ namespace ZEngine::Hardwares
         }
 
         VkMemoryPropertyFlags mem_prop_flags;
-        vmaGetAllocationMemoryProperties(m_device->VmaAllocator, Buffer.Allocation, &mem_prop_flags);
+        vmaGetAllocationMemoryProperties(m_device->VmaAllocatorValue, Buffer.Allocation, &mem_prop_flags);
 
         if (mem_prop_flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
         {
-            ZENGINE_VALIDATE_ASSERT(vmaCopyMemoryToAllocation(m_device->VmaAllocator, data, Buffer.Allocation, offset, byte_size) == VK_SUCCESS, "Failed to perform memory copy operation")
+            ZENGINE_VALIDATE_ASSERT(vmaCopyMemoryToAllocation(m_device->VmaAllocatorValue, data, Buffer.Allocation, offset, byte_size) == VK_SUCCESS, "Failed to perform memory copy operation")
 
             VkAccessFlags        dst_access_mask    = VK_ACCESS_NONE;
             VkPipelineStageFlags dst_pipeline_stage = VK_PIPELINE_STAGE_TRANSFER_BIT;
@@ -2223,7 +2224,7 @@ namespace ZEngine::Hardwares
         {
             BufferView staging_buffer = m_device->CreateBuffer(static_cast<VkDeviceSize>(byte_size), VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT);
 
-            ZENGINE_VALIDATE_ASSERT(vmaCopyMemoryToAllocation(m_device->VmaAllocator, data, staging_buffer.Allocation, offset, byte_size) == VK_SUCCESS, "Failed to perform memory copy operation")
+            ZENGINE_VALIDATE_ASSERT(vmaCopyMemoryToAllocation(m_device->VmaAllocatorValue, data, staging_buffer.Allocation, offset, byte_size) == VK_SUCCESS, "Failed to perform memory copy operation")
 
             m_device->CopyBuffer(staging_buffer, Buffer, byte_size, 0u, offset);
 

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.h
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.h
@@ -6,8 +6,8 @@
 #include <Helpers/HandleManager.h>
 #include <Helpers/MemoryOperations.h>
 #include <Helpers/ThreadSafeQueue.h>
-#include <Primitives/Fence.h>
-#include <Primitives/Semaphore.h>
+#include <Rendering/Primitives/Fence.h>
+#include <Rendering/Primitives/Semaphore.h>
 #include <Rendering/Pools/CommandPool.h>
 #include <Rendering/Primitives/ImageMemoryBarrier.h>
 #include <Rendering/ResourceTypes.h>
@@ -20,6 +20,8 @@
 #include <Core/Memory/Allocator.h>
 #include <AsyncResourceLoader.h>
 #include <set>
+#include <limits>
+#include <cstdint>
 // clang-format on
 
 namespace ZEngine::Windows
@@ -555,7 +557,7 @@ namespace ZEngine::Hardwares
         VkPhysicalDeviceFeatures                                                            PhysicalDeviceFeature              = {};
         VkPhysicalDeviceMemoryProperties                                                    PhysicalDeviceMemoryProperties     = {};
         VkSwapchainKHR                                                                      SwapchainHandle                    = VK_NULL_HANDLE;
-        VmaAllocator                                                                        VmaAllocator                       = nullptr;
+        VmaAllocator                                                                        VmaAllocatorValue                  = nullptr;
         Core::Containers::Array<VkFormat>                                                   DefaultDepthFormats                = {};
         Rendering::Renderers::RenderPasses::Attachment*                                     SwapchainAttachment                = {};
         Core::Containers::Array<VkImageView>                                                SwapchainImageViews                = {};

--- a/ZEngine/ZEngine/Rendering/Renderers/ImGUIRenderer.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/ImGUIRenderer.cpp
@@ -1,9 +1,11 @@
 #include <Hardwares/VulkanDevice.h>
-#include <ImGuizmo/ImGuizmo.h>
 #include <Rendering/Renderers/ImGUIRenderer.h>
 #include <Windows/CoreWindow.h>
+// clang-format off
 #include <backends/imgui_impl_glfw.h>
 #include <backends/imgui_impl_vulkan.h>
+#include <ImGuizmo/ImGuizmo.h>
+// clang-format on
 
 using namespace ZEngine::Hardwares;
 using namespace ZEngine::Rendering;

--- a/ZEngine/ZEngine/Rendering/Renderers/Pipelines/RendererPipeline.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/Pipelines/RendererPipeline.cpp
@@ -1,5 +1,6 @@
 #include <Hardwares/VulkanDevice.h>
 #include <Rendering/Renderers/Pipelines/RendererPipeline.h>
+#include <array>
 
 using namespace ZEngine::Helpers;
 using namespace ZEngine::Core::Containers;
@@ -10,7 +11,7 @@ namespace ZEngine::Rendering::Renderers::Pipelines
     {
         Device             = device;
         Specification      = std::move(spec);
-        auto shader_handle = Device->CompileShader(Specification.ShaderSpecification);
+        auto shader_handle = Device->CompileShader(Specification.ShaderSpecificationValue);
         if (!shader_handle)
         {
             ZENGINE_CORE_ERROR("")

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/RenderPass.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/RenderPass.cpp
@@ -1,6 +1,7 @@
 #include <Hardwares/VulkanDevice.h>
 #include <Rendering/Renderers/RenderPasses/RenderPass.h>
 #include <fmt/format.h>
+#include <numeric>
 
 using namespace ZEngine::Rendering::Buffers;
 using namespace ZEngine::Rendering::Specifications;
@@ -389,13 +390,13 @@ namespace ZEngine::Rendering::Renderers::RenderPasses
 
     RenderPassBuilder& RenderPassBuilder::SetShaderOverloadMaxSet(uint32_t count)
     {
-        m_spec.PipelineSpecification.ShaderSpecification.OverloadMaxSet = count;
+        m_spec.PipelineSpecification.ShaderSpecificationValue.OverloadMaxSet = count;
         return *this;
     }
 
     RenderPassBuilder& RenderPassBuilder::SetOverloadPoolSize(uint32_t count)
     {
-        m_spec.PipelineSpecification.ShaderSpecification.OverloadPoolSize = count;
+        m_spec.PipelineSpecification.ShaderSpecificationValue.OverloadPoolSize = count;
         return *this;
     }
 
@@ -449,7 +450,7 @@ namespace ZEngine::Rendering::Renderers::RenderPasses
 
     RenderPassBuilder& RenderPassBuilder::UseShader(std::string_view name)
     {
-        m_spec.PipelineSpecification.ShaderSpecification.Name = name.data();
+        m_spec.PipelineSpecification.ShaderSpecificationValue.Name = name.data();
         return *this;
     }
 

--- a/ZEngine/ZEngine/Rendering/Scenes/GraphicScene.h
+++ b/ZEngine/ZEngine/Rendering/Scenes/GraphicScene.h
@@ -2,7 +2,7 @@
 #include <Hardwares/VulkanDevice.h>
 #include <Helpers/NodeHierarchyHelper.h>
 #include <Rendering/Meshes/Mesh.h>
-#include <Textures/Texture.h>
+#include <Rendering/Textures/Texture.h>
 #include <ZEngineDef.h>
 #include <entt/entt.hpp>
 #include <uuid.h>
@@ -85,7 +85,7 @@ namespace ZEngine::Rendering::Scenes
          */
         std::vector<float>                         Vertices                     = {};
         std::vector<uint32_t>                      Indices                      = {};
-        std::vector<DrawData>                      DrawData                     = {};
+        std::vector<DrawData>                      DrawDataValue                = {};
         std::vector<std::string>                   Names                        = {};
         std::vector<std::string>                   MaterialNames                = {};
         std::unordered_map<uint32_t, uint32_t>     NodeMeshes                   = {};

--- a/ZEngine/ZEngine/Rendering/Shaders/Shader.cpp
+++ b/ZEngine/ZEngine/Rendering/Shaders/Shader.cpp
@@ -98,7 +98,7 @@ namespace ZEngine::Rendering::Shaders
                     LayoutBindingSpecificationMap[set].init(m_device->Arena, 10);
                 }
 
-                LayoutBindingSpecificationMap[set].push(LayoutBindingSpecification{.Set = set, .Binding = binding, .Name = UB_resource.name, .DescriptorType = DescriptorType::UNIFORM_BUFFER, .Flags = ShaderStageFlags::VERTEX});
+                LayoutBindingSpecificationMap[set].push(LayoutBindingSpecification{.Set = set, .Binding = binding, .Name = UB_resource.name, .DescriptorTypeValue = DescriptorType::UNIFORM_BUFFER, .Flags = ShaderStageFlags::VERTEX});
             }
 
             for (const auto& SB_resource : vertex_resources.storage_buffers)
@@ -111,7 +111,7 @@ namespace ZEngine::Rendering::Shaders
                     LayoutBindingSpecificationMap[set].init(m_device->Arena, 10);
                 }
 
-                LayoutBindingSpecificationMap[set].push(LayoutBindingSpecification{.Set = set, .Binding = binding, .Name = SB_resource.name, .DescriptorType = DescriptorType::STORAGE_BUFFER, .Flags = ShaderStageFlags::VERTEX});
+                LayoutBindingSpecificationMap[set].push(LayoutBindingSpecification{.Set = set, .Binding = binding, .Name = SB_resource.name, .DescriptorTypeValue = DescriptorType::STORAGE_BUFFER, .Flags = ShaderStageFlags::VERTEX});
             }
 
             for (const auto& pushConstant_resource : vertex_resources.push_constant_buffers)
@@ -167,7 +167,7 @@ namespace ZEngine::Rendering::Shaders
                     LayoutBindingSpecificationMap[set].init(m_device->Arena, 10);
                 }
 
-                LayoutBindingSpecificationMap[set].push(LayoutBindingSpecification{.Set = set, .Binding = binding, .Name = UB_resource.name, .DescriptorType = DescriptorType::UNIFORM_BUFFER, .Flags = ShaderStageFlags::FRAGMENT});
+                LayoutBindingSpecificationMap[set].push(LayoutBindingSpecification{.Set = set, .Binding = binding, .Name = UB_resource.name, .DescriptorTypeValue = DescriptorType::UNIFORM_BUFFER, .Flags = ShaderStageFlags::FRAGMENT});
             }
 
             for (const auto& SB_resource : fragment_resources.storage_buffers)
@@ -180,7 +180,7 @@ namespace ZEngine::Rendering::Shaders
                     LayoutBindingSpecificationMap[set].init(m_device->Arena, 10);
                 }
 
-                LayoutBindingSpecificationMap[set].push(LayoutBindingSpecification{.Set = set, .Binding = binding, .Name = SB_resource.name, .DescriptorType = DescriptorType::STORAGE_BUFFER, .Flags = ShaderStageFlags::FRAGMENT});
+                LayoutBindingSpecificationMap[set].push(LayoutBindingSpecification{.Set = set, .Binding = binding, .Name = SB_resource.name, .DescriptorTypeValue = DescriptorType::STORAGE_BUFFER, .Flags = ShaderStageFlags::FRAGMENT});
             }
 
             for (const auto& pushConstant_resource : fragment_resources.push_constant_buffers)
@@ -225,7 +225,7 @@ namespace ZEngine::Rendering::Shaders
                     LayoutBindingSpecificationMap[set].init(m_device->Arena, 10);
                 }
 
-                LayoutBindingSpecificationMap[set].push(LayoutBindingSpecification{.Set = set, .Binding = binding, .Count = count, .Name = SI_resource.name, .DescriptorType = DescriptorType::COMBINED_IMAGE_SAMPLER, .Flags = ShaderStageFlags::FRAGMENT});
+                LayoutBindingSpecificationMap[set].push(LayoutBindingSpecification{.Set = set, .Binding = binding, .Count = count, .Name = SI_resource.name, .DescriptorTypeValue = DescriptorType::COMBINED_IMAGE_SAMPLER, .Flags = ShaderStageFlags::FRAGMENT});
             }
         }
     }
@@ -280,7 +280,7 @@ namespace ZEngine::Rendering::Shaders
             layout_binding_collection.init(&LocalArena, 10);
             for (uint32_t i = 0; i < layout_binding_set.second.size(); ++i)
             {
-                layout_binding_collection.push(VkDescriptorSetLayoutBinding{.binding = layout_binding_set.second[i].Binding, .descriptorType = DescriptorTypeMap[static_cast<uint32_t>(layout_binding_set.second[i].DescriptorType)], .descriptorCount = layout_binding_set.second[i].Count, .stageFlags = ShaderStageFlagsMap[static_cast<uint32_t>(layout_binding_set.second[i].Flags)], .pImmutableSamplers = nullptr});
+                layout_binding_collection.push(VkDescriptorSetLayoutBinding{.binding = layout_binding_set.second[i].Binding, .descriptorType = DescriptorTypeMap[static_cast<uint32_t>(layout_binding_set.second[i].DescriptorTypeValue)], .descriptorCount = layout_binding_set.second[i].Count, .stageFlags = ShaderStageFlagsMap[static_cast<uint32_t>(layout_binding_set.second[i].Flags)], .pImmutableSamplers = nullptr});
             }
             /*
              * Binding flag extension

--- a/ZEngine/ZEngine/Rendering/Shaders/ShaderReader.cpp
+++ b/ZEngine/ZEngine/Rendering/Shaders/ShaderReader.cpp
@@ -18,7 +18,7 @@ namespace ZEngine::Rendering::Shaders
     std::vector<uint32_t> ShaderReader::ReadAsBinary(std::string_view filename)
     {
         std::ifstream file_stream = {};
-        file_stream.open(filename, std::ifstream::binary | std::ifstream::ate);
+        file_stream.open(std::string(filename), std::ifstream::binary | std::ifstream::ate);
         if (!file_stream.is_open())
         {
             ZENGINE_CORE_ERROR("====== Shader file : {} cannot be opened ======", filename.data())

--- a/ZEngine/ZEngine/Rendering/Specifications/GraphicRendererPipelineSpecification.h
+++ b/ZEngine/ZEngine/Rendering/Specifications/GraphicRendererPipelineSpecification.h
@@ -29,7 +29,7 @@ namespace ZEngine::Rendering::Specifications
         uint32_t                                                   DepthCompareOp                     = VK_COMPARE_OP_LESS_OR_EQUAL;
         bool                                                       EnableStencilTest                  = false;
         const char*                                                DebugName                          = {};
-        ShaderSpecification                                        ShaderSpecification                = {};
+        ShaderSpecification                                        ShaderSpecificationValue           = {};
         Rendering::Buffers::FramebufferVNext*                      TargetFrameBuffer                  = {};
         Renderers::RenderPasses::Attachment*                       Attachment                         = {};
         Core::Containers::Array<VertexInputBindingSpecification>   VertexInputBindingSpecifications   = {};

--- a/ZEngine/ZEngine/Rendering/Specifications/ShaderSpecification.h
+++ b/ZEngine/ZEngine/Rendering/Specifications/ShaderSpecification.h
@@ -39,7 +39,7 @@ namespace ZEngine::Rendering::Specifications
         uint32_t         Binding{0xFFFFFFFF};
         uint32_t         Count{1};
         std::string      Name;
-        DescriptorType   DescriptorType;
+        DescriptorType   DescriptorTypeValue;
         ShaderStageFlags Flags;
     };
 

--- a/ZEngine/ZEngine/Rendering/Specifications/TextureSpecification.h
+++ b/ZEngine/ZEngine/Rendering/Specifications/TextureSpecification.h
@@ -34,13 +34,14 @@ namespace ZEngine::Rendering::Specifications
     {
         uint32_t              Width;
         uint32_t              Height;
-        ImageViewType         ImageViewType = ImageViewType::TYPE_2D;
+
+        ImageViewType         ImageViewTypeValue = ImageViewType::TYPE_2D;
         ImageBufferUsageType  BufferUsageType;
         VkFormat              ImageFormat;
         VkImageUsageFlags     ImageUsage;
         VkImageAspectFlagBits ImageAspectFlag;
-        uint32_t              LayerCount      = 1U;
-        ImageCreateFlag       ImageCreateFlag = ImageCreateFlag::NONE;
+        uint32_t              LayerCount           = 1U;
+        ImageCreateFlag       ImageCreateFlagValue = ImageCreateFlag::NONE;
     };
 
 } // namespace ZEngine::Rendering::Specifications

--- a/ZEngine/ZEngine/Windows/Inputs/KeyCode.h
+++ b/ZEngine/ZEngine/Windows/Inputs/KeyCode.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include <iostream>
 
 namespace ZEngine::Windows::Inputs
 {
@@ -136,4 +137,10 @@ namespace ZEngine::Windows::Inputs
         MOUSE_BUTTON_8      = 7
 
     } GlfwKey;
+
+    inline std::ostream& operator<<(std::ostream& stream, GlfwKeyCode f)
+    {
+        stream << static_cast<int32_t>(f);
+        return stream;
+    }
 } // namespace ZEngine::Windows::Inputs

--- a/ZEngine/ZEngine/ZEngineDef.h
+++ b/ZEngine/ZEngine/ZEngineDef.h
@@ -12,7 +12,8 @@
 #include <signal.h>
 #define ZENGINE_DEBUG_BREAK() __builtin_trap();
 #else
-#error "Platform not supported!"
+#include <signal.h>
+#define ZENGINE_DEBUG_BREAK() raise(SIGTRAP);
 #endif
 
 #ifdef _MSC_VER

--- a/ZEngine/tests/CMakeLists.txt
+++ b/ZEngine/tests/CMakeLists.txt
@@ -8,6 +8,5 @@ add_executable(ZEngineTests ${TEST_SOURCES})
 
 target_link_libraries(ZEngineTests PRIVATE
     zEngineLib
-    GTest::gtest
     GTest::gtest_main
 )

--- a/ZEngine/tests/Memory/allocator_test.cpp
+++ b/ZEngine/tests/Memory/allocator_test.cpp
@@ -82,14 +82,14 @@ TEST(AllocatorTest, ArenaMemoryManager)
         void  Func() {}
     };
 
-    int* intPtr    = ZPushArray(&(manager.ArenaAllocator), int, 1);
-    auto structPtr = ZPushStruct(&(manager.ArenaAllocator), Foo);
+    int* intPtr    = ZPushArray(&(manager.Allocator), int, 1);
+    auto structPtr = ZPushStruct(&(manager.Allocator), Foo);
 
     *intPtr        = 12;
     structPtr->x   = 12;
     structPtr->y   = 798.0f;
 
-    char* str      = ZPushString(&(manager.ArenaAllocator), 12);
+    char* str      = ZPushString(&(manager.Allocator), 12);
     Helpers::secure_memmove(str, 12, "hello", 5);
 
     EXPECT_EQ(*intPtr, 12);
@@ -121,7 +121,7 @@ TEST(AllocatorTest, ArenaMemoryTemp)
 {
     MemoryManager manager{};
     manager.Initialize({.DefaultSize = ZKilo(10)});
-    auto arena = &(manager.ArenaAllocator);
+    auto arena = &(manager.Allocator);
     {
         auto fooPtr  = ZPushStruct(arena, Foo);
         fooPtr->x    = 10;
@@ -142,7 +142,7 @@ TEST(AllocatorTest, ArenaMemoryPool)
 {
     MemoryManager manager{};
     manager.Initialize({.DefaultSize = ZKilo(10)});
-    auto arena = &(manager.ArenaAllocator);
+    auto arena = &(manager.Allocator);
     {
         PoolAllocator pool;
         pool.Initialize(arena, sizeof(Foo) * 100, sizeof(Foo));

--- a/ZEngine/tests/Memory/handleManager_test.cpp
+++ b/ZEngine/tests/Memory/handleManager_test.cpp
@@ -10,7 +10,7 @@ protected:
     void SetUp() override
     {
         manager.Initialize({.DefaultSize = ZKilo(10)});
-        auto arena = &(manager.ArenaAllocator);
+        auto arena = &(manager.Allocator);
         handle_manager.Initialize(arena, 10);
     }
 
@@ -114,7 +114,7 @@ TEST_F(HandleManagerTest, ReuseSlot)
 TEST_F(HandleManagerTest, ConcurrentAccess)
 {
     ZEngine::Helpers::HandleManager<int*> h_manager;
-    h_manager.Initialize(&(manager.ArenaAllocator), 40);
+    h_manager.Initialize(&(manager.Allocator), 40);
     const int                numThreads             = 4;
     const int                numOperationsPerThread = 10;
     std::vector<std::thread> threads;

--- a/repoConfiguration.json
+++ b/repoConfiguration.json
@@ -10,6 +10,9 @@
             },
             "macOS": {
                 "Url": "https://storage.googleapis.com/shaderc/artifacts/prod/graphics_shader_compiler/shaderc/macos/continuous_clang_release/472/20240708-061139/install.tgz"
+            },
+            "Linux": {
+                "Url": "https://storage.googleapis.com/shaderc/artifacts/prod/graphics_shader_compiler/shaderc/linux/continuous_gcc_release/500/20250807-100822/install.tgz"
             }
         },
         "GlslangValidator": {


### PR DESCRIPTION
# Changes made to enable cross platform builds

- Upgrade submodule dependencies to newer versions as upstream generally have fixed issues with them. For example assimp -Werror issues and GLM requiring old CMake Flags
- Rename variables that have the same name as the naming type as this wasn't working with GCC.
- Replicate Linux CI workflow using Ninja Generator for Linux
- Remove hard requirement for gcc11 and let the default compiler on the system to be used