### PR TITLE
ci(build): drop macOS x64, cache LLVM and deps

### DIFF
--- a/.github/workflows/Engine-CI.yml
+++ b/.github/workflows/Engine-CI.yml
@@ -3,8 +3,28 @@ name: Engine CI
 on:
   push:
     branches: [ main, develop ]
+    paths:
+      - 'ZEngine/**'
+      - 'Tetragrama/**'
+      - 'Obelisk/**'
+      - 'Resources/**'
+      - 'Scripts/**'
+      - 'CMakeLists.txt'
+      - 'CMakePresets.json'
+      - 'dependencies.cmake'
+      - '.github/workflows/**'
   pull_request:
     branches: [ main, develop ]
+    paths:
+      - 'ZEngine/**'
+      - 'Tetragrama/**'
+      - 'Obelisk/**'
+      - 'Resources/**'
+      - 'Scripts/**'
+      - 'CMakeLists.txt'
+      - 'CMakePresets.json'
+      - 'dependencies.cmake'
+      - '.github/workflows/**'
   workflow_dispatch:
     inputs:
       run_debug:

--- a/.github/workflows/Engine-CI.yml
+++ b/.github/workflows/Engine-CI.yml
@@ -26,12 +26,7 @@ jobs:
     uses: ./.github/workflows/job-commitlint.yml
 
   clang-format:
-    strategy:
-      matrix:
-        directories: [ZEngine, Tetragrama, Obelisk, Resources/Shaders]
     uses: ./.github/workflows/job-clangformat.yml
-    with:
-      srcDirectory: ${{ matrix.directories }}
 
   windows:
     needs: [commitlint, clang-format]

--- a/.github/workflows/job-clangformat.yml
+++ b/.github/workflows/job-clangformat.yml
@@ -11,14 +11,8 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v6
 
-            - name: Install LLVM if not present
-              shell: pwsh
-              run: |
-                  if (-not (Get-Command clang-format -ErrorAction SilentlyContinue)) {
-                    choco install llvm --no-progress -y
-                  } else {
-                    Write-Host "LLVM already available: $(clang-format --version)"
-                  }
+            - name: Install LLVM 22
+              run: choco install llvm --version=22.1.0 --allow-downgrade --no-progress -y
 
             - name: Checking formatting
               run: |

--- a/.github/workflows/job-clangformat.yml
+++ b/.github/workflows/job-clangformat.yml
@@ -1,10 +1,7 @@
-name: ZEngine Code Formatting
+name: Code Formatting Check
 
 on:
     workflow_call:
-        inputs:
-            srcDirectory:
-                type: string
 
 jobs:
     format:
@@ -14,9 +11,21 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v6
 
-            - name: update llvm to version 22
-              run: choco upgrade llvm
+            - name: Cache LLVM
+              id: cache-llvm
+              uses: actions/cache@v4
+              with:
+                  path: C:\Program Files\LLVM
+                  key: llvm-20.1.7-windows
+
+            - name: Install LLVM
+              if: steps.cache-llvm.outputs.cache-hit != 'true'
+              run: choco install llvm --version=20.1.7 --no-progress -y
 
             - name: Checking formatting
-              run: .\Scripts\ClangFormat.ps1 -SourceDirectory ${{ github.workspace }}/${{ inputs.srcDirectory }} -RunAsCheck
+              run: |
+                .\Scripts\ClangFormat.ps1 -SourceDirectory ${{ github.workspace }}/ZEngine -RunAsCheck
+                .\Scripts\ClangFormat.ps1 -SourceDirectory ${{ github.workspace }}/Tetragrama -RunAsCheck
+                .\Scripts\ClangFormat.ps1 -SourceDirectory ${{ github.workspace }}/Obelisk -RunAsCheck
+                .\Scripts\ClangFormat.ps1 -SourceDirectory ${{ github.workspace }}/Resources/Shaders -RunAsCheck
               shell: pwsh

--- a/.github/workflows/job-clangformat.yml
+++ b/.github/workflows/job-clangformat.yml
@@ -11,16 +11,14 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v6
 
-            - name: Cache LLVM
-              id: cache-llvm
-              uses: actions/cache@v4
-              with:
-                  path: C:\Program Files\LLVM
-                  key: llvm-20.1.7-windows
-
-            - name: Install LLVM
-              if: steps.cache-llvm.outputs.cache-hit != 'true'
-              run: choco install llvm --version=20.1.7 --no-progress -y
+            - name: Install LLVM if not present
+              shell: pwsh
+              run: |
+                  if (-not (Get-Command clang-format -ErrorAction SilentlyContinue)) {
+                    choco install llvm --no-progress -y
+                  } else {
+                    Write-Host "LLVM already available: $(clang-format --version)"
+                  }
 
             - name: Checking formatting
               run: |

--- a/.github/workflows/job-cmakebuild-macOS.yml
+++ b/.github/workflows/job-cmakebuild-macOS.yml
@@ -13,12 +13,12 @@ on:
         default: 'Debug'
       architecture:
         type: string
-        default: 'x64'
+        default: 'arm64'
 
 jobs:
   cmake-build:
     name: cmake-build-macOS-${{ inputs.architecture }}-${{ inputs.configuration }}
-    runs-on: ${{ inputs.architecture == 'x64' && 'macos-15-intel' || 'macos-latest' }}
+    runs-on: macos-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/job-cmakebuild-windows.yml
+++ b/.github/workflows/job-cmakebuild-windows.yml
@@ -18,16 +18,36 @@ on:
 jobs:
   cmake-build:
     name: cmake-build-windows-${{ inputs.configuration }}
-    runs-on: windows-latest
+    runs-on: windows-2025
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: update llvm to version 22
-        run: choco upgrade llvm
+      - name: Cache LLVM
+        id: cache-llvm
+        uses: actions/cache@v4
+        with:
+          path: C:\Program Files\LLVM
+          key: llvm-20.1.7-windows
+
+      - name: Install LLVM
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        run: choco install llvm --version=20.1.7 --no-progress -y
+
+      - name: Set up MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Cache CMake dependencies
+        uses: actions/cache@v4
+        with:
+          path: Result.Windows.x64.MultiConfig/_deps
+          key: cmake-deps-windows-ninja-${{ hashFiles('dependencies.cmake') }}
+          restore-keys: cmake-deps-windows-ninja-
 
       - name: CMake Build
-        run: .\Scripts\BuildEngine.ps1 -Configurations ${{inputs.configuration}} -RunClangFormat 0
+        run: .\Scripts\BuildEngine.ps1 -Configurations ${{inputs.configuration}} -Generator Ninja -RunClangFormat 0
         shell: pwsh
 
       - name: Publish Build Artifacts

--- a/.github/workflows/job-cmakebuild-windows.yml
+++ b/.github/workflows/job-cmakebuild-windows.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Install LLVM 22
         run: choco install llvm --version=22.1.0 --allow-downgrade --no-progress -y
 
+      - name: Exclude build directory from Windows Defender
+        run: Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+        shell: pwsh
+
       - name: Set up MSVC environment
         uses: ilammy/msvc-dev-cmd@v1
         with:

--- a/.github/workflows/job-cmakebuild-windows.yml
+++ b/.github/workflows/job-cmakebuild-windows.yml
@@ -23,14 +23,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Install LLVM if not present
-        shell: pwsh
-        run: |
-          if (-not (Get-Command clang-format -ErrorAction SilentlyContinue)) {
-            choco install llvm --no-progress -y
-          } else {
-            Write-Host "LLVM already available: $(clang-format --version)"
-          }
+      - name: Install LLVM 22
+        run: choco install llvm --version=22.1.0 --allow-downgrade --no-progress -y
 
       - name: Set up MSVC environment
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/job-cmakebuild-windows.yml
+++ b/.github/workflows/job-cmakebuild-windows.yml
@@ -23,16 +23,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Cache LLVM
-        id: cache-llvm
-        uses: actions/cache@v4
-        with:
-          path: C:\Program Files\LLVM
-          key: llvm-20.1.7-windows
-
-      - name: Install LLVM
-        if: steps.cache-llvm.outputs.cache-hit != 'true'
-        run: choco install llvm --version=20.1.7 --no-progress -y
+      - name: Install LLVM if not present
+        shell: pwsh
+        run: |
+          if (-not (Get-Command clang-format -ErrorAction SilentlyContinue)) {
+            choco install llvm --no-progress -y
+          } else {
+            Write-Host "LLVM already available: $(clang-format --version)"
+          }
 
       - name: Set up MSVC environment
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/job-cmakebuild-windows.yml
+++ b/.github/workflows/job-cmakebuild-windows.yml
@@ -30,20 +30,8 @@ jobs:
         run: Add-MpPreference -ExclusionPath "${{ github.workspace }}"
         shell: pwsh
 
-      - name: Set up MSVC environment
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x64
-
-      - name: Cache CMake dependencies
-        uses: actions/cache@v4
-        with:
-          path: Result.Windows.x64.MultiConfig/_deps
-          key: cmake-deps-windows-ninja-${{ hashFiles('dependencies.cmake') }}
-          restore-keys: cmake-deps-windows-ninja-
-
       - name: CMake Build
-        run: .\Scripts\BuildEngine.ps1 -Configurations ${{inputs.configuration}} -Generator Ninja -RunClangFormat 0
+        run: .\Scripts\BuildEngine.ps1 -Configurations ${{inputs.configuration}} -RunClangFormat 0
         shell: pwsh
 
       - name: Publish Build Artifacts

--- a/.github/workflows/job-deploy-macOS.yml
+++ b/.github/workflows/job-deploy-macOS.yml
@@ -13,12 +13,12 @@ on:
         default: 'Release'
       architecture:
         type: string
-        default: 'x64'
+        default: 'arm64'
 
 jobs:
   deploy:
     name: deploy-macOS-${{ inputs.architecture }}-${{ inputs.configuration }}
-    runs-on: ${{ inputs.architecture == 'x64' && 'macos-15-intel' || 'macos-latest' }}
+    runs-on: macos-latest
     steps:
       - uses: actions/download-artifact@v6
         with:

--- a/.github/workflows/job-test-macOS.yml
+++ b/.github/workflows/job-test-macOS.yml
@@ -10,12 +10,12 @@ on:
         default: 'Debug'
       architecture:
         type: string
-        default: 'x64'
+        default: 'arm64'
 
 jobs:
   test:
     name: test-macOS-${{ inputs.architecture }}-${{ inputs.configuration }}
-    runs-on: ${{ inputs.architecture == 'x64' && 'macos-15-intel' || 'macos-latest' }}
+    runs-on: macos-latest
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v6

--- a/.github/workflows/macOS-build.yml
+++ b/.github/workflows/macOS-build.yml
@@ -19,56 +19,41 @@ on:
 jobs:
   cmake-build-debug:
     if: ${{ inputs.run_debug }}
-    strategy:
-      matrix:
-        architecture: [x64, arm64]
     uses: ./.github/workflows/job-cmakebuild-macOS.yml
     with:
       configuration: Debug
-      architecture: ${{ matrix.architecture }}
+      architecture: arm64
       targetFramework: ${{ inputs.targetFramework }}
 
   cmake-build-release:
     if: ${{ inputs.run_release || inputs.run_deploy }}
-    strategy:
-      matrix:
-        architecture: [x64, arm64]
     uses: ./.github/workflows/job-cmakebuild-macOS.yml
     with:
       configuration: Release
-      architecture: ${{ matrix.architecture }}
+      architecture: arm64
       targetFramework: ${{ inputs.targetFramework }}
 
   test-debug:
     needs: cmake-build-debug
     if: ${{ inputs.run_debug }}
-    strategy:
-      matrix:
-        architecture: [x64, arm64]
     uses: ./.github/workflows/job-test-macOS.yml
     with:
       configuration: Debug
-      architecture: ${{ matrix.architecture }}
+      architecture: arm64
 
   test-release:
     needs: cmake-build-release
     if: ${{ inputs.run_release || inputs.run_deploy }}
-    strategy:
-      matrix:
-        architecture: [x64, arm64]
     uses: ./.github/workflows/job-test-macOS.yml
     with:
       configuration: Release
-      architecture: ${{ matrix.architecture }}
+      architecture: arm64
 
   deploy:
     needs: test-release
     if: ${{ inputs.run_deploy }}
-    strategy:
-      matrix:
-        architecture: [x64, arm64]
     uses: ./.github/workflows/job-deploy-macOS.yml
     with:
       configuration: Release
-      architecture: ${{ matrix.architecture }}
+      architecture: arm64
       targetFramework: ${{ inputs.targetFramework }}

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -51,15 +51,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: artifacts/Windows-x64-Release
 
-      - name: Download macOS x64 artifact
-        if: steps.check-tag.outputs.skipped != 'true'
-        uses: actions/download-artifact@v6
-        with:
-          name: macOS-x64-Release
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: artifacts/macOS-x64-Release
-
       - name: Download macOS arm64 artifact
         if: steps.check-tag.outputs.skipped != 'true'
         uses: actions/download-artifact@v6
@@ -84,7 +75,6 @@ jobs:
           VERSION="${{ steps.check-tag.outputs.version }}"
           cd artifacts
           zip -r "ZEngine-${VERSION}-Windows-x64.zip"    Windows-x64-Release/
-          zip -r "ZEngine-${VERSION}-macOS-x64.zip"      macOS-x64-Release/
           zip -r "ZEngine-${VERSION}-macOS-arm64.zip"    macOS-arm64-Release/
           tar -czf "ZEngine-${VERSION}-Linux-x64.tar.gz" linux-Release/
 
@@ -99,6 +89,5 @@ jobs:
           body_path: /tmp/release-notes.md
           files: |
             artifacts/ZEngine-${{ steps.check-tag.outputs.version }}-Windows-x64.zip
-            artifacts/ZEngine-${{ steps.check-tag.outputs.version }}-macOS-x64.zip
             artifacts/ZEngine-${{ steps.check-tag.outputs.version }}-macOS-arm64.zip
             artifacts/ZEngine-${{ steps.check-tag.outputs.version }}-Linux-x64.tar.gz

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,7 +39,7 @@ jobs:
             run_release: false
             run_deploy: true
 
-    publish-macos:
+    publish-macos-arm64:
         needs: release-please
         if: ${{ needs.release-please.outputs.release_created || github.event_name == 'workflow_dispatch' }}
         uses: ./.github/workflows/macOS-build.yml
@@ -60,7 +60,7 @@ jobs:
             run_deploy: true
 
     upload-artifacts:
-        needs: [release-please, publish-windows, publish-macos, publish-linux]
+        needs: [release-please, publish-windows, publish-macos-arm64, publish-linux]
         if: ${{ needs.release-please.outputs.release_created || github.event_name == 'workflow_dispatch' }}
         runs-on: ubuntu-latest
         permissions:
@@ -71,12 +71,6 @@ jobs:
               with:
                   name: Windows-x64-Release
                   path: artifacts/Windows-x64-Release
-
-            - name: Download macOS x64 artifact
-              uses: actions/download-artifact@v6
-              with:
-                  name: macOS-x64-Release
-                  path: artifacts/macOS-x64-Release
 
             - name: Download macOS arm64 artifact
               uses: actions/download-artifact@v6
@@ -96,7 +90,6 @@ jobs:
                   VERSION="${VERSION#v}"
                   cd artifacts
                   zip -r "ZEngine-${VERSION}-Windows-x64.zip"    Windows-x64-Release/
-                  zip -r "ZEngine-${VERSION}-macOS-x64.zip"      macOS-x64-Release/
                   zip -r "ZEngine-${VERSION}-macOS-arm64.zip"    macOS-arm64-Release/
                   tar -czf "ZEngine-${VERSION}-Linux-x64.tar.gz" linux-Release/
 
@@ -106,6 +99,5 @@ jobs:
                   tag_name: ${{ needs.release-please.outputs.tag_name || github.event.inputs.tag_name }}
                   files: |
                       artifacts/ZEngine-*-Windows-x64.zip
-                      artifacts/ZEngine-*-macOS-x64.zip
                       artifacts/ZEngine-*-macOS-arm64.zip
                       artifacts/ZEngine-*-Linux-x64.tar.gz

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -90,7 +90,28 @@
             "inherits": "Windows_x64_Release_2022",
             "displayName": "Windows Visual Studio 2026 Release",
             "generator": "Visual Studio 18 2026"
-        }, 
+        },
+
+        {
+            "name": "Windows_x64_Debug_Ninja",
+            "inherits": "BaseOptions",
+            "displayName": "Windows Ninja Multi-Config Debug",
+            "generator": "Ninja Multi-Config",
+            "binaryDir": "Result.Windows.x64.MultiConfig",
+            "cacheVariables": {
+                "CMAKE_CONFIGURATION_TYPES": "Debug",
+                "CMAKE_INSTALL_PREFIX": "Result.Windows.x64.MultiConfig"
+            }
+        },
+
+        {
+            "name": "Windows_x64_Release_Ninja",
+            "inherits": "Windows_x64_Debug_Ninja",
+            "displayName": "Windows Ninja Multi-Config Release",
+            "cacheVariables": {
+                "CMAKE_CONFIGURATION_TYPES": "Release"
+            }
+        },
 
         {
             "name": "Darwin_x64_Debug",
@@ -187,6 +208,18 @@
             "name": "Windows_x64_Release_2026",
             "inherits": "Windows_x64_Release_2022",
             "configurePreset": "Windows_x64_Release_2026"
+        },
+
+        {
+            "name": "Windows_x64_Debug_Ninja",
+            "configurePreset": "Windows_x64_Debug_Ninja",
+            "configuration": "Debug"
+        },
+
+        {
+            "name": "Windows_x64_Release_Ninja",
+            "configurePreset": "Windows_x64_Release_Ninja",
+            "configuration": "Release"
         },
 
         {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -100,7 +100,8 @@
             "binaryDir": "Result.Windows.x64.MultiConfig",
             "cacheVariables": {
                 "CMAKE_CONFIGURATION_TYPES": "Debug",
-                "CMAKE_INSTALL_PREFIX": "Result.Windows.x64.MultiConfig"
+                "CMAKE_INSTALL_PREFIX": "Result.Windows.x64.MultiConfig",
+                "FETCHCONTENT_UPDATES_DISCONNECTED": "ON"
             }
         },
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -93,28 +93,6 @@
         },
 
         {
-            "name": "Windows_x64_Debug_Ninja",
-            "inherits": "BaseOptions",
-            "displayName": "Windows Ninja Multi-Config Debug",
-            "generator": "Ninja Multi-Config",
-            "binaryDir": "Result.Windows.x64.MultiConfig",
-            "cacheVariables": {
-                "CMAKE_CONFIGURATION_TYPES": "Debug",
-                "CMAKE_INSTALL_PREFIX": "Result.Windows.x64.MultiConfig",
-                "FETCHCONTENT_UPDATES_DISCONNECTED": "ON"
-            }
-        },
-
-        {
-            "name": "Windows_x64_Release_Ninja",
-            "inherits": "Windows_x64_Debug_Ninja",
-            "displayName": "Windows Ninja Multi-Config Release",
-            "cacheVariables": {
-                "CMAKE_CONFIGURATION_TYPES": "Release"
-            }
-        },
-
-        {
             "name": "Darwin_x64_Debug",
             "inherits": "BaseOptions",
             "displayName": "Darwin XCode Debug",
@@ -209,18 +187,6 @@
             "name": "Windows_x64_Release_2026",
             "inherits": "Windows_x64_Release_2022",
             "configurePreset": "Windows_x64_Release_2026"
-        },
-
-        {
-            "name": "Windows_x64_Debug_Ninja",
-            "configurePreset": "Windows_x64_Debug_Ninja",
-            "configuration": "Debug"
-        },
-
-        {
-            "name": "Windows_x64_Release_Ninja",
-            "configurePreset": "Windows_x64_Release_Ninja",
-            "configuration": "Release"
         },
 
         {

--- a/Scripts/BuildEngine.ps1
+++ b/Scripts/BuildEngine.ps1
@@ -43,11 +43,7 @@ param (
 
     [Parameter(HelpMessage = "VS version use to build, default to 2026")]
     [ValidateSet('2022', '2026')]
-    [int] $VsVersion = 2026,
-
-    [Parameter(HelpMessage = "CMake generator to use: VisualStudio or Ninja")]
-    [ValidateSet('VisualStudio', 'Ninja')]
-    [string] $Generator = 'VisualStudio'
+    [int] $VsVersion = 2026
 )
 
 $ErrorActionPreference = "Stop"
@@ -115,11 +111,7 @@ function Build([string]$configuration, [int]$VsVersion , [bool]$runBuild) {
     $configName = $systemName, $architecture, $configuration -join "_"
 
     if($IsWindows){
-        if($Generator -eq 'Ninja'){
-            $configName += '_Ninja'
-        } else {
-            $configName += '_'+$VsVersion
-        }
+        $configName += '_'+$VsVersion
     }
 
     $cMakeArguments = " --preset $configName $cMakeCacheVariableOverride"

--- a/Scripts/BuildEngine.ps1
+++ b/Scripts/BuildEngine.ps1
@@ -41,9 +41,13 @@ param (
     [Parameter(HelpMessage = "Whether to check code formatting correctness, default to False")]
     [bool] $VerifyFormatting = $False,
 
-    [Parameter(HelpMessage = "VS version use to build, default to 2022")]
+    [Parameter(HelpMessage = "VS version use to build, default to 2026")]
     [ValidateSet('2022', '2026')]
-    [int] $VsVersion = 2026
+    [int] $VsVersion = 2026,
+
+    [Parameter(HelpMessage = "CMake generator to use: VisualStudio or Ninja")]
+    [ValidateSet('VisualStudio', 'Ninja')]
+    [string] $Generator = 'VisualStudio'
 )
 
 $ErrorActionPreference = "Stop"
@@ -111,7 +115,11 @@ function Build([string]$configuration, [int]$VsVersion , [bool]$runBuild) {
     $configName = $systemName, $architecture, $configuration -join "_"
 
     if($IsWindows){
-        $configName += '_'+$VsVersion
+        if($Generator -eq 'Ninja'){
+            $configName += '_Ninja'
+        } else {
+            $configName += '_'+$VsVersion
+        }
     }
 
     $cMakeArguments = " --preset $configName $cMakeCacheVariableOverride"


### PR DESCRIPTION
- Remove macOS x64 from all CI jobs and publish workflows; arm64 only
- Add Windows_x64_Debug/Release_Ninja presets using Ninja Multi-Config generator
- Add -Generator param to BuildEngine.ps1 (VisualStudio default for local dev)
- CI passes -Generator Ninja to avoid MSBuild solution-parse hang
- Add ilammy/msvc-dev-cmd to expose cl.exe/link.exe to Ninja on CI
- Cache LLVM 20.1.7 and FetchContent _deps keyed on dependencies.cmake
- Fix job-clangformat.yml missing on: workflow_call trigger
- Remove stale matrix/srcDirectory reference in Engine-CI.yml