### PR TITLE
Fix buildengine.ps1 to include missing functionality

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -56,9 +56,9 @@
             }
         },
         {
-            "name": "Windows_x64_Debug",
+            "name": "Windows_x64_Debug_2022",
             "inherits": "BaseOptions",
-            "displayName": "Windows Visual Studio Debug",
+            "displayName": "Windows Visual Studio 2022 Debug",
             "generator": "Visual Studio 17 2022",
             "binaryDir": "Result.Windows.x64.MultiConfig",
             "architecture": "x64",
@@ -69,13 +69,27 @@
 
         },
         {
-            "name": "Windows_x64_Release",
-            "displayName": "Windows Visual Studio Release",
-            "inherits": "Windows_x64_Debug",
+            "name": "Windows_x64_Release_2022",
+            "displayName": "Windows Visual Studio 2022 Release",
+            "inherits": "Windows_x64_Debug_2022",
             "cacheVariables": {
                 "CMAKE_CONFIGURATION_TYPES": "Release"
             }
         },
+
+        {
+            "name": "Windows_x64_Debug_2026",
+            "inherits": "Windows_x64_Debug_2022",
+            "displayName": "Windows Visual Studio 2026 Debug",
+            "generator": "Visual Studio 18 2026"
+        }, 
+
+        {
+            "name": "Windows_x64_Release_2026",
+            "inherits": "Windows_x64_Release_2022",
+            "displayName": "Windows Visual Studio 2026 Release",
+            "generator": "Visual Studio 18 2026"
+        }, 
 
         {
             "name": "Darwin_x64_Debug",
@@ -146,20 +160,32 @@
 
     "buildPresets": [
         {
-            "name": "Windows_x64_Debug",
-            "configurePreset": "Windows_x64_Debug",
+            "name": "Windows_x64_Debug_2022",
+            "configurePreset": "Windows_x64_Debug_2022",
             "configuration": "Debug",
             "nativeToolOptions": [
                 "-nodeReuse:false"
             ]
         },
         {
-            "name": "Windows_x64_Release",
-            "configurePreset": "Windows_x64_Release",
+            "name": "Windows_x64_Release_2022",
+            "configurePreset": "Windows_x64_Release_2022",
             "configuration": "Release",
             "nativeToolOptions": [
                 "-nodeReuse:false"
             ]
+        },
+
+        {
+            "name": "Windows_x64_Debug_2026",
+            "inherits": "Windows_x64_Debug_2022",
+            "configurePreset": "Windows_x64_Debug_2026"
+        },
+
+        {
+            "name": "Windows_x64_Release_2026",
+            "inherits": "Windows_x64_Release_2022",
+            "configurePreset": "Windows_x64_Release_2026"
         },
 
         {

--- a/Scripts/BuildEngine.ps1
+++ b/Scripts/BuildEngine.ps1
@@ -42,7 +42,7 @@ param (
     [bool] $VerifyFormatting = $False,
 
     [Parameter(HelpMessage = "VS version use to build, default to 2022")]
-    [ValidateSet(2022)]
+    [ValidateSet('2022', '2026')]
     [int] $VsVersion = 2022,
 
     [Parameter(HelpMessage = "Build Launcher only")]
@@ -121,6 +121,10 @@ function Build([string]$configuration, [int]$VsVersion , [bool]$runBuild) {
     # Define CMake Generator arguments
     $configName = $systemName, $architecture, $configuration -join "_"
 
+    if($IsWindows){
+        $configName += '_'+$VsVersion
+    }
+
     $cMakeArguments = " --preset $configName $cMakeCacheVariableOverride"
 
     # CMake Generation process
@@ -130,8 +134,9 @@ function Build([string]$configuration, [int]$VsVersion , [bool]$runBuild) {
         throw "cmake failed generation for '$cMakeArguments' with exit code '$cMakeProcess.ExitCode'"
     }
 
+
+    if ($runBuild) {
     # CMake Build Process
-    #
     
         Write-Host "Building $systemName $architecture $configuration"
 
@@ -166,6 +171,7 @@ function Build([string]$configuration, [int]$VsVersion , [bool]$runBuild) {
         if($installProcess.ExitCode -ne 0){
             throw "cmake failed to install to '$install_directory'"
         }
+    }
 }
 
 


### PR DESCRIPTION
Add Functionality that was left out in the migration to the use of CMake Presets.

Should Close #501 

Also adds support for selecting the Visual Studio Version. Currently Supporting 2022 and 2026.