### PR TITLE
Make Builds Run in Parallel

### DIFF
--- a/Scripts/BuildEngine.ps1
+++ b/Scripts/BuildEngine.ps1
@@ -140,7 +140,9 @@ function Build([string]$configuration, [int]$VsVersion , [bool]$runBuild) {
     
         Write-Host "Building $systemName $architecture $configuration"
 
-        $buildArguments = "--build --preset $configName"
+        $processorCount = [ENVIRONMENT]::ProcessorCount
+
+        $buildArguments = "--build --preset $configName --parallel $processorCount"
 
         $buildProcess = Start-Process $cMakeProgram -ArgumentList $buildArguments -NoNewWindow -PassThru
 


### PR DESCRIPTION
- Use CMake's `--parallel` flag to allow MSVC and/or Apple based builds to work in parallel. 
- Ninja on Linux works in parallel by default and that is why its CI works alot faster.