### PR TITLE
Fix incorrect pre-compiled-header usage

### DIFF
--- a/Obelisk/EntryPoint.cpp
+++ b/Obelisk/EntryPoint.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <CLI/CLI.hpp>
 #include <ZEngine/Core/Memory/MemoryManager.h>
 #include <ZEngine/EngineConfiguration.h>

--- a/Obelisk/pch.cpp
+++ b/Obelisk/pch.cpp
@@ -1,1 +1,0 @@
-#include <pch.h>

--- a/Tetragrama/Components/DockspaceUIComponent.cpp
+++ b/Tetragrama/Components/DockspaceUIComponent.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <DockspaceUIComponent.h>
 #include <Editor.h>
 #include <Helpers/UIDispatcher.h>

--- a/Tetragrama/Components/HierarchyViewUIComponent.cpp
+++ b/Tetragrama/Components/HierarchyViewUIComponent.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Controllers/EditorCameraController.h>
 #include <Editor.h>
 #include <HierarchyViewUIComponent.h>

--- a/Tetragrama/Components/InspectorViewUIComponent.cpp
+++ b/Tetragrama/Components/InspectorViewUIComponent.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Editor.h>
 #include <InspectorViewUIComponent.h>
 #include <UIComponentDrawerHelper.h>

--- a/Tetragrama/Components/LogUIComponent.cpp
+++ b/Tetragrama/Components/LogUIComponent.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Helpers/MemoryOperations.h>
 #include <LogUIComponent.h>
 #include <SearchPatternAlgorithm.h>

--- a/Tetragrama/Components/ProjectViewUIComponent.cpp
+++ b/Tetragrama/Components/ProjectViewUIComponent.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Editor.h>
 #include <Helpers/SearchPatternAlgorithm.h>
 #include <ProjectViewUIComponent.h>

--- a/Tetragrama/Components/SceneViewportUIComponent.cpp
+++ b/Tetragrama/Components/SceneViewportUIComponent.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Controllers/EditorCameraController.h>
 #include <MessageToken.h>
 #include <Messengers/Messenger.h>

--- a/Tetragrama/Editor.cpp
+++ b/Tetragrama/Editor.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Controllers/EditorCameraController.h>
 #include <Editor.h>
 #include <MessageToken.h>

--- a/Tetragrama/EditorScene.cpp
+++ b/Tetragrama/EditorScene.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <EditorScene.h>
 #include <ZEngine/Managers/AssetManager.h>
 #include <stack>

--- a/Tetragrama/Helpers/SearchPatternAlgorithm.cpp
+++ b/Tetragrama/Helpers/SearchPatternAlgorithm.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <SearchPatternAlgorithm.h>
 #include <ZEngine/Helpers/MemoryOperations.h>
 

--- a/Tetragrama/Helpers/UIComponentDrawerHelper.cpp
+++ b/Tetragrama/Helpers/UIComponentDrawerHelper.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <UIComponentDrawerHelper.h>
 
 namespace Tetragrama::Helpers

--- a/Tetragrama/Layers/ImguiLayer.cpp
+++ b/Tetragrama/Layers/ImguiLayer.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Components/DemoUIComponent.h>
 #include <Components/DockspaceUIComponent.h>
 #include <Components/HierarchyViewUIComponent.h>

--- a/Tetragrama/Serializers/EditorSceneSerializer.cpp
+++ b/Tetragrama/Serializers/EditorSceneSerializer.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <EditorSceneSerializer.h>
 #include <Importers/IAssetImporter.h>
 #include <ZEngine/Core/Containers/Array.h>

--- a/Tetragrama/pch.cpp
+++ b/Tetragrama/pch.cpp
@@ -1,1 +1,0 @@
-#include <pch.h>

--- a/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp
+++ b/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <AppRenderPipeline.h>
 #include <Core/Containers/Array.h>
 

--- a/ZEngine/ZEngine/Applications/GameApplication.cpp
+++ b/ZEngine/ZEngine/Applications/GameApplication.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Engine.h>
 #include <GameApplication.h>
 

--- a/ZEngine/ZEngine/Controllers/PerspectiveCameraController.cpp
+++ b/ZEngine/ZEngine/Controllers/PerspectiveCameraController.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Controllers/PerspectiveCameraController.h>
 #include <Core/EventDispatcher.h>
 #include <Inputs/IDevice.h>

--- a/ZEngine/ZEngine/Core/Memory/Allocator.cpp
+++ b/ZEngine/ZEngine/Core/Memory/Allocator.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Allocator.h>
 #include <MemoryOperations.h>
 

--- a/ZEngine/ZEngine/Engine.cpp
+++ b/ZEngine/ZEngine/Engine.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Applications/AppRenderPipeline.h>
 #include <Applications/GameApplication.h>
 #include <Engine.h>

--- a/ZEngine/ZEngine/Hardwares/AsyncResourceLoader.cpp
+++ b/ZEngine/ZEngine/Hardwares/AsyncResourceLoader.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <AsyncResourceLoader.h>
 #include <Helpers/ThreadPool.h>
 #include <Rendering/Buffers/Bitmap.h>

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <ZEngineDef.h>
 
 /*

--- a/ZEngine/ZEngine/Hardwares/VulkanLayer.cpp
+++ b/ZEngine/ZEngine/Hardwares/VulkanLayer.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Hardwares/VulkanLayer.h>
 #include <Helpers/MemoryOperations.h>
 #include <Logging/LoggerDefinition.h>

--- a/ZEngine/ZEngine/Helpers/Helper.cpp
+++ b/ZEngine/ZEngine/Helpers/Helper.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Core/Coroutine.h>
 #include <Hardwares/VulkanDevice.h>
 #include <Helpers/MathHelper.h>

--- a/ZEngine/ZEngine/Helpers/SerializerCommonHelper.cpp
+++ b/ZEngine/ZEngine/Helpers/SerializerCommonHelper.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Helpers/MemoryOperations.h>
 #include <SerializerCommonHelper.h>
 

--- a/ZEngine/ZEngine/Helpers/ThreadPool.cpp
+++ b/ZEngine/ZEngine/Helpers/ThreadPool.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Helpers/ThreadPool.h>
 
 namespace ZEngine::Helpers

--- a/ZEngine/ZEngine/Importers/AssimpImporter.cpp
+++ b/ZEngine/ZEngine/Importers/AssimpImporter.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <AssimpImporter.h>
 #include <Core/Coroutine.h>
 #include <Helpers/MemoryOperations.h>

--- a/ZEngine/ZEngine/Importers/IAssetImporter.cpp
+++ b/ZEngine/ZEngine/Importers/IAssetImporter.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Core/Containers/Array.h>
 #include <Helpers/SerializerCommonHelper.h>
 #include <IAssetImporter.h>

--- a/ZEngine/ZEngine/Logging/Logger.cpp
+++ b/ZEngine/ZEngine/Logging/Logger.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Core/Containers/Array.h>
 #include <Core/Containers/HashMap.h>
 #include <Core/Memory/Allocator.h>

--- a/ZEngine/ZEngine/Managers/AssetManager.cpp
+++ b/ZEngine/ZEngine/Managers/AssetManager.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <AssetManager.h>
 #include <Helpers/MemoryOperations.h>
 #include <Helpers/ThreadPool.h>

--- a/ZEngine/ZEngine/Maths/Math.cpp
+++ b/ZEngine/ZEngine/Maths/Math.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Maths/Math.h>
 
 #define GLM_ENABLE_EXPERIMENTAL

--- a/ZEngine/ZEngine/Rendering/Buffers/FrameBuffer.cpp
+++ b/ZEngine/ZEngine/Rendering/Buffers/FrameBuffer.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Hardwares/VulkanDevice.h>
 #include <Rendering/Buffers/Framebuffer.h>
 

--- a/ZEngine/ZEngine/Rendering/Cameras/PerspectiveCamera.cpp
+++ b/ZEngine/ZEngine/Rendering/Cameras/PerspectiveCamera.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Rendering/Cameras/PerspectiveCamera.h>
 #include <glm/gtx/quaternion.hpp>
 

--- a/ZEngine/ZEngine/Rendering/Entities/GraphicSceneEntity.cpp
+++ b/ZEngine/ZEngine/Rendering/Entities/GraphicSceneEntity.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Rendering/Entities/GraphicSceneEntity.h>
 
 namespace ZEngine::Rendering::Entities

--- a/ZEngine/ZEngine/Rendering/Geometries/CubeGeometry.cpp
+++ b/ZEngine/ZEngine/Rendering/Geometries/CubeGeometry.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Rendering/Geometries/CubeGeometry.h>
 
 namespace ZEngine::Rendering::Geometries

--- a/ZEngine/ZEngine/Rendering/Geometries/QuadGeometry.cpp
+++ b/ZEngine/ZEngine/Rendering/Geometries/QuadGeometry.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Rendering/Geometries/QuadGeometry.h>
 
 namespace ZEngine::Rendering::Geometries

--- a/ZEngine/ZEngine/Rendering/Geometries/SquareGeometry.cpp
+++ b/ZEngine/ZEngine/Rendering/Geometries/SquareGeometry.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Rendering/Geometries/SquareGeometry.h>
 
 namespace ZEngine::Rendering::Geometries

--- a/ZEngine/ZEngine/Rendering/Materials/BasicMaterial.cpp
+++ b/ZEngine/ZEngine/Rendering/Materials/BasicMaterial.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Rendering/Materials/BasicMaterial.h>
 
 using namespace ZEngine::Helpers;

--- a/ZEngine/ZEngine/Rendering/Materials/ShaderMaterial.cpp
+++ b/ZEngine/ZEngine/Rendering/Materials/ShaderMaterial.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Rendering/Materials/ShaderMaterial.h>
 
 using namespace ZEngine::Helpers;

--- a/ZEngine/ZEngine/Rendering/Materials/StandardMaterial.cpp
+++ b/ZEngine/ZEngine/Rendering/Materials/StandardMaterial.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Rendering/Materials/StandardMaterial.h>
 
 using namespace ZEngine::Helpers;

--- a/ZEngine/ZEngine/Rendering/Meshes/MeshBuilder.cpp
+++ b/ZEngine/ZEngine/Rendering/Meshes/MeshBuilder.cpp
@@ -1,4 +1,3 @@
-// #include <pch.h>
 // #include <Rendering/Meshes/MeshBuilder.h>
 // #include <Rendering/Geometries/QuadGeometry.h>
 // #include <Rendering/Geometries/SquareGeometry.h>

--- a/ZEngine/ZEngine/Rendering/Pools/CommandPool.cpp
+++ b/ZEngine/ZEngine/Rendering/Pools/CommandPool.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Hardwares/VulkanDevice.h>
 #include <Rendering/Pools/CommandPool.h>
 #include <ZEngineDef.h>

--- a/ZEngine/ZEngine/Rendering/Primitives/Fence.cpp
+++ b/ZEngine/ZEngine/Rendering/Primitives/Fence.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Hardwares/VulkanDevice.h>
 #include <Rendering/Primitives/Fence.h>
 

--- a/ZEngine/ZEngine/Rendering/Primitives/Semaphore.cpp
+++ b/ZEngine/ZEngine/Rendering/Primitives/Semaphore.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Hardwares/VulkanDevice.h>
 #include <Rendering/Primitives/Semaphore.h>
 

--- a/ZEngine/ZEngine/Rendering/Renderers/GraphicRenderer.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/GraphicRenderer.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Managers/AssetManager.h>
 #include <RendererPasses.h>
 #include <Rendering/Renderers/Contracts/RendererDataContract.h>

--- a/ZEngine/ZEngine/Rendering/Renderers/ImGUIRenderer.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/ImGUIRenderer.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Hardwares/VulkanDevice.h>
 #include <ImGuizmo/ImGuizmo.h>
 #include <Rendering/Renderers/ImGUIRenderer.h>

--- a/ZEngine/ZEngine/Rendering/Renderers/Pipelines/RendererPipeline.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/Pipelines/RendererPipeline.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Hardwares/VulkanDevice.h>
 #include <Rendering/Renderers/Pipelines/RendererPipeline.h>
 

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <IRenderer.h>
 #include <RenderGraph.h>
 

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/RenderPass.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/RenderPass.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Hardwares/VulkanDevice.h>
 #include <Rendering/Renderers/RenderPasses/RenderPass.h>
 #include <fmt/format.h>

--- a/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <GraphicRenderer.h>
 #include <RendererPasses.h>
 

--- a/ZEngine/ZEngine/Rendering/Renderers/Storages/GraphicVertex.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/Storages/GraphicVertex.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Rendering/Renderers/Storages/GraphicVertex.h>
 #include <vulkan/vulkan.h>
 

--- a/ZEngine/ZEngine/Rendering/Scenes/GraphicScene.cpp
+++ b/ZEngine/ZEngine/Rendering/Scenes/GraphicScene.cpp
@@ -1,5 +1,4 @@
-﻿#include <pch.h>
-#include <Core/Coroutine.h>
+﻿#include <Core/Coroutine.h>
 #include <Renderers/GraphicRenderer.h>
 #include <Rendering/Components/CameraComponent.h>
 #include <Rendering/Components/LightComponent.h>

--- a/ZEngine/ZEngine/Rendering/Shaders/Compilers/CompilationStage.cpp
+++ b/ZEngine/ZEngine/Rendering/Shaders/Compilers/CompilationStage.cpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <pch.h>
 #include <Core/Coroutine.h>
 #include <Logging/LoggerDefinition.h>
 #include <Rendering/Shaders/Compilers/CompilationStage.h>

--- a/ZEngine/ZEngine/Rendering/Shaders/Compilers/ShaderCompiler.cpp
+++ b/ZEngine/ZEngine/Rendering/Shaders/Compilers/ShaderCompiler.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Core/Coroutine.h>
 #include <Logging/LoggerDefinition.h>
 #include <Rendering/Shaders/Compilers/CompilationStage.h>

--- a/ZEngine/ZEngine/Rendering/Shaders/Compilers/ShaderFileGenerator.cpp
+++ b/ZEngine/ZEngine/Rendering/Shaders/Compilers/ShaderFileGenerator.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Core/Coroutine.h>
 #include <Logging/LoggerDefinition.h>
 #include <Rendering/Shaders/Compilers/ShaderFileGenerator.h>

--- a/ZEngine/ZEngine/Rendering/Shaders/Compilers/ValidationStage.cpp
+++ b/ZEngine/ZEngine/Rendering/Shaders/Compilers/ValidationStage.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Core/Coroutine.h>
 #include <Logging/LoggerDefinition.h>
 #include <Rendering/Shaders/Compilers/ShaderFileGenerator.h>

--- a/ZEngine/ZEngine/Rendering/Shaders/Shader.cpp
+++ b/ZEngine/ZEngine/Rendering/Shaders/Shader.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Hardwares/VulkanDevice.h>
 #include <Helpers/MemoryOperations.h>
 #include <Logging/LoggerDefinition.h>

--- a/ZEngine/ZEngine/Rendering/Shaders/ShaderReader.cpp
+++ b/ZEngine/ZEngine/Rendering/Shaders/ShaderReader.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Core/Coroutine.h>
 #include <Logging/LoggerDefinition.h>
 #include <Rendering/Shaders/ShaderReader.h>

--- a/ZEngine/ZEngine/Rendering/Textures/Texture.cpp
+++ b/ZEngine/ZEngine/Rendering/Textures/Texture.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Hardwares/VulkanDevice.h>
 #include <Texture.h>
 

--- a/ZEngine/ZEngine/Rendering/Textures/Texture2D.cpp
+++ b/ZEngine/ZEngine/Rendering/Textures/Texture2D.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Core/Coroutine.h>
 #include <Rendering/Buffers/Bitmap.h>
 #include <Rendering/Primitives/ImageMemoryBarrier.h>

--- a/ZEngine/ZEngine/Serializers/GraphicScene3DSerializer.cpp
+++ b/ZEngine/ZEngine/Serializers/GraphicScene3DSerializer.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Core/Coroutine.h>
 #include <Helpers/MeshHelper.h>
 #include <Rendering/Components/CameraComponent.h>

--- a/ZEngine/ZEngine/Windows/CoreWindow.cpp
+++ b/ZEngine/ZEngine/Windows/CoreWindow.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <CoreWindow.h>
 
 using namespace ZEngine::Helpers;

--- a/ZEngine/ZEngine/Windows/GameWindow.cpp
+++ b/ZEngine/ZEngine/Windows/GameWindow.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Core/Coroutine.h>
 #include <Engine.h>
 #include <Event/EngineClosedEvent.h>

--- a/ZEngine/ZEngine/Windows/Inputs/IDevice.cpp
+++ b/ZEngine/ZEngine/Windows/Inputs/IDevice.cpp
@@ -1,4 +1,3 @@
-#include <pch.h>
 #include <Inputs/IDevice.h>
 
 namespace ZEngine::Windows::Inputs

--- a/ZEngine/ZEngine/pch.cpp
+++ b/ZEngine/ZEngine/pch.cpp
@@ -1,1 +1,0 @@
-#include <pch.h>


### PR DESCRIPTION
- Remove `#include <pch.h>` directive from source and header files as the benefits of using precompiled headers with cmake comes in not adding that compilation burder per translation unit.
- The `target_precompile_headers()` cmake command was being used correctly, but the include statement negates the benefits

  https://cmake.org/cmake/help/latest/command/target_precompile_headers.html