### PR TITLE
updating macos runner image

### DIFF
--- a/.github/workflows/job-cmakebuild-macOS.yml
+++ b/.github/workflows/job-cmakebuild-macOS.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   cmake-build:
     name: cmake-build-macOS-${{ inputs.architecture }}-${{ inputs.configuration }}
-    runs-on: ${{ inputs.architecture == 'x64' && 'macos-13' || 'macos-14' }}
+    runs-on: ${{ inputs.architecture == 'x64' && 'macos-15-intel' || 'macos-latest' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/job-cmakebuild-macOS.yml
+++ b/.github/workflows/job-cmakebuild-macOS.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      
+      - name: Install NuGet CLI
+        run: brew install nuget
 
       - name: CMake Build
         run: .\Scripts\BuildEngine.ps1 -Configurations ${{inputs.configuration}} -Architecture ${{inputs.architecture}} -RunClangFormat 0

--- a/.github/workflows/job-deploy-macOS.yml
+++ b/.github/workflows/job-deploy-macOS.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   deploy:
     name: deploy-macOS-${{ inputs.architecture }}-${{ inputs.configuration }}
-    runs-on: ${{ inputs.architecture == 'x64' && 'macos-13' || 'macos-latest' }}
+    runs-on: ${{ inputs.architecture == 'x64' && 'macos-15-intel' || 'macos-latest' }}
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/job-test-macOS.yml
+++ b/.github/workflows/job-test-macOS.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   test:
     name: test-macOS-${{ inputs.architecture }}-${{ inputs.configuration }}
-    runs-on: ${{ inputs.architecture == 'x64' && 'macos-13' || 'macos-latest' }}
+    runs-on: ${{ inputs.architecture == 'x64' && 'macos-15-intel' || 'macos-latest' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
As annonced by Github, macos-13 will be retired December 4th, 2025.
To avoid our pipeline failing by that time , this PR migrates our runner images to the recommended ones