### PR TITLE
fix: startup crashes and resize

### DIFF
--- a/ZEngine/ZEngine/CrashHandlers/CrashHandlerMacOS.mm
+++ b/ZEngine/ZEngine/CrashHandlers/CrashHandlerMacOS.mm
@@ -266,14 +266,26 @@ static bool ShowCrashDialogCocoa(cstring app_name,
         }
         else
         {
-            // Path B: signal path — bootstrap NSApp on a dedicated thread.
+            // Path B: signal path — the crashing thread is in sigsuspend.
+            // If the crash happened on a non-main thread, the main thread is still
+            // running the GLFW event loop and will drain the main queue.
+            // If the crash happened on the main thread, the wait below times out
+            // and we skip the dialog rather than crash trying to show it on the
+            // wrong thread (NSWindow requires the main thread on modern macOS).
             dispatch_semaphore_t sem = dispatch_semaphore_create(0);
-            NSThread* dlgThread = [[NSThread alloc] initWithBlock:^{
+            dispatch_async(dispatch_get_main_queue(), ^{
                 @autoreleasepool
                 {
-                    [NSApplication sharedApplication];
-                    [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
-                    [NSApp finishLaunching];
+                    if (NSApp == nil)
+                    {
+                        [NSApplication sharedApplication];
+                        [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+                        [NSApp finishLaunching];
+                    }
+                    else
+                    {
+                        [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+                    }
                     ZEngineCrashWindowController* ctrl =
                         [[ZEngineCrashWindowController alloc] initWithAppName:appName
                                                                        signal:signal
@@ -284,9 +296,8 @@ static bool ShowCrashDialogCocoa(cstring app_name,
                     comment = ctrl.userComment;
                     dispatch_semaphore_signal(sem);
                 }
-            }];
-            [dlgThread start];
-            dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
+            });
+            dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, 60 * NSEC_PER_SEC));
         }
 
         if (didSend && comment.length > 0)

--- a/ZEngine/ZEngine/Hardwares/AsyncResourceLoader.cpp
+++ b/ZEngine/ZEngine/Hardwares/AsyncResourceLoader.cpp
@@ -33,11 +33,13 @@ namespace ZEngine::Hardwares
         Timelines.init(Device->Arena, Device->CommandBufferMgr->TotalPoolCount, Device->CommandBufferMgr->TotalPoolCount);
         NextValues.init(Device->Arena, Device->CommandBufferMgr->TotalPoolCount, Device->CommandBufferMgr->TotalPoolCount);
         RetireValues.init(Device->Arena, Device->CommandBufferMgr->TotalPoolCount, Device->CommandBufferMgr->TotalPoolCount);
+        RetireStagingBuffers.init(Device->Arena, Device->CommandBufferMgr->TotalPoolCount, Device->CommandBufferMgr->TotalPoolCount);
 
         for (uint32_t i = 0; i < Device->CommandBufferMgr->TotalPoolCount; ++i)
         {
             Timelines[i] = ZPushStructCtorArgs(Device->Arena, Rendering::Primitives::Semaphore, Device, true);
             RetireValues[i].init(Device->Arena, TotalCommandBufferCount, TotalCommandBufferCount);
+            RetireStagingBuffers[i].init(Device->Arena, TotalCommandBufferCount, TotalCommandBufferCount);
             NextValues[i].store(1, std::memory_order_release);
         }
 
@@ -46,11 +48,13 @@ namespace ZEngine::Hardwares
             TransferTimelines.init(Device->Arena, Device->CommandBufferMgr->TotalPoolCount, Device->CommandBufferMgr->TotalPoolCount);
             TransferNextValues.init(Device->Arena, Device->CommandBufferMgr->TotalPoolCount, Device->CommandBufferMgr->TotalPoolCount);
             TransferRetireValues.init(Device->Arena, Device->CommandBufferMgr->TotalPoolCount, Device->CommandBufferMgr->TotalPoolCount);
+            TransferRetireStagingBuffers.init(Device->Arena, Device->CommandBufferMgr->TotalPoolCount, Device->CommandBufferMgr->TotalPoolCount);
 
             for (uint32_t i = 0; i < Device->CommandBufferMgr->TotalPoolCount; ++i)
             {
                 TransferTimelines[i] = ZPushStructCtorArgs(Device->Arena, Rendering::Primitives::Semaphore, Device, true);
                 TransferRetireValues[i].init(Device->Arena, TotalCommandBufferCount, TotalCommandBufferCount);
+                TransferRetireStagingBuffers[i].init(Device->Arena, TotalCommandBufferCount, TotalCommandBufferCount);
                 TransferNextValues[i].store(1, std::memory_order_release);
             }
         }
@@ -238,10 +242,10 @@ namespace ZEngine::Hardwares
 
         command_buffer->End();
 
-        uint64_t signal_value = NextValues[pool_index].fetch_add(1, std::memory_order_acq_rel);
-        retire_values[i]      = signal_value;
+        uint64_t signal_value               = NextValues[pool_index].fetch_add(1, std::memory_order_acq_rel);
+        retire_values[i]                    = signal_value;
+        RetireStagingBuffers[pool_index][i] = staging_buffer;
         AsyncTimelineJobQueue.Enqueue({command_buffer, Timelines[pool_index], nullptr, dst_pipeline_stage, signal_value});
-        Device->EnqueueBufferForDeletion(staging_buffer);
     }
 
     void AsyncResourceLoader::ClearBuffer(uint8_t frame_index, uint8_t thread_index, BufferView* const buffer_view, uint32_t offset, size_t byte_size, uint32_t clear_value)
@@ -293,13 +297,15 @@ namespace ZEngine::Hardwares
                 auto dst_pipeline_stage = Device->CopyBuffer(command_buffer, staging_buffer, *buffer_view, byte_size, 0u, offset);
 
                 command_buffer->End();
-                uint64_t signal_value = NextValues[pool_index].fetch_add(1, std::memory_order_acq_rel);
-                retire_values[i]      = signal_value;
+                uint64_t signal_value               = NextValues[pool_index].fetch_add(1, std::memory_order_acq_rel);
+                retire_values[i]                    = signal_value;
+                RetireStagingBuffers[pool_index][i] = staging_buffer;
                 AsyncTimelineJobQueue.Enqueue({command_buffer, Timelines[pool_index], nullptr, dst_pipeline_stage, signal_value});
             }
-
-            /* Cleanup resource */
-            Device->EnqueueBufferForDeletion(staging_buffer);
+            else
+            {
+                vmaDestroyBuffer(Device->VmaAllocatorValue, staging_buffer.Handle, staging_buffer.Allocation);
+            }
         }
     }
 
@@ -343,31 +349,32 @@ namespace ZEngine::Hardwares
             to_transfer.DestinationQueueFamily                           = Device->TransferFamilyIndex;
             transfer_cmd->TransitionImageLayout(Primitives::ImageMemoryBarrier{to_transfer});
 
-            img_buf->Layout = to_transfer.NewLayout;
+            img_buf->Layout                                                  = to_transfer.NewLayout;
 
             // 3. Copy data to image
-            Device->WriteTextureData(transfer_cmd, handle, data);
+            BufferView                                      transfer_staging = Device->WriteTextureData(transfer_cmd, handle, data);
 
             // Release barrier: transfer → graphics ownership
-            Specifications::ImageMemoryBarrierSpecification release = {};
-            release.ImageHandle                                     = buffer_handle;
-            release.OldLayout                                       = Specifications::ImageLayout::TRANSFER_DST_OPTIMAL;
-            release.NewLayout                                       = (img_buf_aspect & VK_IMAGE_ASPECT_DEPTH_BIT) ? Specifications::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL : Specifications::ImageLayout::SHADER_READ_ONLY_OPTIMAL;
-            release.ImageAspectMask                                 = VkImageAspectFlagBits(img_buf_aspect);
-            release.SourceAccessMask                                = VK_ACCESS_TRANSFER_WRITE_BIT;
-            release.DestinationAccessMask                           = VK_ACCESS_NONE; // Must be 0 for release
-            release.SourceStageMask                                 = VK_PIPELINE_STAGE_TRANSFER_BIT;
-            release.DestinationStageMask                            = (img_buf_aspect & VK_IMAGE_ASPECT_DEPTH_BIT) ? VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT : VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-            release.LayerCount                                      = texture->Specification.LayerCount;
-            release.SourceQueueFamily                               = Device->TransferFamilyIndex;
-            release.DestinationQueueFamily                          = Device->GraphicFamilyIndex;
+            Specifications::ImageMemoryBarrierSpecification release          = {};
+            release.ImageHandle                                              = buffer_handle;
+            release.OldLayout                                                = Specifications::ImageLayout::TRANSFER_DST_OPTIMAL;
+            release.NewLayout                                                = (img_buf_aspect & VK_IMAGE_ASPECT_DEPTH_BIT) ? Specifications::ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL : Specifications::ImageLayout::SHADER_READ_ONLY_OPTIMAL;
+            release.ImageAspectMask                                          = VkImageAspectFlagBits(img_buf_aspect);
+            release.SourceAccessMask                                         = VK_ACCESS_TRANSFER_WRITE_BIT;
+            release.DestinationAccessMask                                    = VK_ACCESS_NONE; // Must be 0 for release
+            release.SourceStageMask                                          = VK_PIPELINE_STAGE_TRANSFER_BIT;
+            release.DestinationStageMask                                     = (img_buf_aspect & VK_IMAGE_ASPECT_DEPTH_BIT) ? VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT : VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+            release.LayerCount                                               = texture->Specification.LayerCount;
+            release.SourceQueueFamily                                        = Device->TransferFamilyIndex;
+            release.DestinationQueueFamily                                   = Device->GraphicFamilyIndex;
 
             transfer_cmd->TransitionImageLayout(ImageMemoryBarrier{release});
             img_buf->Layout = release.NewLayout;
             transfer_cmd->End();
 
-            uint64_t transfer_val               = TransferNextValues[pool_index].fetch_add(1, std::memory_order_acq_rel);
-            TransferRetireValues[pool_index][i] = transfer_val;
+            uint64_t transfer_val                       = TransferNextValues[pool_index].fetch_add(1, std::memory_order_acq_rel);
+            TransferRetireValues[pool_index][i]         = transfer_val;
+            TransferRetireStagingBuffers[pool_index][i] = transfer_staging;
 
             AsyncTimelineJobQueue.Enqueue({
                 transfer_cmd,
@@ -433,29 +440,30 @@ namespace ZEngine::Hardwares
             to_transfer.DestinationQueueFamily          = Device->GraphicFamilyIndex;
 
             cmd->TransitionImageLayout(ImageMemoryBarrier{to_transfer});
-            img_buf->Layout = to_transfer.NewLayout;
+            img_buf->Layout                                      = to_transfer.NewLayout;
 
-            Device->WriteTextureData(cmd, handle, data);
+            BufferView                      single_queue_staging = Device->WriteTextureData(cmd, handle, data);
 
             // Single Queue: No ownership transfer needed. Just a normal barrier.
-            ImageMemoryBarrierSpecification to_final = {};
-            to_final.ImageHandle                     = buffer_handle;
-            to_final.OldLayout                       = ImageLayout::TRANSFER_DST_OPTIMAL;
-            to_final.NewLayout                       = (img_buf_aspect & VK_IMAGE_ASPECT_DEPTH_BIT) ? ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL : ImageLayout::SHADER_READ_ONLY_OPTIMAL;
-            to_final.ImageAspectMask                 = VkImageAspectFlagBits(img_buf_aspect);
-            to_final.SourceAccessMask                = VK_ACCESS_TRANSFER_WRITE_BIT;
-            to_final.DestinationAccessMask           = VK_ACCESS_SHADER_READ_BIT;
-            to_final.SourceStageMask                 = VK_PIPELINE_STAGE_TRANSFER_BIT;
-            to_final.DestinationStageMask            = (img_buf_aspect & VK_IMAGE_ASPECT_DEPTH_BIT) ? VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT : VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-            to_final.LayerCount                      = texture->Specification.LayerCount;
-            to_final.SourceQueueFamily               = Device->GraphicFamilyIndex;
-            to_final.DestinationQueueFamily          = Device->GraphicFamilyIndex;
+            ImageMemoryBarrierSpecification to_final             = {};
+            to_final.ImageHandle                                 = buffer_handle;
+            to_final.OldLayout                                   = ImageLayout::TRANSFER_DST_OPTIMAL;
+            to_final.NewLayout                                   = (img_buf_aspect & VK_IMAGE_ASPECT_DEPTH_BIT) ? ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL : ImageLayout::SHADER_READ_ONLY_OPTIMAL;
+            to_final.ImageAspectMask                             = VkImageAspectFlagBits(img_buf_aspect);
+            to_final.SourceAccessMask                            = VK_ACCESS_TRANSFER_WRITE_BIT;
+            to_final.DestinationAccessMask                       = VK_ACCESS_SHADER_READ_BIT;
+            to_final.SourceStageMask                             = VK_PIPELINE_STAGE_TRANSFER_BIT;
+            to_final.DestinationStageMask                        = (img_buf_aspect & VK_IMAGE_ASPECT_DEPTH_BIT) ? VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT : VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+            to_final.LayerCount                                  = texture->Specification.LayerCount;
+            to_final.SourceQueueFamily                           = Device->GraphicFamilyIndex;
+            to_final.DestinationQueueFamily                      = Device->GraphicFamilyIndex;
 
             cmd->TransitionImageLayout(ImageMemoryBarrier{to_final});
             cmd->End();
 
-            uint64_t signal_value = NextValues[pool_index].fetch_add(1, std::memory_order_acq_rel);
-            retire_values[i]      = signal_value;
+            uint64_t signal_value               = NextValues[pool_index].fetch_add(1, std::memory_order_acq_rel);
+            retire_values[i]                    = signal_value;
+            RetireStagingBuffers[pool_index][i] = single_queue_staging;
             AsyncTimelineJobQueue.Enqueue({cmd, Timelines[pool_index], nullptr, (uint32_t) to_final.DestinationStageMask, signal_value, UINT64_MAX});
             img_buf->Layout = to_final.NewLayout;
         }
@@ -562,6 +570,14 @@ namespace ZEngine::Hardwares
                 command_buffer->ResetState();
                 vkResetCommandBuffer(command_buffer->GetHandle(), 0);
                 retire_values[i] = 0;
+
+                auto& sb         = RetireStagingBuffers[pool_index][i];
+                if (sb.Handle != VK_NULL_HANDLE)
+                {
+                    vmaDestroyBuffer(Device->VmaAllocatorValue, sb.Handle, sb.Allocation);
+                    sb.Handle     = VK_NULL_HANDLE;
+                    sb.Allocation = VK_NULL_HANDLE;
+                }
             }
         }
 
@@ -580,6 +596,14 @@ namespace ZEngine::Hardwares
                     transfer_cmd->ResetState();
                     vkResetCommandBuffer(transfer_cmd->GetHandle(), 0);
                     transfer_retire[i] = 0;
+
+                    auto& tsb          = TransferRetireStagingBuffers[pool_index][i];
+                    if (tsb.Handle != VK_NULL_HANDLE)
+                    {
+                        vmaDestroyBuffer(Device->VmaAllocatorValue, tsb.Handle, tsb.Allocation);
+                        tsb.Handle     = VK_NULL_HANDLE;
+                        tsb.Allocation = VK_NULL_HANDLE;
+                    }
                 }
             }
         }
@@ -760,8 +784,34 @@ namespace ZEngine::Hardwares
     void AsyncResourceLoader::Shutdown()
     {
         m_cancellation_token.store(true, std::memory_order_release);
-        // We are safe to call destructor to clean up semaphore resources
-        // Timeline->~Semaphore();
+
+        // VulkanDevice::Deinitialize calls QueueWaitAll before Shutdown, so the GPU
+        // is already idle here. Free any staging buffers that ResetCommandBuffers
+        // hasn't drained yet (e.g. slots whose retire_val was never reached).
+        uint32_t total_pool_count = Device->CommandBufferMgr->TotalPoolCount;
+        for (uint32_t p = 0; p < total_pool_count; ++p)
+        {
+            for (uint32_t i = 0; i < TotalCommandBufferCount; ++i)
+            {
+                auto& sb = RetireStagingBuffers[p][i];
+                if (sb.Handle != VK_NULL_HANDLE)
+                {
+                    vmaDestroyBuffer(Device->VmaAllocatorValue, sb.Handle, sb.Allocation);
+                    sb.Handle     = VK_NULL_HANDLE;
+                    sb.Allocation = VK_NULL_HANDLE;
+                }
+                if (Device->HasSeperateTransfertQueueFamily)
+                {
+                    auto& tsb = TransferRetireStagingBuffers[p][i];
+                    if (tsb.Handle != VK_NULL_HANDLE)
+                    {
+                        vmaDestroyBuffer(Device->VmaAllocatorValue, tsb.Handle, tsb.Allocation);
+                        tsb.Handle     = VK_NULL_HANDLE;
+                        tsb.Allocation = VK_NULL_HANDLE;
+                    }
+                }
+            }
+        }
     }
 
     void AsyncResourceLoader::Reset()

--- a/ZEngine/ZEngine/Hardwares/AsyncResourceLoader.h
+++ b/ZEngine/ZEngine/Hardwares/AsyncResourceLoader.h
@@ -84,37 +84,39 @@ namespace ZEngine::Hardwares
             Rendering::Textures::TextureHandle                 TexHandle = {};
         };
 
-        VulkanDevice*                                              Device                  = nullptr;
-        uint32_t                                                   TotalCommandBufferCount = 0;
-        Core::Containers::Array<std::atomic_uint64_t>              NextValues              = {};
-        Core::Containers::Array<std::atomic_uint64_t>              TransferNextValues      = {};
-        Core::Containers::Array<Rendering::Primitives::Semaphore*> Timelines               = {};
-        Core::Containers::Array<Rendering::Primitives::Semaphore*> TransferTimelines       = {};
-        Core::Containers::Array<Core::Containers::Array<uint64_t>> RetireValues            = {};
-        Core::Containers::Array<Core::Containers::Array<uint64_t>> TransferRetireValues    = {};
-        Helpers::ThreadSafeQueue<TimelineJob>                      AsyncTimelineJobQueue   = {};
-        Helpers::ThreadSafeQueue<DeferralUpload>                   DeferralUploadQueue     = {};
+        VulkanDevice*                                                Device                       = nullptr;
+        uint32_t                                                     TotalCommandBufferCount      = 0;
+        Core::Containers::Array<std::atomic_uint64_t>                NextValues                   = {};
+        Core::Containers::Array<std::atomic_uint64_t>                TransferNextValues           = {};
+        Core::Containers::Array<Rendering::Primitives::Semaphore*>   Timelines                    = {};
+        Core::Containers::Array<Rendering::Primitives::Semaphore*>   TransferTimelines            = {};
+        Core::Containers::Array<Core::Containers::Array<uint64_t>>   RetireValues                 = {};
+        Core::Containers::Array<Core::Containers::Array<uint64_t>>   TransferRetireValues         = {};
+        Core::Containers::Array<Core::Containers::Array<BufferView>> RetireStagingBuffers         = {};
+        Core::Containers::Array<Core::Containers::Array<BufferView>> TransferRetireStagingBuffers = {};
+        Helpers::ThreadSafeQueue<TimelineJob>                        AsyncTimelineJobQueue        = {};
+        Helpers::ThreadSafeQueue<DeferralUpload>                     DeferralUploadQueue          = {};
 
-        void                                                       Initialize(VulkanDevice* device);
+        void                                                         Initialize(VulkanDevice* device);
 
-        void                                                       UploadTextureBuffer(uint8_t frame_index, uint8_t thread_index, const Rendering::Textures::TextureHandle& handle, unsigned char* data);
-        void                                                       UploadBuffer(uint8_t frame_index, uint8_t thread_index, BufferView* const buffer, const void* data, uint32_t offset, size_t byte_size);
-        void                                                       UploadFromStagingBuffer(uint8_t frame_index, uint8_t thread_index, BufferView* const destination, const void* data, uint32_t offset, size_t byte_size);
-        void                                                       ClearBuffer(uint8_t frame_index, uint8_t thread_index, BufferView* const buffer, uint32_t offset, size_t byte_size, uint32_t clear_value);
-        Rendering::Textures::TextureHandle                         LoadTextureFile(cstring filename) = delete;
+        void                                                         UploadTextureBuffer(uint8_t frame_index, uint8_t thread_index, const Rendering::Textures::TextureHandle& handle, unsigned char* data);
+        void                                                         UploadBuffer(uint8_t frame_index, uint8_t thread_index, BufferView* const buffer, const void* data, uint32_t offset, size_t byte_size);
+        void                                                         UploadFromStagingBuffer(uint8_t frame_index, uint8_t thread_index, BufferView* const destination, const void* data, uint32_t offset, size_t byte_size);
+        void                                                         ClearBuffer(uint8_t frame_index, uint8_t thread_index, BufferView* const buffer, uint32_t offset, size_t byte_size, uint32_t clear_value);
+        Rendering::Textures::TextureHandle                           LoadTextureFile(cstring filename) = delete;
 
-        void                                                       Submit(UploadType type, uint8_t frame_index, uint8_t thread_index, const UploadRequest& request);
-        void                                                       SubmitDeferral(DeferralUpload&& deferral);
-        Rendering::Textures::TextureHandle                         Submit(uint8_t frame_index, uint8_t thread_index, const UploadRequest& request);
+        void                                                         Submit(UploadType type, uint8_t frame_index, uint8_t thread_index, const UploadRequest& request);
+        void                                                         SubmitDeferral(DeferralUpload&& deferral);
+        Rendering::Textures::TextureHandle                           Submit(uint8_t frame_index, uint8_t thread_index, const UploadRequest& request);
 
-        void                                                       CompleteDeferrals();
-        void                                                       SubmitAsyncJobs();
-        void                                                       ResetCommandBuffers(uint8_t frame_index, uint8_t thread_index);
-        void                                                       ClearAsyncJobs();
+        void                                                         CompleteDeferrals();
+        void                                                         SubmitAsyncJobs();
+        void                                                         ResetCommandBuffers(uint8_t frame_index, uint8_t thread_index);
+        void                                                         ClearAsyncJobs();
 
-        void                                                       Run();
-        void                                                       Shutdown();
-        void                                                       Reset();
+        void                                                         Run();
+        void                                                         Shutdown();
+        void                                                         Reset();
 
     private:
         std::atomic_bool                               m_cancellation_token{false};

--- a/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
+++ b/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
@@ -330,7 +330,9 @@ namespace ZEngine::Hardwares
                 auto texture = Device->GlobalTextures.Access(tex_to_dispose);
                 if (texture)
                 {
+                    auto buf_handle = texture->BufferHandle;
                     texture->Dispose();
+                    Device->Image2DBufferManager.Remove(buf_handle);
                     Device->GlobalTextures.Remove(tex_to_dispose);
                 }
             }

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
@@ -13,6 +13,7 @@
 #include <ZEngine/Rendering/Renderers/RenderPasses/Attachment.h>
 #include <ZEngine/Rendering/Renderers/RenderPasses/RenderPass.h>
 #include <ZEngine/Windows/CoreWindow.h>
+#include <cstdlib>
 #include <filesystem>
 
 using namespace std::chrono_literals;
@@ -142,13 +143,38 @@ namespace ZEngine::Hardwares
 
 #ifdef __APPLE__
         enabled_extension_layer_name_collection.push(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+        enabled_extension_layer_name_collection.push(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME);
 #endif
         instance_create_info.enabledLayerCount       = enabled_layer_name_collection.size();
         instance_create_info.ppEnabledLayerNames     = enabled_layer_name_collection.data();
         instance_create_info.enabledExtensionCount   = enabled_extension_layer_name_collection.size();
         instance_create_info.ppEnabledExtensionNames = enabled_extension_layer_name_collection.data();
 
-        VkResult result                              = vkCreateInstance(&instance_create_info, nullptr, &Instance);
+#ifdef __APPLE__
+        // Metal argument buffers require useResource tracking for every bindless texture slot.
+        // MoltenVK 1.4 does not mark all textures in a large bindless array as used on the encoder,
+        // causing MTLResourceUsage faults when sampling textures added after the first draw.
+        // Disable argument buffers to use the explicit resource-binding path.
+        VkBool32          mvk_arg_buffers = VK_FALSE;
+        VkLayerSettingEXT mvk_settings[]  = {
+            {
+             .pLayerName   = "MoltenVK",
+             .pSettingName = "MVK_CONFIG_USE_METAL_ARGUMENT_BUFFERS",
+             .type         = VK_LAYER_SETTING_TYPE_BOOL32_EXT,
+             .valueCount   = 1,
+             .pValues      = &mvk_arg_buffers,
+             }
+        };
+        VkLayerSettingsCreateInfoEXT mvk_layer_settings_create_info = {
+            .sType        = VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT,
+            .pNext        = nullptr,
+            .settingCount = 1,
+            .pSettings    = mvk_settings,
+        };
+        instance_create_info.pNext = &mvk_layer_settings_create_info;
+#endif
+
+        VkResult result = vkCreateInstance(&instance_create_info, nullptr, &Instance);
 
         if (result == VK_ERROR_INCOMPATIBLE_DRIVER)
         {
@@ -2379,11 +2405,11 @@ namespace ZEngine::Hardwares
         return handle;
     }
 
-    void VulkanDevice::WriteTextureData(CommandBufferPtr command_buf, const Rendering::Textures::TextureHandle& handle, const void* data)
+    BufferView VulkanDevice::WriteTextureData(CommandBufferPtr command_buf, const Rendering::Textures::TextureHandle& handle, const void* data)
     {
         if (!handle.Valid() || !(data) || !(command_buf))
         {
-            return;
+            return {};
         }
 
         auto       resource       = GlobalTextures.Access(handle);
@@ -2392,7 +2418,7 @@ namespace ZEngine::Hardwares
         BufferView staging_buffer = CreateBuffer(resource->BufferSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT);
         MapAndCopyToMemory(staging_buffer, resource->BufferSize, data);
         command_buf->CopyBufferToImage(staging_buffer, image_buf->GetBuffer(), resource->Width, resource->Height, resource->Specification.LayerCount, Specifications::ImageLayoutMap[VALUE_FROM_SPEC_MAP(image_buf->Layout)]);
-        EnqueueBufferForDeletion(staging_buffer);
+        return staging_buffer;
     }
 
     Rendering::Renderers::RenderPasses::RenderPass* VulkanDevice::CreateRenderPass(const Rendering::Specifications::RenderPassSpecification& spec)

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.h
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.h
@@ -677,7 +677,7 @@ namespace ZEngine::Hardwares
         Rendering::Textures::TextureHandle              CreateTexture(uint32_t width, uint32_t height);
         Rendering::Textures::TextureHandle              CreateTexture(uint32_t width, uint32_t height, float r = 255, float g = 255, float b = 255, float a = 255);
         Rendering::Textures::TextureHandle              CreateTexture(const Rendering::Specifications::TextureSpecification& spec);
-        void                                            WriteTextureData(CommandBufferPtr command_buf, const Rendering::Textures::TextureHandle& handle, const void* data);
+        BufferView                                      WriteTextureData(CommandBufferPtr command_buf, const Rendering::Textures::TextureHandle& handle, const void* data);
 
         Rendering::Renderers::RenderPasses::RenderPass* CreateRenderPass(const Rendering::Specifications::RenderPassSpecification& spec);
 

--- a/ZEngine/ZEngine/Rendering/Renderers/Pipelines/RendererPipeline.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/Pipelines/RendererPipeline.cpp
@@ -153,12 +153,15 @@ namespace ZEngine::Rendering::Renderers::Pipelines
             }
         }
 
+        // MoltenVK dereferences pAttachments unconditionally even when attachmentCount == 0,
+        // so provide a dummy entry for depth-only pipelines to avoid a null-pointer fault.
+        VkPipelineColorBlendAttachmentState dummy_attachment              = {};
         VkPipelineColorBlendStateCreateInfo color_blend_state_create_info = {};
         color_blend_state_create_info.sType                               = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
         color_blend_state_create_info.logicOpEnable                       = VK_FALSE;
         color_blend_state_create_info.logicOp                             = VK_LOGIC_OP_COPY; // Optional
         color_blend_state_create_info.attachmentCount                     = color_blend_attachment_states.size();
-        color_blend_state_create_info.pAttachments                        = color_blend_attachment_states.data();
+        color_blend_state_create_info.pAttachments                        = (attachment_count > 0) ? color_blend_attachment_states.data() : &dummy_attachment;
         color_blend_state_create_info.blendConstants[0]                   = 0.0f; // Optional
         color_blend_state_create_info.blendConstants[1]                   = 0.0f; // Optional
         color_blend_state_create_info.blendConstants[2]                   = 0.0f; // Optional

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/RenderPass.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/RenderPass.cpp
@@ -157,16 +157,23 @@ namespace ZEngine::Rendering::Renderers::RenderPasses
             return;
         }
 
-        const auto& spec               = validity_output.second;
-        auto        shader             = Pipeline->Shader;
-        const auto& descriptor_set_map = shader->DescriptorSetMap;
-        auto        frame_count        = m_device->SwapchainPtr->BufferredFrameCount;
-        auto        ubo_buf            = m_device->UniformBufferSetManager.Access(handle);
-        auto        write_reqs         = std::vector<VkWriteDescriptorSet>(frame_count);
+        const auto& spec      = validity_output.second;
+        auto        shader    = Pipeline->Shader;
+        const auto* set_array = shader->DescriptorSetMap.find(spec.Set);
+        if (!set_array)
+            set_array = m_device->ShaderReservedDescriptorSetMap.find(spec.Set);
+        if (!set_array)
+        {
+            ZENGINE_CORE_ERROR("SetInput(UBO): descriptor set {} not found for key '{}'", spec.Set, key_name.data())
+            return;
+        }
+        auto frame_count = m_device->SwapchainPtr->BufferredFrameCount;
+        auto ubo_buf     = m_device->UniformBufferSetManager.Access(handle);
+        auto write_reqs  = std::vector<VkWriteDescriptorSet>(frame_count);
 
         for (unsigned i = 0; i < frame_count; ++i)
         {
-            auto  set      = descriptor_set_map.at(spec.Set)[i];
+            auto  set      = (*set_array)[i];
             auto& buf      = ubo_buf->At(i);
             auto& buf_info = buf->GetDescriptorBufferInfo();
 
@@ -188,16 +195,23 @@ namespace ZEngine::Rendering::Renderers::RenderPasses
             return;
         }
 
-        const auto& spec               = validity_output.second;
-        auto        shader             = Pipeline->Shader;
-        const auto& descriptor_set_map = shader->DescriptorSetMap;
-        auto        frame_count        = m_device->SwapchainPtr->BufferredFrameCount;
-        auto        sbo_buf            = m_device->StorageBufferSetManager.Access(handle);
-        auto        write_reqs         = std::vector<VkWriteDescriptorSet>(frame_count);
+        const auto& spec      = validity_output.second;
+        auto        shader    = Pipeline->Shader;
+        const auto* set_array = shader->DescriptorSetMap.find(spec.Set);
+        if (!set_array)
+            set_array = m_device->ShaderReservedDescriptorSetMap.find(spec.Set);
+        if (!set_array)
+        {
+            ZENGINE_CORE_ERROR("SetInput(SBO): descriptor set {} not found for key '{}'", spec.Set, key_name.data())
+            return;
+        }
+        auto frame_count = m_device->SwapchainPtr->BufferredFrameCount;
+        auto sbo_buf     = m_device->StorageBufferSetManager.Access(handle);
+        auto write_reqs  = std::vector<VkWriteDescriptorSet>(frame_count);
 
         for (unsigned i = 0; i < frame_count; ++i)
         {
-            auto  set      = descriptor_set_map.at(spec.Set)[i];
+            auto  set      = (*set_array)[i];
             auto& buf      = sbo_buf->At(i);
             auto& buf_info = buf->GetDescriptorBufferInfo();
 
@@ -219,18 +233,24 @@ namespace ZEngine::Rendering::Renderers::RenderPasses
             return;
         }
 
-        const auto& spec               = validity_output.second;
-
-        auto        shader             = Pipeline->Shader;
-        const auto& descriptor_set_map = shader->DescriptorSetMap;
-        auto        frame_count        = m_device->SwapchainPtr->BufferredFrameCount;
-        auto        tex_buf            = m_device->GlobalTextures.Access(handle);
-        auto        img_buf            = m_device->Image2DBufferManager.Access(tex_buf->BufferHandle);
-        auto        write_reqs         = std::vector<VkWriteDescriptorSet>(frame_count);
+        const auto& spec      = validity_output.second;
+        auto        shader    = Pipeline->Shader;
+        const auto* set_array = shader->DescriptorSetMap.find(spec.Set);
+        if (!set_array)
+            set_array = m_device->ShaderReservedDescriptorSetMap.find(spec.Set);
+        if (!set_array)
+        {
+            ZENGINE_CORE_ERROR("SetInput(Texture): descriptor set {} not found for key '{}'", spec.Set, key_name.data())
+            return;
+        }
+        auto frame_count = m_device->SwapchainPtr->BufferredFrameCount;
+        auto tex_buf     = m_device->GlobalTextures.Access(handle);
+        auto img_buf     = m_device->Image2DBufferManager.Access(tex_buf->BufferHandle);
+        auto write_reqs  = std::vector<VkWriteDescriptorSet>(frame_count);
 
         for (unsigned i = 0; i < frame_count; ++i)
         {
-            auto  set        = descriptor_set_map.at(spec.Set)[i];
+            auto  set        = (*set_array)[i];
             auto& image_info = img_buf->GetDescriptorImageInfo();
 
             write_reqs[i]    = VkWriteDescriptorSet{.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, .pNext = nullptr, .dstSet = set, .dstBinding = spec.Binding, .dstArrayElement = 0, .descriptorCount = 1, .descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, .pImageInfo = &(image_info), .pBufferInfo = nullptr, .pTexelBufferView = nullptr};
@@ -248,17 +268,22 @@ namespace ZEngine::Rendering::Renderers::RenderPasses
             return;
         }
 
-        const auto& spec               = validity_output.second;
-
-        auto        shader             = Pipeline->Shader;
-        const auto& descriptor_set_map = shader->DescriptorSetMap;
-        auto        frame_count        = m_device->SwapchainPtr->BufferredFrameCount;
-
-        auto        write_reqs         = std::vector<VkWriteDescriptorSet>(frame_count);
+        const auto& spec      = validity_output.second;
+        auto        shader    = Pipeline->Shader;
+        const auto* set_array = shader->DescriptorSetMap.find(spec.Set);
+        if (!set_array)
+            set_array = m_device->ShaderReservedDescriptorSetMap.find(spec.Set);
+        if (!set_array)
+        {
+            ZENGINE_CORE_ERROR("SetInput(Sampler): descriptor set {} not found for key '{}'", spec.Set, key_name)
+            return;
+        }
+        auto frame_count = m_device->SwapchainPtr->BufferredFrameCount;
+        auto write_reqs  = std::vector<VkWriteDescriptorSet>(frame_count);
 
         for (unsigned i = 0; i < frame_count; ++i)
         {
-            auto set      = descriptor_set_map.at(spec.Set)[i];
+            auto set      = (*set_array)[i];
 
             write_reqs[i] = VkWriteDescriptorSet{.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, .pNext = nullptr, .dstSet = set, .dstBinding = spec.Binding, .dstArrayElement = 0, .descriptorCount = 1, .descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER, .pImageInfo = &(sampler_info), .pBufferInfo = nullptr, .pTexelBufferView = nullptr};
         }
@@ -274,15 +299,21 @@ namespace ZEngine::Rendering::Renderers::RenderPasses
         {
             return;
         }
-        const auto& binding_spec       = validity_output.second;
-
-        auto        shader             = Pipeline->Shader;
-        auto        descriptor_set_map = shader->DescriptorSetMap;
-        auto        frame_count        = m_device->SwapchainPtr->BufferredFrameCount;
+        const auto& binding_spec = validity_output.second;
+        auto        shader       = Pipeline->Shader;
+        const auto* set_array    = shader->DescriptorSetMap.find(binding_spec.Set);
+        if (!set_array)
+            set_array = m_device->ShaderReservedDescriptorSetMap.find(binding_spec.Set);
+        if (!set_array)
+        {
+            ZENGINE_CORE_ERROR("SetBindlessInput: descriptor set {} not found for key '{}'", binding_spec.Set, key_name.data())
+            return;
+        }
+        auto frame_count = m_device->SwapchainPtr->BufferredFrameCount;
 
         for (unsigned i = 0; i < frame_count; ++i)
         {
-            auto                                    set  = descriptor_set_map[binding_spec.Set][i];
+            auto                                    set  = (*set_array)[i];
             Hardwares::WriteDescriptorSetRequestKey key  = {.Binding = binding_spec.Binding, .DstSet = set};
             auto&                                   reqs = m_device->WriteBindlessDescriptorSetRequests;
             reqs.insert(key);


### PR DESCRIPTION
Fixes five distinct crashes that prevented ZEngine from running on macOS arm64 (Apple M4 Pro / MoltenVK 1.4).

NSWindow crash-handler assertion — crash dialog was shown from a background thread; moved to dispatch_async(main queue) ([CrashHandlerMacOS.mm](vscode-webview://1mqtrpggjui8b0ic4b0s3pfg09pufcq0e406c705rpna9vlvks4n/ZEngine/ZEngine/CrashHandlers/CrashHandlerMacOS.mm))

Depth-only pipeline crash — pColorBlendState was set even when attachment_count == 0; Vulkan validation requires it be nullptr for depth-only passes ([RendererPipeline.cpp](vscode-webview://1mqtrpggjui8b0ic4b0s3pfg09pufcq0e406c705rpna9vlvks4n/ZEngine/ZEngine/Rendering/Renderers/Pipelines/RendererPipeline.cpp))

Descriptor set lookup OOB assert — ShaderReservedDescriptorSetMap lookup used operator[] which asserted on missing keys; added find() fallback in all five SetInput/SetBindlessInput overloads ([RenderPass.cpp](vscode-webview://1mqtrpggjui8b0ic4b0s3pfg09pufcq0e406c705rpna9vlvks4n/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/RenderPass.cpp))

Staging buffer GPU use-after-free (kIOGPUCommandBufferCallbackErrorInnocentVictim) — WriteTextureData, UploadFromStagingBuffer, and ClearBuffer all called EnqueueBufferForDeletion immediately after recording CopyBufferToImage, before the command buffer was submitted. Staging buffers are now returned to the caller and stored in RetireStagingBuffers[pool][slot]; freed in ResetCommandBuffers only after the timeline semaphore signals GPU completion ([AsyncResourceLoader.h](vscode-webview://1mqtrpggjui8b0ic4b0s3pfg09pufcq0e406c705rpna9vlvks4n/ZEngine/ZEngine/Hardwares/AsyncResourceLoader.h), [AsyncResourceLoader.cpp](vscode-webview://1mqtrpggjui8b0ic4b0s3pfg09pufcq0e406c705rpna9vlvks4n/ZEngine/ZEngine/Hardwares/AsyncResourceLoader.cpp), [VulkanDevice.h](vscode-webview://1mqtrpggjui8b0ic4b0s3pfg09pufcq0e406c705rpna9vlvks4n/ZEngine/ZEngine/Hardwares/VulkanDevice.h), [VulkanDevice.cpp](vscode-webview://1mqtrpggjui8b0ic4b0s3pfg09pufcq0e406c705rpna9vlvks4n/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp))

Metal argument buffer bindless texture fault — MoltenVK 1.4 with Metal3 argument buffers does not call useResource for all 600 slots in the bindless TextureArray, causing MTLResourceUsage flags mismatch GPU faults every frame. Disabled via VK_EXT_layer_settings chained to VkInstanceCreateInfo.pNext at instance creation time ([VulkanDevice.cpp](vscode-webview://1mqtrpggjui8b0ic4b0s3pfg09pufcq0e406c705rpna9vlvks4n/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp))

Viewport resize null-pointer crash — RenderGraph::Resize enqueued old texture handles into TextureHandleToDispose, but the consumer only freed the GlobalTextures slot, never the paired Image2DBuffer slot. After enough resizes the 600-slot Image2DBufferManager pool exhausted, Create() returned an invalid handle, Access() returned nullptr, and the struct assignment crashed at address 0x4. Fixed by calling Image2DBufferManager.Remove(buf_handle) alongside GlobalTextures.Remove() ([DeviceSwapchain.cpp](vscode-webview://1mqtrpggjui8b0ic4b0s3pfg09pufcq0e406c705rpna9vlvks4n/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp))

Test plan
 App launches without crash on macOS arm64 (M4 Pro)
 Environment map (bergen_4k.zenvmap) uploads and skybox renders correctly — no kIOGPUCommandBufferCallbackErrorInnocentVictim in logs
 Viewport can be resized repeatedly without crash
 Depth pass renders correctly (no validation errors for depth-only pipelines)