### PR TITLE
Use CStrings as data members for ShaderSpecifications

### DIFF
--- a/ZEngine/ZEngine/Rendering/Shaders/Shader.cpp
+++ b/ZEngine/ZEngine/Rendering/Shaders/Shader.cpp
@@ -98,7 +98,7 @@ namespace ZEngine::Rendering::Shaders
                     LayoutBindingSpecificationMap[set].init(m_device->Arena, 10);
                 }
 
-                LayoutBindingSpecificationMap[set].push(LayoutBindingSpecification{.Set = set, .Binding = binding, .Name = UB_resource.name, .DescriptorTypeValue = DescriptorType::UNIFORM_BUFFER, .Flags = ShaderStageFlags::VERTEX});
+                LayoutBindingSpecificationMap[set].push(LayoutBindingSpecification{.Set = set, .Binding = binding, .Name = UB_resource.name.c_str(), .DescriptorTypeValue = DescriptorType::UNIFORM_BUFFER, .Flags = ShaderStageFlags::VERTEX});
             }
 
             for (const auto& SB_resource : vertex_resources.storage_buffers)
@@ -111,7 +111,7 @@ namespace ZEngine::Rendering::Shaders
                     LayoutBindingSpecificationMap[set].init(m_device->Arena, 10);
                 }
 
-                LayoutBindingSpecificationMap[set].push(LayoutBindingSpecification{.Set = set, .Binding = binding, .Name = SB_resource.name, .DescriptorTypeValue = DescriptorType::STORAGE_BUFFER, .Flags = ShaderStageFlags::VERTEX});
+                LayoutBindingSpecificationMap[set].push(LayoutBindingSpecification{.Set = set, .Binding = binding, .Name = SB_resource.name.c_str(), .DescriptorTypeValue = DescriptorType::STORAGE_BUFFER, .Flags = ShaderStageFlags::VERTEX});
             }
 
             for (const auto& pushConstant_resource : vertex_resources.push_constant_buffers)
@@ -127,7 +127,7 @@ namespace ZEngine::Rendering::Shaders
                         uint32_t memberSize  = spirv_compiler->get_declared_struct_member_size(type, i);
                         struct_total_size   += memberSize;
                     }
-                    PushConstantSpecifications.push(PushConstantSpecification{.Name = pushConstant_resource.name, .Size = struct_total_size, .Offset = struct_offset, .Flags = ShaderStageFlags::VERTEX});
+                    PushConstantSpecifications.push(PushConstantSpecification{.Name = pushConstant_resource.name.c_str(), .Size = struct_total_size, .Offset = struct_offset, .Flags = ShaderStageFlags::VERTEX});
                     /*
                      * We update the offset for next iteration
                      */
@@ -167,7 +167,7 @@ namespace ZEngine::Rendering::Shaders
                     LayoutBindingSpecificationMap[set].init(m_device->Arena, 10);
                 }
 
-                LayoutBindingSpecificationMap[set].push(LayoutBindingSpecification{.Set = set, .Binding = binding, .Name = UB_resource.name, .DescriptorTypeValue = DescriptorType::UNIFORM_BUFFER, .Flags = ShaderStageFlags::FRAGMENT});
+                LayoutBindingSpecificationMap[set].push(LayoutBindingSpecification{.Set = set, .Binding = binding, .Name = UB_resource.name.c_str(), .DescriptorTypeValue = DescriptorType::UNIFORM_BUFFER, .Flags = ShaderStageFlags::FRAGMENT});
             }
 
             for (const auto& SB_resource : fragment_resources.storage_buffers)
@@ -180,7 +180,7 @@ namespace ZEngine::Rendering::Shaders
                     LayoutBindingSpecificationMap[set].init(m_device->Arena, 10);
                 }
 
-                LayoutBindingSpecificationMap[set].push(LayoutBindingSpecification{.Set = set, .Binding = binding, .Name = SB_resource.name, .DescriptorTypeValue = DescriptorType::STORAGE_BUFFER, .Flags = ShaderStageFlags::FRAGMENT});
+                LayoutBindingSpecificationMap[set].push(LayoutBindingSpecification{.Set = set, .Binding = binding, .Name = SB_resource.name.c_str(), .DescriptorTypeValue = DescriptorType::STORAGE_BUFFER, .Flags = ShaderStageFlags::FRAGMENT});
             }
 
             for (const auto& pushConstant_resource : fragment_resources.push_constant_buffers)
@@ -196,7 +196,7 @@ namespace ZEngine::Rendering::Shaders
                         uint32_t memberSize  = spirv_compiler->get_declared_struct_member_size(type, i);
                         struct_total_size   += memberSize;
                     }
-                    PushConstantSpecifications.push(PushConstantSpecification{.Name = pushConstant_resource.name, .Size = struct_total_size, .Offset = struct_offset, .Flags = ShaderStageFlags::FRAGMENT});
+                    PushConstantSpecifications.push(PushConstantSpecification{.Name = pushConstant_resource.name.c_str(), .Size = struct_total_size, .Offset = struct_offset, .Flags = ShaderStageFlags::FRAGMENT});
                     /*
                      * We update the offset for next iteration
                      */
@@ -225,7 +225,7 @@ namespace ZEngine::Rendering::Shaders
                     LayoutBindingSpecificationMap[set].init(m_device->Arena, 10);
                 }
 
-                LayoutBindingSpecificationMap[set].push(LayoutBindingSpecification{.Set = set, .Binding = binding, .Count = count, .Name = SI_resource.name, .DescriptorTypeValue = DescriptorType::COMBINED_IMAGE_SAMPLER, .Flags = ShaderStageFlags::FRAGMENT});
+                LayoutBindingSpecificationMap[set].push(LayoutBindingSpecification{.Set = set, .Binding = binding, .Count = count, .Name = SI_resource.name.c_str(), .DescriptorTypeValue = DescriptorType::COMBINED_IMAGE_SAMPLER, .Flags = ShaderStageFlags::FRAGMENT});
             }
         }
     }

--- a/ZEngine/ZEngine/Rendering/Specifications/ShaderSpecification.h
+++ b/ZEngine/ZEngine/Rendering/Specifications/ShaderSpecification.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <ZEngineDef.h>
 #include <vulkan/vulkan.h>
 
 namespace ZEngine::Rendering::Specifications
@@ -38,14 +39,14 @@ namespace ZEngine::Rendering::Specifications
         uint32_t         Set{0xFFFFFFFF};
         uint32_t         Binding{0xFFFFFFFF};
         uint32_t         Count{1};
-        std::string      Name;
+        cstring          Name;
         DescriptorType   DescriptorTypeValue;
         ShaderStageFlags Flags;
     };
 
     struct PushConstantSpecification
     {
-        std::string      Name;
+        cstring          Name;
         uint32_t         Size;
         uint32_t         Offset;
         ShaderStageFlags Flags;
@@ -53,10 +54,10 @@ namespace ZEngine::Rendering::Specifications
 
     struct ShaderSpecification
     {
-        uint32_t    OverloadMaxSet   = 1;
-        uint32_t    OverloadPoolSize = 0;
-        const char* VertexFilename   = {};
-        const char* FragmentFilename = {};
-        const char* Name             = {};
+        uint32_t OverloadMaxSet   = 1;
+        uint32_t OverloadPoolSize = 0;
+        cstring  VertexFilename   = {};
+        cstring  FragmentFilename = {};
+        cstring  Name             = {};
     };
 } // namespace ZEngine::Rendering::Specifications


### PR DESCRIPTION
- To solve the segmentation fault when moving the Specifications with `std::string` members, using Cstrings instead prevents the segmentation fault

Closes #488 

This is a smaller pull-request implementing code that was included in #480.

It is an issue that comes up after solving #486 