### PR TITLE
Constrain Entt Version to tag v3.16.0

### DIFF
--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -47,7 +47,7 @@ FetchContent_Declare(
   EnTT 
   GIT_REPOSITORY https://github.com/skypjack/entt.git
   GIT_SHALLOW TRUE 
-  GIT_TAG main
+  GIT_TAG v3.16.0
   )
 
 FetchContent_Declare(


### PR DESCRIPTION
- The dependency previously tracked the main branch where current development was happening and breaking changes cause conflicts in our builds.
- Constraining to a known version should fix this.

Closes #499 