### PR TITLE
 Add CMake-Presets Based Configuration

### DIFF
--- a/.github/workflows/job-cmakebuild-macOS.yml
+++ b/.github/workflows/job-cmakebuild-macOS.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: CMake Build
-        run: .\Scripts\BuildEngine.ps1 -Configurations ${{inputs.configuration}} -RunClangFormat 0
+        run: .\Scripts\BuildEngine.ps1 -Configurations ${{inputs.configuration}} -Architecture ${{inputs.architecture}} -RunClangFormat 0
         shell: pwsh
 
       - name: Publish Build Artifacts
@@ -32,10 +32,10 @@ jobs:
         with:
           name: Build-macOS-${{ inputs.architecture }}-${{inputs.configuration}}
           path: |
-            Result.Darwin.x64.${{inputs.configuration}}/Panzerfaust/${{inputs.configuration}}/${{inputs.targetFramework}}/osx-${{ inputs.architecture }}/publish/
-            Result.Darwin.x64.${{inputs.configuration}}/__externals/Vulkan-Loader/loader/${{ inputs.configuration }}/
-            Result.Darwin.x64.${{inputs.configuration}}/ZEngine/tests/${{inputs.configuration}}/
-            !Result.Darwin.x64.${{inputs.configuration}}/Panzerfaust/${{inputs.configuration}}/${{inputs.targetFramework}}/**/Microsoft.CodeAnalysis.CSharp.resources.dll
-            !Result.Darwin.x64.${{inputs.configuration}}/Panzerfaust/${{inputs.configuration}}/${{inputs.targetFramework}}/**/Microsoft.CodeAnalysis.CSharp.Scripting.resources.dll
-            !Result.Darwin.x64.${{inputs.configuration}}/Panzerfaust/${{inputs.configuration}}/${{inputs.targetFramework}}/**/Microsoft.CodeAnalysis.resources.dll
-            !Result.Darwin.x64.${{inputs.configuration}}/Panzerfaust/${{inputs.configuration}}/${{inputs.targetFramework}}/**/Microsoft.CodeAnalysis.Scripting.resources.dll
+            Result.Darwin.${{inputs.architecture}}.${{inputs.configuration}}/Panzerfaust/${{inputs.configuration}}/${{inputs.targetFramework}}/osx-${{ inputs.architecture }}/publish/
+            Result.Darwin.${{inputs.architecture}}.${{inputs.configuration}}/__externals/Vulkan-Loader/loader/${{ inputs.configuration }}/
+            Result.Darwin.${{inputs.architecture}}.${{inputs.configuration}}/ZEngine/tests/${{inputs.configuration}}/
+            !Result.Darwin.${{inputs.architecture}}.${{inputs.configuration}}/Panzerfaust/${{inputs.configuration}}/${{inputs.targetFramework}}/**/Microsoft.CodeAnalysis.CSharp.resources.dll
+            !Result.Darwin.${{inputs.architecture}}.${{inputs.configuration}}/Panzerfaust/${{inputs.configuration}}/${{inputs.targetFramework}}/**/Microsoft.CodeAnalysis.CSharp.Scripting.resources.dll
+            !Result.Darwin.${{inputs.architecture}}.${{inputs.configuration}}/Panzerfaust/${{inputs.configuration}}/${{inputs.targetFramework}}/**/Microsoft.CodeAnalysis.resources.dll
+            !Result.Darwin.${{inputs.architecture}}.${{inputs.configuration}}/Panzerfaust/${{inputs.configuration}}/${{inputs.targetFramework}}/**/Microsoft.CodeAnalysis.Scripting.resources.dll

--- a/.github/workflows/job-cmakebuild-windows.yml
+++ b/.github/workflows/job-cmakebuild-windows.yml
@@ -38,11 +38,10 @@ jobs:
             !Result.Windows.x64.MultiConfig/Panzerfaust/${{inputs.configuration}}/${{inputs.targetFramework}}/**/createdump.exe
 
       - name: Publish Vulkan Build Artifacts
-        if: ${{ inputs.configuration == 'Release'}}
         uses: actions/upload-artifact@v4
         with:
-          name: Vulkan-build-x64-release
+          name: Vulkan-build-x64-${{inputs.configuration}}
           path: |
-            Result.Windows.x64.MultiConfig/__externals/Vulkan-Loader/loader/release/vulkan-1.dll
-            Result.Windows.x64.MultiConfig/__externals/Vulkan-Loader/loader/release/vulkan-1.exp
-            Result.Windows.x64.MultiConfig/__externals/Vulkan-Loader/loader/release/vulkan-1.lib
+            Result.Windows.x64.MultiConfig/__externals/Vulkan-Loader/loader/${{inputs.configuration}}/vulkan-1.dll
+            Result.Windows.x64.MultiConfig/__externals/Vulkan-Loader/loader/${{inputs.configuration}}/vulkan-1.exp
+            Result.Windows.x64.MultiConfig/__externals/Vulkan-Loader/loader/${{inputs.configuration}}/vulkan-1.lib

--- a/.github/workflows/job-deploy-macOS.yml
+++ b/.github/workflows/job-deploy-macOS.yml
@@ -22,11 +22,11 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          path: Result.Darwin.x64.${{ inputs.configuration }}
+          path: Result.Darwin.${{ inputs.architecture }}.${{ inputs.configuration }}
           name: Build-macOS-${{ inputs.architecture }}-Release
 
       - name: Publish Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: macOS-${{ inputs.architecture }}-${{ inputs.configuration }}
-          path: Result.Darwin.x64.${{ inputs.configuration }}/Panzerfaust/${{ inputs.configuration }}/${{inputs.targetFramework}}/osx-${{ inputs.architecture }}/publish/
+          path: Result.Darwin.${{inputs.architecture}}.${{ inputs.configuration }}/Panzerfaust/${{ inputs.configuration }}/${{inputs.targetFramework}}/osx-${{ inputs.architecture }}/publish/

--- a/.github/workflows/job-test-macOS.yml
+++ b/.github/workflows/job-test-macOS.yml
@@ -24,11 +24,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: Build-macOS-${{ inputs.architecture }}-${{ inputs.configuration }}
-          path: Result.Darwin.x64.${{ inputs.configuration }}
+          path: Result.Darwin.${{inputs.architecture}}.${{ inputs.configuration }}
 
       - name: Update access permission of ZEngineTests
-        run: chmod +x ./Result.Darwin.x64.${{ inputs.configuration }}/ZEngine/tests/${{ inputs.configuration }}/ZEngineTests
+        run: chmod +x ./Result.Darwin.${{inputs.architecture}}.${{ inputs.configuration }}/ZEngine/tests/${{ inputs.configuration }}/ZEngineTests
 
       - name: Run Tests
-        run: .\Scripts\RunTests.ps1 -Configurations ${{ inputs.configuration }}
+        run: .\Scripts\RunTests.ps1 -Configurations ${{ inputs.configuration }} -Architecture ${{ inputs.architecture }}
         shell: pwsh

--- a/.github/workflows/job-test-windows.yml
+++ b/.github/workflows/job-test-windows.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: vulkan-build
-          name: Vulkan-build-x64-release
+          name: Vulkan-build-x64-${{inputs.configuration}}
 
       - name: Run Tests
         shell: pwsh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,8 @@ endif()
 # Externals dependencies
 #
 if (NOT LAUNCHER_ONLY)
+    add_subdirectory (${EXTERNAL_DIR}/Vulkan-Headers)
+	add_subdirectory (${EXTERNAL_DIR}/Vulkan-Loader)
 	add_subdirectory (${EXTERNAL_DIR}/fmt)
 	add_subdirectory (${EXTERNAL_DIR}/imgui)
 	add_subdirectory (${EXTERNAL_DIR}/glfw)
@@ -59,12 +61,8 @@ if (NOT LAUNCHER_ONLY)
 	add_subdirectory (${EXTERNAL_DIR}/tlsf)
 	add_subdirectory (${EXTERNAL_DIR}/rapidhash)
 	add_subdirectory (${EXTERNAL_DIR}/CLI11)
+	add_subdirectory (${EXTERNAL_DIR}/nlohmann_json)
 
-	set (CMAKE_PREFIX_PATH
-		${CMAKE_PREFIX_PATH}
-		${EXTERNAL_DIR}/Vulkan-Headers/build/install/share/cmake
-	)
-	add_subdirectory (${EXTERNAL_DIR}/Vulkan-Loader)
 
 	# Core engine lib is here
 	#
@@ -91,20 +89,20 @@ endif ()
 #
 set (SYSTEM_NAME ${CMAKE_SYSTEM_NAME})
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
-	set (SYSTEM_ARCHITECTURE "win-x64")
+	set (SYSTEM_ARCHITECTURE "x64")
 elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-	set (SYSTEM_ARCHITECTURE "linux-x64")
+	set (SYSTEM_ARCHITECTURE "x64")
 elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
 	if (MACOSX_ARCHITECTURE_ARM64)
-		set (SYSTEM_ARCHITECTURE "osx-arm64")
+		set (SYSTEM_ARCHITECTURE "arm64")
 	else ()
-		set (SYSTEM_ARCHITECTURE "osx-x64")
+		set (SYSTEM_ARCHITECTURE "x64")
 	endif ()
 endif ()
 
 add_custom_target (AssembleContent ALL
 	COMMENT "Copying assets and resources contents"
-	COMMAND pwsh ${CMAKE_CURRENT_SOURCE_DIR}/Scripts/PostBuild.ps1 -SystemName ${SYSTEM_NAME} -Architectures ${SYSTEM_ARCHITECTURE} -Configurations $<IF:$<CONFIG:Debug>,Debug,Release> $<$<BOOL:${LAUNCHER_ONLY}>:-LauncherOnly>
+	COMMAND pwsh ${CMAKE_CURRENT_SOURCE_DIR}/Scripts/PostBuild.ps1 -SystemName ${SYSTEM_NAME} -Architecture ${SYSTEM_ARCHITECTURE} -Configurations $<IF:$<CONFIG:Debug>,Debug,Release> $<$<BOOL:${LAUNCHER_ONLY}>:-LauncherOnly>
 )
 
 if (NOT LAUNCHER_ONLY)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,180 @@
+{
+    "version": 10,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 23,
+        "patch": 0
+    },
+    "configurePresets":[
+        {
+            "name": "BaseOptions",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+
+                "VULKAN_HEADERS_ENABLE_INSTALL": "ON",
+                "ENTT_INCLUDE_HEADERS": "ON",
+
+                "SPDLOG_BUILD_SHARED": "OFF",
+                "SPDLOG_FMT_EXTERNAL": "ON",
+                "SPDLOG_FMT_EXTERNAL_HO": "OFF",
+
+                "GLFW_BUILD_DOCS": "OFF",
+                "GLFW_BUILD_EXAMPLES": "OFF",
+                "GLFW_INSTALL": "OFF",
+
+                "ASSIMP_BUILD_TESTS": "OFF",
+                "ASSIMP_INSTALL": "OFF",
+                "ASSIMP_BUILD_SAMPLES": "OFF",
+                "ASSIMP_BUILD_ASSIMP_TOOLS": "OFF",
+                "ASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT": "OFF",
+                "ASSIMP_BUILD_OBJ_IMPORTER": "ON",
+                "ASSIMP_BUILD_ALL_EXPORTERS_BY_DEFAULT": "OFF",
+                "ASSIMP_BUILD_OBJ_EXPORTER": "ON",
+
+                "UUID_BUILD_TESTS": "OFF",
+                "UUID_USING_CXX20_SPAN": "ON",
+                "UUID_SYSTEM_GENERATOR": "OFF",
+
+                "YAML_CPP_BUILD_TOOLS": "OFF",
+                "YAML_CPP_BUILD_TESTS": "OFF",
+                "YAML_CPP_FORMAT_SOURCE": "OFF",
+                "YAML_BUILD_SHARED_LIBS": "OFF",
+
+                "USE_MASM": "OFF",
+                "USE_GAS": "OFF",
+
+                "SPIRV_SKIP_EXECUTABLES": "ON",
+                "SPIRV_SKIP_TESTS": "ON",
+                "GLSLANG_ENABLE_INSTALL": "ON",
+                "ALLOW_EXTERNAL_SPIRV_TOOLS": "OFF",
+
+                "SPIRV_CROSS_ENABLE_TESTS": "OFF",
+                "CMAKE_POLICY_VERSION_MINIMUM": "3.5"
+            }
+        },
+        {
+            "name": "Windows_x64_Debug",
+            "inherits": "BaseOptions",
+            "displayName": "Windows Visual Studio Debug",
+            "generator": "Visual Studio 17 2022",
+            "binaryDir": "Result.Windows.x64.MultiConfig",
+            "architecture": "x64",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_CONFIGURATION_TYPES": "Debug"
+            }
+
+        },
+        {
+            "name": "Windows_x64_Release",
+            "displayName": "Windows Visual Studio Release",
+            "inherits": "Windows_x64_Debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_CONFIGURATION_TYPES": "Release"
+            }
+        },
+
+        {
+            "name": "Darwin_x64_Debug",
+            "inherits": "BaseOptions",
+            "displayName": "Darwin XCode Debug",
+            "binaryDir": "Result.Darwin.x64.Debug",
+            "generator": "Xcode",
+            "cacheVariables": {
+                "BUILD_FRAMEWORK": "ON"
+            }
+        },
+        {
+            "name": "Darwin_x64_Release",
+            "inherits": "Darwin_x64_Debug",
+            "displayName": "Darwin XCode Release",
+            "binaryDir": "Result.Darwin.x64.Release",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"  
+            }
+        },
+
+        {
+            "name": "Darwin_arm64_Debug",
+            "inherits": "Darwin_x64_Debug",
+            "binaryDir": "Result.Darwin.arm64.Debug",
+            "displayName": "Darwin ARM XCode Debug"
+        },
+
+        {
+            "name": "Darwin_arm64_Release",
+            "inherits": "Darwin_x64_Release",
+            "binaryDir": "Result.Darwin.arm64.Release",
+            "displayName": "Darwin ARM XCode Release"
+        },
+
+        {
+            "name": "Linux_x64_Debug",
+            "inherits": "BaseOptions",
+            "displayName": "Linux Ninja Debug",
+            "binaryDir": "Result.Linux.x64.Debug",
+            "generator": "Ninja"
+        },
+        {
+            "name": "Linux_x64_Release",
+            "inherits": "Linux_x64_Debug",
+            "displayName": "Linux Ninja Release",
+            "binaryDir": "Result.Linux.x64.Release",
+            "generator": "Ninja",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        }
+    ],
+
+    "buildPresets": [
+        {
+            "name": "Windows_x64_Debug",
+            "configurePreset": "Windows_x64_Debug",
+            "configuration": "Debug",
+            "nativeToolOptions": [
+                "-nodeReuse:false"
+            ]
+        },
+        {
+            "name": "Windows_x64_Release",
+            "configurePreset": "Windows_x64_Release",
+            "configuration": "Release",
+            "nativeToolOptions": [
+                "-nodeReuse:false"
+            ]
+        },
+
+        {
+            "name": "Darwin_x64_Debug",
+            "configuration": "Debug",
+            "configurePreset": "Darwin_x64_Debug"
+        },
+        {
+            "name": "Darwin_x64_Release",
+            "configuration": "Release",
+            "configurePreset": "Darwin_x64_Release"
+        },
+
+        {
+            "name": "Darwin_arm64_Debug",
+            "configuration": "Debug",
+            "configurePreset": "Darwin_arm64_Debug"
+        },
+        {
+            "name": "Darwin_arm64_Release",
+            "configuration": "Release",
+            "configurePreset": "Darwin_arm64_Release"
+        },
+
+        {
+            "name": "Linux_x64_Debug",
+            "configurePreset": "Linux_x64_Debug"
+        },
+        {
+            "name": "Linux_x64_Release",
+            "configurePreset": "Linux_x64_Release"
+        }
+    ]
+}

--- a/Scripts/BuildEngine.ps1
+++ b/Scripts/BuildEngine.ps1
@@ -28,6 +28,10 @@ param (
     [ValidateSet('Debug', 'Release')]
     [string[]] $Configurations = @('Debug', 'Release'),
 
+    [Parameter(HelpMessage = "Architecture to build")]
+    [ValidateSet('x64', 'arm64')]
+    [string] $Architecture = 'x64',
+
     [Parameter(HelpMessage = "Whether to run build, default to True")]
     [bool] $RunBuilds = $True,
 
@@ -88,24 +92,12 @@ if(-Not $LauncherOnly) {
     Write-Host "Ensuring submodules are initialized and updated..."
     & git -C $RepoRoot submodule update --init --recursive
     
-    Write-Host "Configuring Vulkan-Header submodule..."
-    
-    $ExternalVulkanHeadersDir = Join-Path -Path $RepoRoot -ChildPath "__externals/Vulkan-Headers"
-    $ExternalVulkanHeadersOutputDir = Join-Path -Path $ExternalVulkanHeadersDir -ChildPath "build"
-    $ExternalVulkanHeadersInstallDir = Join-Path -Path $ExternalVulkanHeadersOutputDir -ChildPath "install"
-    
-    if(-Not (Test-Path -Path $ExternalVulkanHeadersInstallDir)) {
-        & $cMakeProgram -S $ExternalVulkanHeadersDir -B $ExternalVulkanHeadersOutputDir
-        & $cMakeProgram --install $ExternalVulkanHeadersOutputDir --prefix $ExternalVulkanHeadersInstallDir
-    }
 } else {
     Write-Host "Skipping submodules initialization..."
 }
 
 
 function Build([string]$configuration, [int]$VsVersion , [bool]$runBuild) {
-
-    $architecture = 'x64'
 
     # Check if the system supports multiple configurations
     $isMultipleConfig = $IsWindows
@@ -126,74 +118,20 @@ function Build([string]$configuration, [int]$VsVersion , [bool]$runBuild) {
 
     Write-Host "Building $systemName $architecture $configuration"
 
-    [string]$BuildDirectoryNameExtension = If ($isMultipleConfig) { "MultiConfig" } Else { $configuration }
-    [string]$BuildDirectoryName = "Result." + $systemName + "." + $architecture + "." + $BuildDirectoryNameExtension
-    [string]$buildDirectoryPath = [IO.Path]::Combine($RepoRoot, $BuildDirectoryName)
     [string]$cMakeCacheVariableOverride = ""
 
-    # Create build directory
-    if (-Not (Test-Path $buildDirectoryPath)) {
-        $Null = New-Item -ItemType Directory -Path $BuildDirectoryPath -ErrorAction SilentlyContinue
-    }
-
-    # Define CMake Generator arguments
-    $cMakeOptions = " -DCMAKE_SYSTEM_NAME=$systemName", " -DCMAKE_BUILD_TYPE=$configuration", "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
     $submoduleCMakeOptions = @{
-        'ENTT'      = @("-DENTT_INCLUDE_HEADERS=ON")
-        'SPDLOG'    = @("-DSPDLOG_BUILD_SHARED=OFF", "-DBUILD_STATIC_LIBS=ON", "-DSPDLOG_FMT_EXTERNAL=ON", "-DSPDLOG_FMT_EXTERNAL_HO=OFF");
-        'GLFW '     = @("-DGLFW_BUILD_DOCS=OFF", "-DGLFW_BUILD_EXAMPLES=OFF", "-DGLFW_INSTALL=OFF");
-        'ASSIMP'    = @("-DASSIMP_BUILD_TESTS=OFF", "-DASSIMP_INSTALL=OFF", "-DASSIMP_BUILD_SAMPLES=OFF", "-DASSIMP_BUILD_ASSIMP_TOOLS=OFF", "-DASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT=OFF", "-DASSIMP_BUILD_OBJ_IMPORTER=ON", "-DASSIMP_BUILD_ALL_EXPORTERS_BY_DEFAULT=OFF", "-DASSIMP_BUILD_OBJ_EXPORTER=ON");
-        'STDUUID'   = @("-DUUID_BUILD_TESTS=OFF", "-DUUID_USING_CXX20_SPAN=ON", "-DUUID_SYSTEM_GENERATOR=OFF");
-        'YAMLCPP'   = @("-DYAML_CPP_BUILD_TOOLS=OFF", "-DYAML_CPP_BUILD_TESTS=OFF", "-DYAML_CPP_FORMAT_SOURCE=OFF", "-DYAML_BUILD_SHARED_LIBS=OFF");
-        'FRAMEWORK' = @("-DBUILD_FRAMEWORK=ON");
-        'VULKAN_LOADER' = @("-DVULKAN_HEADERS_INSTALL_DIR=$ExternalVulkanHeadersInstallDir", "-DUSE_MASM=OFF", "-DUSE_GAS=OFF")
-        'SPIRV_TOOLS' = @("-DSPIRV_SKIP_EXECUTABLES=ON", "-DSPIRV_SKIP_TESTS=ON")
-        'SPIRV_CROSS' = @("-DSPIRV_CROSS_ENABLE_TESTS=OFF")
         'LAUNCHER_ONLY' = @("-DLAUNCHER_ONLY=ON")
-    }
-
-    $cMakeCacheVariableOverride = $cMakeOptions -join ' '
-
-    # Define CMake Generator argument
-    switch ($systemName) {
-        "Windows" {
-            switch ($VsVersion) {
-                2022 {
-                    $cMakeGenerator = "-G `"Visual Studio 17 2022`" -A $architecture"
-                }
-                Default {
-                    throw 'This version of Visual Studio is not supported'
-                }
-            }
-            $cMakeCacheVariableOverride += ' -DCMAKE_CONFIGURATION_TYPES=Debug;Release '
-        }
-        "Linux" {
-            $cMakeGenerator = "-G `"Ninja`""
-        }
-        "Darwin" {
-            $cMakeGenerator = "-G `"Xcode`""
-            $cMakeCacheVariableOverride += ' ' + $submoduleCMakeOptions.FRAMEWORK -join ' '
-        }
-        Default {
-            throw 'This system is not supported'
-        }
     }
 
     if($LauncherOnly) {
         $cMakeCacheVariableOverride += ' ' + $submoduleCMakeOptions.LAUNCHER_ONLY -join ' '
-    } else {
-        $cMakeCacheVariableOverride += ' ' + $submoduleCMakeOptions.ENT -join ' '
-        $cMakeCacheVariableOverride += ' ' + $submoduleCMakeOptions.SPDLOG -join ' '
-        $cMakeCacheVariableOverride += ' ' + $submoduleCMakeOptions.ASSIMP -join ' '
-        $cMakeCacheVariableOverride += ' ' + $submoduleCMakeOptions.STDUUID -join ' '
-        $cMakeCacheVariableOverride += ' ' + $submoduleCMakeOptions.YAMLCPP -join ' '
-        $cMakeCacheVariableOverride += ' ' + $submoduleCMakeOptions.VULKAN_LOADER -join ' '
-        $cMakeCacheVariableOverride += ' ' + $submoduleCMakeOptions.SPIRV_CROSS -join ' '
-        $cMakeCacheVariableOverride += ' ' + $submoduleCMakeOptions.SPIRV_TOOLS -join ' '
-        $cMakeCacheVariableOverride += ' ' + $submoduleCMakeOptions.GLFW -join ' '
-    }
+    } 
 
-    $cMakeArguments = " -S $repositoryRootPath -B $buildDirectoryPath $cMakeGenerator $cMakeCacheVariableOverride"
+    # Define CMake Generator arguments
+    $configName = $systemName, $architecture, $configuration -join "_"
+
+    $cMakeArguments = " --preset $configName $cMakeCacheVariableOverride"
 
     # CMake Generation process
     Write-Host $cMakeArguments
@@ -204,18 +142,7 @@ function Build([string]$configuration, [int]$VsVersion , [bool]$runBuild) {
 
     # CMake Build Process
     #
-    if ($runBuild) {
-        if ($cMakeGenerator -like 'Visual Studio*') {
-            # With a Visual Studio Generator, `msbuild.exe` is used to run the build. By default, `msbuild.exe` will
-            # launch worker processes to opportunistically re-use for subsequent builds. To cause the worker processes
-            # to exit at the end of the main process, pass `-nodeReuse:false`.
-            $buildToolOptions = '-nodeReuse:false'
-        }
-
-        $buildArguments = "--build $buildDirectoryPath --config $configuration"
-        if ($buildToolOptions) {
-            $buildArguments = $buildArguments, $buildToolOptions -join " --"
-        }
+        $buildArguments = "--build --preset $configName"
 
         $buildProcess = Start-Process $cMakeProgram -ArgumentList $buildArguments -NoNewWindow -PassThru
 
@@ -227,7 +154,6 @@ function Build([string]$configuration, [int]$VsVersion , [bool]$runBuild) {
         if ($buildProcess.ExitCode -ne 0) {
             throw "cmake failed build for '$buildArguments' with exit code '$buildProcess.ExitCode'"
         }
-    }
 }
 
 

--- a/Scripts/PostBuild.ps1
+++ b/Scripts/PostBuild.ps1
@@ -27,9 +27,9 @@ param (
     [ValidateSet('Windows', 'Darwin', 'Linux')]
     [string[]] $SystemName = 'Windows',
 
-    [Parameter(HelpMessage="Architecture type to build, default to x64")]
-    [ValidateSet('win-x64', 'arm64', 'osx-x64', 'osx-arm64', 'linux-x64')]
-    [string[]] $Architectures = 'win-x64',
+    [Parameter(HelpMessage = "Architecture to build")]
+    [ValidateSet('x64', 'arm64')]
+    [string] $Architecture = 'x64',
 
     [Parameter(HelpMessage="Configuration type to build, default to Debug")]
     [ValidateSet('Debug', 'Release')]
@@ -84,18 +84,18 @@ $ContentsToProcess = @(
         Contents = @(
             switch ($SystemName) {
                 "Windows" {
-                    @{ From = "$OuputBuildDirectory\Obelisk\$Configurations"; To = "$OuputBuildDirectory\Panzerfaust\$Configurations\$TargetFramework\Editor"}
-                    @{ From = "$OuputBuildDirectory\Obelisk\$Configurations"; To = "$OuputBuildDirectory\Panzerfaust\$Configurations\$TargetFramework\$Architectures\publish\Editor"}
+                    @{ From = "$OuputBuildDirectory\Obelisk\$Configurations"; To = "$OuputBuildDirectory\Panzerfaust\$Configurations\$TargetFramework\win-$Architecture\Editor"}
+                    @{ From = "$OuputBuildDirectory\Obelisk\$Configurations"; To = "$OuputBuildDirectory\Panzerfaust\$Configurations\$TargetFramework\win-$Architecture\publish\Editor"}
                 }
                 "Darwin" {
-                    switch ($Architectures) {
-                        "osx-x64" {
-                            @{ From = "$OuputBuildDirectory\Obelisk\$Configurations"; To = "$OuputBuildDirectory\Panzerfaust\$Configurations\$TargetFramework\$Architectures\Editor"}
-                            @{ From = "$OuputBuildDirectory\Obelisk\$Configurations"; To = "$OuputBuildDirectory\Panzerfaust\$Configurations\$TargetFramework\$Architectures\publish\Editor"}
+                    switch ($Architecture) {
+                        "x64" {
+                            @{ From = "$OuputBuildDirectory\Obelisk\$Configurations"; To = "$OuputBuildDirectory\Panzerfaust\$Configurations\$TargetFramework\osx-$Architecture\Editor"}
+                            @{ From = "$OuputBuildDirectory\Obelisk\$Configurations"; To = "$OuputBuildDirectory\Panzerfaust\$Configurations\$TargetFramework\osx-$Architecture\publish\Editor"}
                         }
-                        "osx-arm64" {
-                            @{ From = "$OuputBuildDirectory\Obelisk\$Configurations"; To = "$OuputBuildDirectory\Panzerfaust\$Configurations\$TargetFramework\$Architectures\Editor"}
-                            @{ From = "$OuputBuildDirectory\Obelisk\$Configurations"; To = "$OuputBuildDirectory\Panzerfaust\$Configurations\$TargetFramework\$Architectures\publish\Editor"}
+                        "arm64" {
+                            @{ From = "$OuputBuildDirectory\Obelisk\$Configurations"; To = "$OuputBuildDirectory\Panzerfaust\$Configurations\$TargetFramework\osx-$Architecture\Editor"}
+                            @{ From = "$OuputBuildDirectory\Obelisk\$Configurations"; To = "$OuputBuildDirectory\Panzerfaust\$Configurations\$TargetFramework\osx-$Architecture\publish\Editor"}
                         }
                         Default {
                             throw 'This architecture is not supported'

--- a/Scripts/RunTests.ps1
+++ b/Scripts/RunTests.ps1
@@ -25,7 +25,11 @@
 param (
     [Parameter(HelpMessage = "Configuration type to build, default to Debug")]
     [ValidateSet('Debug', 'Release')]
-    [string[]] $Configurations = 'Debug'
+    [string[]] $Configurations = 'Debug',
+
+    [Parameter(HelpMessage = "Architecture to build")]
+    [ValidateSet('x64', 'arm64')]
+    [string] $Architecture = 'x64'
 )
 
 $ErrorActionPreference = "Stop"
@@ -46,10 +50,10 @@ else {
 
 [string]$RepoRoot = [IO.Path]::Combine($PSScriptRoot, "..")
 [string]$OutputBuildDirectory = If ($IsWindows) { 
-    [IO.Path]::Combine($RepoRoot, "Result.Windows.x64.MultiConfig") 
+    [IO.Path]::Combine($RepoRoot, "Result.Windows.$Architecture.MultiConfig") 
 }
 Else { 
-    [IO.Path]::Combine($RepoRoot, "Result.$SystemName.x64.$Configurations")
+    [IO.Path]::Combine($RepoRoot, "Result.$SystemName.$Architecture.$Configurations")
 }
 
 

--- a/ZEngine/ZEngine/pch.h
+++ b/ZEngine/ZEngine/pch.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <imgui.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <uuid.h>
 #include <algorithm>

--- a/ZEngine/tests/CMakeLists.txt
+++ b/ZEngine/tests/CMakeLists.txt
@@ -4,7 +4,9 @@ file ( GLOB TEST_SOURCES
             Maths/*.cpp
             Misc/*.cpp)
 
-add_executable(ZEngineTests ${TEST_SOURCES})
+add_executable(ZEngineTests)
+
+target_sources(ZEngineTests PRIVATE ${TEST_SOURCES})
 
 target_link_libraries(ZEngineTests PRIVATE
     zEngineLib

--- a/__externals/externals.cmake
+++ b/__externals/externals.cmake
@@ -1,29 +1,9 @@
 # Packages
 #
-set(EXTERNAL_INCLUDE_DIRS
-	${EXTERNAL_DIR}/Vulkan-Headers/build/install/include
-	${EXTERNAL_DIR}/fmt/include
-	${EXTERNAL_DIR}/imgui/src
-	${EXTERNAL_DIR}/tlsf/src
-	${EXTERNAL_DIR}/rapidhash/src
-	${EXTERNAL_DIR}/spdlog/include
-	${EXTERNAL_DIR}/glfw/include
-	${EXTERNAL_DIR}/entt
-	${EXTERNAL_DIR}/assimp/include
-	${EXTERNAL_DIR}/stduuid/include
-	${EXTERNAL_DIR}/yaml-cpp/include
-	${EXTERNAL_DIR}/SPIRV-headers
-	${EXTERNAL_DIR}/SPIRV-Tools
-	${EXTERNAL_DIR}/glslang
-	${EXTERNAL_DIR}/SPIRV-Cross
-	${EXTERNAL_DIR}/VulkanMemoryAllocator
-	${EXTERNAL_DIR}/nlohmann_json/single_include
-	${EXTERNAL_DIR}/CLI11/include
-)
 
 if (MSVC)
 	target_compile_options(assimp PRIVATE /Wv:18) # Fix zip lib compile issue
-elseif(APPLE)
+else()
 	target_compile_options(assimp PRIVATE -Wno-shorten-64-to-32 -Wno-unused-but-set-variable -Wno-deprecated-declarations)
 endif()
 
@@ -40,19 +20,20 @@ target_link_libraries(imported::External_obeliskLibs INTERFACE
 )
 
 target_link_libraries(imported::External_libs INTERFACE
-	vulkan
-	fmt
-	imgui
-	spdlog
-	glfw
-	EnTT
-	assimp
-	stduuid
-	yaml-cpp
-	spirv-cross-reflect spirv-cross-glsl
-	GPUOpen::VulkanMemoryAllocator
-	glslang  SPIRV
-	SPIRV-Tools
-	tlsf
-	rapidhash
+         fmt::fmt
+         imgui
+         spdlog::spdlog
+         EnTT::EnTT
+         assimp::assimp
+         stduuid
+         yaml-cpp::yaml-cpp
+         spirv-cross-core
+         SPIRV-Tools
+         glslang
+         glslang-default-resource-limits
+         SPIRV
+         SPVRemapper
+         GPUOpen::VulkanMemoryAllocator 
+         nlohmann_json::nlohmann_json
+         rapidhash
 )

--- a/__externals/imgui/CMakeLists.txt
+++ b/__externals/imgui/CMakeLists.txt
@@ -1,8 +1,6 @@
 set(CMAKE_CXX_STANDARD 11)
 
 list (APPEND IMGUI_SOURCE
-        src/imgui.h
-        src/imgui_internal.h
 		src/imgui.cpp
 		src/imgui_tables.cpp
 		src/imgui_widgets.cpp
@@ -14,7 +12,9 @@ list (APPEND IMGUI_SOURCE
 
 # Source files
 #
-add_library (imgui STATIC ${IMGUI_SOURCE})
+add_library (imgui STATIC )
+
+target_sources(imgui PRIVATE ${IMGUI_SOURCE})
 
 # include directories
 #
@@ -22,8 +22,7 @@ target_include_directories (imgui
     PUBLIC
         ./src
         ./src/backends
-        ${EXTERNAL_DIR}/glfw/include
-    PRIVATE
-        ${EXTERNAL_DIR}/Vulkan-Headers/build/install/include
 )
+
+target_link_libraries(imgui PUBLIC glfw Vulkan::Headers Vulkan::Loader)
 


### PR DESCRIPTION
 - Change the Powershell BuildEngine.ps1 script to use the Cmake Preset Commands
 - Move the CMake Configuration to the CMakePreset.json file
 - Harmonize the Build Configurations and multiple Architecture support by adding an Architecture Parameter the the BuildEngine.ps1 and RunTests.ps1 scripts
 - Update CI workflows and CMakeFiles to better support the Configurations and Architectures.
 - Vulkan-Loader no longer compiled in the BuildEngine.ps1 script and is now part of the CMake add_subdirectory workflow which brings consistency. This is done using the VULKAN_HEADERS_ENABLE_INSTALL=ON CMakeVariable which avails the VulkanHeadersConfig.cmake file to the Vulkan-Loader, hence removing the need for setting the CMakePrefix and/or pre-compiling the Vulkan-Loader in the BuildEngine.ps1.
 - Removal of unnecessary CMake `target_include_directory` calls in `externals.cmake` and `imgui/CMakeLists.txt` as each target communicates its includes through the `target_link_libraries()` command.

Resolves #76