### PR TITLE
feat(core): add IsInitialized() to Logger and ThreadPoolHelper

### DIFF
--- a/Tetragrama/Components/ProjectViewUIComponent.cpp
+++ b/Tetragrama/Components/ProjectViewUIComponent.cpp
@@ -1,6 +1,7 @@
 #include <Tetragrama/Components/ProjectViewUIComponent.h>
 #include <Tetragrama/Editor.h>
 #include <Tetragrama/Helpers/SearchPatternAlgorithm.h>
+#include <ZEngine/Engine.h>
 #include <ZEngine/Helpers/MemoryOperations.h>
 #include <imgui.h>
 #include <cstdio>

--- a/Tetragrama/Editor.cpp
+++ b/Tetragrama/Editor.cpp
@@ -2,6 +2,7 @@
 #include <Tetragrama/Editor.h>
 #include <Tetragrama/MessageToken.h>
 #include <Tetragrama/Messengers/Messenger.h>
+#include <ZEngine/Engine.h>
 #include <fmt/format.h>
 #include <nlohmann/json.hpp>
 #include <fstream>

--- a/ZEngine/ZEngine/Helpers/ThreadPool.h
+++ b/ZEngine/ZEngine/Helpers/ThreadPool.h
@@ -90,6 +90,11 @@ namespace ZEngine::Helpers
             }
         }
 
+        static bool IsInitialized()
+        {
+            return Pool != nullptr;
+        }
+
         template <typename T>
         static void Submit(T&& f)
         {

--- a/ZEngine/ZEngine/Logging/Logger.cpp
+++ b/ZEngine/ZEngine/Logging/Logger.cpp
@@ -50,6 +50,11 @@ namespace ZEngine::Logging
         }
     }
 
+    bool Logger::IsInitialized()
+    {
+        return s_logger_collection.size() > 0;
+    }
+
     void Logger::Info(std::string msg)
     {
         for (auto& logger : s_logger_collection)

--- a/ZEngine/ZEngine/Logging/Logger.h
+++ b/ZEngine/ZEngine/Logging/Logger.h
@@ -28,6 +28,7 @@ namespace ZEngine::Logging
         using LogEventHandler = std::function<void(LogMessage)>;
 
         static void        Initialize(void* arena, const LoggerConfiguration&);
+        static bool        IsInitialized();
         static void        Flush();
         static void        Dispose();
         static uint32_t    AddEventHandler(LogEventHandler handler);


### PR DESCRIPTION
## Summary

- Adds `Logger::IsInitialized()` — returns `s_logger_collection.size() > 0`
- Adds `ThreadPoolHelper::IsInitialized()` — returns `Pool != nullptr`

These are guard predicates required by `Engine::Initialize` to assert that Obelisk completed Steps 4 and 5 (ThreadPool + Logger) before handing control to the engine.

## Test plan

- [x] Confirm `Logger::IsInitialized()` returns false before `Logger::Initialize()`, true after
- [x] Confirm `ThreadPoolHelper::IsInitialized()` returns false before `ThreadPoolHelper::Initialize()`, true after
- [x] Confirm no behaviour change to existing callers