### PR TITLE
Mitigate undesired unsynchronized effect of changing SwapchainImage Count

### DIFF
--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
@@ -427,8 +427,6 @@ namespace ZEngine::Hardwares
 
         CreateSwapchain();
 
-        EnqueuedCommandbuffers.init(Arena, m_buffer_manager.TotalCommandBufferCount, m_buffer_manager.TotalCommandBufferCount);
-
         SwapchainRenderCompleteSemaphores.init(Arena, SwapchainImageCount, SwapchainImageCount);
         SwapchainAcquiredSemaphores.init(Arena, SwapchainImageCount, SwapchainImageCount);
         SwapchainSignalFences.init(Arena, SwapchainImageCount, SwapchainImageCount);
@@ -1242,7 +1240,8 @@ namespace ZEngine::Hardwares
             SwapchainFramebuffers.init(Arena, SwapchainImageCount, SwapchainImageCount);
         }
 
-        m_buffer_manager.Initialize(this, SwapchainImageCount);
+        m_buffer_manager.Initialize(this);
+        EnqueuedCommandbuffers.init(Arena, m_buffer_manager.TotalCommandBufferCount, m_buffer_manager.TotalCommandBufferCount);
 
         scratch                        = ZGetScratch(Arena);
 
@@ -2006,10 +2005,10 @@ namespace ZEngine::Hardwares
         }
     }
 
-    void CommandBufferManager::Initialize(VulkanDevice* device, uint8_t swapchain_image_count, int thread_count)
+    void CommandBufferManager::Initialize(VulkanDevice* device, int thread_count)
     {
         Device                  = device;
-        m_total_pool_count      = swapchain_image_count * thread_count;
+        m_total_pool_count      = device->SwapchainImageCount * thread_count;
         TotalCommandBufferCount = m_total_pool_count * MaxBufferPerPool;
         m_instant_fence         = ZPushStructCtorArgs(Device->Arena, Primitives::Fence, device);
         m_instant_semaphore     = ZPushStructCtorArgs(Device->Arena, Primitives::Semaphore, device);

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
@@ -409,9 +409,6 @@ namespace ZEngine::Hardwares
         VmaAllocatorCreateInfo vma_allocator_create_info = {.physicalDevice = PhysicalDevice, .device = LogicalDevice, .instance = Instance, .vulkanApiVersion = VK_API_VERSION_1_3};
         ZENGINE_VALIDATE_ASSERT(vmaCreateAllocator(&vma_allocator_create_info, &VmaAllocatorValue) == VK_SUCCESS, "Failed to create VMA Allocator")
 
-        m_buffer_manager.Initialize(this);
-        EnqueuedCommandbuffers.init(Arena, m_buffer_manager.TotalCommandBufferCount, m_buffer_manager.TotalCommandBufferCount);
-
         /*
          * Creating Swapchain
          */
@@ -428,6 +425,10 @@ namespace ZEngine::Hardwares
         PreviousFrameIndex                                    = 0;
         CurrentFrameIndex                                     = 0;
 
+        CreateSwapchain();
+
+        EnqueuedCommandbuffers.init(Arena, m_buffer_manager.TotalCommandBufferCount, m_buffer_manager.TotalCommandBufferCount);
+
         SwapchainRenderCompleteSemaphores.init(Arena, SwapchainImageCount, SwapchainImageCount);
         SwapchainAcquiredSemaphores.init(Arena, SwapchainImageCount, SwapchainImageCount);
         SwapchainSignalFences.init(Arena, SwapchainImageCount, SwapchainImageCount);
@@ -438,7 +439,6 @@ namespace ZEngine::Hardwares
             SwapchainRenderCompleteSemaphores[i] = ZPushStructCtorArgs(Arena, Primitives::Semaphore, this);
             SwapchainSignalFences[i]             = ZPushStructCtorArgs(Arena, Primitives::Fence, this, true);
         }
-        CreateSwapchain();
 
         /*
          * Creating Global Descriptor Pool for : Textures
@@ -1241,6 +1241,8 @@ namespace ZEngine::Hardwares
         {
             SwapchainFramebuffers.init(Arena, SwapchainImageCount, SwapchainImageCount);
         }
+
+        m_buffer_manager.Initialize(this, SwapchainImageCount);
 
         scratch                        = ZGetScratch(Arena);
 


### PR DESCRIPTION
When creating the Swapchain we check with the device for the supported value. If this value is higher than the pre-configured values, structures created with the initial values are now out of sync, leading to crashes.

This approach attemps to create those structures after getting the supported Swapchain image count