### PR TITLE
Enable CMake's CTest Functionality & Update FMT Base Branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,11 +40,16 @@ list( APPEND CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib )
 #
 if (NOT LAUNCHER_ONLY)
 
-    ## Setup Dependencies
+    # Enable CMake's CTest Functionality
+    #
+    include(CTest)
+
+    # Setup Dependencies
+    #
     include(dependencies.cmake)
 
-    ## Compile Shaders
-
+    # Compile Shaders
+    #
     add_subdirectory (Resources)
 
 	# Core engine lib is here

--- a/ZEngine/tests/CMakeLists.txt
+++ b/ZEngine/tests/CMakeLists.txt
@@ -17,3 +17,8 @@ set_target_properties(ZEngineTests PROPERTIES INSTALL_RPATH ${CMAKE_INSTALL_PREF
 
 install(TARGETS ZEngineTests 
     RUNTIME DESTINATION tests)
+
+if(BUILD_TESTING)
+    include(GoogleTest)
+    gtest_discover_tests(ZEngineTests)
+endif()

--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -4,6 +4,7 @@ FetchContent_Declare(
   fmt
   GIT_REPOSITORY https://github.com/fmtlib/fmt.git
   GIT_SHALLOW TRUE
+  GIT_TAG main
     )
 
 FetchContent_Declare(


### PR DESCRIPTION
- Enable the testing machinery and enumerate the tests using CMake
- This enables testing using the CTest Command
- Also cleaned up the CMakeLists.txt file for consistency in style
- Updated the fmt lib base branch as it changed from `master` to `main`