### PR TITLE
update CI github/actions to version 6

### DIFF
--- a/.github/workflows/job-clangformat.yml
+++ b/.github/workflows/job-clangformat.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on: windows-2022
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: update llvm to version 22
               run: choco upgrade llvm

--- a/.github/workflows/job-cmakebuild-linux.yml
+++ b/.github/workflows/job-cmakebuild-linux.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
       
     - name: Download the Microsoft repository GPG keys
       run: wget -q https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb
@@ -42,7 +42,7 @@ jobs:
       shell: pwsh
 
     - name: Publish Build Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Build-linux-${{inputs.configuration}}
         if-no-files-found: error

--- a/.github/workflows/job-cmakebuild-macOS.yml
+++ b/.github/workflows/job-cmakebuild-macOS.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ inputs.architecture == 'x64' && 'macos-15-intel' || 'macos-latest' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Install NuGet CLI
         run: brew install nuget
@@ -34,7 +34,7 @@ jobs:
         shell: pwsh
 
       - name: Publish Build Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Build-macOS-${{ inputs.architecture }}-${{inputs.configuration}}
           if-no-files-found: error

--- a/.github/workflows/job-cmakebuild-windows.yml
+++ b/.github/workflows/job-cmakebuild-windows.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: windows-2025
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: update llvm to version 22
         run: choco upgrade llvm
@@ -31,7 +31,7 @@ jobs:
         shell: pwsh
 
       - name: Publish Build Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Build-Windows-x64-${{inputs.configuration}}
           if-no-files-found: error

--- a/.github/workflows/job-deploy-linux.yml
+++ b/.github/workflows/job-deploy-linux.yml
@@ -17,13 +17,13 @@ jobs:
     name: deploy-linux-${{ inputs.configuration }}
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v6
         with:
           name: Build-linux-Release
           path: Result.Linux.x64.${{ inputs.configuration }}
 
       - name: Publish Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: linux-${{ inputs.configuration }}
           if-no-files-found: error

--- a/.github/workflows/job-deploy-macOS.yml
+++ b/.github/workflows/job-deploy-macOS.yml
@@ -20,13 +20,13 @@ jobs:
     name: deploy-macOS-${{ inputs.architecture }}-${{ inputs.configuration }}
     runs-on: ${{ inputs.architecture == 'x64' && 'macos-15-intel' || 'macos-latest' }}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v6
         with:
           path: Result.Darwin.${{ inputs.architecture }}.${{ inputs.configuration }}
           name: Build-macOS-${{ inputs.architecture }}-Release
 
       - name: Publish Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: macOS-${{ inputs.architecture }}-${{ inputs.configuration }}
           if-no-files-found: error

--- a/.github/workflows/job-deploy-windows.yml
+++ b/.github/workflows/job-deploy-windows.yml
@@ -17,13 +17,13 @@ jobs:
     name: deploy-windows-x64-${{ inputs.configuration }}
     runs-on: windows-2025
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v6
         with:
           path: Result.Windows.x64.MultiConfig
           name: Build-Windows-x64-Release
 
       - name: Publish Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Windows-x64-${{ inputs.configuration }}
           if-no-files-found: error

--- a/.github/workflows/job-test-linux.yml
+++ b/.github/workflows/job-test-linux.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: Build-linux-${{ inputs.configuration }}
 

--- a/.github/workflows/job-test-macOS.yml
+++ b/.github/workflows/job-test-macOS.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ inputs.architecture == 'x64' && 'macos-15-intel' || 'macos-latest' }}
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: Build-macOS-${{ inputs.architecture }}-${{ inputs.configuration }}
 

--- a/.github/workflows/job-test-windows.yml
+++ b/.github/workflows/job-test-windows.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-2025
     steps:
       - name: Download All Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: Build-Windows-x64-${{ inputs.configuration }}
 


### PR DESCRIPTION
- The CI actions have been warning about deprecation of the older versions especially due to the nodejs version.
- Bumping up to keep up to date