### PR TITLE
fix: switch ArenaAllocator to VirtualAlloc/mmap with on-demand page commit

### DIFF
--- a/Obelisk/EntryPoint.cpp
+++ b/Obelisk/EntryPoint.cpp
@@ -16,9 +16,9 @@ using namespace ZEngine::Applications;
 int applicationEntryPoint(int argc, char* argv[])
 {
     MemoryManager       manager = {};
-    MemoryConfiguration config  = {.DefaultSize = ZGiga(3u)};
+    MemoryConfiguration config  = {.BufferSize = ZGiga(3u)};
     manager.Initialize(config);
-    auto                arena      = &(manager.Allocator);
+    auto                arena      = &(manager.MainArena);
 
     LoggerConfiguration logger_cfg = {};
     Logger::Initialize(arena, logger_cfg);
@@ -51,7 +51,7 @@ int applicationEntryPoint(int argc, char* argv[])
 
     Logger::Dispose();
 
-    manager.Shutdowm();
+    manager.Shutdown();
 
     return 0;
 }

--- a/ZEngine/ZEngine/Core/Memory/Allocator.cpp
+++ b/ZEngine/ZEngine/Core/Memory/Allocator.cpp
@@ -1,29 +1,98 @@
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <sys/mman.h>
+#endif
+
 #include <Allocator.h>
 #include <MemoryOperations.h>
 
 namespace ZEngine::Core::Memory
 {
-    void ArenaAllocator::Initialize(uint64_t size)
+    void ArenaAllocator::Initialize(uint64_t size, unsigned long page_size)
     {
-        m_memory          = (uint8_t*) malloc(size);
-        m_total_size      = size;
-        m_current_offset  = 0;
-        m_previous_offset = 0;
+#ifdef _WIN32
+        m_memory = (uint8_t*) VirtualAlloc(nullptr, size, MEM_RESERVE, PAGE_NOACCESS);
+#else
+        m_memory = (uint8_t*) mmap(nullptr, size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (m_memory == MAP_FAILED)
+        {
+            m_memory = nullptr;
+        }
+#endif
+        if (!m_memory)
+        {
+            // Failed to allocate memory
+            return;
+        }
+        m_total_size              = size;
+        m_mem_page_size           = page_size;
+        m_initial_current_offset  = 0;
+        m_initial_previous_offset = 0;
     }
 
     void ArenaAllocator::Shutdown()
     {
-        Clear();
-        free(m_memory);
+        // Not thread-safe: external synchronization is required if the arena is shared across threads.
+        m_total_size      = 0;
+        m_committed_size  = 0;
+        m_current_offset  = m_initial_current_offset;
+        m_previous_offset = m_initial_previous_offset;
+
+        if (m_is_sub_arena)
+        {
+            // Sub-arenas do not own the memory, so we don't free it
+            m_memory = nullptr;
+            return;
+        }
+
+        if (m_memory)
+        {
+#ifdef _WIN32
+            VirtualFree(m_memory, 0, MEM_RELEASE);
+#else
+            munmap(m_memory, m_total_size);
+#endif
+            m_memory = nullptr;
+        }
     }
 
     void* ArenaAllocator::Allocate(size_t size, size_t alignment)
     {
+        if (!m_memory)
+        {
+            // Memory not initialized or failed to allocate memory or already shutdown
+            return nullptr;
+        }
+
         uintptr_t current_ptr  = (uintptr_t) m_memory + (uintptr_t) m_current_offset;
         uintptr_t offset       = Helpers::memory_align(current_ptr, alignment);
         offset                -= (uintptr_t) m_memory;
 
-        assert((offset + size) <= m_total_size);
+        if ((offset + size) > m_total_size)
+        {
+            // Out of memory
+            return nullptr;
+        }
+
+        if ((offset + size) > m_committed_size)
+        {
+            // this use the general formula to round up to the nearest multiple of m_mem_page_size
+            // formula: (x + y - 1) & ~(y - 1)
+            size_t commit_size = (offset + size + m_mem_page_size - 1) & ~(m_mem_page_size - 1);
+#ifdef _WIN32
+            void* commit_result = VirtualAlloc(m_memory + m_committed_size, commit_size - m_committed_size, MEM_COMMIT, PAGE_READWRITE);
+            if (!commit_result)
+#else
+            int commit_result = mprotect(m_memory + m_committed_size, commit_size - m_committed_size, PROT_READ | PROT_WRITE);
+            if (commit_result != 0)
+#endif
+            {
+                // Failed to commit memory
+                return nullptr;
+            }
+            m_committed_size = commit_size;
+        }
 
         void* ptr         = &m_memory[offset];
         m_previous_offset = offset;
@@ -41,6 +110,7 @@ namespace ZEngine::Core::Memory
     void* ArenaAllocator::Resize(void* old_memory, size_t old_size, size_t new_size, size_t alignment)
     {
         ZENGINE_VALIDATE_ASSERT(Helpers::is_power_of_two(alignment), "Alignment should be power of 2")
+        ZENGINE_VALIDATE_ASSERT(new_size > 0, "ArenaAllocator::Resize: new_size must be > 0")
 
         uint8_t* old_mem = reinterpret_cast<uint8_t*>(old_memory);
         if (old_mem == nullptr || old_size == 0)
@@ -51,27 +121,53 @@ namespace ZEngine::Core::Memory
         {
             if ((m_memory + m_previous_offset) == old_mem)
             {
-                m_current_offset = m_previous_offset + new_size;
-                if (m_current_offset <= m_total_size)
+                if ((m_previous_offset + new_size) <= m_total_size)
                 {
                     if (new_size > old_size)
                     {
-                        void*  dst  = &m_memory[m_previous_offset + old_size];
-                        size_t size = new_size - old_size;
-                        Helpers::secure_memset(dst, 0, size, size);
+                        size_t new_end = m_previous_offset + new_size;
+                        if (new_end > m_committed_size)
+                        {
+                            size_t commit_size = (new_end + m_mem_page_size - 1) & ~(m_mem_page_size - 1);
+#ifdef _WIN32
+                            void* commit_result = VirtualAlloc(m_memory + m_committed_size, commit_size - m_committed_size, MEM_COMMIT, PAGE_READWRITE);
+                            if (!commit_result)
+#else
+                            int commit_result = mprotect(m_memory + m_committed_size, commit_size - m_committed_size, PROT_READ | PROT_WRITE);
+                            if (commit_result != 0)
+#endif
+                            {
+                                ZENGINE_VALIDATE_ASSERT(false, "ArenaAllocator::Resize: failed to commit new pages")
+                                return nullptr;
+                            }
+                            m_committed_size = commit_size;
+                        }
+
+                        void*  dst       = &m_memory[m_previous_offset + old_size];
+                        size_t zero_size = new_size - old_size;
+                        Helpers::secure_memset(dst, 0, zero_size, zero_size);
                     }
+                    else
+                    {
+                        void*  dst       = &m_memory[m_previous_offset + new_size];
+                        size_t zero_size = old_size - new_size;
+                        Helpers::secure_memset(dst, 0, zero_size, zero_size);
+                    }
+
+                    m_current_offset = m_previous_offset + new_size;
                     return old_memory;
                 }
+                // fast path capacity exceeded — fall through to slow path
             }
-            else
-            {
-                auto   new_mem = Allocate(new_size, alignment);
-                size_t size    = old_size < new_size ? old_size : new_size;
-                Helpers::secure_memmove(new_mem, size, old_memory, size);
-                return new_mem;
-            }
+
+            auto new_mem = Allocate(new_size, alignment);
+            ZENGINE_VALIDATE_ASSERT(new_mem != nullptr, "ArenaAllocator::Resize: arena out of memory")
+            size_t copy_size = old_size < new_size ? old_size : new_size;
+            Helpers::secure_memcpy(new_mem, new_size, old_memory, copy_size);
+            return new_mem;
         }
 
+        ZENGINE_VALIDATE_ASSERT(false, "ArenaAllocator::Resize: pointer not owned by this arena")
         return nullptr;
     }
 
@@ -84,12 +180,15 @@ namespace ZEngine::Core::Memory
     void ArenaAllocator::CreateSubArena(size_t size, ArenaAllocator* out_arena)
     {
         out_arena->m_memory                  = reinterpret_cast<uint8_t*>(Allocate(size));
+        out_arena->m_is_sub_arena            = true;
         out_arena->m_initial_previous_offset = 0;
         out_arena->m_initial_current_offset  = 0;
 
         out_arena->m_previous_offset         = 0;
         out_arena->m_current_offset          = 0;
         out_arena->m_total_size              = size;
+        out_arena->m_committed_size          = size; // memory already committed by parent arena
+        out_arena->m_mem_page_size           = m_mem_page_size;
     }
 
     ArenaTemp BeginTempArena(ArenaAllocator* arena)
@@ -110,18 +209,18 @@ namespace ZEngine::Core::Memory
 
     void PoolAllocator::Initialize(Arena* arena, size_t size, size_t chk_size, size_t alignment)
     {
-        uintptr_t initial_start  = (uintptr_t) &arena->m_memory[arena->m_current_offset];
-        uintptr_t start          = Helpers::memory_align(initial_start, (uintptr_t) alignment);
-        size                    -= (size_t) (start - initial_start);
-
-        chk_size                 = Helpers::memory_align_size_t(chk_size, alignment);
+        // Let Allocate manage alignment internally — do not pre-subtract padding.
+        // Pre-subtracting caused a double-reduction: size was reduced by the padding
+        // computed here, then Allocate re-aligned internally, potentially adding no
+        // padding (if the arena was already aligned) while size was already shrunk.
+        chk_size = Helpers::memory_align_size_t(chk_size, alignment);
 
         ZENGINE_VALIDATE_ASSERT(chk_size >= sizeof(PoolFreeNode), "Chunk size is too small");
         ZENGINE_VALIDATE_ASSERT(size >= chk_size, "Backing buffer length is smaller than the chunk size");
 
         memory = (uint8_t*) arena->Allocate(size, alignment);
 
-        ZENGINE_VALIDATE_ASSERT(memory, "Failed to allocate memory");
+        ZENGINE_VALIDATE_ASSERT(memory != nullptr, "PoolAllocator::Initialize: allocation failed");
 
         total_size = size;
         chunk_size = chk_size;
@@ -152,34 +251,30 @@ namespace ZEngine::Core::Memory
 
     void PoolAllocator::Free(void* ptr)
     {
-        if (!ptr)
-        {
-            return;
-        }
+        ZENGINE_VALIDATE_ASSERT(ptr != nullptr, "PoolAllocator::Free: null pointer")
 
-        auto start = memory;
-        auto end   = &memory[total_size];
+        auto p     = (uintptr_t) ptr;
+        auto start = (uintptr_t) memory;
+        auto end   = (uintptr_t) memory + total_size;
 
-        if (!(start <= ptr && ptr < end))
-        {
-            return;
-        }
+        ZENGINE_VALIDATE_ASSERT(p >= start && p < end, "PoolAllocator::Free: pointer not owned by this pool")
+        ZENGINE_VALIDATE_ASSERT((p - start) % chunk_size == 0, "PoolAllocator::Free: pointer is not chunk-aligned — possible corruption or wrong pointer")
 
-        PoolFreeNode* node = (PoolFreeNode*) (ptr);
+        PoolFreeNode* node = (PoolFreeNode*) ptr;
         node->Next         = head;
         head               = node;
     }
 
     void PoolAllocator::Clear()
     {
-        auto   chunk_count = total_size / chunk_size;
-        size_t i           = 0;
+        auto chunk_count = total_size / chunk_size;
 
-        for (i = 0; i < chunk_count; i++)
+        for (size_t i = 0; i < chunk_count; i++)
         {
-            void*         ptr  = &memory[i * chunk_size];
+            void* ptr = &memory[i * chunk_size];
+            Helpers::secure_memset(ptr, 0, chunk_size, chunk_size);
+
             PoolFreeNode* node = (PoolFreeNode*) ptr;
-            // Push free node onto thte free list
             node->Next         = head;
             head               = node;
         }

--- a/ZEngine/ZEngine/Core/Memory/Allocator.h
+++ b/ZEngine/ZEngine/Core/Memory/Allocator.h
@@ -15,27 +15,57 @@ namespace ZEngine::Core::Memory
         size_t          PreviousOffset = 0;
     };
 
+    // ArenaAllocator — linear bump-pointer allocator backed by a virtual memory reservation.
+    //
+    // Memory is reserved upfront via mmap/VirtualAlloc (PROT_NONE / PAGE_NOACCESS) and
+    // committed on demand in page-aligned increments as allocations are made. Individual
+    // allocations cannot be freed — the entire arena is reclaimed at once via Clear() or
+    // Shutdown(). This makes it suitable for per-frame, per-task, or lifetime-scoped data.
+    //
+    // LIFETIME CONTRACT — all users must observe:
+    //   1. Any PoolAllocator carved from this arena via PoolAllocator::Initialize() must
+    //      not be accessed after this arena's Clear() or Shutdown() is called. Clear()
+    //      rewinds the bump pointer but does NOT notify carved pools — the pool's memory
+    //      pointer becomes aliased to future allocations without warning.
+    //   2. Sub-arenas created via CreateSubArena() must be Shutdown() before their parent.
+    //      Sub-arenas do not own their backing memory; the parent's Shutdown() unmaps it.
+    //   3. This arena must outlive all objects allocated from it. Pointers into the arena
+    //      become dangling after Shutdown() — there is no destructor notification.
+    //   4. Clear() does not call destructors on objects allocated from the arena. Callers
+    //      are responsible for manually destroying any non-trivial objects before calling
+    //      Clear().
+    //   5. Scratch scopes (ZGetScratch / ZReleaseScratch) are not re-entrant on the same
+    //      arena. Do not open a scratch scope on an arena that is already inside an outer
+    //      scratch scope — the inner release will rewind the arena beneath the outer's
+    //      allocations, corrupting them.
     struct ArenaAllocator
     {
-        ~ArenaAllocator() {};
+        ~ArenaAllocator()
+        {
+            Shutdown();
+        };
 
-        void     Initialize(uint64_t size);
-        void     Shutdown();
+        void          Initialize(uint64_t size, unsigned long page_size);
+        void          Shutdown();
 
-        void*    Allocate(size_t size, size_t alignment = DEFAULT_ALIGNMENT);
-        void*    Allocate(size_t size, size_t alignment, const char* file, int line);
+        void*         Allocate(size_t size, size_t alignment = DEFAULT_ALIGNMENT);
+        void*         Allocate(size_t size, size_t alignment, const char* file, int line);
 
-        void*    Resize(void* old_memory, size_t old_size, size_t new_size, size_t alignment = DEFAULT_ALIGNMENT);
-        void     Clear();
+        void*         Resize(void* old_memory, size_t old_size, size_t new_size, size_t alignment = DEFAULT_ALIGNMENT);
+        void          Clear();
 
-        void     CreateSubArena(size_t size, ArenaAllocator* out_arena);
+        void          CreateSubArena(size_t size, ArenaAllocator* out_arena);
 
-        uint8_t* m_memory                  = nullptr;
-        size_t   m_total_size              = 0;
-        size_t   m_initial_current_offset  = 0;
-        size_t   m_initial_previous_offset = 0;
-        size_t   m_current_offset          = 0;
-        size_t   m_previous_offset         = 0;
+        uint8_t*      m_memory                  = nullptr;
+        bool          m_is_sub_arena            = false;
+        size_t        m_total_size              = 0;
+        size_t        m_initial_current_offset  = 0;
+        size_t        m_initial_previous_offset = 0;
+        size_t        m_current_offset          = 0;
+        size_t        m_previous_offset         = 0;
+        size_t        m_committed_size          = 0;
+        unsigned long m_mem_page_size           = 0;
+
     }; // struct ArenaAllocator
 
     struct PoolFreeNode
@@ -43,6 +73,29 @@ namespace ZEngine::Core::Memory
         PoolFreeNode* Next = nullptr;
     };
 
+    // PoolAllocator — fixed-size chunk allocator with O(1) alloc and free.
+    //
+    // Backing memory is carved from an ArenaAllocator at Initialize() time. The pool does
+    // NOT own its memory — it manages a free list over a region owned by the parent arena.
+    //
+    // LIFETIME CONTRACT — all users must observe:
+    //   1. The parent ArenaAllocator must outlive this pool. After the arena's Shutdown()
+    //      or Clear(), pool.memory is a dangling pointer. Any subsequent Allocate(), Free(),
+    //      or Clear() call on this pool is undefined behavior.
+    //   2. Do not call the parent arena's Clear() while this pool has live allocations.
+    //      Clear() rewinds the arena's bump pointer without notifying the pool — the pool's
+    //      free list and live chunks will be silently aliased by future arena allocations.
+    //   3. Declaration order in structs matters: if an ArenaAllocator and a PoolAllocator
+    //      carved from it are members of the same struct, the arena must be declared AFTER
+    //      the pool so it is destroyed first (C++ destroys members in reverse declaration
+    //      order). If the arena is destroyed first, pool.memory becomes dangling before the
+    //      pool's own destructor runs.
+    //   4. Clear() zeros all chunk memory before rebuilding the free list. Pointers to
+    //      previously allocated chunks become invalid after Clear() — do not retain them
+    //      across a Clear() call.
+    //   5. Free() asserts that the pointer is owned by this pool and is chunk-aligned.
+    //      Passing a pointer from a different pool or an interior pointer will halt the
+    //      program in both debug and release builds.
     struct PoolAllocator
     {
         using Arena = ArenaAllocator;

--- a/ZEngine/ZEngine/Core/Memory/MemoryManager.h
+++ b/ZEngine/ZEngine/Core/Memory/MemoryManager.h
@@ -1,25 +1,47 @@
 #pragma once
+#ifdef _WIN32
+// clang-format off
+#include <windows.h>
+// clang-format on
+#include <sysinfoapi.h>
+#elif defined(__linux__) || defined(__APPLE__)
+#include <unistd.h>
+#endif
+
 #include <Core/Memory/Allocator.h>
 
 namespace ZEngine::Core::Memory
 {
     struct MemoryConfiguration
     {
-        uint64_t DefaultSize = ZGiga(2ull);
+        uint64_t BufferSize = ZGiga(2ull);
     };
 
     struct MemoryManager
     {
         void Initialize(const MemoryConfiguration& config)
         {
-            this->Allocator.Initialize(config.DefaultSize);
+            unsigned long page_size = 0ul;
+
+            // Get the system page size
+            // This is platform-specific, so we need to handle it differently for Windows and Linux/macOS
+            // 4KB is the default page size, but it isn't guaranteed.
+            // Linux on ARM64 has a 16KB page size, macOS on ARM64 has a 16KB page size, and Windows on ARM64 has a 4KB page size.
+#ifdef _WIN32
+            SYSTEM_INFO sys_info;
+            GetSystemInfo(&sys_info);
+            page_size = sys_info.dwPageSize;
+#elif defined(__linux__) || defined(__APPLE__)
+            page_size = sysconf(_SC_PAGESIZE);
+#endif
+            MainArena.Initialize(config.BufferSize, page_size);
         }
 
-        void Shutdowm()
+        void Shutdown()
         {
-            Allocator.Shutdown();
+            MainArena.Shutdown();
         }
 
-        ArenaAllocator Allocator = {};
+        ArenaAllocator MainArena = {};
     };
 } // namespace ZEngine::Core::Memory

--- a/ZEngine/ZEngine/Helpers/MemoryOperations.h
+++ b/ZEngine/ZEngine/Helpers/MemoryOperations.h
@@ -90,7 +90,9 @@ namespace ZEngine::Helpers
         errno_t err = strncpy_s(dest, destSize, src, count);
         return (err == 0) ? MEMORY_OP_SUCCESS : MEMORY_OP_FAILURE;
 #else
-        return (std::strncpy(dest, src, count) == dest) ? MEMORY_OP_SUCCESS : MEMORY_OP_FAILURE;
+        std::strncpy(dest, src, count);
+        dest[count] = '\0';
+        return MEMORY_OP_SUCCESS;
 #endif
     }
     inline size_t secure_strlen(const char* str)
@@ -160,7 +162,7 @@ namespace ZEngine::Helpers
 
     inline bool is_power_of_two(uintptr_t x)
     {
-        return (x & (x - 1)) == 0;
+        return (x != 0) && ((x & (x - 1)) == 0);
     }
 
     inline uintptr_t memory_align(uintptr_t ptr, size_t align)

--- a/ZEngine/ZEngine/ZEngineDef.h
+++ b/ZEngine/ZEngine/ZEngineDef.h
@@ -7,13 +7,17 @@
 #define ZENGINE_KEYCODE        ZEngine::Windows::Inputs::GlfwKeyCode
 
 #ifdef _MSC_VER
-#define ZENGINE_DEBUG_BREAK() __debugbreak();
+#define ZENGINE_DEBUG_BREAK() \
+    __debugbreak();           \
+    __assume(false);
 #elif defined(__APPLE__)
 #include <signal.h>
 #define ZENGINE_DEBUG_BREAK() __builtin_trap();
 #else
 #include <signal.h>
-#define ZENGINE_DEBUG_BREAK() raise(SIGTRAP);
+#define ZENGINE_DEBUG_BREAK() \
+    raise(SIGTRAP);           \
+    __builtin_unreachable();
 #endif
 
 #ifdef _MSC_VER
@@ -29,7 +33,6 @@
         if (!(condition))                           \
         {                                           \
             ZENGINE_CORE_CRITICAL(message)          \
-            assert(condition && message);           \
             ZENGINE_DEBUG_BREAK()                   \
         }                                           \
     }

--- a/ZEngine/tests/Containers/array_test.cpp
+++ b/ZEngine/tests/Containers/array_test.cpp
@@ -1,4 +1,5 @@
 #include <Core/Containers/Array.h>
+#include <Core/Memory/MemoryManager.h>
 #include <gtest/gtest.h>
 
 using namespace ZEngine::Core::Containers;
@@ -9,21 +10,20 @@ class ArrayTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        allocator.Initialize(200);
+        manager.Initialize({.BufferSize = 200});
     }
 
     void TearDown() override
     {
-        allocator.Shutdown();
+        manager.Shutdown();
     }
-
-    ArenaAllocator allocator;
+    MemoryManager manager;
 };
 
 TEST_F(ArrayTest, InitialState)
 {
     Array<int> array;
-    array.init(&allocator, 10);
+    array.init(&manager.MainArena, 10);
 
     EXPECT_EQ(array.size(), 0);
     EXPECT_EQ(array.capacity(), 10);
@@ -33,7 +33,7 @@ TEST_F(ArrayTest, InitialState)
 TEST_F(ArrayTest, PushBack)
 {
     Array<int> array;
-    array.init(&allocator, 4, make_initializer_list(&allocator, 1, 2, 3));
+    array.init(&manager.MainArena, 4, make_initializer_list(&manager.MainArena, 1, 2, 3));
 
     EXPECT_EQ(array.size(), 3);
     EXPECT_FALSE(array.empty());
@@ -45,7 +45,7 @@ TEST_F(ArrayTest, PushBack)
 TEST_F(ArrayTest, AutoResize)
 {
     Array<int> array;
-    array.init(&allocator, 2);
+    array.init(&manager.MainArena, 2);
 
     EXPECT_EQ(array.capacity(), 2);
 
@@ -61,7 +61,7 @@ TEST_F(ArrayTest, AutoResize)
 TEST_F(ArrayTest, PopBack)
 {
     Array<int> array;
-    array.init(&allocator, 4, make_initializer_list(&allocator, 1, 2, 3));
+    array.init(&manager.MainArena, 4, make_initializer_list(&manager.MainArena, 1, 2, 3));
 
     EXPECT_EQ(array.size(), 3);
 
@@ -79,7 +79,7 @@ TEST_F(ArrayTest, PopBack)
 TEST_F(ArrayTest, Clear)
 {
     Array<int> array;
-    array.init(&allocator, 4, make_initializer_list(&allocator, 1, 2, 3));
+    array.init(&manager.MainArena, 4, make_initializer_list(&manager.MainArena, 1, 2, 3));
 
     EXPECT_EQ(array.size(), 3);
 
@@ -93,7 +93,7 @@ TEST_F(ArrayTest, Clear)
 TEST_F(ArrayTest, Reserve)
 {
     Array<int> array;
-    array.init(&allocator, 4);
+    array.init(&manager.MainArena, 4);
 
     EXPECT_EQ(array.capacity(), 4);
 
@@ -107,7 +107,7 @@ TEST_F(ArrayTest, Reserve)
 TEST_F(ArrayTest, FrontAndBack)
 {
     Array<int> array;
-    array.init(&allocator, 4);
+    array.init(&manager.MainArena, 4);
 
     array.push(10);
     EXPECT_EQ(array.front(), 10);
@@ -123,7 +123,7 @@ TEST_F(ArrayTest, FrontAndBack)
 TEST_F(ArrayTest, ArrayViewWrap)
 {
     Array<int> array;
-    array.init(&allocator, 4, make_initializer_list(&allocator, 10, 20, 30));
+    array.init(&manager.MainArena, 4, make_initializer_list(&manager.MainArena, 10, 20, 30));
 
     ArrayView<int> view(array);
 

--- a/ZEngine/tests/Containers/hashset_test.cpp
+++ b/ZEngine/tests/Containers/hashset_test.cpp
@@ -1,5 +1,6 @@
 #include <Core/Containers/Strings.h>
 #include <Core/Containers/UnorderedHashSet.h>
+#include <Core/Memory/MemoryManager.h>
 #include <gtest/gtest.h>
 #include <unordered_set>
 
@@ -11,19 +12,19 @@ class UnorderedHashSetTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        allocator.Initialize(2000);
+        manager.Initialize({.BufferSize = 2000});
     }
     void TearDown() override
     {
-        allocator.Shutdown();
+        manager.Shutdown();
     }
-    ArenaAllocator allocator;
+    MemoryManager manager;
 };
 
 TEST_F(UnorderedHashSetTest, InitialState)
 {
     UnorderedHashSet<int> set;
-    set.init(&allocator, 10);
+    set.init(&manager.MainArena, 10);
     EXPECT_EQ(set.size(), 0);
     EXPECT_EQ(set.capacity(), 10);
     EXPECT_TRUE(set.empty());
@@ -32,7 +33,7 @@ TEST_F(UnorderedHashSetTest, InitialState)
 TEST_F(UnorderedHashSetTest, InsertAndContains)
 {
     UnorderedHashSet<int> set;
-    set.init(&allocator, 10);
+    set.init(&manager.MainArena, 10);
     set.insert(1);
     set.insert(2);
     EXPECT_TRUE(set.contains(1));
@@ -43,7 +44,7 @@ TEST_F(UnorderedHashSetTest, InsertAndContains)
 TEST_F(UnorderedHashSetTest, InsertDuplicateDoesNotGrow)
 {
     UnorderedHashSet<int> set;
-    set.init(&allocator, 10);
+    set.init(&manager.MainArena, 10);
     set.insert(1);
     set.insert(1);
     EXPECT_EQ(set.size(), 1);
@@ -52,7 +53,7 @@ TEST_F(UnorderedHashSetTest, InsertDuplicateDoesNotGrow)
 TEST_F(UnorderedHashSetTest, Remove)
 {
     UnorderedHashSet<int> set;
-    set.init(&allocator, 10);
+    set.init(&manager.MainArena, 10);
     set.insert(1);
     set.insert(2);
     EXPECT_EQ(set.size(), 2);
@@ -65,7 +66,7 @@ TEST_F(UnorderedHashSetTest, Remove)
 TEST_F(UnorderedHashSetTest, RemoveNonExistentIsNoOp)
 {
     UnorderedHashSet<int> set;
-    set.init(&allocator, 10);
+    set.init(&manager.MainArena, 10);
     set.insert(1);
     set.remove(99);
     EXPECT_EQ(set.size(), 1);
@@ -75,7 +76,7 @@ TEST_F(UnorderedHashSetTest, RemoveNonExistentIsNoOp)
 TEST_F(UnorderedHashSetTest, Find)
 {
     UnorderedHashSet<int> set;
-    set.init(&allocator, 10);
+    set.init(&manager.MainArena, 10);
     set.insert(42);
     const int* found = set.find(42);
     ASSERT_NE(found, nullptr);
@@ -86,7 +87,7 @@ TEST_F(UnorderedHashSetTest, Find)
 TEST_F(UnorderedHashSetTest, Clear)
 {
     UnorderedHashSet<int> set;
-    set.init(&allocator, 10);
+    set.init(&manager.MainArena, 10);
     set.insert(1);
     set.insert(2);
     set.insert(3);
@@ -102,7 +103,7 @@ TEST_F(UnorderedHashSetTest, Clear)
 TEST_F(UnorderedHashSetTest, Resize)
 {
     UnorderedHashSet<int> set;
-    set.init(&allocator, 2);
+    set.init(&manager.MainArena, 2);
     for (int i = 0; i < 10; ++i)
     {
         set.insert(i);
@@ -118,7 +119,7 @@ TEST_F(UnorderedHashSetTest, Resize)
 TEST_F(UnorderedHashSetTest, CollisionHandling)
 {
     UnorderedHashSet<int> set;
-    set.init(&allocator, 2);
+    set.init(&manager.MainArena, 2);
     set.insert(1);
     set.insert(3);
     set.insert(5);
@@ -130,7 +131,7 @@ TEST_F(UnorderedHashSetTest, CollisionHandling)
 TEST_F(UnorderedHashSetTest, Iteration)
 {
     UnorderedHashSet<int> set;
-    set.init(&allocator, 8);
+    set.init(&manager.MainArena, 8);
     set.insert(10);
     set.insert(20);
     set.insert(30);
@@ -148,12 +149,12 @@ TEST_F(UnorderedHashSetTest, Iteration)
 TEST_F(UnorderedHashSetTest, StringKeys)
 {
     UnorderedHashSet<String> set;
-    set.init(&allocator, 8);
+    set.init(&manager.MainArena, 8);
 
     String a, b, c;
-    a.init(&allocator, "alpha");
-    b.init(&allocator, "beta");
-    c.init(&allocator, "gamma");
+    a.init(&manager.MainArena, "alpha");
+    b.init(&manager.MainArena, "beta");
+    c.init(&manager.MainArena, "gamma");
 
     set.insert(a);
     set.insert(b);

--- a/ZEngine/tests/Containers/initializerlist_test.cpp
+++ b/ZEngine/tests/Containers/initializerlist_test.cpp
@@ -1,6 +1,7 @@
 #include <Core/Containers/Array.h>
 #include <Core/Containers/InitializerList.h>
 #include <Core/Containers/Strings.h>
+#include <Core/Memory/MemoryManager.h>
 #include <gtest/gtest.h>
 
 using namespace ZEngine::Core::Containers;
@@ -11,21 +12,20 @@ class InitializerListTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        arena.Initialize(512);
+        manager.Initialize({.BufferSize = 512});
     }
 
     void TearDown() override
     {
-        arena.Shutdown();
+        manager.Shutdown();
     }
-
-    ArenaAllocator arena;
+    MemoryManager manager;
 };
 
 TEST_F(InitializerListTest, WithArray)
 {
     Array<int> array;
-    array.init(&arena, 4, make_initializer_list(&arena, 1, 2, 3, 4));
+    array.init(&manager.MainArena, 4, make_initializer_list(&manager.MainArena, 1, 2, 3, 4));
 
     InitializerList<int> list(array.data(), array.size());
 
@@ -45,12 +45,12 @@ TEST_F(InitializerListTest, WithArray)
 TEST_F(InitializerListTest, WithStrings)
 {
     Array<String> str_array;
-    str_array.init(&arena, 3);
-    str_array.init(&arena, 3, make_initializer_list(&arena, String(), String(), String()));
+    str_array.init(&manager.MainArena, 3);
+    str_array.init(&manager.MainArena, 3, make_initializer_list(&manager.MainArena, String(), String(), String()));
 
-    str_array[0].init(&arena, "Alpha");
-    str_array[1].init(&arena, "Beta");
-    str_array[2].init(&arena, "Gamma");
+    str_array[0].init(&manager.MainArena, "Alpha");
+    str_array[1].init(&manager.MainArena, "Beta");
+    str_array[2].init(&manager.MainArena, "Gamma");
 
     InitializerList<String> list(str_array.data(), str_array.size());
 
@@ -68,7 +68,7 @@ TEST_F(InitializerListTest, WithStrings)
 TEST_F(InitializerListTest, EmptyFromArray)
 {
     Array<int> empty_array;
-    empty_array.init(&arena, 0);
+    empty_array.init(&manager.MainArena, 0);
 
     InitializerList<int> list(empty_array.data(), empty_array.size());
 

--- a/ZEngine/tests/Containers/ordered_hashmap_test.cpp
+++ b/ZEngine/tests/Containers/ordered_hashmap_test.cpp
@@ -1,5 +1,6 @@
 #include <Core/Containers/HashMap.h>
 #include <Core/Containers/Strings.h>
+#include <Core/Memory/MemoryManager.h>
 #include <gtest/gtest.h>
 #include <string>
 #include <vector>
@@ -12,19 +13,19 @@ class OrderedHashMapTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        allocator.Initialize(2000);
+        manager.Initialize({.BufferSize = 2000});
     }
     void TearDown() override
     {
-        allocator.Shutdown();
+        manager.Shutdown();
     }
-    ArenaAllocator allocator;
+    MemoryManager manager;
 };
 
 TEST_F(OrderedHashMapTest, InitialState)
 {
     HashMap<int, int> map;
-    map.init(&allocator, 10);
+    map.init(&manager.MainArena, 10);
     EXPECT_EQ(map.size(), 0);
     EXPECT_EQ(map.capacity(), 10);
     EXPECT_TRUE(map.empty());
@@ -33,7 +34,7 @@ TEST_F(OrderedHashMapTest, InitialState)
 TEST_F(OrderedHashMapTest, Contains)
 {
     HashMap<int, int> map;
-    map.init(&allocator, 10);
+    map.init(&manager.MainArena, 10);
     map.insert(1, 10);
     EXPECT_TRUE(map.contains(1));
     EXPECT_FALSE(map.contains(2));
@@ -42,7 +43,7 @@ TEST_F(OrderedHashMapTest, Contains)
 TEST_F(OrderedHashMapTest, BracketOperator)
 {
     HashMap<int, int> map;
-    map.init(&allocator, 10);
+    map.init(&manager.MainArena, 10);
     map[1] = 10;
     EXPECT_EQ(map[1], 10);
 
@@ -56,7 +57,7 @@ TEST_F(OrderedHashMapTest, BracketOperator)
 TEST_F(OrderedHashMapTest, Remove)
 {
     HashMap<int, int> map;
-    map.init(&allocator, 10);
+    map.init(&manager.MainArena, 10);
     map.insert(1, 10);
     map.insert(2, 20);
     EXPECT_EQ(map.size(), 2);
@@ -69,7 +70,7 @@ TEST_F(OrderedHashMapTest, Remove)
 TEST_F(OrderedHashMapTest, Find)
 {
     HashMap<int, int> map;
-    map.init(&allocator, 10);
+    map.init(&manager.MainArena, 10);
     map.insert(1, 10);
     int* value = map.find(1);
     ASSERT_NE(value, nullptr);
@@ -81,7 +82,7 @@ TEST_F(OrderedHashMapTest, Find)
 TEST_F(OrderedHashMapTest, Clear)
 {
     HashMap<int, int> map;
-    map.init(&allocator, 10);
+    map.init(&manager.MainArena, 10);
 
     map.insert(1, 10);
     map.insert(2, 20);
@@ -102,7 +103,7 @@ TEST_F(OrderedHashMapTest, Clear)
 TEST_F(OrderedHashMapTest, Resize)
 {
     HashMap<int, int> map;
-    map.init(&allocator, 2);
+    map.init(&manager.MainArena, 2);
 
     for (int i = 0; i < 10; ++i)
     {
@@ -123,13 +124,13 @@ TEST_F(OrderedHashMapTest, Resize)
 TEST_F(OrderedHashMapTest, OverwriteValue)
 {
     HashMap<int, String> map;
-    map.init(&allocator, 10);
+    map.init(&manager.MainArena, 10);
 
     String str1;
-    str1.init(&allocator, "first");
+    str1.init(&manager.MainArena, "first");
 
     String str2;
-    str2.init(&allocator, "updated");
+    str2.init(&manager.MainArena, "updated");
 
     map.insert(1, str1);
     EXPECT_STREQ(map[1].c_str(), str1.c_str());
@@ -141,7 +142,7 @@ TEST_F(OrderedHashMapTest, OverwriteValue)
 TEST_F(OrderedHashMapTest, CollisionHandling)
 {
     HashMap<int, int> map;
-    map.init(&allocator, 2);
+    map.init(&manager.MainArena, 2);
 
     map.insert(1, 10);
     map.insert(3, 30);
@@ -161,7 +162,7 @@ TEST_F(OrderedHashMapTest, CollisionHandling)
 TEST_F(OrderedHashMapTest, InsertionOrderPreserved)
 {
     HashMap<int, int> map;
-    map.init(&allocator, 16);
+    map.init(&manager.MainArena, 16);
 
     map.insert(10, 100);
     map.insert(20, 200);
@@ -182,7 +183,7 @@ TEST_F(OrderedHashMapTest, InsertionOrderPreserved)
 TEST_F(OrderedHashMapTest, InsertionOrderAfterRemove)
 {
     HashMap<int, int> map;
-    map.init(&allocator, 16);
+    map.init(&manager.MainArena, 16);
 
     map.insert(1, 10);
     map.insert(2, 20);
@@ -205,7 +206,7 @@ TEST_F(OrderedHashMapTest, InsertionOrderAfterRemove)
 TEST_F(OrderedHashMapTest, InsertionOrderPreservedAfterResize)
 {
     HashMap<int, int> map;
-    map.init(&allocator, 2);
+    map.init(&manager.MainArena, 2);
 
     for (int i = 0; i < 10; ++i)
         map.insert(i, i * 10);
@@ -222,7 +223,7 @@ TEST_F(OrderedHashMapTest, InsertionOrderPreservedAfterResize)
 TEST_F(OrderedHashMapTest, UpdateDoesNotChangeOrder)
 {
     HashMap<int, int> map;
-    map.init(&allocator, 16);
+    map.init(&manager.MainArena, 16);
 
     map.insert(1, 10);
     map.insert(2, 20);
@@ -245,7 +246,7 @@ TEST_F(OrderedHashMapTest, UpdateDoesNotChangeOrder)
 TEST_F(OrderedHashMapTest, SortKeysAscending)
 {
     HashMap<int, int> map;
-    map.init(&allocator, 16);
+    map.init(&manager.MainArena, 16);
     map.insert(30, 300);
     map.insert(10, 100);
     map.insert(20, 200);
@@ -265,7 +266,7 @@ TEST_F(OrderedHashMapTest, SortKeysAscending)
 TEST_F(OrderedHashMapTest, SortKeysPreservesValues)
 {
     HashMap<int, int> map;
-    map.init(&allocator, 16);
+    map.init(&manager.MainArena, 16);
     map.insert(3, 300);
     map.insert(1, 100);
     map.insert(2, 200);
@@ -290,7 +291,7 @@ TEST_F(OrderedHashMapTest, SortKeysPreservesValues)
 TEST_F(OrderedHashMapTest, SortKeysDoesNotAffectLookup)
 {
     HashMap<int, int> map;
-    map.init(&allocator, 16);
+    map.init(&manager.MainArena, 16);
     map.insert(30, 300);
     map.insert(10, 100);
     map.insert(20, 200);
@@ -305,7 +306,7 @@ TEST_F(OrderedHashMapTest, SortKeysDoesNotAffectLookup)
 TEST_F(OrderedHashMapTest, SortKeysOnEmptyMap)
 {
     HashMap<int, int> map;
-    map.init(&allocator, 16);
+    map.init(&manager.MainArena, 16);
     map.sort_keys();
     EXPECT_TRUE(map.empty());
 }
@@ -313,7 +314,7 @@ TEST_F(OrderedHashMapTest, SortKeysOnEmptyMap)
 TEST_F(OrderedHashMapTest, InsertAfterSortAppendsTail)
 {
     HashMap<int, int> map;
-    map.init(&allocator, 16);
+    map.init(&manager.MainArena, 16);
     map.insert(30, 300);
     map.insert(10, 100);
     map.sort_keys(); // order: 10, 30

--- a/ZEngine/tests/Containers/ordered_hashset_test.cpp
+++ b/ZEngine/tests/Containers/ordered_hashset_test.cpp
@@ -1,5 +1,6 @@
 #include <Core/Containers/HashSet.h>
 #include <Core/Containers/Strings.h>
+#include <Core/Memory/MemoryManager.h>
 #include <gtest/gtest.h>
 #include <vector>
 
@@ -11,19 +12,19 @@ class OrderedHashSetTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        allocator.Initialize(2000);
+        manager.Initialize({.BufferSize = 2000});
     }
     void TearDown() override
     {
-        allocator.Shutdown();
+        manager.Shutdown();
     }
-    ArenaAllocator allocator;
+    MemoryManager manager;
 };
 
 TEST_F(OrderedHashSetTest, InitialState)
 {
     HashSet<int> set;
-    set.init(&allocator, 10);
+    set.init(&manager.MainArena, 10);
     EXPECT_EQ(set.size(), 0);
     EXPECT_EQ(set.capacity(), 10);
     EXPECT_TRUE(set.empty());
@@ -32,7 +33,7 @@ TEST_F(OrderedHashSetTest, InitialState)
 TEST_F(OrderedHashSetTest, InsertAndContains)
 {
     HashSet<int> set;
-    set.init(&allocator, 10);
+    set.init(&manager.MainArena, 10);
     set.insert(1);
     set.insert(2);
     EXPECT_TRUE(set.contains(1));
@@ -43,7 +44,7 @@ TEST_F(OrderedHashSetTest, InsertAndContains)
 TEST_F(OrderedHashSetTest, InsertDuplicateDoesNotGrow)
 {
     HashSet<int> set;
-    set.init(&allocator, 10);
+    set.init(&manager.MainArena, 10);
     set.insert(1);
     set.insert(1);
     EXPECT_EQ(set.size(), 1);
@@ -52,7 +53,7 @@ TEST_F(OrderedHashSetTest, InsertDuplicateDoesNotGrow)
 TEST_F(OrderedHashSetTest, Remove)
 {
     HashSet<int> set;
-    set.init(&allocator, 10);
+    set.init(&manager.MainArena, 10);
     set.insert(1);
     set.insert(2);
     EXPECT_EQ(set.size(), 2);
@@ -65,7 +66,7 @@ TEST_F(OrderedHashSetTest, Remove)
 TEST_F(OrderedHashSetTest, RemoveNonExistentIsNoOp)
 {
     HashSet<int> set;
-    set.init(&allocator, 10);
+    set.init(&manager.MainArena, 10);
     set.insert(1);
     set.remove(99);
     EXPECT_EQ(set.size(), 1);
@@ -75,7 +76,7 @@ TEST_F(OrderedHashSetTest, RemoveNonExistentIsNoOp)
 TEST_F(OrderedHashSetTest, Find)
 {
     HashSet<int> set;
-    set.init(&allocator, 10);
+    set.init(&manager.MainArena, 10);
     set.insert(42);
     const int* found = set.find(42);
     ASSERT_NE(found, nullptr);
@@ -86,7 +87,7 @@ TEST_F(OrderedHashSetTest, Find)
 TEST_F(OrderedHashSetTest, Clear)
 {
     HashSet<int> set;
-    set.init(&allocator, 10);
+    set.init(&manager.MainArena, 10);
     set.insert(1);
     set.insert(2);
     set.insert(3);
@@ -102,7 +103,7 @@ TEST_F(OrderedHashSetTest, Clear)
 TEST_F(OrderedHashSetTest, Resize)
 {
     HashSet<int> set;
-    set.init(&allocator, 2);
+    set.init(&manager.MainArena, 2);
     for (int i = 0; i < 10; ++i)
     {
         set.insert(i);
@@ -118,7 +119,7 @@ TEST_F(OrderedHashSetTest, Resize)
 TEST_F(OrderedHashSetTest, CollisionHandling)
 {
     HashSet<int> set;
-    set.init(&allocator, 2);
+    set.init(&manager.MainArena, 2);
     set.insert(1);
     set.insert(3);
     set.insert(5);
@@ -132,7 +133,7 @@ TEST_F(OrderedHashSetTest, CollisionHandling)
 TEST_F(OrderedHashSetTest, InsertionOrderPreserved)
 {
     HashSet<int> set;
-    set.init(&allocator, 16);
+    set.init(&manager.MainArena, 16);
     set.insert(30);
     set.insert(10);
     set.insert(20);
@@ -152,7 +153,7 @@ TEST_F(OrderedHashSetTest, InsertionOrderPreserved)
 TEST_F(OrderedHashSetTest, InsertionOrderAfterRemove)
 {
     HashSet<int> set;
-    set.init(&allocator, 16);
+    set.init(&manager.MainArena, 16);
     set.insert(1);
     set.insert(2);
     set.insert(3);
@@ -174,7 +175,7 @@ TEST_F(OrderedHashSetTest, InsertionOrderAfterRemove)
 TEST_F(OrderedHashSetTest, InsertionOrderPreservedAfterResize)
 {
     HashSet<int> set;
-    set.init(&allocator, 2);
+    set.init(&manager.MainArena, 2);
     for (int i = 0; i < 10; ++i)
     {
         set.insert(i);
@@ -196,7 +197,7 @@ TEST_F(OrderedHashSetTest, InsertionOrderPreservedAfterResize)
 TEST_F(OrderedHashSetTest, DuplicateInsertDoesNotChangeOrder)
 {
     HashSet<int> set;
-    set.init(&allocator, 16);
+    set.init(&manager.MainArena, 16);
     set.insert(1);
     set.insert(2);
     set.insert(3);
@@ -219,7 +220,7 @@ TEST_F(OrderedHashSetTest, DuplicateInsertDoesNotChangeOrder)
 TEST_F(OrderedHashSetTest, SortKeysAscending)
 {
     HashSet<int> set;
-    set.init(&allocator, 16);
+    set.init(&manager.MainArena, 16);
     set.insert(30);
     set.insert(10);
     set.insert(20);
@@ -241,7 +242,7 @@ TEST_F(OrderedHashSetTest, SortKeysAscending)
 TEST_F(OrderedHashSetTest, SortKeysDoesNotAffectLookup)
 {
     HashSet<int> set;
-    set.init(&allocator, 16);
+    set.init(&manager.MainArena, 16);
     set.insert(30);
     set.insert(10);
     set.insert(20);
@@ -259,7 +260,7 @@ TEST_F(OrderedHashSetTest, SortKeysDoesNotAffectLookup)
 TEST_F(OrderedHashSetTest, SortKeysOnEmptySet)
 {
     HashSet<int> set;
-    set.init(&allocator, 16);
+    set.init(&manager.MainArena, 16);
     set.sort_keys();
     EXPECT_TRUE(set.empty());
 }
@@ -267,7 +268,7 @@ TEST_F(OrderedHashSetTest, SortKeysOnEmptySet)
 TEST_F(OrderedHashSetTest, InsertAfterSortAppendsTail)
 {
     HashSet<int> set;
-    set.init(&allocator, 16);
+    set.init(&manager.MainArena, 16);
     set.insert(30);
     set.insert(10);
     set.sort_keys();

--- a/ZEngine/tests/Containers/string_test.cpp
+++ b/ZEngine/tests/Containers/string_test.cpp
@@ -1,4 +1,5 @@
 #include <Core/Containers/Strings.h>
+#include <Core/Memory/MemoryManager.h>
 #include <gtest/gtest.h>
 
 using namespace ZEngine::Core::Containers;
@@ -9,28 +10,27 @@ class StringTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        arena.Initialize(200);
+        manager.Initialize({.BufferSize = 200});
     }
 
     void TearDown() override
     {
-        arena.Shutdown();
+        manager.Shutdown();
     }
-
-    ArenaAllocator arena;
+    MemoryManager manager;
 };
 
 TEST_F(StringTest, DefaultConstructor)
 {
     String str1;
-    str1.init(&arena);
+    str1.init(&manager.MainArena);
     EXPECT_EQ(str1.size(), 0);
     EXPECT_TRUE(str1.empty());
     EXPECT_STREQ(str1.c_str(), "");
     EXPECT_GE(str1.capacity(), 16);
 
     String str2;
-    str2.init(&arena, nullptr);
+    str2.init(&manager.MainArena, nullptr);
 
     EXPECT_EQ(str2.size(), 0);
     EXPECT_TRUE(str2.empty());
@@ -41,7 +41,7 @@ TEST_F(StringTest, DefaultConstructor)
 TEST_F(StringTest, AppendCString)
 {
     String str;
-    str.init(&arena);
+    str.init(&manager.MainArena);
 
     str.append("Hello");
     EXPECT_STREQ(str.c_str(), "Hello");
@@ -55,9 +55,9 @@ TEST_F(StringTest, AppendCString)
 TEST_F(StringTest, AppendString)
 {
     String str1;
-    str1.init(&arena, "Hello");
+    str1.init(&manager.MainArena, "Hello");
     String str2;
-    str2.init(&arena, ", World!");
+    str2.init(&manager.MainArena, ", World!");
 
     str1.append(str2);
     EXPECT_STREQ(str1.c_str(), "Hello, World!");
@@ -67,7 +67,7 @@ TEST_F(StringTest, AppendString)
 TEST_F(StringTest, AppendChar)
 {
     String str;
-    str.init(&arena, "Hello");
+    str.init(&manager.MainArena, "Hello");
 
     str.append('!');
     EXPECT_STREQ(str.c_str(), "Hello!");
@@ -82,7 +82,7 @@ TEST_F(StringTest, AppendChar)
 TEST_F(StringTest, ElementAccess)
 {
     String str;
-    str.init(&arena, "Hello");
+    str.init(&manager.MainArena, "Hello");
 
     EXPECT_EQ(str[0], 'H');
     EXPECT_EQ(str[1], 'e');
@@ -95,7 +95,7 @@ TEST_F(StringTest, ElementAccess)
 TEST_F(StringTest, Clear)
 {
     String str;
-    str.init(&arena, "Hello, World!");
+    str.init(&manager.MainArena, "Hello, World!");
 
     EXPECT_FALSE(str.empty());
     EXPECT_EQ(str.size(), 13);
@@ -114,7 +114,7 @@ TEST_F(StringTest, Clear)
 TEST_F(StringTest, Reserve)
 {
     String str;
-    str.init(&arena);
+    str.init(&manager.MainArena);
 
     str.reserve(50);
     EXPECT_GE(str.capacity(), 50);
@@ -150,7 +150,7 @@ TEST_F(StringTest, StringViewFromCString)
 TEST_F(StringTest, StringViewFromString)
 {
     String str;
-    str.init(&arena, "Hello, World!");
+    str.init(&manager.MainArena, "Hello, World!");
     StringView view(str);
 
     EXPECT_EQ(view.size(), 13);
@@ -182,7 +182,7 @@ TEST_F(StringTest, StringViewSet)
     EXPECT_EQ(view.data(), text);
 
     String str;
-    str.init(&arena, "Another string");
+    str.init(&manager.MainArena, "Another string");
     view.set(str);
     EXPECT_EQ(view.size(), 14);
     EXPECT_EQ(view.data(), str.c_str());

--- a/ZEngine/tests/Containers/unordered_hashmap_test.cpp
+++ b/ZEngine/tests/Containers/unordered_hashmap_test.cpp
@@ -1,5 +1,6 @@
 #include <Core/Containers/Strings.h>
 #include <Core/Containers/UnorderedHashMap.h>
+#include <Core/Memory/MemoryManager.h>
 #include <gtest/gtest.h>
 #include <string>
 
@@ -11,19 +12,19 @@ class HashMapTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        allocator.Initialize(2000);
+        manager.Initialize({.BufferSize = 2000});
     }
     void TearDown() override
     {
-        allocator.Shutdown();
+        manager.Shutdown();
     }
-    ArenaAllocator allocator;
+    MemoryManager manager;
 };
 
 TEST_F(HashMapTest, InitialState)
 {
     UnorderedHashMap<int, int> array;
-    array.init(&allocator, 10);
+    array.init(&manager.MainArena, 10);
     EXPECT_EQ(array.size(), 0);
     EXPECT_EQ(array.capacity(), 10);
     EXPECT_TRUE(array.empty());
@@ -32,7 +33,7 @@ TEST_F(HashMapTest, InitialState)
 TEST_F(HashMapTest, Contains)
 {
     UnorderedHashMap<int, int> map;
-    map.init(&allocator, 10);
+    map.init(&manager.MainArena, 10);
     map.insert(1, 10);
     EXPECT_TRUE(map.contains(1));
     EXPECT_FALSE(map.contains(2));
@@ -41,7 +42,7 @@ TEST_F(HashMapTest, Contains)
 TEST_F(HashMapTest, BracketOperator)
 {
     UnorderedHashMap<int, int> map;
-    map.init(&allocator, 10);
+    map.init(&manager.MainArena, 10);
     map[1] = 10;
     EXPECT_EQ(map[1], 10);
 
@@ -55,7 +56,7 @@ TEST_F(HashMapTest, BracketOperator)
 TEST_F(HashMapTest, Remove)
 {
     UnorderedHashMap<int, int> map;
-    map.init(&allocator, 10);
+    map.init(&manager.MainArena, 10);
     map.insert(1, 10);
     map.insert(2, 20);
     EXPECT_EQ(map.size(), 2);
@@ -68,7 +69,7 @@ TEST_F(HashMapTest, Remove)
 TEST_F(HashMapTest, Find)
 {
     UnorderedHashMap<int, int> map;
-    map.init(&allocator, 10);
+    map.init(&manager.MainArena, 10);
     map.insert(1, 10);
     int* value = map.find(1);
     ASSERT_NE(value, nullptr);
@@ -80,7 +81,7 @@ TEST_F(HashMapTest, Find)
 TEST_F(HashMapTest, Clear)
 {
     UnorderedHashMap<int, int> map;
-    map.init(&allocator, 10);
+    map.init(&manager.MainArena, 10);
 
     // Insert multiple elements
     map.insert(1, 10);
@@ -102,7 +103,7 @@ TEST_F(HashMapTest, Clear)
 TEST_F(HashMapTest, Resize)
 {
     UnorderedHashMap<int, int> map;
-    map.init(&allocator, 2);
+    map.init(&manager.MainArena, 2);
 
     for (int i = 0; i < 10; ++i)
     {
@@ -123,13 +124,13 @@ TEST_F(HashMapTest, Resize)
 TEST_F(HashMapTest, OverwriteValue)
 {
     UnorderedHashMap<int, String> map;
-    map.init(&allocator, 10);
+    map.init(&manager.MainArena, 10);
 
     String str1;
-    str1.init(&allocator, "first");
+    str1.init(&manager.MainArena, "first");
 
     String str2;
-    str2.init(&allocator, "updated");
+    str2.init(&manager.MainArena, "updated");
 
     map.insert(1, str1);
     EXPECT_STREQ(map[1].c_str(), str1.c_str());
@@ -141,7 +142,7 @@ TEST_F(HashMapTest, OverwriteValue)
 TEST_F(HashMapTest, CollisionHandling)
 {
     UnorderedHashMap<int, int> map;
-    map.init(&allocator, 2);
+    map.init(&manager.MainArena, 2);
 
     map.insert(1, 10);
     map.insert(3, 30);
@@ -159,7 +160,7 @@ TEST_F(HashMapTest, CollisionHandling)
 TEST_F(HashMapTest, ViewIteration)
 {
     UnorderedHashMap<int, int> map;
-    map.init(&allocator, 8);
+    map.init(&manager.MainArena, 8);
 
     map.insert(10, 100);
     map.insert(20, 200);
@@ -196,20 +197,20 @@ TEST_F(HashMapTest, UserDefinedStructViewIterations)
     };
 
     UnorderedHashMap<Person, String> map;
-    map.init(&allocator, 8);
+    map.init(&manager.MainArena, 8);
 
     String str1;
-    str1.init(&allocator, "Alice");
+    str1.init(&manager.MainArena, "Alice");
     String str2;
-    str2.init(&allocator, "Bob");
+    str2.init(&manager.MainArena, "Bob");
     String str3;
-    str3.init(&allocator, "Carol");
+    str3.init(&manager.MainArena, "Carol");
     String str4;
-    str4.init(&allocator, "Engineer");
+    str4.init(&manager.MainArena, "Engineer");
     String str5;
-    str5.init(&allocator, "Designer");
+    str5.init(&manager.MainArena, "Designer");
     String str6;
-    str6.init(&allocator, "Artist");
+    str6.init(&manager.MainArena, "Artist");
 
     Person alice{str1, 30};
     Person bob{str2, 25};

--- a/ZEngine/tests/Memory/allocator_test.cpp
+++ b/ZEngine/tests/Memory/allocator_test.cpp
@@ -8,15 +8,16 @@ using namespace ZEngine::Core::Memory;
 
 TEST(AllocatorTest, ArenaInit)
 {
-    ArenaAllocator arena{};
-    arena.Initialize(200);
-    arena.Shutdown();
+    MemoryManager manager{};
+    manager.Initialize({.BufferSize = 200});
+    manager.Shutdown();
 }
 
 TEST(AllocatorTest, ArenaAllocate)
 {
-    ArenaAllocator arena{};
-    arena.Initialize(200);
+    MemoryManager manager{};
+    manager.Initialize({.BufferSize = 200});
+    auto arena = manager.MainArena;
 
     for (int i = 0; i < 10; ++i)
     {
@@ -45,8 +46,7 @@ TEST(AllocatorTest, ArenaAllocate)
         EXPECT_EQ(*x, 123);
         EXPECT_EQ(*f, 987.0f);
     }
-
-    arena.Shutdown();
+    manager.Shutdown();
 }
 
 TEST(AllocatorTest, ArenaStruct)
@@ -58,14 +58,15 @@ TEST(AllocatorTest, ArenaStruct)
         void  Func() {}
     };
 
-    ArenaAllocator a{};
-    a.Initialize(200);
+    MemoryManager manager{};
+    manager.Initialize({.BufferSize = 200});
+    auto arena  = &(manager.MainArena);
 
-    auto fooPtr = (Foo*) a.Allocate(sizeof(Foo));
+    auto fooPtr = (Foo*) arena->Allocate(sizeof(Foo));
     fooPtr->x   = 23;
     fooPtr->y   = 100.f;
 
-    a.Shutdown();
+    manager.Shutdown();
     fooPtr = nullptr;
 }
 
@@ -73,7 +74,7 @@ TEST(AllocatorTest, ArenaMemoryManager)
 {
     MemoryManager manager{};
 
-    manager.Initialize(MemoryConfiguration{.DefaultSize = ZKilo(8)});
+    manager.Initialize(MemoryConfiguration{.BufferSize = ZKilo(8)});
 
     struct Foo
     {
@@ -82,14 +83,14 @@ TEST(AllocatorTest, ArenaMemoryManager)
         void  Func() {}
     };
 
-    int* intPtr    = ZPushArray(&(manager.Allocator), int, 1);
-    auto structPtr = ZPushStruct(&(manager.Allocator), Foo);
+    int* intPtr    = ZPushArray(&(manager.MainArena), int, 1);
+    auto structPtr = ZPushStruct(&(manager.MainArena), Foo);
 
     *intPtr        = 12;
     structPtr->x   = 12;
     structPtr->y   = 798.0f;
 
-    char* str      = ZPushString(&(manager.Allocator), 12);
+    char* str      = ZPushString(&(manager.MainArena), 12);
     Helpers::secure_memmove(str, 12, "hello", 5);
 
     EXPECT_EQ(*intPtr, 12);
@@ -97,7 +98,7 @@ TEST(AllocatorTest, ArenaMemoryManager)
     EXPECT_EQ(structPtr->y, 798.0f);
     EXPECT_STREQ(str, "hello");
 
-    manager.Shutdowm();
+    manager.Shutdown();
 }
 
 struct Foo
@@ -120,8 +121,8 @@ void ComPareFoo(ArenaAllocator* arena, const Foo& f)
 TEST(AllocatorTest, ArenaMemoryTemp)
 {
     MemoryManager manager{};
-    manager.Initialize({.DefaultSize = ZKilo(10)});
-    auto arena = &(manager.Allocator);
+    manager.Initialize({.BufferSize = ZKilo(10)});
+    auto arena = &(manager.MainArena);
     {
         auto fooPtr  = ZPushStruct(arena, Foo);
         fooPtr->x    = 10;
@@ -135,14 +136,14 @@ TEST(AllocatorTest, ArenaMemoryTemp)
         EXPECT_EQ(fooPtr->y, 789.f);
         EXPECT_STREQ(fooPtr->name, "Foo::Name");
     }
-    manager.Shutdowm();
+    manager.Shutdown();
 }
 
 TEST(AllocatorTest, ArenaMemoryPool)
 {
     MemoryManager manager{};
-    manager.Initialize({.DefaultSize = ZKilo(10)});
-    auto arena = &(manager.Allocator);
+    manager.Initialize({.BufferSize = ZKilo(10)});
+    auto arena = &(manager.MainArena);
     {
         PoolAllocator pool;
         pool.Initialize(arena, sizeof(Foo) * 100, sizeof(Foo));
@@ -157,5 +158,232 @@ TEST(AllocatorTest, ArenaMemoryPool)
 
         pool.Free(fooPtr);
     }
-    manager.Shutdowm();
+    manager.Shutdown();
+}
+
+TEST(AllocatorTest, ArenaAllocateAlignment)
+{
+    MemoryManager manager{};
+    manager.Initialize({.BufferSize = ZKilo(4)});
+    auto arena = &(manager.MainArena);
+
+    for (size_t alignment : {1u, 8u, 16u, 64u})
+    {
+        arena->Clear();
+        void* ptr = arena->Allocate(1, alignment);
+        ASSERT_NE(ptr, nullptr);
+        EXPECT_EQ(reinterpret_cast<uintptr_t>(ptr) % alignment, 0u) << "misaligned for alignment=" << alignment;
+    }
+    manager.Shutdown();
+}
+
+TEST(AllocatorTest, ArenaAllocateZeroesMemory)
+{
+    MemoryManager manager{};
+    manager.Initialize({.BufferSize = ZKilo(4)});
+    auto             arena = &(manager.MainArena);
+
+    constexpr size_t sz    = 64;
+    auto*            ptr   = reinterpret_cast<uint8_t*>(arena->Allocate(sz));
+    ASSERT_NE(ptr, nullptr);
+    for (size_t i = 0; i < sz; ++i)
+    {
+        EXPECT_EQ(ptr[i], 0u) << "non-zero byte at index " << i;
+    }
+    manager.Shutdown();
+}
+
+TEST(AllocatorTest, ArenaAllocateOOM)
+{
+    MemoryManager manager{};
+    manager.Initialize({.BufferSize = 128});
+    auto  arena = &(manager.MainArena);
+
+    void* ptr   = arena->Allocate(256);
+    EXPECT_EQ(ptr, nullptr);
+    manager.Shutdown();
+}
+
+TEST(AllocatorTest, ArenaResizeSlowPath)
+{
+    MemoryManager manager{};
+    manager.Initialize({.BufferSize = ZKilo(4)});
+    auto arena = &(manager.MainArena);
+
+    int* a     = reinterpret_cast<int*>(arena->Allocate(sizeof(int)));
+    int* b     = reinterpret_cast<int*>(arena->Allocate(sizeof(int)));
+    *a         = 42;
+    *b         = 99;
+
+    int* a2    = reinterpret_cast<int*>(arena->Resize(a, sizeof(int), sizeof(int) * 4));
+    ASSERT_NE(a2, nullptr);
+    EXPECT_NE(a2, a);
+    EXPECT_EQ(*a2, 42);
+    manager.Shutdown();
+}
+
+TEST(AllocatorTest, ArenaResizeInPlaceShrink)
+{
+    MemoryManager manager{};
+    manager.Initialize({.BufferSize = ZKilo(4)});
+    auto             arena  = &(manager.MainArena);
+
+    constexpr size_t old_sz = 32;
+    constexpr size_t new_sz = 16;
+    auto*            ptr    = reinterpret_cast<uint8_t*>(arena->Allocate(old_sz));
+    ASSERT_NE(ptr, nullptr);
+
+    auto* ptr2 = reinterpret_cast<uint8_t*>(arena->Resize(ptr, old_sz, new_sz));
+    EXPECT_EQ(ptr2, ptr);
+    for (size_t i = new_sz; i < old_sz; ++i)
+    {
+        EXPECT_EQ(ptr[i], 0u) << "tail byte " << i << " not zeroed after shrink";
+    }
+    manager.Shutdown();
+}
+
+TEST(AllocatorTest, ArenaResizeNullDelegatesToAllocate)
+{
+    MemoryManager manager{};
+    manager.Initialize({.BufferSize = ZKilo(4)});
+    auto  arena = &(manager.MainArena);
+
+    void* ptr   = arena->Resize(nullptr, 0, sizeof(int));
+    EXPECT_NE(ptr, nullptr);
+    manager.Shutdown();
+}
+
+TEST(AllocatorTest, ArenaShutdownIdempotent)
+{
+    MemoryManager manager{};
+    manager.Initialize({.BufferSize = ZKilo(4)});
+    manager.Shutdown();
+    EXPECT_NO_FATAL_FAILURE(manager.Shutdown());
+}
+
+TEST(AllocatorTest, ArenaSubArenaLifecycle)
+{
+    MemoryManager manager{};
+    manager.Initialize({.BufferSize = ZKilo(64)});
+    auto           parent = &(manager.MainArena);
+
+    ArenaAllocator sub{};
+    parent->CreateSubArena(ZKilo(4), &sub);
+
+    ASSERT_NE(sub.m_memory, nullptr);
+    EXPECT_TRUE(sub.m_is_sub_arena);
+    EXPECT_EQ(sub.m_total_size, ZKilo(4));
+
+    int* val = reinterpret_cast<int*>(sub.Allocate(sizeof(int)));
+    ASSERT_NE(val, nullptr);
+    *val = 77;
+    EXPECT_EQ(*val, 77);
+
+    sub.Shutdown();
+    EXPECT_EQ(sub.m_memory, nullptr);
+
+    void* after = parent->Allocate(sizeof(int));
+    EXPECT_NE(after, nullptr);
+
+    manager.Shutdown();
+}
+
+TEST(AllocatorTest, TempArenaRestoresOffsets)
+{
+    MemoryManager manager{};
+    manager.Initialize({.BufferSize = ZKilo(4)});
+    auto arena = &(manager.MainArena);
+
+    arena->Allocate(32);
+    size_t saved_current  = arena->m_current_offset;
+    size_t saved_previous = arena->m_previous_offset;
+
+    {
+        auto scratch = ZGetScratch(arena);
+        arena->Allocate(64);
+        arena->Allocate(128);
+        ZReleaseScratch(scratch);
+    }
+
+    EXPECT_EQ(arena->m_current_offset, saved_current);
+    EXPECT_EQ(arena->m_previous_offset, saved_previous);
+    manager.Shutdown();
+}
+
+TEST(AllocatorTest, PoolExhaustion)
+{
+    MemoryManager manager{};
+    manager.Initialize({.BufferSize = ZKilo(4)});
+    auto             arena       = &(manager.MainArena);
+
+    constexpr size_t chunk_count = 4;
+    PoolAllocator    pool;
+    pool.Initialize(arena, sizeof(Foo) * chunk_count, sizeof(Foo));
+
+    for (size_t i = 0; i < chunk_count; ++i)
+    {
+        EXPECT_NE(pool.Allocate(), nullptr) << "expected valid slot at i=" << i;
+    }
+    EXPECT_EQ(pool.Allocate(), nullptr) << "expected nullptr on exhausted pool";
+    manager.Shutdown();
+}
+
+TEST(AllocatorTest, PoolFreeRestoresSlot)
+{
+    MemoryManager manager{};
+    manager.Initialize({.BufferSize = ZKilo(4)});
+    auto          arena = &(manager.MainArena);
+
+    PoolAllocator pool;
+    pool.Initialize(arena, sizeof(Foo) * 2, sizeof(Foo));
+
+    auto* slot = reinterpret_cast<Foo*>(pool.Allocate());
+    ASSERT_NE(slot, nullptr);
+    slot->x = 99;
+    pool.Free(slot);
+
+    auto* reused = reinterpret_cast<Foo*>(pool.Allocate());
+    ASSERT_NE(reused, nullptr);
+    EXPECT_EQ(reused->x, 0);
+    manager.Shutdown();
+}
+
+TEST(AllocatorTest, PoolClearResetsAllSlots)
+{
+    MemoryManager manager{};
+    manager.Initialize({.BufferSize = ZKilo(4)});
+    auto             arena       = &(manager.MainArena);
+
+    constexpr size_t chunk_count = 8;
+    PoolAllocator    pool;
+    pool.Initialize(arena, sizeof(Foo) * chunk_count, sizeof(Foo));
+
+    for (size_t i = 0; i < chunk_count; ++i)
+    {
+        ASSERT_NE(pool.Allocate(), nullptr);
+    }
+    EXPECT_EQ(pool.Allocate(), nullptr);
+
+    pool.Clear();
+
+    for (size_t i = 0; i < chunk_count; ++i)
+    {
+        EXPECT_NE(pool.Allocate(), nullptr) << "slot " << i << " unavailable after Clear";
+    }
+    manager.Shutdown();
+}
+
+TEST(AllocatorTest, PoolChunkSizeAlignedUp)
+{
+    MemoryManager manager{};
+    manager.Initialize({.BufferSize = ZKilo(4)});
+    auto             arena     = &(manager.MainArena);
+
+    constexpr size_t raw_chunk = 3;
+    constexpr size_t alignment = 8;
+    PoolAllocator    pool;
+    pool.Initialize(arena, alignment * 16, raw_chunk, alignment);
+
+    EXPECT_EQ(pool.chunk_size, alignment);
+    manager.Shutdown();
 }

--- a/ZEngine/tests/Memory/handleManager_test.cpp
+++ b/ZEngine/tests/Memory/handleManager_test.cpp
@@ -9,14 +9,14 @@ class HandleManagerTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        manager.Initialize({.DefaultSize = ZKilo(10)});
-        auto arena = &(manager.Allocator);
+        manager.Initialize({.BufferSize = ZKilo(10)});
+        auto arena = &(manager.MainArena);
         handle_manager.Initialize(arena, 10);
     }
 
     void TearDown() override
     {
-        manager.Shutdowm();
+        manager.Shutdown();
     }
 
     MemoryManager                         manager{};
@@ -113,8 +113,10 @@ TEST_F(HandleManagerTest, ReuseSlot)
 
 TEST_F(HandleManagerTest, ConcurrentAccess)
 {
+    MemoryManager concurrent_manager{};
+    concurrent_manager.Initialize({.BufferSize = ZKilo(64)});
     ZEngine::Helpers::HandleManager<int*> h_manager;
-    h_manager.Initialize(&(manager.Allocator), 40);
+    h_manager.Initialize(&(concurrent_manager.MainArena), 40);
     const int                numThreads             = 4;
     const int                numOperationsPerThread = 10;
     std::vector<std::thread> threads;
@@ -145,4 +147,5 @@ TEST_F(HandleManagerTest, ConcurrentAccess)
     {
         thread.join();
     }
+    concurrent_manager.Shutdown();
 }


### PR DESCRIPTION
This PR addresses reported bugs from [memory-allocator-audit](https://github.com/JeanPhilippeKernel/RendererEngine/blob/develop/ZEngine/docs/memory-allocator-audit.md)
