### PR TITLE
feat(memory): implement MemoryBudgetConfig and wire MemoryManager through application stack

### DIFF
--- a/Obelisk/EntryPoint.cpp
+++ b/Obelisk/EntryPoint.cpp
@@ -19,27 +19,31 @@ int applicationEntryPoint(int argc, char* argv[])
 {
     CrashHandler::Install("Obelisk", "1.0.0", "CrashDumps");
 
-    MemoryManager       manager = {};
-    MemoryConfiguration config  = {.BufferSize = ZGiga(3u)};
-    manager.Initialize(config);
-    auto                arena      = &(manager.MainArena);
-
-    LoggerConfiguration logger_cfg = {};
-    Logger::Initialize(arena, logger_cfg);
-
-    Helpers::ThreadPoolHelper::Initialize();
-
-    GameApplicationPtr app = nullptr;
-
-    CLI::App           cli{"ObeliskCLI"};
+    CLI::App cli{"ObeliskCLI"};
     argv                      = cli.ensure_utf8(argv);
-
     std::string config_file   = "";
     bool        launch_editor = false;
     cli.add_option("--projectConfigFile", config_file, "The project config file");
-    cli.add_option("--launchEditor", launch_editor, "The project config file");
+    cli.add_option("--launchEditor", launch_editor, "Activate the editor");
 
     CLI11_PARSE(cli, argc, argv);
+
+    MemoryManager manager = {};
+    manager.Initialize(ZGiga(3u), launch_editor ? MemoryBudgetConfig::Editor() : MemoryBudgetConfig::Default());
+
+    Helpers::ThreadPoolHelper::Initialize();
+
+    ArenaAllocator      logger_arena = {};
+    LoggerConfiguration logger_cfg   = {};
+    manager.CreateBudgetedArena(manager.Budget.Logging, &logger_arena);
+    Logger::Initialize(&logger_arena, logger_cfg);
+
+    auto arena                = &(manager.MainArena);
+    auto config_file_str_size = config_file.size() + 1;
+    auto config_file_str      = ZPushString(arena, config_file_str_size);
+    Helpers::secure_strncpy(config_file_str, config_file_str_size, config_file.c_str(), config_file.size());
+
+    GameApplicationPtr app = nullptr;
 
     if (launch_editor)
     {
@@ -47,12 +51,9 @@ int applicationEntryPoint(int argc, char* argv[])
         app->EnableRenderOverlay = true;
     }
 
-    auto config_file_str_size = config_file.size() + 1;
-    auto config_file_str      = ZPushString(arena, config_file_str_size);
-    Helpers::secure_strncpy(config_file_str, config_file_str_size, config_file.c_str(), config_file.size());
     app->ConfigFile = config_file_str;
 
-    app->Initialize(arena);
+    app->Initialize(&manager);
     app->Run();
     app->Shutdown();
 

--- a/Tetragrama/Editor.cpp
+++ b/Tetragrama/Editor.cpp
@@ -16,11 +16,11 @@ namespace Tetragrama
 {
     void Editor::OnInitializing()
     {
-        Configuration = ZPushStructCtor(Arena, EditorConfiguration);
+        Configuration = ZPushStructCtor(&Memory->MainArena, EditorConfiguration);
 
         if (ZEngine::Helpers::secure_strlen(ConfigFile))
         {
-            Configuration->ReadConfig(Arena, ConfigFile);
+            Configuration->ReadConfig(&Memory->MainArena, ConfigFile);
         }
 
         if (Configuration->ActiveSceneName.empty())
@@ -38,18 +38,18 @@ namespace Tetragrama
     {
         std::string title     = fmt::format("{0} - Active Scene : {1}", Configuration->ProjectName.c_str(), Configuration->ActiveSceneName.c_str());
         WindowCfg.EnableVsync = true;
-        WindowCfg.Title.init(Arena, title.c_str());
+        WindowCfg.Title.init(&Memory->MainArena, title.c_str());
     }
 
     void Editor::OnInitialized()
     {
-        auto editor_scene          = ZPushStructCtor(Arena, EditorScene);
-        auto editor_cam_controller = ZPushStructCtor(Arena, Controllers::EditorCameraController);
-        UILayer                    = ZPushStructCtor(Arena, ImguiLayer);
+        auto editor_scene          = ZPushStructCtor(&Memory->MainArena, EditorScene);
+        auto editor_cam_controller = ZPushStructCtor(&Memory->MainArena, Controllers::EditorCameraController);
+        UILayer                    = ZPushStructCtor(&Memory->MainArena, ImguiLayer);
 
-        UILayer->Initialize(Arena, this);
-        editor_cam_controller->Initialize(Arena, CurrentWindow);
-        editor_scene->Initialize(Arena, Configuration->ActiveSceneName.c_str());
+        UILayer->Initialize(&Memory->MainArena, this);
+        editor_cam_controller->Initialize(&Memory->MainArena, CurrentWindow);
+        editor_scene->Initialize(&Memory->MainArena, Configuration->ActiveSceneName.c_str());
 
         CameraController = editor_cam_controller;
         CurrentScene     = editor_scene;

--- a/ZEngine/ZEngine/Applications/GameApplication.cpp
+++ b/ZEngine/ZEngine/Applications/GameApplication.cpp
@@ -3,16 +3,16 @@
 
 namespace ZEngine::Applications
 {
-    void GameApplication::Initialize(Core::Memory::ArenaAllocator* arena)
+    void GameApplication::Initialize(Core::Memory::MemoryManager* memory)
     {
-        Arena = arena;
+        Memory = memory;
 
-        State = ZPushStructCtor(Arena, ApplicationState);
+        State  = ZPushStructCtor(&Memory->MainArena, ApplicationState);
 
         OnInitializing();
         OverrideWindowConfiguration();
 
-        Engine::Initialize(Arena, &WindowCfg, this);
+        Engine::Initialize(&Memory->MainArena, &WindowCfg, this);
 
         OnInitialized();
     }

--- a/ZEngine/ZEngine/Applications/GameApplication.h
+++ b/ZEngine/ZEngine/Applications/GameApplication.h
@@ -2,6 +2,7 @@
 #include <ZEngine/Applications/AppRenderPipeline.h>
 #include <ZEngine/Controllers/ICameraController.h>
 #include <ZEngine/Core/Memory/Allocator.h>
+#include <ZEngine/Core/Memory/MemoryManager.h>
 #include <ZEngine/Core/TimeStep.h>
 #include <ZEngine/Rendering/Scenes/GraphicScene.h>
 #include <ZEngine/Windows/CoreWindow.h>
@@ -31,14 +32,14 @@ namespace ZEngine::Applications
         cstring                           WorkingSpacePath    = nullptr;
         Windows::WindowConfiguration      WindowCfg           = {};
 
-        Core::Memory::ArenaAllocator*     Arena               = nullptr;
+        Core::Memory::MemoryManager*      Memory              = nullptr;
         Windows::CoreWindowPtr            CurrentWindow       = nullptr;
         ApplicationStatePtr               State               = nullptr;
         AppRenderPipelinePtr              RenderPipeline      = nullptr;
         Controllers::ICameraControllerPtr CameraController    = nullptr;
         Rendering::Scenes::RenderScenePtr CurrentScene        = nullptr;
 
-        void                              Initialize(Core::Memory::ArenaAllocator* arena);
+        void                              Initialize(Core::Memory::MemoryManager* memory);
         void                              Update(Core::TimeStep dt);
         void                              ProcessEvent(Core::CoreEvent&);
         void                              Run();

--- a/ZEngine/ZEngine/Core/Memory/MemoryManager.h
+++ b/ZEngine/ZEngine/Core/Memory/MemoryManager.h
@@ -12,15 +12,98 @@
 
 namespace ZEngine::Core::Memory
 {
-    struct MemoryConfiguration
+
+    struct SubArenaConfig
     {
-        uint64_t BufferSize = ZGiga(2ull);
+        cstring  Name      = nullptr;
+        uint64_t SizeBytes = 0u;
+    };
+
+    struct MemoryBudgetConfig
+    {
+        SubArenaConfig  AudioEngine      = {};
+        SubArenaConfig  AnimationManager = {};
+        SubArenaConfig  AssetManager     = {};
+        SubArenaConfig  ECSScene         = {};
+        SubArenaConfig  Logging          = {};
+        SubArenaConfig  VirtualFS        = {};
+        SubArenaConfig  VulkanDevice     = {};
+        SubArenaConfig  Importer         = {};
+        SubArenaConfig  UIContext        = {};
+        SubArenaConfig  Swapchain        = {};
+        SubArenaConfig  ShaderCache      = {};
+        SubArenaConfig  Serializer       = {};
+        SubArenaConfig  Network          = {};
+
+        // Returns the total bytes committed by all SubArenaConfig entries.
+        inline uint64_t TotalCommitted() const
+        {
+            return AudioEngine.SizeBytes + AnimationManager.SizeBytes + AssetManager.SizeBytes + ECSScene.SizeBytes + Logging.SizeBytes + VirtualFS.SizeBytes + VulkanDevice.SizeBytes + Importer.SizeBytes + UIContext.SizeBytes + Swapchain.SizeBytes + ShaderCache.SizeBytes + Serializer.SizeBytes + Network.SizeBytes;
+        }
+
+        // Validates that the sum of all SizeBytes fields does not exceed total_available_bytes.
+        // Returns false and logs the overage if the budget is exceeded.
+        inline bool Validate(uint64_t total_available_bytes) const
+        {
+            const uint64_t committed = TotalCommitted();
+            ZENGINE_VALIDATE_ASSERT(committed <= total_available_bytes, "MemoryBudgetConfig::Validate: budget exceeds arena size")
+            return committed <= total_available_bytes;
+        }
+
+        inline static MemoryBudgetConfig Default()
+        {
+            MemoryBudgetConfig cfg = {};
+            cfg.AudioEngine        = {"AudioEngine", ZMega(32ULL)};
+            cfg.AnimationManager   = {"AnimationManager", ZMega(64ULL)};
+            cfg.AssetManager       = {"AssetManager", ZMega(100ULL)};
+            cfg.ECSScene           = {"ECSScene", ZMega(128ULL)};
+            cfg.Logging            = {"Logging", ZMega(4ULL)};
+            cfg.VirtualFS          = {"VirtualFS", ZMega(32ULL)};
+            cfg.VulkanDevice       = {"VulkanDevice", ZMega(512ULL)};
+            cfg.Importer           = {"Importer", ZMega(350ULL)};
+            cfg.UIContext          = {"UIContext", ZMega(8ULL)};
+            cfg.Swapchain          = {"Swapchain", ZMega(3ULL)};
+            cfg.ShaderCache        = {"ShaderCache", ZMega(16ULL)};
+            cfg.Serializer         = {"Serializer", ZMega(150ULL)};
+            cfg.Network            = {"Network", ZMega(32ULL)};
+
+            return cfg;
+        }
+
+        // Returns a reduced budget for dedicated server builds (no GPU, no audio, no UI).
+        inline static MemoryBudgetConfig Server()
+        {
+            auto cfg                   = Default();
+            cfg.AudioEngine.SizeBytes  = 0ull;
+            cfg.UIContext.SizeBytes    = 0ull;
+            cfg.VulkanDevice.SizeBytes = 0ull;
+            cfg.Network.SizeBytes      = 0ull;
+
+            return cfg;
+        }
+
+        // Returns a reduced budget for tool / editor builds (no audio, no network).
+        inline static MemoryBudgetConfig Editor()
+        {
+            auto cfg                  = Default();
+            cfg.AudioEngine.SizeBytes = 0ull;
+            cfg.Network.SizeBytes     = 0ull;
+            cfg.UIContext.SizeBytes   = ZMega(32ULL);
+
+            return cfg;
+        }
     };
 
     struct MemoryManager
     {
-        void Initialize(const MemoryConfiguration& config)
+        ArenaAllocator     MainArena = {};
+        MemoryBudgetConfig Budget    = {};
+
+        void               Initialize(uint64_t buffer_size, const MemoryBudgetConfig& config)
         {
+            Budget = config;
+            config.Validate(buffer_size);
+
             unsigned long page_size = 0ul;
 
             // Get the system page size
@@ -34,14 +117,24 @@ namespace ZEngine::Core::Memory
 #elif defined(__linux__) || defined(__APPLE__)
             page_size = sysconf(_SC_PAGESIZE);
 #endif
-            MainArena.Initialize(config.BufferSize, page_size);
+            MainArena.Initialize(buffer_size, page_size);
+        }
+
+        void CreateBudgetedArena(const SubArenaConfig& config, ArenaAllocator* result)
+        {
+            ZENGINE_VALIDATE_ASSERT(config.SizeBytes > 0, "MemoryManager::CreateBudgetedArena: SizeBytes must be > 0")
+            ZENGINE_VALIDATE_ASSERT(result != nullptr, "MemoryManager::CreateBudgetedArena: out must not be null")
+
+            MainArena.CreateSubArena(config.SizeBytes, result);
+
+#if defined(ZENGINE_ENABLE_PROFILING)
+            MemoryProfiler::TrackArena(config.Name, result);
+#endif
         }
 
         void Shutdown()
         {
             MainArena.Shutdown();
         }
-
-        ArenaAllocator MainArena = {};
     };
 } // namespace ZEngine::Core::Memory

--- a/ZEngine/tests/Containers/array_test.cpp
+++ b/ZEngine/tests/Containers/array_test.cpp
@@ -11,7 +11,7 @@ class ArrayTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        manager.Initialize({.BufferSize = 200});
+        manager.Initialize(200, {});
     }
 
     void TearDown() override

--- a/ZEngine/tests/Containers/hashset_test.cpp
+++ b/ZEngine/tests/Containers/hashset_test.cpp
@@ -12,7 +12,7 @@ class UnorderedHashSetTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        manager.Initialize({.BufferSize = 2000});
+        manager.Initialize(2000, {});
     }
     void TearDown() override
     {

--- a/ZEngine/tests/Containers/initializerlist_test.cpp
+++ b/ZEngine/tests/Containers/initializerlist_test.cpp
@@ -12,7 +12,7 @@ class InitializerListTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        manager.Initialize({.BufferSize = 512});
+        manager.Initialize(512, {});
     }
 
     void TearDown() override

--- a/ZEngine/tests/Containers/ordered_hashmap_test.cpp
+++ b/ZEngine/tests/Containers/ordered_hashmap_test.cpp
@@ -13,7 +13,7 @@ class OrderedHashMapTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        manager.Initialize({.BufferSize = 2000});
+        manager.Initialize(2000, {});
     }
     void TearDown() override
     {

--- a/ZEngine/tests/Containers/ordered_hashset_test.cpp
+++ b/ZEngine/tests/Containers/ordered_hashset_test.cpp
@@ -12,7 +12,7 @@ class OrderedHashSetTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        manager.Initialize({.BufferSize = 2000});
+        manager.Initialize(2000, {});
     }
     void TearDown() override
     {

--- a/ZEngine/tests/Containers/string_test.cpp
+++ b/ZEngine/tests/Containers/string_test.cpp
@@ -10,7 +10,7 @@ class StringTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        manager.Initialize({.BufferSize = 200});
+        manager.Initialize(200, {});
     }
 
     void TearDown() override

--- a/ZEngine/tests/Containers/unordered_hashmap_test.cpp
+++ b/ZEngine/tests/Containers/unordered_hashmap_test.cpp
@@ -12,7 +12,7 @@ class HashMapTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        manager.Initialize({.BufferSize = 2000});
+        manager.Initialize(2000, {});
     }
     void TearDown() override
     {

--- a/ZEngine/tests/Memory/allocator_test.cpp
+++ b/ZEngine/tests/Memory/allocator_test.cpp
@@ -9,14 +9,14 @@ using namespace ZEngine::Core::Memory;
 TEST(AllocatorTest, ArenaInit)
 {
     MemoryManager manager{};
-    manager.Initialize({.BufferSize = 200});
+    manager.Initialize(200, {});
     manager.Shutdown();
 }
 
 TEST(AllocatorTest, ArenaAllocate)
 {
     MemoryManager manager{};
-    manager.Initialize({.BufferSize = 200});
+    manager.Initialize(200, {});
     auto arena = manager.MainArena;
 
     for (int i = 0; i < 10; ++i)
@@ -59,7 +59,7 @@ TEST(AllocatorTest, ArenaStruct)
     };
 
     MemoryManager manager{};
-    manager.Initialize({.BufferSize = 200});
+    manager.Initialize(200, {});
     auto arena  = &(manager.MainArena);
 
     auto fooPtr = (Foo*) arena->Allocate(sizeof(Foo));
@@ -74,7 +74,7 @@ TEST(AllocatorTest, ArenaMemoryManager)
 {
     MemoryManager manager{};
 
-    manager.Initialize(MemoryConfiguration{.BufferSize = ZKilo(8)});
+    manager.Initialize(ZKilo(8), {});
 
     struct Foo
     {
@@ -121,7 +121,7 @@ void ComPareFoo(ArenaAllocator* arena, const Foo& f)
 TEST(AllocatorTest, ArenaMemoryTemp)
 {
     MemoryManager manager{};
-    manager.Initialize({.BufferSize = ZKilo(10)});
+    manager.Initialize(ZKilo(10), {});
     auto arena = &(manager.MainArena);
     {
         auto fooPtr  = ZPushStruct(arena, Foo);
@@ -142,7 +142,7 @@ TEST(AllocatorTest, ArenaMemoryTemp)
 TEST(AllocatorTest, ArenaMemoryPool)
 {
     MemoryManager manager{};
-    manager.Initialize({.BufferSize = ZKilo(10)});
+    manager.Initialize(ZKilo(10), {});
     auto arena = &(manager.MainArena);
     {
         PoolAllocator pool;
@@ -164,7 +164,7 @@ TEST(AllocatorTest, ArenaMemoryPool)
 TEST(AllocatorTest, ArenaAllocateAlignment)
 {
     MemoryManager manager{};
-    manager.Initialize({.BufferSize = ZKilo(4)});
+    manager.Initialize(ZKilo(4), {});
     auto arena = &(manager.MainArena);
 
     for (size_t alignment : {1u, 8u, 16u, 64u})
@@ -180,7 +180,7 @@ TEST(AllocatorTest, ArenaAllocateAlignment)
 TEST(AllocatorTest, ArenaAllocateZeroesMemory)
 {
     MemoryManager manager{};
-    manager.Initialize({.BufferSize = ZKilo(4)});
+    manager.Initialize(ZKilo(4), {});
     auto             arena = &(manager.MainArena);
 
     constexpr size_t sz    = 64;
@@ -196,7 +196,7 @@ TEST(AllocatorTest, ArenaAllocateZeroesMemory)
 TEST(AllocatorTest, ArenaAllocateOOM)
 {
     MemoryManager manager{};
-    manager.Initialize({.BufferSize = 128});
+    manager.Initialize(128, {});
     auto  arena = &(manager.MainArena);
 
     void* ptr   = arena->Allocate(256);
@@ -207,7 +207,7 @@ TEST(AllocatorTest, ArenaAllocateOOM)
 TEST(AllocatorTest, ArenaResizeSlowPath)
 {
     MemoryManager manager{};
-    manager.Initialize({.BufferSize = ZKilo(4)});
+    manager.Initialize(ZKilo(4), {});
     auto arena = &(manager.MainArena);
 
     int* a     = reinterpret_cast<int*>(arena->Allocate(sizeof(int)));
@@ -225,7 +225,7 @@ TEST(AllocatorTest, ArenaResizeSlowPath)
 TEST(AllocatorTest, ArenaResizeInPlaceShrink)
 {
     MemoryManager manager{};
-    manager.Initialize({.BufferSize = ZKilo(4)});
+    manager.Initialize(ZKilo(4), {});
     auto             arena  = &(manager.MainArena);
 
     constexpr size_t old_sz = 32;
@@ -245,7 +245,7 @@ TEST(AllocatorTest, ArenaResizeInPlaceShrink)
 TEST(AllocatorTest, ArenaResizeNullDelegatesToAllocate)
 {
     MemoryManager manager{};
-    manager.Initialize({.BufferSize = ZKilo(4)});
+    manager.Initialize(ZKilo(4), {});
     auto  arena = &(manager.MainArena);
 
     void* ptr   = arena->Resize(nullptr, 0, sizeof(int));
@@ -256,7 +256,7 @@ TEST(AllocatorTest, ArenaResizeNullDelegatesToAllocate)
 TEST(AllocatorTest, ArenaShutdownIdempotent)
 {
     MemoryManager manager{};
-    manager.Initialize({.BufferSize = ZKilo(4)});
+    manager.Initialize(ZKilo(4), {});
     manager.Shutdown();
     EXPECT_NO_FATAL_FAILURE(manager.Shutdown());
 }
@@ -264,7 +264,7 @@ TEST(AllocatorTest, ArenaShutdownIdempotent)
 TEST(AllocatorTest, ArenaSubArenaLifecycle)
 {
     MemoryManager manager{};
-    manager.Initialize({.BufferSize = ZKilo(64)});
+    manager.Initialize(ZKilo(64), {});
     auto           parent = &(manager.MainArena);
 
     ArenaAllocator sub{};
@@ -291,7 +291,7 @@ TEST(AllocatorTest, ArenaSubArenaLifecycle)
 TEST(AllocatorTest, TempArenaRestoresOffsets)
 {
     MemoryManager manager{};
-    manager.Initialize({.BufferSize = ZKilo(4)});
+    manager.Initialize(ZKilo(4), {});
     auto arena = &(manager.MainArena);
 
     arena->Allocate(32);
@@ -313,7 +313,7 @@ TEST(AllocatorTest, TempArenaRestoresOffsets)
 TEST(AllocatorTest, PoolExhaustion)
 {
     MemoryManager manager{};
-    manager.Initialize({.BufferSize = ZKilo(4)});
+    manager.Initialize(ZKilo(4), {});
     auto             arena       = &(manager.MainArena);
 
     constexpr size_t chunk_count = 4;
@@ -331,7 +331,7 @@ TEST(AllocatorTest, PoolExhaustion)
 TEST(AllocatorTest, PoolFreeRestoresSlot)
 {
     MemoryManager manager{};
-    manager.Initialize({.BufferSize = ZKilo(4)});
+    manager.Initialize(ZKilo(4), {});
     auto          arena = &(manager.MainArena);
 
     PoolAllocator pool;
@@ -351,7 +351,7 @@ TEST(AllocatorTest, PoolFreeRestoresSlot)
 TEST(AllocatorTest, PoolClearResetsAllSlots)
 {
     MemoryManager manager{};
-    manager.Initialize({.BufferSize = ZKilo(4)});
+    manager.Initialize(ZKilo(4), {});
     auto             arena       = &(manager.MainArena);
 
     constexpr size_t chunk_count = 8;
@@ -376,7 +376,7 @@ TEST(AllocatorTest, PoolClearResetsAllSlots)
 TEST(AllocatorTest, PoolChunkSizeAlignedUp)
 {
     MemoryManager manager{};
-    manager.Initialize({.BufferSize = ZKilo(4)});
+    manager.Initialize(ZKilo(4), {});
     auto             arena     = &(manager.MainArena);
 
     constexpr size_t raw_chunk = 3;

--- a/ZEngine/tests/Memory/handleManager_test.cpp
+++ b/ZEngine/tests/Memory/handleManager_test.cpp
@@ -9,7 +9,7 @@ class HandleManagerTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        manager.Initialize({.BufferSize = ZKilo(10)});
+        manager.Initialize(ZKilo(10), {});
         auto arena = &(manager.MainArena);
         handle_manager.Initialize(arena, 10);
     }
@@ -114,7 +114,7 @@ TEST_F(HandleManagerTest, ReuseSlot)
 TEST_F(HandleManagerTest, ConcurrentAccess)
 {
     MemoryManager concurrent_manager{};
-    concurrent_manager.Initialize({.BufferSize = ZKilo(64)});
+    concurrent_manager.Initialize(ZKilo(64), {});
     ZEngine::Helpers::HandleManager<int*> h_manager;
     h_manager.Initialize(&(concurrent_manager.MainArena), 40);
     const int                numThreads             = 4;

--- a/ZEngine/tests/VFS/test_vfspath.cpp
+++ b/ZEngine/tests/VFS/test_vfspath.cpp
@@ -81,7 +81,7 @@ TEST(VFSPathParse, RootEscapeFails)
 TEST(VFSPathParse, TooLongFails)
 {
     MemoryManager mgr;
-    mgr.Initialize({.BufferSize = ZKilo(64)});
+    mgr.Initialize(ZKilo(64), {});
 
     String             huge = Repeat(&mgr.MainArena, 300, 'a');
     VFSResult<VFSPath> r    = VFSPath::Parse(huge.c_str());
@@ -202,7 +202,7 @@ TEST(VFSPathCompose, OperatorSlash)
 TEST(VFSPathCompose, AppendTooLongFails)
 {
     MemoryManager mgr;
-    mgr.Initialize({.BufferSize = ZKilo(64)});
+    mgr.Initialize(ZKilo(64), {});
 
     String base_str;
     base_str.init(&mgr.MainArena, 256);
@@ -273,7 +273,7 @@ TEST(VFSPathToNative, UsesPlatformSeparator)
     MustParse("/a/b").ToNative(buffer, sizeof(buffer));
 
     MemoryManager mgr;
-    mgr.Initialize({.BufferSize = ZKilo(64)});
+    mgr.Initialize(ZKilo(64), {});
 
     String expected;
     expected.init(&mgr.MainArena, "/a/b");

--- a/ZEngine/tests/VFS/vfs_disk_test.cpp
+++ b/ZEngine/tests/VFS/vfs_disk_test.cpp
@@ -30,7 +30,7 @@ class VFSDiskBackendTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        m_manager.Initialize({.BufferSize = ZKilo(256)});
+        m_manager.Initialize(ZKilo(256), {});
 
         m_root.init(&m_manager.MainArena, (std::filesystem::temp_directory_path() / "zengine_vfs_disk_tests").string().c_str());
 

--- a/ZEngine/tests/VFS/vfs_mount_test.cpp
+++ b/ZEngine/tests/VFS/vfs_mount_test.cpp
@@ -58,7 +58,7 @@ class VFSMountTableTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        m_manager.Initialize({.BufferSize = ZKilo(256)});
+        m_manager.Initialize(ZKilo(256), {});
         m_table.Initialize(&m_manager.MainArena, 8);
     }
     void TearDown() override
@@ -165,7 +165,7 @@ class VFSContextTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        m_manager.Initialize({.BufferSize = ZKilo(256)});
+        m_manager.Initialize(ZKilo(256), {});
         m_ctx.Initialize(&m_manager.MainArena, 8);
     }
     void TearDown() override

--- a/ZEngine/tests/VFS/vfs_zip_test.cpp
+++ b/ZEngine/tests/VFS/vfs_zip_test.cpp
@@ -51,7 +51,7 @@ class VFSZipBackendTest : public ::testing::Test
 protected:
     void SetUp() override
     {
-        m_manager.Initialize({.BufferSize = ZKilo(512)});
+        m_manager.Initialize(ZKilo(512), {});
 
         m_archive.init(&m_manager.MainArena, (std::filesystem::temp_directory_path() / "zengine_vfs_zip_tests.zip").string().c_str());
 
@@ -250,7 +250,7 @@ TEST_F(VFSZipBackendTest, CapabilitiesAndType)
 TEST(VFSContextOverlayTest, ZipOverridesLowerPriorityDisk)
 {
     MemoryManager manager{};
-    manager.Initialize({.BufferSize = ZKilo(512)});
+    manager.Initialize(ZKilo(512), {});
 
     String disk_root;
     disk_root.init(&manager.MainArena, (std::filesystem::temp_directory_path() / "zengine_vfs_overlay_disk").string().c_str());


### PR DESCRIPTION
- Add SubArenaConfig and MemoryBudgetConfig with Default(), Editor(), Server() variants
- Implement TotalCommitted() and Validate() on MemoryBudgetConfig
- MemoryManager stores Budget and exposes CreateBudgetedArena with optional profiler tracking
- Remove Instance() singleton; Obelisk stack-allocates MemoryManager and passes it explicitly
- CLI parsing moved before budget selection so Editor() vs Default() is chosen correctly
- GameApplication and Editor updated to accept MemoryManager* instead of ArenaAllocator*
- Update all test call sites to new Initialize(size, config) signature