### PR TITLE
feat(engine): move VFS into EngineContext, pass MemoryManager to Engine::Initialize

### DIFF
--- a/Tetragrama/Components/ProjectViewUIComponent.cpp
+++ b/Tetragrama/Components/ProjectViewUIComponent.cpp
@@ -1,6 +1,7 @@
 #include <Tetragrama/Components/ProjectViewUIComponent.h>
 #include <Tetragrama/Editor.h>
 #include <Tetragrama/Helpers/SearchPatternAlgorithm.h>
+#include <ZEngine/Engine.h>
 #include <ZEngine/Helpers/MemoryOperations.h>
 #include <imgui.h>
 #include <cstdio>

--- a/Tetragrama/Components/ProjectViewUIComponent.cpp
+++ b/Tetragrama/Components/ProjectViewUIComponent.cpp
@@ -22,7 +22,7 @@ namespace Tetragrama::Components
         UIComponent::Initialize(parent, name, visibility, closed);
         parent->LocalArena.CreateSubArena(ZMega(1), &m_local_arena);
 
-        m_vfs_context     = ParentLayer->CurrentApp->GetVFSContext();
+        m_vfs_context     = ZEngine::Engine::GetContext()->VFS;
         m_directory_cache = &ParentLayer->Cache;
         m_scanner         = &ParentLayer->Scanner;
 

--- a/Tetragrama/Editor.cpp
+++ b/Tetragrama/Editor.cpp
@@ -2,6 +2,7 @@
 #include <Tetragrama/Editor.h>
 #include <Tetragrama/MessageToken.h>
 #include <Tetragrama/Messengers/Messenger.h>
+#include <ZEngine/Engine.h>
 #include <fmt/format.h>
 #include <nlohmann/json.hpp>
 #include <fstream>

--- a/Tetragrama/Editor.cpp
+++ b/Tetragrama/Editor.cpp
@@ -35,7 +35,7 @@ namespace Tetragrama
         if (WorkingSpacePath && WorkingSpacePath[0] != '\0')
         {
             WorkingSpaceBackend.Initialize(WorkingSpacePath, ZEngine::Core::VFS::VFSBackendCaps::Read | ZEngine::Core::VFS::VFSBackendCaps::List, &Memory->MainArena);
-            if (GetVFSContext()->Mount(&WorkingSpaceBackend, ZEngine::Core::VFS::VFSPath::Root(), 0).Failed())
+            if (ZEngine::Engine::GetContext()->VFS->Mount(&WorkingSpaceBackend, ZEngine::Core::VFS::VFSPath::Root(), 0).Failed())
             {
                 ZENGINE_CORE_ERROR("Failed to mount working space '{}' into the VFS", WorkingSpacePath)
             }

--- a/ZEngine/ZEngine/Applications/GameApplication.cpp
+++ b/ZEngine/ZEngine/Applications/GameApplication.cpp
@@ -9,19 +9,12 @@ namespace ZEngine::Applications
 
         State  = ZPushStructCtor(&Memory->MainArena, ApplicationState);
 
-        // TODO: move to engine context
-        VFS.Initialize(&Memory->MainArena);
         OnInitializing();
         OverrideWindowConfiguration();
 
-        Engine::Initialize(&Memory->MainArena, &WindowCfg, this);
+        Engine::Initialize(Memory, &WindowCfg, this);
 
         OnInitialized();
-    }
-
-    Core::VFS::IVFSContext* GameApplication::GetVFSContext()
-    {
-        return &VFS;
     }
 
     void GameApplication::Run()

--- a/ZEngine/ZEngine/Applications/GameApplication.h
+++ b/ZEngine/ZEngine/Applications/GameApplication.h
@@ -4,7 +4,6 @@
 #include <ZEngine/Core/Memory/Allocator.h>
 #include <ZEngine/Core/Memory/MemoryManager.h>
 #include <ZEngine/Core/TimeStep.h>
-#include <ZEngine/Core/VFS/VFSContext.h>
 #include <ZEngine/Rendering/Scenes/GraphicScene.h>
 #include <ZEngine/Windows/CoreWindow.h>
 #include <ZEngine/Windows/WindowConfiguration.h>
@@ -39,9 +38,6 @@ namespace ZEngine::Applications
         AppRenderPipelinePtr              RenderPipeline      = nullptr;
         Controllers::ICameraControllerPtr CameraController    = nullptr;
         Rendering::Scenes::RenderScenePtr CurrentScene        = nullptr;
-
-        Core::VFS::VFSContext             VFS                 = {};
-        Core::VFS::IVFSContext*           GetVFSContext();
 
         void                              Initialize(Core::Memory::MemoryManager* memory);
         void                              Update(Core::TimeStep dt);

--- a/ZEngine/ZEngine/Engine.cpp
+++ b/ZEngine/ZEngine/Engine.cpp
@@ -1,7 +1,9 @@
 #include <ZEngine/Applications/AppRenderPipeline.h>
 #include <ZEngine/Applications/GameApplication.h>
+#include <ZEngine/Core/VFS/VFSContext.h>
 #include <ZEngine/Engine.h>
 #include <ZEngine/Helpers/ThreadPool.h>
+#include <ZEngine/Logging/Logger.h>
 #include <ZEngine/Logging/LoggerDefinition.h>
 #include <ZEngine/Managers/AssetManager.h>
 #include <ZEngine/Windows/GameWindow.h>
@@ -22,23 +24,40 @@ namespace ZEngine
     static Applications::AppRenderPipelinePtr g_appRenderPipeline = nullptr;
     static std::thread                        g_render_thread     = {};
 
-    void                                      Engine::Initialize(ZEngine::Core::Memory::ArenaAllocator* arena, Windows::WindowConfigurationPtr window_cfg_ptr, Applications::GameApplicationPtr app)
+    void                                      Engine::Initialize(Core::Memory::MemoryManager* memory, Windows::WindowConfigurationPtr window_cfg_ptr, Applications::GameApplicationPtr app)
     {
-        g_engine_ctx         = ZPushStruct(arena, EngineContext);
-        g_engine_ctx->Device = ZPushStructCtor(arena, Hardwares::VulkanDevice);
-        auto window          = ZPushStructCtor(arena, Windows::GameWindow);
+        // Step 6 — assert Obelisk pre-conditions (Steps 1–5 must be complete before this call)
+        ZENGINE_VALIDATE_ASSERT(memory != nullptr, "Engine::Initialize: memory is null — Obelisk must call MemoryManager::Initialize first")
+        ZENGINE_VALIDATE_ASSERT(Logging::Logger::IsInitialized(), "Engine::Initialize: Logger not initialized — Obelisk must call Logger::Initialize first")
+        ZENGINE_VALIDATE_ASSERT(Helpers::ThreadPoolHelper::IsInitialized(), "Engine::Initialize: ThreadPool not initialized — Obelisk must call ThreadPoolHelper::Initialize first")
 
+        auto& arena  = memory->MainArena;
+
+        g_engine_ctx = ZPushStruct(&arena, EngineContext);
+
+        // Step 9 — GameWindow (surface must exist before device queries surface capabilities)
+        auto window  = ZPushStructCtor(&arena, Windows::GameWindow);
         window->SetCallbackFunction(std::bind(&Applications::GameApplication::ProcessEvent, app, std::placeholders::_1));
-        window->Initialize(arena, *window_cfg_ptr);
+        window->Initialize(&arena, *window_cfg_ptr);
         g_engine_ctx->Window         = window;
 
-        g_appRenderPipeline          = ZPushStructCtor(arena, Applications::AppRenderPipeline);
-
+        // Step 10 — VulkanDevice
+        g_engine_ctx->Device         = ZPushStructCtor(&arena, Hardwares::VulkanDevice);
         uint32_t worker_thread_count = std::max(1u, (uint32_t) (Helpers::ThreadPoolHelper::Pool->MaxThreadCount / 2u));
-        g_engine_ctx->Device->Initialize(arena, window, worker_thread_count /*, k_mailbox_buffer_size */);
-        g_appRenderPipeline->Initialize(g_engine_ctx->Device);
+        g_engine_ctx->Device->Initialize(&arena, window, worker_thread_count /*, k_mailbox_buffer_size */);
 
-        Managers::AssetManager::Initialize(arena, g_engine_ctx->Device, app->WorkingSpacePath);
+        // Step 11 — VFS
+        memory->CreateBudgetedArena(memory->Budget.VirtualFS, &g_engine_ctx->VFSArena);
+        auto vfs_ctx = ZPushStructCtor(&g_engine_ctx->VFSArena, Core::VFS::VFSContext);
+        vfs_ctx->Initialize(&g_engine_ctx->VFSArena);
+        g_engine_ctx->VFS = vfs_ctx;
+
+        // Step 12 — AssetManager
+        Managers::AssetManager::Initialize(&arena, g_engine_ctx->Device, app->WorkingSpacePath);
+
+        // Step 22 — AppRenderPipeline (temporary position — must move after WorldTick::Commit, Sprint 3)
+        g_appRenderPipeline = ZPushStructCtor(&arena, Applications::AppRenderPipeline);
+        g_appRenderPipeline->Initialize(g_engine_ctx->Device);
 
         app->RenderPipeline = g_appRenderPipeline;
         app->CurrentWindow  = g_engine_ctx->Window;
@@ -66,6 +85,11 @@ namespace ZEngine
         g_engine_ctx->Device->Dispose();
 
         ZENGINE_CORE_INFO("Engine destroyed")
+    }
+
+    EngineContextPtr Engine::GetContext()
+    {
+        return g_engine_ctx;
     }
 
     bool Engine::OnEngineClosed(Event::EngineClosedEvent& event)

--- a/ZEngine/ZEngine/Engine.h
+++ b/ZEngine/ZEngine/Engine.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <ZEngine/Applications/GameApplication.h>
+#include <ZEngine/Core/Memory/MemoryManager.h>
+#include <ZEngine/Core/VFS/IVFSContext.h>
 #include <ZEngine/EngineConfiguration.h>
 #include <ZEngine/Event/EngineClosedEvent.h>
 #include <ZEngine/Hardwares/VulkanDevice.h>
@@ -9,21 +11,24 @@ namespace ZEngine
 {
     struct EngineContext
     {
-        Hardwares::VulkanDevicePtr Device = nullptr;
-        Windows::CoreWindowPtr     Window = nullptr;
+        Hardwares::VulkanDevicePtr   Device   = nullptr;
+        Windows::CoreWindowPtr       Window   = nullptr;
+        Core::Memory::ArenaAllocator VFSArena = {};
+        Core::VFS::IVFSContext*      VFS      = nullptr;
     };
     ZDEFINE_PTR(EngineContext);
 
     struct Engine
     {
-        static void Initialize(ZEngine::Core::Memory::ArenaAllocator* arena, Windows::WindowConfigurationPtr window_cfg_ptr, Applications::GameApplicationPtr app);
-        static void Run();
-        static void Deinitialize();
-        static void Dispose();
-        static bool OnEngineClosed(Event::EngineClosedEvent&);
+        static void             Initialize(Core::Memory::MemoryManager* memory, Windows::WindowConfigurationPtr window_cfg_ptr, Applications::GameApplicationPtr app);
+        static void             Run();
+        static void             Deinitialize();
+        static void             Dispose();
+        static bool             OnEngineClosed(Event::EngineClosedEvent&);
+        static EngineContextPtr GetContext();
 
-        static void MainThreadRun();
-        static void RenderThreadRun();
+        static void             MainThreadRun();
+        static void             RenderThreadRun();
 
     private:
         Engine()              = delete;

--- a/ZEngine/ZEngine/Helpers/ThreadPool.h
+++ b/ZEngine/ZEngine/Helpers/ThreadPool.h
@@ -90,7 +90,7 @@ namespace ZEngine::Helpers
             }
         }
 
-        static bool IsInitialized()
+        static bool              IsInitialized()
         {
             return Pool != nullptr;
         }

--- a/ZEngine/ZEngine/Helpers/ThreadPool.h
+++ b/ZEngine/ZEngine/Helpers/ThreadPool.h
@@ -90,7 +90,7 @@ namespace ZEngine::Helpers
             }
         }
 
-        static bool              IsInitialized()
+        static bool IsInitialized()
         {
             return Pool != nullptr;
         }

--- a/ZEngine/ZEngine/Helpers/ThreadPool.h
+++ b/ZEngine/ZEngine/Helpers/ThreadPool.h
@@ -90,6 +90,11 @@ namespace ZEngine::Helpers
             }
         }
 
+        static bool IsInitialized()
+        {
+            return Pool != nullptr;
+        }
+
         template <typename T>
         static void Submit(T&& f)
         {

--- a/ZEngine/ZEngine/Logging/Logger.cpp
+++ b/ZEngine/ZEngine/Logging/Logger.cpp
@@ -50,6 +50,11 @@ namespace ZEngine::Logging
         }
     }
 
+    bool Logger::IsInitialized()
+    {
+        return s_logger_collection.size() > 0;
+    }
+
     void Logger::Info(std::string msg)
     {
         for (auto& logger : s_logger_collection)

--- a/ZEngine/ZEngine/Logging/Logger.h
+++ b/ZEngine/ZEngine/Logging/Logger.h
@@ -28,6 +28,7 @@ namespace ZEngine::Logging
         using LogEventHandler = std::function<void(LogMessage)>;
 
         static void        Initialize(void* arena, const LoggerConfiguration&);
+        static bool        IsInitialized();
         static void        Flush();
         static void        Dispose();
         static uint32_t    AddEventHandler(LogEventHandler handler);


### PR DESCRIPTION
## Summary

- Moves `VFS` (and its arena) from `GameApplication` into `EngineContext`; access via `Engine::GetContext()->VFS`
- Changes `Engine::Initialize` to accept `MemoryManager*` instead of `ArenaAllocator*`
- Adds `Engine::GetContext()` static accessor; removes `GameApplication::GetVFSContext()`
- Adds Step 6 precondition asserts: `memory != nullptr`, `Logger::IsInitialized()`, `ThreadPoolHelper::IsInitialized()`
- Corrects init order: GameWindow (9) → VulkanDevice (10) → VFS (11) → AssetManager (12) → AppRenderPipeline (22)
- Stores VFS arena in `EngineContext::VFSArena` to keep lifetime correct (was a dangling local)
- Updates `Tetragrama/Editor.cpp` and `ProjectViewUIComponent.cpp` to use `Engine::GetContext()->VFS`

Depends on: #574

## Test plan

- [x] Editor boots and mounts VFS without crash
- [x] `Engine::GetContext()->VFS` is non-null after `Engine::Initialize`
- [x] Assert fires if `Engine::Initialize` is called without prior `Logger::Initialize`
- [x] Assert fires if `Engine::Initialize` is called without prior `ThreadPoolHelper::Initialize`