### PR TITLE
fix(engine): prevent zero command buffer count on low-core Linux machines

### DIFF
--- a/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp
+++ b/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp
@@ -9,7 +9,7 @@ namespace ZEngine::Applications
     void AppRenderPipeline::Initialize(Hardwares::VulkanDevicePtr device)
     {
         Device                  = device;
-        RenderWorkerThreadCount = Device->CommandBufferMgr->TotalThreadCount - 1u;
+        RenderWorkerThreadCount = Device->CommandBufferMgr->TotalThreadCount > 0u ? Device->CommandBufferMgr->TotalThreadCount - 1u : 0u;
         UICommandBufferIndex    = RenderMainThreadIndex + 1u;
         Device->Arena->CreateSubArena(ZMega(30), &LocalArena);
 

--- a/ZEngine/ZEngine/Engine.cpp
+++ b/ZEngine/ZEngine/Engine.cpp
@@ -30,11 +30,12 @@ namespace ZEngine
 
         window->SetCallbackFunction(std::bind(&Applications::GameApplication::ProcessEvent, app, std::placeholders::_1));
         window->Initialize(arena, *window_cfg_ptr);
-        g_engine_ctx->Window = window;
+        g_engine_ctx->Window         = window;
 
-        g_appRenderPipeline  = ZPushStructCtor(arena, Applications::AppRenderPipeline);
+        g_appRenderPipeline          = ZPushStructCtor(arena, Applications::AppRenderPipeline);
 
-        g_engine_ctx->Device->Initialize(arena, window, (Helpers::ThreadPoolHelper::Pool->MaxThreadCount / 2u) /*, k_mailbox_buffer_size */);
+        uint32_t worker_thread_count = std::max(1u, (uint32_t) (Helpers::ThreadPoolHelper::Pool->MaxThreadCount / 2u));
+        g_engine_ctx->Device->Initialize(arena, window, worker_thread_count /*, k_mailbox_buffer_size */);
         g_appRenderPipeline->Initialize(g_engine_ctx->Device);
 
         Managers::AssetManager::Initialize(arena, g_engine_ctx->Device, app->WorkingSpacePath);

--- a/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
+++ b/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
@@ -1,3 +1,4 @@
+#include <GLFW/glfw3.h>
 #include <ZEngine/Hardwares/DeviceSwapchain.h>
 #include <ZEngine/Hardwares/VulkanDevice.h>
 #include <ZEngine/Rendering/Renderers/RenderPasses/Attachment.h>
@@ -67,6 +68,14 @@ namespace ZEngine::Hardwares
         {
             SwapchainImageWidth  = capabilities.currentExtent.width;
             SwapchainImageHeight = capabilities.currentExtent.height;
+        }
+        else
+        {
+            // Wayland does not provide a concrete extent — query the framebuffer size directly.
+            int w = 0, h = 0;
+            glfwGetFramebufferSize(reinterpret_cast<GLFWwindow*>(Device->CurrentWindow->GetNativeWindow()), &w, &h);
+            SwapchainImageWidth  = static_cast<uint32_t>(w);
+            SwapchainImageHeight = static_cast<uint32_t>(h);
         }
 
         VkSwapchainKHR           old_swapchain         = (SwapchainHandle != VK_NULL_HANDLE) ? SwapchainHandle : VK_NULL_HANDLE;

--- a/ZEngine/tests/Misc/WorkerThreadCount_test.cpp
+++ b/ZEngine/tests/Misc/WorkerThreadCount_test.cpp
@@ -1,0 +1,54 @@
+#include <ZEngine/Helpers/ThreadPool.h>
+#include <gtest/gtest.h>
+
+// Mirrors the formula in Engine::Initialize exactly.
+// If the formula changes there, update it here too.
+static uint32_t ComputeWorkerThreadCount(size_t hardware_concurrency)
+{
+    ZEngine::Helpers::ThreadPool pool(hardware_concurrency);
+    return std::max(1u, (uint32_t) (pool.MaxThreadCount / 2u));
+}
+
+class WorkerThreadCountTest : public ::testing::Test
+{
+};
+
+// 1-vCPU: MaxThreadCount = 0 after reserving 1, halved = 0, clamped to 1.
+TEST_F(WorkerThreadCountTest, SingleCoreClampsToOne)
+{
+    EXPECT_EQ(ComputeWorkerThreadCount(1), 1u);
+}
+
+// 2-vCPU (Linux CI): MaxThreadCount = 1 after reserving 1, halved = 0, clamped to 1.
+// This is the exact configuration that triggered the crash.
+TEST_F(WorkerThreadCountTest, TwoCoreLinuxCIClampsToOne)
+{
+    EXPECT_EQ(ComputeWorkerThreadCount(2), 1u);
+}
+
+// 3-vCPU (macOS CI): MaxThreadCount = 2, halved = 1. No clamp needed.
+TEST_F(WorkerThreadCountTest, ThreeCoreReturnsOne)
+{
+    EXPECT_EQ(ComputeWorkerThreadCount(3), 1u);
+}
+
+// 4-vCPU: MaxThreadCount = 3, halved = 1.
+TEST_F(WorkerThreadCountTest, FourCoreReturnsOne)
+{
+    EXPECT_EQ(ComputeWorkerThreadCount(4), 1u);
+}
+
+// 8-vCPU (typical dev machine): MaxThreadCount = 7, halved = 3.
+TEST_F(WorkerThreadCountTest, EightCoreReturnsThree)
+{
+    EXPECT_EQ(ComputeWorkerThreadCount(8), 3u);
+}
+
+// Result is always at least 1 regardless of core count.
+TEST_F(WorkerThreadCountTest, ResultIsNeverZero)
+{
+    for (size_t cores = 1; cores <= 32; ++cores)
+    {
+        EXPECT_GE(ComputeWorkerThreadCount(cores), 1u) << "failed for core count: " << cores;
+    }
+}


### PR DESCRIPTION
Engine crashes immediately on Linux with an array index out of bounds error.

Reported on Intel Core Ultra 9 185H running Linux. The crash surfaces as Index out of range in CommandBuffers[0] on the first render frame, but the root cause is two levels above it.

Root cause — Wayland swapchain extent
On Wayland (default on modern Ubuntu/Fedora), vkGetPhysicalDeviceSurfaceCapabilitiesKHR returns currentExtent = {UINT32_MAX, UINT32_MAX} — the Vulkan spec's signal that the compositor owns the surface size and the application should query the window system directly. The previous code only handled the non-Wayland path. When the if was false, SwapchainImageWidth and SwapchainImageHeight kept their UINT32_MAX defaults. vkCreateSwapchainKHR was called with that invalid extent, producing a broken swapchain with SwapchainImageCount = 0.

Why that becomes an array OOB
CommandBufferManager sizes its buffer array from the swapchain image count:


TotalCommandBufferCount = image_count * TotalThreadCount * MaxBufferPerPool
                        = 0 * 15 * 4 = 0
CommandBuffers is allocated empty. The first render frame unconditionally accesses CommandBuffers[0], the bounds assert fires, and the process crashes.

Changes
[DeviceSwapchain.cpp](vscode-webview://1mqtrpggjui8b0ic4b0s3pfg09pufcq0e406c705rpna9vlvks4n/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp#L66) — add else branch that calls glfwGetFramebufferSize when currentExtent is UINT32_MAX, getting the actual pixel dimensions from the Wayland compositor via GLFW
[Engine.cpp](vscode-webview://1mqtrpggjui8b0ic4b0s3pfg09pufcq0e406c705rpna9vlvks4n/ZEngine/ZEngine/Engine.cpp#L37) — clamp worker thread count to a minimum of 1 to prevent a second zero-buffer path on machines with ≤ 2 vCPUs
[AppRenderPipeline.cpp](vscode-webview://1mqtrpggjui8b0ic4b0s3pfg09pufcq0e406c705rpna9vlvks4n/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp#L12) — guard TotalThreadCount - 1u against unsigned underflow
[WorkerThreadCount_test.cpp](vscode-webview://1mqtrpggjui8b0ic4b0s3pfg09pufcq0e406c705rpna9vlvks4n/ZEngine/tests/Misc/WorkerThreadCount_test.cpp) — six test cases covering the thread count formula across 1–32 core counts, including the exact 2-vCPU configuration
