### PR TITLE
Fix Warnings raised during compilation

### DIFF
--- a/Tetragrama/Components/DockspaceUIComponent.cpp
+++ b/Tetragrama/Components/DockspaceUIComponent.cpp
@@ -40,7 +40,7 @@ namespace Tetragrama::Components
         m_editor_serializer->Initialize(parent->Arena);
         m_asset_importer->Initialize(parent->Arena);
 
-        m_dockspace_node_flag                 = ImGuiDockNodeFlags_NoWindowMenuButton | ImGuiDockNodeFlags_PassthruCentralNode;
+        m_dockspace_node_flag                 = ImGuiDockNodeFlags_NoWindowMenuButton | static_cast<decltype(ImGuiDockNodeFlags_NoWindowMenuButton)>(ImGuiDockNodeFlags_PassthruCentralNode);
         m_window_flags                        = ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavFocus;
 
         auto app                              = reinterpret_cast<EditorPtr>(ParentLayer->CurrentApp);
@@ -211,7 +211,7 @@ namespace Tetragrama::Components
 
             ImGui::PushFont(ImGui::GetIO().Fonts->Fonts[0]);
             ImGui::SetCursorPos(ImVec2(10, ImGui::GetWindowSize().y - 30));
-            ImGui::TextColored(s_asset_importer_report_msg_color, s_asset_importer_report_msg.c_str());
+            ImGui::TextColored(s_asset_importer_report_msg_color, "%s", s_asset_importer_report_msg.c_str());
             ImGui::PopFont();
 
             ImGui::EndPopup();
@@ -244,7 +244,7 @@ namespace Tetragrama::Components
 
             ImGui::PushFont(ImGui::GetIO().Fonts->Fonts[0]);
             ImGui::SetCursorPos(ImVec2(10, wind_size.y - 30));
-            ImGui::TextColored(s_scene_serializer_log_color, s_scene_serializer_log);
+            ImGui::TextColored(s_scene_serializer_log_color, "%s", s_scene_serializer_log);
             ImGui::PopFont();
 
             ImGui::EndPopup();
@@ -385,7 +385,7 @@ namespace Tetragrama::Components
 
         if (ImGui::BeginPopupModal(str_id, NULL, ImGuiWindowFlags_AlwaysAutoResize))
         {
-            ImGui::Text(fmt::format("You have unsaved changes for your current scene : {}", current_scene->Name).c_str());
+            ImGui::Text("%s", fmt::format("You have unsaved changes for your current scene : {}", current_scene->Name).c_str());
             ImGui::Separator();
 
             if (ImGui::Button("Save", ImVec2(120, 0)))

--- a/Tetragrama/Messengers/Messenger.h
+++ b/Tetragrama/Messengers/Messenger.h
@@ -141,6 +141,7 @@ namespace Tetragrama::Messengers
             // catch (...)
             //{
             //}
+            return {};
         }
 
         template <typename TRecipient, typename TMessage>

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
@@ -721,22 +721,22 @@ namespace ZEngine::Hardwares
 
     VKAPI_ATTR VkBool32 VKAPI_CALL VulkanDevice::__debugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageType, const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData, void* pUserData)
     {
-        if ((messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) == VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT)
+        if ((messageSeverity & static_cast<decltype(messageSeverity)>(VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT)) == VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT)
         {
             ZENGINE_CORE_ERROR("{}", pCallbackData->pMessage)
         }
 
-        if ((messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) == VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT)
+        if ((messageSeverity & static_cast<decltype(messageSeverity)>(VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT)) == VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT)
         {
             ZENGINE_CORE_WARN("{}", pCallbackData->pMessage)
         }
 
-        if ((messageSeverity & VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT) == VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)
+        if ((messageSeverity & static_cast<decltype(messageSeverity)>(VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)) == VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT)
         {
             ZENGINE_CORE_WARN("{}", pCallbackData->pMessage)
         }
 
-        if ((messageSeverity & VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT) == VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT)
+        if ((messageSeverity & static_cast<decltype(messageSeverity)>(VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT)) == VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT)
         {
             ZENGINE_CORE_WARN("{}", pCallbackData->pMessage)
         }
@@ -960,6 +960,8 @@ namespace ZEngine::Hardwares
             case BufferType::INDIRECT:
                 dst_access_mask    = VK_ACCESS_INDIRECT_COMMAND_READ_BIT;
                 dst_pipeline_stage = VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT;
+                break;
+            case UNKNOWN:
                 break;
         }
 
@@ -1583,6 +1585,8 @@ namespace ZEngine::Hardwares
                                 vkFreeDescriptorSets(LogicalDevice, reinterpret_cast<VkDescriptorPool>(res_handle.Data1), 1, &ds);
                                 break;
                             }
+                            case DeviceResourceType::RESOURCE_COUNT:
+                                break;
                         }
 
                         DirtyResources.Remove(handle);
@@ -2360,7 +2364,7 @@ namespace ZEngine::Hardwares
 
     void Image2DBuffer::Dispose()
     {
-        if (this && m_buffer_image)
+        if (m_buffer_image)
         {
             Device->EnqueueBufferImageForDeletion(m_buffer_image);
             m_buffer_image = {};
@@ -2497,6 +2501,8 @@ namespace ZEngine::Hardwares
                 case BufferType::INDIRECT:
                     dst_access_mask    = VK_ACCESS_INDIRECT_COMMAND_READ_BIT;
                     dst_pipeline_stage = VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT;
+                    break;
+                case UNKNOWN:
                     break;
             }
 

--- a/ZEngine/ZEngine/Helpers/HandleManager.h
+++ b/ZEngine/ZEngine/Helpers/HandleManager.h
@@ -18,11 +18,11 @@ namespace ZEngine::Helpers
     template <typename T>
     struct Handle
     {
-        uint32_t Index = UINT32_MAX;
+        uint64_t Index = UINT64_MAX;
 
         bool     Valid() const
         {
-            return Index != UINT32_MAX;
+            return Index != UINT64_MAX;
         }
 
         operator bool() const


### PR DESCRIPTION
Attempted to fix the warnings that would persistently come up when compiling. These are possibly a source of bugs.

Changes made include:j
- use String version of ImGui calls in DockspaceUIComponent
- Change Handle::Index from uint32_t to uint64_t because it is we are using it to represent a void* and as we are generally targeting x64 the system would warn about this conversion.
- Used static_casts to deal with enum-to-enum comparisons using different enum types.
- return default typed Node in Messenger.h
- Close off switch statements with a default clause.