### PR TITLE
docs(rendering): add rendering architecture future-plan docs

### DIFF
--- a/ZEngine/docs/future-plan/compute-pipeline.md
+++ b/ZEngine/docs/future-plan/compute-pipeline.md
@@ -1,0 +1,960 @@
+# ZEngine — Compute Pipeline Support
+
+**Priority:** P2 — Required for SSAO, bloom threshold, GPU-driven culling, and any effect that
+benefits from general-purpose GPU compute.
+**Status:** Design
+**Depends on:** `render-graph-redesign.md`, `shader-asset-pipeline.md`
+**Blocks:** `post-processing.md` (SSAO, bloom), `next-year-plans/culling-system.md` (DrawCull)
+
+**Goal:** Add end-to-end compute pipeline support to ZEngine. This covers shader-stage
+recognition, pipeline creation, command recording, the render pass compute path, a thin
+builder and callback helper, and three concrete compute pass examples that exercise the
+full stack. Every change is grounded in the current state of the codebase; nothing is
+designed in the abstract.
+
+---
+
+## 1. ShaderType::COMPUTE — ShaderEnums.h
+
+`ShaderEnums.h` currently defines four shader types. `COMPUTE` is absent and
+`CompilationStage::GetEShLanguage` falls through to `EShLangGeometry` for any type it does
+not explicitly recognise, which means feeding a compute source file through the current
+pipeline silently produces broken SPIR-V.
+
+**Before:**
+
+```cpp
+// ZEngine/Rendering/Shaders/ShaderEnums.h
+enum class ShaderType
+{
+    VERTEX   = 0,
+    FRAGMENT = 1,
+    GEOMETRY = 2,
+    UNKNOWN  = 3
+};
+```
+
+```cpp
+// ZEngine/Rendering/Shaders/Compilers/CompilationStage.cpp
+EShLanguage CompilationStage::GetEShLanguage(const ShaderType type)
+{
+    if (type == ShaderType::VERTEX)
+        return EShLangVertex;
+    if (type == ShaderType::FRAGMENT)
+        return EShLangFragment;
+    return EShLangGeometry;   // COMPUTE falls here — incorrect
+}
+```
+
+**After:**
+
+```cpp
+// ZEngine/Rendering/Shaders/ShaderEnums.h
+enum class ShaderType
+{
+    VERTEX   = 0,
+    FRAGMENT = 1,
+    GEOMETRY = 2,
+    UNKNOWN  = 3,
+    COMPUTE  = 4
+};
+```
+
+```cpp
+// ZEngine/Rendering/Shaders/Compilers/CompilationStage.cpp
+EShLanguage CompilationStage::GetEShLanguage(const ShaderType type)
+{
+    if (type == ShaderType::VERTEX)
+        return EShLangVertex;
+    if (type == ShaderType::FRAGMENT)
+        return EShLangFragment;
+    if (type == ShaderType::COMPUTE)
+        return EShLangCompute;
+    return EShLangGeometry;
+}
+```
+
+No other changes are required in `CompilationStage`. The existing `SetShaderRules` call
+already passes `GetEShLanguage(information_list.Type)` to `shader.setEnvInput`, so compute
+shaders automatically get the correct GLSL environment once the function returns
+`EShLangCompute`. The Vulkan 1.3 / SPIR-V 1.6 target set in `SetShaderRules` is valid for
+compute shaders.
+
+The `shader-asset-pipeline.md` design defines a `ShaderStage::Compute` value and maps the
+`.comp` extension to it. The `COMPUTE = 4` value added here must align with that mapping when
+the asset pipeline is implemented: the import code should translate `ShaderStage::Compute` to
+`ShaderType::COMPUTE` before invoking `CompilationStage`.
+
+---
+
+## 2. ComputePipeline Struct — RendererPipeline.h
+
+`GraphicPipeline` lives in
+`ZEngine/Rendering/Renderers/Pipelines/RendererPipeline.h`. A parallel `ComputePipeline`
+struct is added to the same file and namespace.
+
+**Declaration (RendererPipeline.h):**
+
+```cpp
+struct ComputePipeline
+{
+public:
+    ComputePipeline() {}
+    ~ComputePipeline() {}
+
+    Shaders::Shader*         Shader = nullptr;
+    Hardwares::VulkanDevice* Device = nullptr;
+    VkPipeline               Handle = VK_NULL_HANDLE;
+    VkPipelineLayout         Layout = VK_NULL_HANDLE;
+
+    void Initialize(Hardwares::VulkanDevice* device, const char* shader_name);
+    void Bake();
+    void Dispose();
+};
+```
+
+**Implementation (RendererPipeline.cpp):**
+
+`Initialize` resolves the shader from the device shader cache, the same way
+`GraphicPipeline::Initialize` does. The layout is built from the shader's descriptor set
+layout — identical to the graphics path.
+
+```cpp
+void ComputePipeline::Initialize(Hardwares::VulkanDevice* device, const char* shader_name)
+{
+    Device = device;
+    Shader = device->ShaderCaches.Find(shader_name);
+    ZENGINE_VALIDATE_ASSERT(Shader != nullptr, "ComputePipeline: shader not found in cache");
+
+    // Build the pipeline layout from the shader's descriptor set layout.
+    // Same path as GraphicPipeline::Initialize — one descriptor set, optional push constants.
+    VkPipelineLayoutCreateInfo layout_info = {};
+    layout_info.sType                      = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    layout_info.setLayoutCount             = 1;
+    layout_info.pSetLayouts                = &Shader->DescriptorSetLayout;
+    layout_info.pushConstantRangeCount     = Shader->PushConstantRanges.size();
+    layout_info.pPushConstantRanges        = Shader->PushConstantRanges.data();
+
+    ZENGINE_VALIDATE_ASSERT(
+        vkCreatePipelineLayout(Device->LogicalDevice, &layout_info, nullptr, &Layout) == VK_SUCCESS,
+        "ComputePipeline: failed to create pipeline layout");
+}
+```
+
+`Bake` calls `vkCreateComputePipelines`. The shader stage is always
+`VK_SHADER_STAGE_COMPUTE_BIT`. No render pass handle, no vertex input state, no
+blend state — compute pipelines require none of those.
+
+```cpp
+void ComputePipeline::Bake()
+{
+    ZENGINE_VALIDATE_ASSERT(Shader   != nullptr,       "ComputePipeline::Bake: shader is null");
+    ZENGINE_VALIDATE_ASSERT(Layout   != VK_NULL_HANDLE, "ComputePipeline::Bake: layout is null");
+    ZENGINE_VALIDATE_ASSERT(Handle   == VK_NULL_HANDLE, "ComputePipeline::Bake: already baked");
+
+    VkPipelineShaderStageCreateInfo stage = {};
+    stage.sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stage.stage  = VK_SHADER_STAGE_COMPUTE_BIT;
+    stage.module = Shader->GetShaderModule();
+    stage.pName  = "main";
+
+    VkComputePipelineCreateInfo create_info = {};
+    create_info.sType  = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;
+    create_info.stage  = stage;
+    create_info.layout = Layout;
+
+    ZENGINE_VALIDATE_ASSERT(
+        vkCreateComputePipelines(
+            Device->LogicalDevice,
+            VK_NULL_HANDLE,   // no pipeline cache in this path; add later if profiling shows benefit
+            1, &create_info,
+            nullptr,
+            &Handle) == VK_SUCCESS,
+        "ComputePipeline::Bake: vkCreateComputePipelines failed");
+}
+```
+
+`Dispose` mirrors `GraphicPipeline::Dispose`:
+
+```cpp
+void ComputePipeline::Dispose()
+{
+    if (Handle != VK_NULL_HANDLE)
+    {
+        vkDestroyPipeline(Device->LogicalDevice, Handle, nullptr);
+        Handle = VK_NULL_HANDLE;
+    }
+    if (Layout != VK_NULL_HANDLE)
+    {
+        vkDestroyPipelineLayout(Device->LogicalDevice, Layout, nullptr);
+        Layout = VK_NULL_HANDLE;
+    }
+}
+```
+
+---
+
+## 3. CommandBuffer::Dispatch — VulkanDevice.h
+
+`CommandBuffer` in `VulkanDevice.h` exposes `DrawIndirect`, `BeginRenderPass`,
+`EndRenderPass`, `BindPipeline`, `BindDescriptorSets`, `PushConstants`, and
+`TransitionImageLayout`, but no dispatch command. Compute passes cannot call `vkCmdDispatch`
+directly on a raw `VkCommandBuffer` handle — doing so bypasses the state tracking used by the
+rest of the command buffer API.
+
+Add the declaration to the `CommandBuffer` struct in `VulkanDevice.h`:
+
+```cpp
+void Dispatch(uint32_t x, uint32_t y, uint32_t z);
+```
+
+The implementation in `VulkanDevice.cpp`:
+
+```cpp
+void CommandBuffer::Dispatch(uint32_t x, uint32_t y, uint32_t z)
+{
+    vkCmdDispatch(m_command_buffer, x, y, z);
+}
+```
+
+No state validation is needed beyond what the Vulkan validation layer catches. The caller is
+responsible for having bound a compute pipeline before calling `Dispatch`. Parallel to how
+`DrawIndirect` requires a bound graphics pipeline, this contract is enforced at the validation
+layer level, not in the wrapper.
+
+---
+
+## 4. RenderPass Compute Path — RenderPass.h / RenderPass.cpp
+
+`RenderPass` currently has a single `Pipelines::GraphicPipeline* Pipeline` field.
+`Initialize` and `Bake` always construct a `GraphicPipeline`, and a `COMPUTE` pass type
+would crash in `vkCreateRenderPass` because a compute pipeline has no attachment or
+framebuffer.
+
+**RenderPass.h change:** Add a `ComputePipeline` field alongside the existing `Pipeline`
+field. Exactly one is non-null at runtime, depending on pass type.
+
+```cpp
+struct RenderPass
+{
+    // ... existing fields unchanged ...
+    Pipelines::GraphicPipeline*  Pipeline        = {nullptr};
+    Pipelines::ComputePipeline*  ComputePipeline = {nullptr};  // new
+
+    void Initialize(Hardwares::VulkanDevice* device,
+                    const Specifications::RenderPassSpecification& specification);
+    void Bake();
+    // ... rest unchanged ...
+};
+```
+
+**RenderPass::Initialize change:**
+
+```cpp
+void RenderPass::Initialize(Hardwares::VulkanDevice* device,
+                             const Specifications::RenderPassSpecification& spec)
+{
+    m_device      = device;
+    Specification = spec;
+
+    if (spec.Type == RenderPassType::COMPUTE)
+    {
+        // No VkRenderPass object. No attachment. No framebuffer.
+        ComputePipeline = ZPushStructCtorArgs(device->Arena, Pipelines::ComputePipeline);
+        ComputePipeline->Initialize(
+            device,
+            spec.PipelineSpecification.ShaderSpecificationValue.Name);
+        return;
+    }
+
+    if (spec.Type != RenderPassType::GRAPHIC)
+        return;
+
+    // Existing graphics path — unchanged below this line.
+    Pipeline = ZPushStructCtorArgs(device->Arena, Pipelines::GraphicPipeline);
+    Pipeline->Initialize(device, Specifications::GraphicRendererPipelineSpecification{spec.PipelineSpecification});
+    // ... attachment creation, VkRenderPass creation, etc. ...
+}
+```
+
+**RenderPass::Bake change:**
+
+```cpp
+void RenderPass::Bake()
+{
+    if (Specification.Type == RenderPassType::COMPUTE)
+    {
+        ComputePipeline->Bake();
+        return;
+    }
+    if (Specification.Type != RenderPassType::GRAPHIC)
+        return;
+
+    Pipeline->Bake();
+}
+```
+
+**Framebuffer contract:** `ComputePipeline` passes leave `Framebuffer` null in the owning
+`RGPass`. Pass `Execute` implementations that receive a null framebuffer must not call
+`BeginRenderPass`. This is enforced by the pattern shown in section 6 below.
+
+---
+
+## 5. ComputePassBuilder
+
+`RenderPassBuilder` in `RenderPass.h` provides a fluent API for configuring graphics passes.
+Its members include vertex input bindings, attribute descriptions, blend state, depth test
+flags, and attachment lists — none of which are applicable to compute. A separate builder
+eliminates the possibility of a compute pass accidentally configuring vertex input state or
+enabling depth write.
+
+`ComputePassBuilder` is added to `RenderPass.h` in the same namespace as
+`RenderPassBuilder`:
+
+```cpp
+struct ComputePassBuilder
+{
+    Core::Memory::ArenaAllocator* Arena = nullptr;
+
+    void Initialize(Core::Memory::ArenaAllocator* arena);
+
+    ComputePassBuilder& UseShader(const char* name);
+    ComputePassBuilder& SetPushConstantRange(
+        uint32_t size,
+        VkShaderStageFlags stage = VK_SHADER_STAGE_COMPUTE_BIT);
+
+    // Returns the completed spec with Type = RenderPassType::COMPUTE.
+    // No pipeline state flags, no attachment list, no render area defaults.
+    Specifications::RenderPassSpecification Detach();
+
+private:
+    Specifications::RenderPassSpecification m_spec{};
+};
+```
+
+Implementation:
+
+```cpp
+void ComputePassBuilder::Initialize(Core::Memory::ArenaAllocator* arena)
+{
+    Arena  = arena;
+    m_spec = {};
+    m_spec.Type = Specifications::RenderPassType::COMPUTE;
+}
+
+ComputePassBuilder& ComputePassBuilder::UseShader(const char* name)
+{
+    m_spec.PipelineSpecification.ShaderSpecificationValue.Name = name;
+    return *this;
+}
+
+ComputePassBuilder& ComputePassBuilder::SetPushConstantRange(
+    uint32_t size, VkShaderStageFlags stage)
+{
+    m_spec.PipelineSpecification.PushConstantSize  = size;
+    m_spec.PipelineSpecification.PushConstantStage = stage;
+    return *this;
+}
+
+Specifications::RenderPassSpecification ComputePassBuilder::Detach()
+{
+    return std::move(m_spec);
+}
+```
+
+A pass's `Compile` call is reduced to:
+
+```cpp
+ComputePassBuilder builder;
+builder.Initialize(arena);
+auto spec = builder
+    .UseShader("ssao_compute")
+    .SetPushConstantRange(sizeof(SSAOPushConstants))
+    .Detach();
+```
+
+---
+
+## 6. IComputeCallbackPass
+
+`IRenderGraphCallbackPass` has three methods: `Setup`, `Compile`, and `Execute`. A concrete
+pass must implement all three. For compute passes the `Compile` step is always the same:
+construct a `COMPUTE` `RenderPassSpecification` via `ComputePassBuilder`, create a
+`RenderPass`, and write it to the output pointer. The `Execute` step always starts with a
+`vkCmdBindPipeline(VK_PIPELINE_BIND_POINT_COMPUTE)` before the pass-specific dispatch.
+Repeating this boilerplate in every compute pass implementation introduces a class of bug
+where a pass forgets to bind the pipeline or binds it with the wrong bind point.
+
+`IComputeCallbackPass` is a convenience base class that handles `Compile` and the pipeline
+bind inside `Execute`, leaving only `SetupCompute` and `ExecuteCompute` for subclasses.
+
+```cpp
+// ZEngine/Rendering/Renderers/RenderPasses/IComputeCallbackPass.h
+#pragma once
+#include <ZEngine/Rendering/Renderers/RenderPasses/RenderPass.h>
+#include <ZEngine/Rendering/RenderGraph/IRenderGraphCallbackPass.h>
+
+namespace ZEngine::Rendering::Renderers::RenderPasses
+{
+    struct IComputeCallbackPass : public IRenderGraphCallbackPass
+    {
+        // Setup() delegates to SetupCompute() so the subclass sees only
+        // RGBuilder — it never needs to touch RGInspector during setup.
+        void Setup(
+            Hardwares::VulkanDevicePtr device,
+            cstring                    name,
+            RGBuilder*                 builder,
+            RGInspector*               inspector) final;
+
+        // Compile() builds the COMPUTE RenderPass. Subclasses do not override this.
+        void Compile(
+            Hardwares::VulkanDevicePtr  device,
+            Scenes::SceneDataPtr        scene,
+            RenderPassBuilder*          /*unused*/,
+            RGInspector*                inspector,
+            RenderPass**                output) final;
+
+        // Execute() binds the compute pipeline then delegates to ExecuteCompute().
+        void Execute(
+            Hardwares::VulkanDevicePtr  device,
+            RGInspector*                inspector,
+            Scenes::SceneDataPtr        scene,
+            RenderPass*                 pass,
+            Buffers::FramebufferVNext*  framebuffer,   // always null for compute
+            Hardwares::CommandBufferPtr cb) final;
+
+        // Subclass interface.
+        virtual void SetupCompute(Hardwares::VulkanDevicePtr, RGBuilder*) = 0;
+        virtual void ExecuteCompute(
+            Hardwares::VulkanDevicePtr  device,
+            RGInspector*                inspector,
+            Scenes::SceneDataPtr        scene,
+            VkPipeline                  pipeline,
+            VkPipelineLayout            layout,
+            Hardwares::CommandBufferPtr cb) = 0;
+
+        // Subclass provides the shader name; Compile() uses it.
+        virtual const char* GetShaderName() const = 0;
+
+        // Optional: subclass overrides to supply push constant size.
+        // Default: 0 (no push constants).
+        virtual uint32_t GetPushConstantSize() const { return 0; }
+
+    private:
+        Core::Memory::ArenaAllocator* m_arena = nullptr;
+    };
+}
+```
+
+**IComputeCallbackPass::Compile implementation:**
+
+```cpp
+void IComputeCallbackPass::Compile(
+    Hardwares::VulkanDevicePtr  device,
+    Scenes::SceneDataPtr        /*scene*/,
+    RenderPassBuilder*          /*unused*/,
+    RGInspector*                /*inspector*/,
+    RenderPass**                output)
+{
+    ComputePassBuilder builder;
+    builder.Initialize(device->Arena);
+    builder.UseShader(GetShaderName());
+    if (GetPushConstantSize() > 0)
+        builder.SetPushConstantRange(GetPushConstantSize());
+
+    auto spec = builder.Detach();
+    auto* pass = ZPushStructCtorArgs(device->Arena, RenderPass);
+    pass->Initialize(device, spec);
+    pass->Bake();
+    *output = pass;
+}
+```
+
+**IComputeCallbackPass::Execute implementation:**
+
+```cpp
+void IComputeCallbackPass::Execute(
+    Hardwares::VulkanDevicePtr  device,
+    RGInspector*                inspector,
+    Scenes::SceneDataPtr        scene,
+    RenderPass*                 pass,
+    Buffers::FramebufferVNext*  /*framebuffer — always null*/,
+    Hardwares::CommandBufferPtr cb)
+{
+    VkCommandBuffer cmd = cb->GetHandle();
+
+    vkCmdBindPipeline(
+        cmd,
+        VK_PIPELINE_BIND_POINT_COMPUTE,
+        pass->ComputePipeline->Handle);
+
+    ExecuteCompute(device, inspector, scene,
+                   pass->ComputePipeline->Handle,
+                   pass->ComputePipeline->Layout,
+                   cb);
+}
+```
+
+The subclass receives `VkPipeline` and `VkPipelineLayout` directly so it can bind descriptor
+sets and push constants without digging into `RenderPass` internals.
+
+---
+
+## 7. Concrete Compute Pass Examples
+
+### 7a. SSAOComputePass
+
+Reads the depth render target and a world-space normals render target as shader inputs.
+Writes to a half-resolution R8 occlusion render target. The output is consumed by the
+lighting pass.
+
+Resource declarations use `RGAccess::ShaderRead` for inputs and `RGAccess::ShaderReadWrite`
+for the output, which maps to `VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT` and
+`VK_IMAGE_LAYOUT_GENERAL` in the access table defined in `render-graph-redesign.md`,
+section 6.2.
+
+```cpp
+struct SSAOComputePass final : public IComputeCallbackPass
+{
+    RGResourceHandle m_depth_handle     = {};
+    RGResourceHandle m_normals_handle   = {};
+    RGResourceHandle m_occlusion_handle = {};
+    uint32_t         m_width            = 0;
+    uint32_t         m_height           = 0;
+
+    const char* GetShaderName()      const override { return "ssao_compute"; }
+    uint32_t    GetPushConstantSize() const override { return sizeof(SSAOPushConstants); }
+
+    void SetupCompute(Hardwares::VulkanDevicePtr device, RGBuilder* builder) override
+    {
+        // Read depth and normals produced by earlier passes.
+        m_depth_handle   = builder->ReadTexture("FrameDepthRT",   "depth_input");
+        m_normals_handle = builder->ReadTexture("GBufferNormals", "normals_input");
+
+        // Half-resolution R8 occlusion map — transient, aliasable after last consumer.
+        Specifications::TextureSpecification occl_spec = {};
+        occl_spec.Format = Specifications::ImageFormat::R8_UNORM;
+        occl_spec.Width  = device->Swapchain->Width  / 2;
+        occl_spec.Height = device->Swapchain->Height / 2;
+        m_width          = occl_spec.Width;
+        m_height         = occl_spec.Height;
+
+        m_occlusion_handle = builder->WriteColorAttachment("SSAOOcclusion", occl_spec);
+    }
+
+    void ExecuteCompute(
+        Hardwares::VulkanDevicePtr  device,
+        RGInspector*                inspector,
+        Scenes::SceneDataPtr        /*scene*/,
+        VkPipeline                  /*pipeline — already bound by IComputeCallbackPass*/,
+        VkPipelineLayout            layout,
+        Hardwares::CommandBufferPtr cb) override
+    {
+        VkCommandBuffer cmd = cb->GetHandle();
+
+        SSAOPushConstants push = {};
+        push.DepthTextureIndex   = inspector->GetTextureBindlessIndex(m_depth_handle);
+        push.NormalsTextureIndex = inspector->GetTextureBindlessIndex(m_normals_handle);
+        push.OutputImageIndex    = inspector->GetTextureBindlessIndex(m_occlusion_handle);
+        push.Width               = m_width;
+        push.Height              = m_height;
+
+        vkCmdPushConstants(cmd, layout, VK_SHADER_STAGE_COMPUTE_BIT,
+                           0, sizeof(push), &push);
+
+        uint32_t gx = (m_width  + 7) / 8;
+        uint32_t gy = (m_height + 7) / 8;
+        cb->Dispatch(gx, gy, 1);
+    }
+};
+```
+
+GLSL compute shader (`ssao_compute.comp`):
+
+```glsl
+#version 460
+#extension GL_EXT_nonuniform_qualifier : require
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+layout(push_constant) uniform PushConstants {
+    uint DepthTextureIndex;
+    uint NormalsTextureIndex;
+    uint OutputImageIndex;
+    uint Width;
+    uint Height;
+} pc;
+
+layout(set = 0, binding = 0) uniform sampler2D Textures[];
+layout(set = 0, binding = 1, r8) uniform writeonly image2D StorageImages[];
+
+void main()
+{
+    ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+    if (coord.x >= int(pc.Width) || coord.y >= int(pc.Height))
+        return;
+
+    vec2 uv = (vec2(coord) + 0.5) / vec2(pc.Width, pc.Height);
+
+    float depth   = texture(Textures[pc.DepthTextureIndex],   uv).r;
+    vec3  normal  = texture(Textures[pc.NormalsTextureIndex], uv).xyz * 2.0 - 1.0;
+
+    // SSAO kernel sampling omitted for brevity; result clamped to [0, 1].
+    float occlusion = 1.0;
+
+    imageStore(StorageImages[nonuniformEXT(pc.OutputImageIndex)],
+               coord, vec4(occlusion, 0.0, 0.0, 0.0));
+}
+```
+
+### 7b. BloomThresholdComputePass
+
+Reads the full-resolution HDR color render target. Writes to a bloom threshold render target
+of the same dimensions. Only pixels whose luminance exceeds the threshold value are written
+as non-zero. This pass is the first stage of the bloom chain described in
+`post-processing.md`.
+
+```cpp
+struct BloomThresholdComputePass final : public IComputeCallbackPass
+{
+    RGResourceHandle m_hdr_handle       = {};
+    RGResourceHandle m_threshold_handle = {};
+    uint32_t         m_width            = 0;
+    uint32_t         m_height           = 0;
+
+    const char* GetShaderName()      const override { return "bloom_threshold_compute"; }
+    uint32_t    GetPushConstantSize() const override { return sizeof(BloomThresholdPushConstants); }
+
+    void SetupCompute(Hardwares::VulkanDevicePtr device, RGBuilder* builder) override
+    {
+        m_hdr_handle = builder->ReadTexture("FrameColorRT", "hdr_input");
+
+        Specifications::TextureSpecification spec = {};
+        spec.Format = Specifications::ImageFormat::R16G16B16A16_SFLOAT;
+        spec.Width  = device->Swapchain->Width;
+        spec.Height = device->Swapchain->Height;
+        m_width     = spec.Width;
+        m_height    = spec.Height;
+
+        m_threshold_handle = builder->WriteColorAttachment("BloomThreshold", spec);
+    }
+
+    void ExecuteCompute(
+        Hardwares::VulkanDevicePtr  /*device*/,
+        RGInspector*                inspector,
+        Scenes::SceneDataPtr        /*scene*/,
+        VkPipeline                  /*pipeline*/,
+        VkPipelineLayout            layout,
+        Hardwares::CommandBufferPtr cb) override
+    {
+        VkCommandBuffer cmd = cb->GetHandle();
+
+        BloomThresholdPushConstants push = {};
+        push.HdrTextureIndex    = inspector->GetTextureBindlessIndex(m_hdr_handle);
+        push.OutputImageIndex   = inspector->GetTextureBindlessIndex(m_threshold_handle);
+        push.Threshold          = 1.0f;   // luminance threshold; could be a UBO field
+        push.Width              = m_width;
+        push.Height             = m_height;
+
+        vkCmdPushConstants(cmd, layout, VK_SHADER_STAGE_COMPUTE_BIT,
+                           0, sizeof(push), &push);
+
+        uint32_t gx = (m_width  + 7) / 8;
+        uint32_t gy = (m_height + 7) / 8;
+        cb->Dispatch(gx, gy, 1);
+    }
+};
+```
+
+GLSL compute shader (`bloom_threshold_compute.comp`):
+
+```glsl
+#version 460
+#extension GL_EXT_nonuniform_qualifier : require
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+layout(push_constant) uniform PushConstants {
+    uint  HdrTextureIndex;
+    uint  OutputImageIndex;
+    float Threshold;
+    uint  Width;
+    uint  Height;
+} pc;
+
+layout(set = 0, binding = 0) uniform sampler2D Textures[];
+layout(set = 0, binding = 1, rgba16f) uniform writeonly image2D StorageImages[];
+
+void main()
+{
+    ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+    if (coord.x >= int(pc.Width) || coord.y >= int(pc.Height))
+        return;
+
+    vec2 uv    = (vec2(coord) + 0.5) / vec2(pc.Width, pc.Height);
+    vec3 color = texture(Textures[pc.HdrTextureIndex], uv).rgb;
+    float lum  = dot(color, vec3(0.2126, 0.7152, 0.0722));
+    vec3  out_color = lum > pc.Threshold ? color : vec3(0.0);
+
+    imageStore(StorageImages[nonuniformEXT(pc.OutputImageIndex)],
+               coord, vec4(out_color, 1.0));
+}
+```
+
+### 7c. DrawCullPass
+
+GPU-driven visibility culling. Reads a per-draw-call scene bounds buffer (a storage buffer
+containing `AABB` structs for each draw call). Writes a filtered `VkDrawIndirectCommand`
+buffer that the base pass consumes via `DrawIndirect`. Only draw calls whose bounding boxes
+pass the frustum test are written with a non-zero instance count.
+
+This pass is the compute component of the GPU-driven rendering path described in
+`next-year-plans/culling-system.md`.
+
+```cpp
+struct DrawCullPass final : public IComputeCallbackPass
+{
+    RGResourceHandle m_scene_bounds_handle   = {};
+    RGResourceHandle m_indirect_buffer_handle = {};
+    uint32_t         m_draw_count            = 0;
+
+    const char* GetShaderName()      const override { return "draw_cull_compute"; }
+    uint32_t    GetPushConstantSize() const override { return sizeof(DrawCullPushConstants); }
+
+    void SetupCompute(Hardwares::VulkanDevicePtr /*device*/, RGBuilder* builder) override
+    {
+        // Read-only: per-object AABB data uploaded once per frame by UploadPass.
+        m_scene_bounds_handle = builder->AttachBuffer(
+            "SceneBoundsBuffer",
+            inspector->GetStorageBufferSetHandle("SceneBoundsBuffer"));
+
+        // Read-write: indirect draw buffer. The cull shader writes draw commands;
+        // the base pass reads them via vkCmdDrawIndirect.
+        // RGAccess::ShaderReadWrite maps to VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT
+        // in the kAccessTable in render-graph-redesign.md section 6.2.
+        m_indirect_buffer_handle = builder->AttachBuffer(
+            "IndirectDrawBuffer",
+            inspector->GetIndirectBufferSetHandle("IndirectDrawBuffer"));
+    }
+
+    void ExecuteCompute(
+        Hardwares::VulkanDevicePtr  /*device*/,
+        RGInspector*                inspector,
+        Scenes::SceneDataPtr        scene,
+        VkPipeline                  /*pipeline*/,
+        VkPipelineLayout            layout,
+        Hardwares::CommandBufferPtr cb) override
+    {
+        VkCommandBuffer cmd = cb->GetHandle();
+
+        m_draw_count = scene->DrawList.size();
+
+        DrawCullPushConstants push = {};
+        push.DrawCount            = m_draw_count;
+        push.FrustumPlanes[0]     = scene->Camera.FrustumPlane(0);
+        push.FrustumPlanes[1]     = scene->Camera.FrustumPlane(1);
+        push.FrustumPlanes[2]     = scene->Camera.FrustumPlane(2);
+        push.FrustumPlanes[3]     = scene->Camera.FrustumPlane(3);
+        push.FrustumPlanes[4]     = scene->Camera.FrustumPlane(4);
+        push.FrustumPlanes[5]     = scene->Camera.FrustumPlane(5);
+
+        vkCmdPushConstants(cmd, layout, VK_SHADER_STAGE_COMPUTE_BIT,
+                           0, sizeof(push), &push);
+
+        uint32_t gx = (m_draw_count + 63) / 64;
+        cb->Dispatch(gx, 1, 1);
+    }
+};
+```
+
+GLSL compute shader (`draw_cull_compute.comp`):
+
+```glsl
+#version 460
+
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+
+struct AABB {
+    vec3 Min;
+    float _pad0;
+    vec3 Max;
+    float _pad1;
+};
+
+struct VkDrawIndirectCommand {
+    uint vertexCount;
+    uint instanceCount;
+    uint firstVertex;
+    uint firstInstance;
+};
+
+layout(push_constant) uniform PushConstants {
+    uint  DrawCount;
+    vec4  FrustumPlanes[6];
+} pc;
+
+layout(set = 0, binding = 2) readonly buffer SceneBoundsBuffer {
+    AABB Bounds[];
+};
+
+layout(set = 0, binding = 3) buffer IndirectDrawBuffer {
+    VkDrawIndirectCommand Commands[];
+};
+
+bool FrustumTest(AABB box)
+{
+    for (int i = 0; i < 6; ++i)
+    {
+        vec3 n = pc.FrustumPlanes[i].xyz;
+        float d = pc.FrustumPlanes[i].w;
+        vec3 p = mix(box.Min, box.Max, greaterThanEqual(n, vec3(0.0)));
+        if (dot(n, p) + d < 0.0)
+            return false;
+    }
+    return true;
+}
+
+void main()
+{
+    uint idx = gl_GlobalInvocationID.x;
+    if (idx >= pc.DrawCount)
+        return;
+
+    bool visible = FrustumTest(Bounds[idx]);
+    Commands[idx].instanceCount = visible ? 1u : 0u;
+}
+```
+
+---
+
+## 8. Render Graph Integration
+
+The barrier system in `render-graph-redesign.md` already handles compute barriers. The
+`kAccessTable` entry for `RGAccess::ShaderReadWrite` maps to
+`VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT` with `VK_ACCESS_SHADER_READ_BIT |
+VK_ACCESS_SHADER_WRITE_BIT` and `VK_IMAGE_LAYOUT_GENERAL`. A compute pass that writes a
+storage image automatically receives the correct pre-pass barrier, and a graphics pass that
+subsequently reads that image as a texture receives the correct
+`COMPUTE_SHADER -> FRAGMENT_SHADER` barrier with the layout transition from
+`VK_IMAGE_LAYOUT_GENERAL` to `VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL`.
+
+No special registration path is needed. Compute passes call `AddCallbackPass` identically to
+graphics passes:
+
+```cpp
+// GraphicRenderer::RegisterPasses — excerpt showing SSAO compute pass insertion
+void GraphicRenderer::RegisterPasses()
+{
+    RenderGraph->AddCallbackPass("Upload Pass",      upload_pass);
+    RenderGraph->AddCallbackPass("Depth Pre-Pass",   scene_depth_prepass);
+    RenderGraph->AddCallbackPass("Base Pass",        base_pass);
+    RenderGraph->AddCallbackPass("Skybox Pass",      skybox_pass);
+    RenderGraph->AddCallbackPass("Grid Pass",        grid_pass);
+
+    // Compute passes register identically. The graph detects the pass type
+    // from RenderPassSpecification::Type = COMPUTE after Compile() runs.
+    RenderGraph->AddCallbackPass("SSAO Compute",           ssao_compute_pass);
+    RenderGraph->AddCallbackPass("Bloom Threshold Compute", bloom_threshold_pass);
+    RenderGraph->AddCallbackPass("Draw Cull Compute",       draw_cull_pass);
+}
+```
+
+The topology sort in `render-graph-redesign.md` section 8 operates on resource
+producer/consumer declarations regardless of pass type. `DrawCullPass` writes
+`IndirectDrawBuffer`; `BasePass` reads it. The sort places `DrawCullPass` before `BasePass`
+automatically.
+
+---
+
+## 9. Framebuffer Skip in RenderGraph::Compile
+
+`render-graph-redesign.md` section 10.1 describes the framebuffer skip guard. It is
+reproduced here for completeness and to clarify the implementation obligation for
+`RenderGraph::Compile`.
+
+After pipeline creation and before the framebuffer creation loop, insert:
+
+```cpp
+for (auto& pass : Passes)
+{
+    if (!pass.Handle)
+        continue;
+
+    // Compute passes have no VkRenderPass object and no framebuffer.
+    // pass.Framebuffer remains null. Execute() passes it as-is to Callback->Execute.
+    if (pass.Handle->Specification.Type == RenderPassType::COMPUTE)
+        continue;
+
+    Specifications::FrameBufferSpecificationVNext fb_spec = {
+        .Width         = pass.Handle->RenderAreaWidth,
+        .Height        = pass.Handle->RenderAreaHeight,
+        .RenderTargets = pass.Handle->RenderTargets,
+        .Attachment    = pass.Handle->Attachment,
+    };
+    pass.Framebuffer = ZPushStructCtorArgs(
+        Device->Arena, Buffers::FramebufferVNext, Device, fb_spec);
+}
+```
+
+`pass.Framebuffer` is null for every `COMPUTE` pass after `Compile()`. The `Execute` loop
+in section 6.4 of `render-graph-redesign.md` passes it directly to `Callback->Execute`; the
+`IComputeCallbackPass::Execute` override receives a null framebuffer and is defined not to
+call `BeginRenderPass`. Any compute pass that attempts to call `BeginRenderPass` with a null
+framebuffer will produce a validation error and an assertion failure in `BeginRenderPass`.
+
+The `Resize` path also skips framebuffer rebuild for compute passes. The same guard applies
+in `RenderGraph::Resize` where it iterates `OutputsResized(pass)`:
+
+```cpp
+for (auto& pass : Passes)
+{
+    if (pass.Handle && pass.Handle->Specification.Type == RenderPassType::COMPUTE)
+        continue;
+    if (OutputsResized(pass))
+        RebuildFramebuffer(pass, width, height);
+}
+```
+
+---
+
+## 10. File Layout and Deliverables Checklist
+
+Every item below is a discrete deliverable. Items marked as files to create are new; all
+others are modifications to existing files.
+
+### Source changes
+
+- [ ] `ZEngine/Rendering/Shaders/ShaderEnums.h` — add `COMPUTE = 4` to `ShaderType`
+- [ ] `ZEngine/Rendering/Shaders/Compilers/CompilationStage.cpp` — add `EShLangCompute` branch to `GetEShLanguage`
+- [ ] `ZEngine/Rendering/Renderers/Pipelines/RendererPipeline.h` — add `ComputePipeline` struct declaration
+- [ ] `ZEngine/Rendering/Renderers/Pipelines/RendererPipeline.cpp` — add `ComputePipeline::Initialize`, `ComputePipeline::Bake`, `ComputePipeline::Dispose` implementations
+- [ ] `ZEngine/Hardwares/VulkanDevice.h` — add `void Dispatch(uint32_t x, uint32_t y, uint32_t z)` declaration to `CommandBuffer`
+- [ ] `ZEngine/Hardwares/VulkanDevice.cpp` — add `CommandBuffer::Dispatch` implementation calling `vkCmdDispatch`
+- [ ] `ZEngine/Rendering/Renderers/RenderPasses/RenderPass.h` — add `ComputePipeline* ComputePipeline = nullptr` field; add `ComputePassBuilder` struct
+- [ ] `ZEngine/Rendering/Renderers/RenderPasses/RenderPass.cpp` — update `RenderPass::Initialize` and `RenderPass::Bake` with COMPUTE branch; add `ComputePassBuilder` method implementations
+- [ ] `ZEngine/Rendering/Renderers/RenderPasses/IComputeCallbackPass.h` — create new file; declare `IComputeCallbackPass`
+- [ ] `ZEngine/Rendering/Renderers/RenderPasses/IComputeCallbackPass.cpp` — create new file; implement `Compile` and `Execute` overrides
+- [ ] `ZEngine/Rendering/RenderGraph/RenderGraph.cpp` — add COMPUTE skip guard in the framebuffer creation loop and the resize loop
+- [ ] `ZEngine/Rendering/Renderers/GraphicRenderer.cpp` — add SSAO, bloom threshold, and draw cull pass instances to `RegisterPasses`
+
+### Compute pass implementations
+
+- [ ] `ZEngine/Rendering/Renderers/PostProcessing/SSAOComputePass.h` — create; declare `SSAOComputePass`
+- [ ] `ZEngine/Rendering/Renderers/PostProcessing/SSAOComputePass.cpp` — create; implement `SetupCompute` and `ExecuteCompute`
+- [ ] `ZEngine/Rendering/Renderers/PostProcessing/BloomThresholdComputePass.h` — create; declare `BloomThresholdComputePass`
+- [ ] `ZEngine/Rendering/Renderers/PostProcessing/BloomThresholdComputePass.cpp` — create; implement `SetupCompute` and `ExecuteCompute`
+- [ ] `ZEngine/Rendering/Renderers/Culling/DrawCullPass.h` — create; declare `DrawCullPass`
+- [ ] `ZEngine/Rendering/Renderers/Culling/DrawCullPass.cpp` — create; implement `SetupCompute` and `ExecuteCompute`
+
+### Shader assets
+
+- [ ] `Assets/Shaders/ssao_compute.comp` — create; GLSL source from section 7a
+- [ ] `Assets/Shaders/bloom_threshold_compute.comp` — create; GLSL source from section 7b
+- [ ] `Assets/Shaders/draw_cull_compute.comp` — create; GLSL source from section 7c
+
+### Tests
+
+- [ ] `Tests/Rendering/Shaders/ComputeShaderCompilationTest.cpp` — verify that a `.comp` source with `ShaderType::COMPUTE` produces non-empty `BinarySource` and passes `ValidationStage` without error
+- [ ] `Tests/Rendering/Pipelines/ComputePipelineBakeTest.cpp` — call `ComputePipeline::Initialize` + `ComputePipeline::Bake` against a real `VulkanDevice` instance; assert `Handle != VK_NULL_HANDLE` and no validation layer errors
+- [ ] `Tests/Rendering/CommandBuffer/DispatchTest.cpp` — record `CommandBuffer::Dispatch(4, 4, 1)` in a one-time command buffer; verify via mock or validation layer that `vkCmdDispatch(4, 4, 1)` was emitted
+- [ ] `Tests/Rendering/RenderGraph/SSAOComputePassIntegrationTest.cpp` — run one full frame with `SSAOComputePass` registered; assert zero Vulkan validation layer errors; assert `SSAOOcclusion` texture transitions from `UNDEFINED` to `VK_IMAGE_LAYOUT_GENERAL` before dispatch and from `GENERAL` to `VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL` before the first consumer pass reads it

--- a/ZEngine/docs/future-plan/draw-call-sorting.md
+++ b/ZEngine/docs/future-plan/draw-call-sorting.md
@@ -1,0 +1,927 @@
+# Draw Call Sorting — Packed 64-Bit Sort Key and Per-Frame DrawCommandBuffer
+
+**Priority:** P1 — Required for correct transparency ordering and GPU-driver-friendly pipeline batching  
+**Status:** Design  
+**Relates to:** `rendering-flow.md`, `render-graph-redesign.md`, `per-frame-upload-heap.md`  
+**Depends on:** Nothing in flight; can be implemented against the current `RenderScene` and `SceneData` structs  
+**Blocks:** Correct alpha-blended rendering; multi-pipeline batching; future GPU-driven culling
+
+**Goal:** Replace the unsorted, unordered-map-iteration-order indirect draw submission with a
+deterministic, camera-aware sort that groups opaque draws front-to-back (minimizing GPU overdraw
+and early-Z waste), sorts transparent draws back-to-front (producing correct alpha compositing),
+and batches draws by pipeline and material to reduce PSO and descriptor set rebinds. All CPU sort
+work runs on the render thread inside `AppRenderPipeline::RenderScene`, uses arena-allocated
+scratch, and writes a single sorted `VkDrawIndirectCommand` array to the existing
+`IndirectBufferHandle` before the passes execute.
+
+---
+
+## 1. Current State
+
+`AppRenderPipeline::RenderScene` iterates `scene->NodeSubMeshesAllocations` — an
+`UnorderedHashMap<uint32_t, SubMeshAllocation>` — and fills `DrawIndirectCommands` in whatever
+order the hash map returns entries. The resulting `VkDrawIndirectCommand` array contains:
+
+```cpp
+DrawIndirectCommands.push({
+    .vertexCount   = SubMeshAllocations[i].IndexCount,
+    .instanceCount = SubMeshAllocations[i].InstanceCount,
+    .firstVertex   = 0,
+    .firstInstance = i,   // used by the vertex shader as the DrawData index
+});
+```
+
+`firstInstance = i` encodes the draw's index into the GPU-side `RenderDataBufferHandle` storage
+buffer. The vertex shader reads `gl_InstanceIndex` to retrieve the matching `DrawData` record.
+Because `i` follows unordered-map iteration order, the draw-to-data mapping is correct but the
+draw submission order is arbitrary. Three concrete consequences:
+
+- Transparent objects are submitted in arbitrary order. The depth buffer cannot resolve the
+  compositing order, so overdraw produces visually incorrect results for any alpha-blended mesh.
+- Opaque draws are submitted with no depth ordering. The GPU rasterizes far fragments first as
+  often as it rasterizes near fragments first, performing redundant shading work that an early-Z
+  depth pre-pass is meant to avoid.
+- Draws with the same pipeline shader are interleaved with draws using different shaders.
+  Each pipeline switch is a full GPU pipeline state object (PSO) rebind — one of the most
+  expensive per-draw operations on all desktop Vulkan drivers.
+
+`DepthPrePass::Execute` and `GbufferPass::Execute` both call:
+
+```cpp
+command_buffer->DrawIndirect(*indirect_buffer->At(device->SwapchainPtr->CurrentFrame->Index));
+```
+
+The `CommandBuffer::DrawIndirect` implementation forwards to `vkCmdDrawIndirect` with `offset = 0`
+and `buffer.CommandCount` covering the entire buffer. There is no way to issue a partial range or
+two separate ranges from the same buffer without a new API surface on `CommandBuffer`.
+
+The disabled `#if 0` block in `GraphicScene.h` contains `struct DrawData`, which is the correct
+per-draw record shape. It is not yet used in the live path. This design activates a version of it.
+
+---
+
+## 2. Sort Key Structure
+
+Every draw is assigned a 64-bit integer sort key before sorting. All key bits are packed such
+that a single unsigned ascending comparison produces the correct submission order for a given
+bucket. The bit layout from most significant to least significant:
+
+```
+ 63        62 61     59 58        49 48          37 36           13 12          0
+ +-----------+----------+-----------+-------------+----------------+-------------+
+ | Translucency | Pass  | Pipeline  |  Material   |     Depth      |   Scratch   |
+ |   bucket   | layer  |    ID     |     ID      |   (24 bits)    |  (13 bits)  |
+ |  (2 bits)  | (3 bits)| (10 bits)| (12 bits)   |                |             |
+ +-----------+----------+-----------+-------------+----------------+-------------+
+```
+
+Field definitions:
+
+- **Translucency bucket** (bits 63-62, 2 bits): `0` = fully opaque, `1` = alpha-tested,
+  `2` = alpha-blended transparent. Opaque draws come first in ascending key order; transparent
+  draws come last. Alpha-tested sits between the two because it writes to depth normally but
+  may discard fragments; it must precede transparent draws.
+
+- **Pass layer** (bits 61-59, 3 bits): `0` = depth pre-pass, `1` = geometry (G-buffer),
+  `2` = forward, `3` = post. Only one indirect buffer is emitted per pass; this field is used
+  when a single sort buffer is shared across multiple passes. In the current two-pass model
+  (DepthPrePass + GbufferPass) both reads come from the same sorted buffer, so this field is
+  set to `0` for all draws and is reserved for the multi-pass path described in
+  `render-graph-redesign.md`.
+
+- **Pipeline/shader ID** (bits 58-49, 10 bits): a stable integer identifying the PSO variant.
+  Grouping by pipeline ID before material ID ensures that all draws using the same shader are
+  contiguous, eliminating PSO rebinds within a bucket. 1024 distinct pipelines is sufficient
+  for the foreseeable pass set; `render-graph-redesign.md` §4 assigns integer pipeline handles
+  from the same integer pool.
+
+- **Material ID** (bits 48-37, 12 bits): `SubMeshAllocation::MaterialId` truncated to 12 bits.
+  Within the same pipeline, draws sharing a material are contiguous, reducing descriptor set
+  updates. 4096 material slots matches the current `MaterialBufferHandle` capacity.
+
+- **Depth** (bits 36-13, 24 bits): a linearised, quantised view-space depth. Encoding depends
+  on translucency bucket; see section 6.
+
+- **Sub-sort scratch** (bits 12-0, 13 bits): reserved for secondary sorting criteria added
+  later (shadow caster flag, LOD level, instance group). Set to `0` by `Build`.
+
+The named constants and packing function:
+
+```cpp
+// ZEngine/Rendering/Scenes/DrawCommandBuffer.h
+
+namespace ZEngine::Rendering::Scenes
+{
+    namespace SortKey
+    {
+        static constexpr uint64_t kTranslucencyShift = 62u;
+        static constexpr uint64_t kPassLayerShift    = 59u;
+        static constexpr uint64_t kPipelineIdShift   = 49u;
+        static constexpr uint64_t kMaterialIdShift   = 37u;
+        static constexpr uint64_t kDepthShift        = 13u;
+
+        static constexpr uint64_t kTranslucencyMask  = 0x3ULL   << kTranslucencyShift;
+        static constexpr uint64_t kPassLayerMask     = 0x7ULL   << kPassLayerShift;
+        static constexpr uint64_t kPipelineIdMask    = 0x3FFULL << kPipelineIdShift;
+        static constexpr uint64_t kMaterialIdMask    = 0xFFFULL << kMaterialIdShift;
+        static constexpr uint64_t kDepthMask         = 0xFFFFFFULL << kDepthShift;
+        static constexpr uint64_t kScratchMask       = 0x1FFFULL;
+
+        inline uint64_t Pack(
+            uint32_t translucency,   // 0–2
+            uint32_t pass_layer,     // 0–7
+            uint32_t pipeline_id,    // 0–1023
+            uint32_t material_id,    // 0–4095
+            uint32_t depth_key,      // 0–0xFFFFFF
+            uint32_t scratch = 0)    // 0–8191
+        {
+            return (static_cast<uint64_t>(translucency & 0x3)    << kTranslucencyShift)
+                 | (static_cast<uint64_t>(pass_layer   & 0x7)    << kPassLayerShift)
+                 | (static_cast<uint64_t>(pipeline_id  & 0x3FF)  << kPipelineIdShift)
+                 | (static_cast<uint64_t>(material_id  & 0xFFF)  << kMaterialIdShift)
+                 | (static_cast<uint64_t>(depth_key    & 0xFFFFFF) << kDepthShift)
+                 | (static_cast<uint64_t>(scratch      & 0x1FFF));
+        }
+    } // namespace SortKey
+} // namespace ZEngine::Rendering::Scenes
+```
+
+---
+
+## 3. DrawCommand Struct
+
+`DrawCommand` is the CPU-side record that travels through build, sort, and flush. It is never
+written to the GPU directly; `Flush` extracts the two GPU-facing sub-structs from it.
+
+```cpp
+// ZEngine/Rendering/Scenes/DrawCommandBuffer.h
+
+#include <vulkan/vulkan_core.h>
+#include <ZEngine/Rendering/Scenes/GraphicScene.h>  // DrawData (from the #if 0 block, now live)
+
+namespace ZEngine::Rendering::Scenes
+{
+    struct DrawCommand
+    {
+        uint64_t            SortKey;    // packed 64-bit key from SortKey::Pack
+        VkDrawIndirectCommand GpuCmd;   // written verbatim to IndirectBufferHandle
+        DrawData            Data;       // written verbatim to RenderDataBufferHandle
+    };
+} // namespace ZEngine::Rendering::Scenes
+```
+
+`DrawData` is lifted out of the `#if 0` block in `GraphicScene.h` verbatim:
+
+```cpp
+struct DrawData
+{
+    uint32_t TransformIndex;  // index into GlobalTransforms[] / TransformBufferHandle
+    uint32_t MaterialIndex;   // index into Materials[]       / MaterialBufferHandle
+    uint32_t VertexOffset;    // byte-offset start into VertexBufferHandle
+    uint32_t IndexOffset;     // element-offset start into IndexBufferHandle
+    uint32_t VertexCount;     // not consumed by indirect draw; available for compute
+    uint32_t IndexCount;      // = VkDrawIndirectCommand::vertexCount (index draw emulation)
+};
+```
+
+`GpuCmd` mirrors the fields the GPU consumes:
+
+```cpp
+GpuCmd.vertexCount   = alloc.IndexCount;     // index draw encoded as vertex count
+GpuCmd.instanceCount = alloc.InstanceCount;  // always 1 for static meshes
+GpuCmd.firstVertex   = 0;
+GpuCmd.firstInstance = <slot in sorted output array>; // set during Flush, not Build
+```
+
+`firstInstance` is the index of this draw's `DrawData` record in the sorted
+`RenderDataBufferHandle` array. It cannot be set during `Build` because the sorted position is
+unknown until after `Sort`. `Flush` assigns it as it writes out the sorted records.
+
+---
+
+## 4. Sorting Algorithm
+
+`std::sort` applied to `Array<DrawCommand>` would move the full `DrawCommand` struct (48 bytes
+with typical alignment) during each comparison swap. At 10 000 draw calls that is up to
+10 000 × log2(10 000) ≈ 130 000 struct moves, each touching three cache lines. The sort key
+is 8 bytes; the comparison is on 8 bytes; but the move cost is 48 bytes. The comparison-to-move
+ratio is 1:6, making `std::sort` cache-hostile for large draw counts.
+
+The correct algorithm is a stable, in-place LSD (least-significant-digit) radix sort on the
+64-bit key. The sort operates on indices into the `DrawCommand` array rather than on the structs
+themselves, then applies the index permutation in a single pass at the end.
+
+The 64-bit key is processed as two 32-bit halves in LSD order — lower word (bits 0-31) first,
+upper word (bits 32-63) second. Each 32-bit half is sorted using four rounds of 8-bit counting
+sort (256 histogram buckets per round, four rounds × 8 bits = 32 bits per logical pass). The
+total work is eight counting rounds, one pass through the index array per round. Memory cost is
+one 256-entry `uint32_t` histogram (1 KB) and one output-index array of `N × 4` bytes, both
+allocated from the per-frame scratch arena and released after `Flush` completes.
+
+The choice of 8-bit digits (256 buckets) keeps the histogram within a single L1 cache line
+group on all current desktop hardware. 16-bit digits (65 536 buckets) fit in L2 but exceed L1
+on most configurations and produce slower sorts below approximately 100 000 elements.
+
+```cpp
+// ZEngine/Rendering/Scenes/DrawCommandBuffer.cpp (internal, not part of the public interface)
+
+// Sorts indices[0..count) by the 64-bit keys[i] in ascending order.
+// output_indices is a scratch buffer of count uint32_t elements.
+static void RadixSort64(
+    Core::Memory::ArenaAllocator* scratch_arena,
+    const uint64_t*               keys,
+    uint32_t*                     indices,
+    uint32_t                      count)
+{
+    if (count == 0) { return; }
+
+    uint32_t* temp = static_cast<uint32_t*>(
+        scratch_arena->Allocate(count * sizeof(uint32_t), alignof(uint32_t)));
+
+    // Initialise identity permutation.
+    for (uint32_t i = 0; i < count; ++i) { indices[i] = i; }
+
+    uint32_t hist[256] = {};
+
+    // Eight passes: bytes 0-3 (lower word), then bytes 4-7 (upper word).
+    for (uint32_t pass = 0; pass < 8; ++pass)
+    {
+        const uint32_t shift = pass * 8u;
+
+        // Build histogram.
+        for (uint32_t i = 0; i < count; ++i)
+        {
+            uint8_t digit = static_cast<uint8_t>((keys[indices[i]] >> shift) & 0xFF);
+            ++hist[digit];
+        }
+
+        // Prefix sum.
+        uint32_t running = 0;
+        for (uint32_t b = 0; b < 256; ++b)
+        {
+            uint32_t cnt = hist[b];
+            hist[b]      = running;
+            running     += cnt;
+        }
+
+        // Scatter into temp.
+        for (uint32_t i = 0; i < count; ++i)
+        {
+            uint8_t  digit    = static_cast<uint8_t>((keys[indices[i]] >> shift) & 0xFF);
+            temp[hist[digit]] = indices[i];
+            ++hist[digit];
+        }
+
+        // Swap indices and temp for the next pass.
+        for (uint32_t i = 0; i < count; ++i) { indices[i] = temp[i]; }
+
+        for (uint32_t b = 0; b < 256; ++b) { hist[b] = 0; }
+    }
+}
+```
+
+`Sort()` on `DrawCommandBuffer` calls `RadixSort64` twice — once for the opaque bucket, once
+for the transparent bucket — using scratch from `LocalArena` via `ZGetScratch`. The sort runs
+entirely on the render thread after `Build()` and before `Flush()`. No GPU work depends on
+`indices` or `keys`; those are freed when `ZReleaseScratch` is called after `Flush`.
+
+---
+
+## 5. Opaque vs Transparent Split
+
+`Build` partitions draw commands into two flat arrays before sorting:
+
+- `Array<DrawCommand> Opaque` — draws where `MeshMaterial::Factors.x` (transparency) equals
+  `1.0f` and `MeshMaterial::Factors.z` (AlphaTest) equals `0.0f`. These are submitted with
+  depth write enabled and depth test `LESS`. They must appear before transparent draws so the
+  depth buffer is fully populated by the time transparent draws execute.
+
+- `Array<DrawCommand> Transparent` — draws where `MeshMaterial::Factors.x < 1.0f` OR
+  `MeshMaterial::Factors.z > 0.0f`. Alpha-tested draws (`Factors.z > 0`) go here with
+  translucency bucket value `1`; fully blended draws go here with translucency bucket value `2`.
+
+After sorting, `Flush` writes the opaque bucket first into the GPU indirect buffer, immediately
+followed by the transparent bucket. The byte boundary between the two is:
+
+```
+OpaqueByteOffset      = 0
+TransparentByteOffset = OpaqueCount * sizeof(VkDrawIndirectCommand)
+```
+
+Each pass issues two `vkCmdDrawIndirect` calls against the same `VkBuffer`, specifying explicit
+offsets and counts. `CommandBuffer` needs one additional entry point to expose this:
+
+```cpp
+// ZEngine/ZEngine/Hardwares/VulkanDevice.h — new overload on CommandBuffer
+void DrawIndirectRange(
+    const Hardwares::IndirectBuffer& buffer,
+    uint32_t                         first_command,
+    uint32_t                         command_count);
+```
+
+Implementation:
+
+```cpp
+// VulkanDevice.cpp
+void CommandBuffer::DrawIndirectRange(
+    const Hardwares::IndirectBuffer& buffer,
+    uint32_t                         first_command,
+    uint32_t                         command_count)
+{
+    if (command_count == 0) { return; }
+    vkCmdDrawIndirect(
+        m_command_buffer,
+        reinterpret_cast<VkBuffer>(buffer.GetNativeBufferHandle()),
+        static_cast<VkDeviceSize>(first_command) * sizeof(VkDrawIndirectCommand),
+        command_count,
+        sizeof(VkDrawIndirectCommand));
+}
+```
+
+`DepthPrePass::Execute` issues only the opaque range. `GbufferPass::Execute` issues both
+ranges in order. See section 9 for the updated `Execute` bodies.
+
+---
+
+## 6. Depth Value Encoding
+
+View-space depth is computed by transforming the mesh's world-space origin through the camera
+view matrix. The world-space origin is the translation column of `GlobalTransforms[TransformId]`.
+
+```cpp
+// Inside DrawCommandBuffer::Build, per SubMeshAllocation entry
+
+const Core::Maths::Mat4f& world = scene->GlobalTransforms[alloc.TransformId];
+// Column 3 of the world transform is the world-space translation.
+// Mat4f is column-major; index [3] is the 4th column.
+Core::Maths::Vec4f world_origin = Core::Maths::Vec4f(world[3][0], world[3][1], world[3][2], 1.0f);
+
+const Core::Maths::Mat4f& view = camera->GetView();
+Core::Maths::Vec4f view_pos    = view * world_origin;
+
+// Vulkan right-hand view space: camera looks along -Z.
+// Objects in front of the camera have negative view_pos.z.
+// Negate to produce a positive linear depth in [0, far_plane].
+float linear_depth = -view_pos.z;
+float far_plane    = camera->Settings.FarPlane;  // default 10000.0f in CameraSetting
+
+// Clamp to [0, 1] before quantising.
+float norm_depth   = linear_depth / far_plane;
+norm_depth         = norm_depth < 0.0f ? 0.0f : (norm_depth > 1.0f ? 1.0f : norm_depth);
+uint32_t depth_q   = static_cast<uint32_t>(norm_depth * 0xFFFFFFu);
+```
+
+For **opaque** draws (`translucency = 0` or `1`):
+
+```cpp
+uint32_t depth_key = depth_q;
+// Small depth_key = close to camera = drawn first in ascending key sort.
+// Opaque geometry is submitted front-to-back: near fragments write depth early,
+// occluded fragments are culled by early-Z before the fragment shader runs.
+```
+
+For **transparent** draws (`translucency = 2`):
+
+```cpp
+uint32_t depth_key = (~depth_q) & 0xFFFFFFu;
+// Bitwise NOT: far objects (large depth_q) become small depth_key.
+// Ascending key sort submits far transparent draws first, near draws last.
+// This is the correct painter's algorithm order for back-to-front blending.
+```
+
+Both buckets are sorted by ascending 64-bit key. The NOT encoding means the identical sort
+path handles both buckets without a comparator change.
+
+---
+
+## 7. DrawCommandBuffer Struct
+
+`DrawCommandBuffer` is a per-frame-in-flight struct. Three instances live on `AppRenderPipeline`,
+one per swapchain frame slot (matching `SwapchainPtr->BufferredFrameCount = 3`). Each is
+initialised once from `AppRenderPipeline::Initialize` and cleared at the start of each dirty
+rebuild; they are never destroyed until the pipeline shuts down.
+
+```cpp
+// ZEngine/Rendering/Scenes/DrawCommandBuffer.h
+
+#pragma once
+#include <ZEngine/Core/Containers/Array.h>
+#include <ZEngine/Core/Memory/ArenaAllocator.h>
+#include <ZEngine/Hardwares/VulkanDevice.h>
+#include <ZEngine/Rendering/Cameras/Camera.h>
+#include <ZEngine/Rendering/Scenes/GraphicScene.h>
+
+namespace ZEngine::Rendering::Scenes
+{
+    struct DrawCommandBuffer
+    {
+        Core::Containers::Array<DrawCommand> Opaque;
+        Core::Containers::Array<DrawCommand> Transparent;
+        uint32_t                             OpaqueCount      = 0;
+        uint32_t                             TransparentCount = 0;
+
+        // Persistent arena owns the Opaque and Transparent arrays.
+        // Must be sub-arenaed from AppRenderPipeline::LocalArena at init time.
+        Core::Memory::ArenaAllocator*        Arena = nullptr;
+
+        // Called once from AppRenderPipeline::Initialize.
+        void Init(Core::Memory::ArenaAllocator* parent_arena, uint32_t capacity_hint);
+
+        // Clears both buckets (does not free arena memory), then walks scene->NodeSubMeshesAllocations
+        // to fill Opaque and Transparent with one DrawCommand per SubMeshAllocation.
+        // Computes view-space depth from scene->GlobalTransforms and camera->GetView().
+        // Sets SortKey and Data; leaves GpuCmd.firstInstance = 0 (assigned by Flush).
+        // Only callable when DrawCommandsDirty[fi] is true; see section 8.
+        void Build(
+            const Rendering::Scenes::RenderScenePtr& scene,
+            const Rendering::Cameras::CameraPtr&     camera,
+            uint32_t                                 pipeline_id);
+
+        // Runs RadixSort64 on both buckets using scratch from Arena.
+        void Sort(Core::Memory::ArenaAllocator* scratch_arena);
+
+        // Writes sorted VkDrawIndirectCommand and DrawData arrays to the GPU buffers.
+        // Assigns GpuCmd.firstInstance = position in sorted output order.
+        // Opaque records written first, transparent records immediately after.
+        void Flush(
+            uint8_t                             frame_index,
+            uint8_t                             thread_index,
+            Hardwares::IndirectBuffer*          indirect_buf,
+            Hardwares::StorageBuffer*           render_data_buf);
+    };
+} // namespace ZEngine::Rendering::Scenes
+```
+
+`Build` implementation sketch:
+
+```cpp
+void DrawCommandBuffer::Build(
+    const Rendering::Scenes::RenderScenePtr& scene,
+    const Rendering::Cameras::CameraPtr&     camera,
+    uint32_t                                 pipeline_id)
+{
+    OpaqueCount      = 0;
+    TransparentCount = 0;
+    Opaque.clear();
+    Transparent.clear();
+
+    const Core::Maths::Mat4f& view      = camera->GetView();
+    const float               far_plane = camera->Settings.FarPlane;
+
+    for (const auto& [node_id, alloc] : scene->NodeSubMeshesAllocations)
+    {
+        // Retrieve the material to determine translucency bucket.
+        // MaterialId indexes into the asset manager's GPUMeshMaterials array.
+        // For the sort key we only need the bucket; material_id is used for batching.
+        uint32_t material_id  = alloc.MaterialId & 0xFFF;
+        uint32_t transform_id = alloc.TransformId;
+
+        // Compute view-space depth from world-space origin.
+        const Core::Maths::Mat4f& world = scene->GlobalTransforms[transform_id];
+        Core::Maths::Vec4f world_origin(world[3][0], world[3][1], world[3][2], 1.0f);
+        Core::Maths::Vec4f view_pos = view * world_origin;
+
+        float norm = (-view_pos.z) / far_plane;
+        norm       = norm < 0.0f ? 0.0f : (norm > 1.0f ? 1.0f : norm);
+        uint32_t depth_q = static_cast<uint32_t>(norm * 0xFFFFFFu);
+
+        // Determine translucency. Without a live material lookup here, the bucket
+        // is deduced from SubMeshAllocation flags. A future pass-through from the
+        // asset manager's GPUMeshMaterials should feed Factors.x and Factors.z.
+        // For now, treat all draws as opaque (translucency = 0).
+        // The full implementation requires reading MeshMaterial::Factors per draw.
+        uint32_t translucency = 0; // replaced with material lookup in full impl
+        uint32_t depth_key    = (translucency == 2)
+                                    ? ((~depth_q) & 0xFFFFFFu)
+                                    : depth_q;
+
+        DrawCommand cmd = {};
+        cmd.SortKey = SortKey::Pack(translucency, 0, pipeline_id, material_id, depth_key);
+
+        cmd.Data.TransformIndex = transform_id;
+        cmd.Data.MaterialIndex  = alloc.MaterialId;
+        cmd.Data.VertexOffset   = alloc.VertexOffset;
+        cmd.Data.IndexOffset    = alloc.IndexOffset;
+        cmd.Data.VertexCount    = alloc.VertexCount;
+        cmd.Data.IndexCount     = alloc.IndexCount;
+
+        cmd.GpuCmd.vertexCount   = alloc.IndexCount;
+        cmd.GpuCmd.instanceCount = alloc.InstanceCount;
+        cmd.GpuCmd.firstVertex   = 0;
+        cmd.GpuCmd.firstInstance = 0; // assigned by Flush
+
+        if (translucency == 0 || translucency == 1)
+        {
+            Opaque.push(cmd);
+            ++OpaqueCount;
+        }
+        else
+        {
+            Transparent.push(cmd);
+            ++TransparentCount;
+        }
+    }
+}
+```
+
+`Flush` implementation sketch:
+
+```cpp
+void DrawCommandBuffer::Flush(
+    uint8_t                    frame_index,
+    uint8_t                    thread_index,
+    Hardwares::IndirectBuffer* indirect_buf,
+    Hardwares::StorageBuffer*  render_data_buf)
+{
+    auto scratch    = ZGetScratch(Arena);
+
+    uint32_t total  = OpaqueCount + TransparentCount;
+    auto* gpu_cmds  = static_cast<VkDrawIndirectCommand*>(
+        scratch.Arena->Allocate(total * sizeof(VkDrawIndirectCommand),
+                                alignof(VkDrawIndirectCommand)));
+    auto* draw_data = static_cast<DrawData*>(
+        scratch.Arena->Allocate(total * sizeof(DrawData), alignof(DrawData)));
+
+    uint32_t slot = 0;
+
+    // Opaque draws occupy slots [0, OpaqueCount).
+    for (uint32_t i = 0; i < OpaqueCount; ++i, ++slot)
+    {
+        DrawCommand& cmd          = Opaque[i];
+        cmd.GpuCmd.firstInstance  = slot;
+        gpu_cmds[slot]            = cmd.GpuCmd;
+        draw_data[slot]           = cmd.Data;
+    }
+
+    // Transparent draws occupy slots [OpaqueCount, OpaqueCount + TransparentCount).
+    for (uint32_t i = 0; i < TransparentCount; ++i, ++slot)
+    {
+        DrawCommand& cmd          = Transparent[i];
+        cmd.GpuCmd.firstInstance  = slot;
+        gpu_cmds[slot]            = cmd.GpuCmd;
+        draw_data[slot]           = cmd.Data;
+    }
+
+    indirect_buf->Write(
+        frame_index, thread_index,
+        Core::Containers::ArrayView<VkDrawIndirectCommand>{gpu_cmds, total});
+
+    render_data_buf->Write(
+        frame_index, thread_index,
+        gpu_cmds,     // re-used pointer; actual write is draw_data below
+        0);           // placeholder; real call below
+
+    // Correct call:
+    render_data_buf->Write(frame_index, thread_index, draw_data, total * sizeof(DrawData));
+
+    ZReleaseScratch(scratch);
+}
+```
+
+---
+
+## 8. Dirty Flag Integration
+
+The existing dirty flags in `RenderScene` are:
+
+```cpp
+std::atomic_bool MeshAllocationDirty[3]  = {false, false, false};
+std::atomic_bool TransformBufferDirty[3] = {false, false, false};
+```
+
+Both trigger geometry and transform uploads. Neither captures the case where the camera has
+moved but the scene geometry is static. Camera movement changes view-space depth for every
+draw, invalidating all sort keys without changing any mesh or transform data.
+
+Add a third flag to `RenderScene`:
+
+```cpp
+// GraphicScene.h — inside struct RenderScene
+std::atomic_bool DrawCommandsDirty[3] = {false, false, false};
+```
+
+`DrawCommandsDirty[fi]` is set to `true` by any caller that changes data affecting sort order:
+
+1. **Mesh allocation change**: wherever `MeshAllocationDirty[fi]` is set to `true`, also set
+   `DrawCommandsDirty[fi]` to `true`. The two flags track different work (geometry upload vs
+   sort rebuild) and may diverge in future; they are set independently, not aliased.
+
+2. **Transform change**: wherever `TransformBufferDirty[fi]` is set to `true`, also set
+   `DrawCommandsDirty[fi]` to `true`. Object movement changes view-space depth.
+
+3. **Camera movement**: `AppRenderPipeline` stores one `Mat4f PreviousView[3]` array. At the
+   start of `RenderScene`, before the dirty check:
+
+```cpp
+// AppRenderPipeline.cpp — inside RenderScene, before the existing if-block
+const Core::Maths::Mat4f& current_view = camera->GetView();
+if (current_view != PreviousView[frame_index])
+{
+    scene->DrawCommandsDirty[frame_index].store(true, std::memory_order_release);
+    PreviousView[frame_index] = current_view;
+}
+```
+
+`DrawCommandBuffer::Build` is called only when `DrawCommandsDirty[fi]` is true. When neither
+the scene nor the camera has changed for a given frame slot, the sorted buffers from the
+previous cycle for that slot are still valid and can be submitted without a rebuild. This
+matches the existing `MeshAllocationDirty` / `TransformBufferDirty` pattern in
+`AppRenderPipeline::RenderScene` and described in `rendering-flow.md` §2 step [4].
+
+The rebuild sequence in `AppRenderPipeline::RenderScene` after the existing dirty uploads:
+
+```cpp
+if (scene->DrawCommandsDirty[frame_index].exchange(false, std::memory_order_acq_rel))
+{
+    auto& dcb = DrawCmdBuffers[frame_index];
+
+    // pipeline_id 0 is a placeholder until pipeline handle integers are assigned
+    // per render-graph-redesign.md §4.
+    dcb.Build(scene, camera, /*pipeline_id=*/0);
+    dcb.Sort(/*scratch_arena=*/&LocalArena);
+    dcb.Flush(
+        frame_index,
+        RenderMainThreadIndex,
+        indirect_buffer,
+        rd_buffer);
+}
+```
+
+`DrawCmdBuffers` is a member of `AppRenderPipeline`:
+
+```cpp
+// AppRenderPipeline.h
+Rendering::Scenes::DrawCommandBuffer DrawCmdBuffers[3] = {};
+```
+
+Each `DrawCommandBuffer` is initialised in `AppRenderPipeline::Initialize`:
+
+```cpp
+for (int i = 0; i < Device->SwapchainPtr->BufferredFrameCount; ++i)
+{
+    DrawCmdBuffers[i].Init(&LocalArena, /*capacity_hint=*/1024);
+}
+```
+
+---
+
+## 9. Integration with DepthPrePass and GbufferPass
+
+Both passes need the per-frame `DrawCommandBuffer` to know the opaque and transparent counts
+at `Execute` time. The counts are stored as `OpaqueCount` and `TransparentCount` on the struct,
+which is accessible through `AppRenderPipeline`. Since `Execute` receives `SceneDataPtr`, the
+cleanest path is to store the per-frame counts in `SceneData` alongside the buffer handles.
+
+Add two arrays to `SceneData`:
+
+```cpp
+// GraphicScene.h — inside struct SceneData
+uint32_t OpaqueDrawCount[3]      = {0, 0, 0};
+uint32_t TransparentDrawCount[3] = {0, 0, 0};
+```
+
+`Flush` writes these after it writes the GPU buffers:
+
+```cpp
+scene_data->OpaqueDrawCount[frame_index]      = OpaqueCount;
+scene_data->TransparentDrawCount[frame_index] = TransparentCount;
+```
+
+Updated `DepthPrePass::Execute`:
+
+```cpp
+void DepthPrePass::Execute(
+    Hardwares::VulkanDevicePtr const         device,
+    RenderGraphResourceInspectorPtr          res_inspector,
+    Rendering::Scenes::SceneDataPtr const    scene,
+    RenderPasses::RenderPass* const          pass,
+    Buffers::FramebufferVNext* const         framebuffer,
+    Hardwares::CommandBufferPtr const        command_buffer)
+{
+    if (!scene || !scene->IndirectBufferHandle) { return; }
+
+    const uint32_t fi             = device->SwapchainPtr->CurrentFrame->Index;
+    const uint32_t opaque_count   = scene->OpaqueDrawCount[fi];
+    if (opaque_count == 0) { return; }
+
+    auto indirect_buffer = device->IndirectBufferSetManager.Access(scene->IndirectBufferHandle);
+    auto* buf            = indirect_buffer->At(fi);
+
+    command_buffer->BeginRenderPass(pass, framebuffer->Handle, false);
+    {
+        uint32_t w = pass->GetRenderAreaWidth();
+        uint32_t h = pass->GetRenderAreaHeight();
+        command_buffer->SetViewport(w, h);
+        command_buffer->SetScissor(w, h);
+    }
+    command_buffer->BindPipeline(Specifications::PipelineBindPoint::GRAPHIC, pass->Pipeline);
+    command_buffer->BindDescriptorSets(fi);
+
+    // Opaque range only. DepthPrePass does not submit transparent draws.
+    command_buffer->DrawIndirectRange(*buf, /*first_command=*/0, opaque_count);
+
+    command_buffer->EndRenderPass();
+}
+```
+
+Updated `GbufferPass::Execute`:
+
+```cpp
+void GbufferPass::Execute(
+    Hardwares::VulkanDevicePtr const         device,
+    RenderGraphResourceInspectorPtr          res_inspector,
+    Rendering::Scenes::SceneDataPtr const    scene,
+    RenderPasses::RenderPass* const          pass,
+    Buffers::FramebufferVNext* const         framebuffer,
+    Hardwares::CommandBufferPtr const        command_buffer)
+{
+    CHECK_AND_ESCAPE_NULL(scene)
+    CHECK_AND_ESCAPE_NULL(scene->IndirectBufferHandle)
+
+    const uint32_t fi               = device->SwapchainPtr->CurrentFrame->Index;
+    const uint32_t opaque_count     = scene->OpaqueDrawCount[fi];
+    const uint32_t transparent_count = scene->TransparentDrawCount[fi];
+    if (opaque_count == 0 && transparent_count == 0) { return; }
+
+    auto indirect_buffer = device->IndirectBufferSetManager.Access(scene->IndirectBufferHandle);
+    auto* buf            = indirect_buffer->At(fi);
+
+    command_buffer->BeginRenderPass(pass, framebuffer->Handle, false);
+    {
+        uint32_t w = pass->GetRenderAreaWidth();
+        uint32_t h = pass->GetRenderAreaHeight();
+        command_buffer->SetViewport(w, h);
+        command_buffer->SetScissor(w, h);
+    }
+    command_buffer->BindPipeline(Specifications::PipelineBindPoint::GRAPHIC, pass->Pipeline);
+    command_buffer->BindDescriptorSets(fi);
+
+    // Opaque range: slots [0, opaque_count). Sorted front-to-back.
+    if (opaque_count > 0)
+    {
+        command_buffer->DrawIndirectRange(*buf, 0, opaque_count);
+    }
+
+    // Transparent range: slots [opaque_count, opaque_count + transparent_count).
+    // Sorted back-to-front. The GBuffer pipeline must have depth write disabled and
+    // blending enabled for this range; a pipeline variant switch precedes this call
+    // once per-draw pipeline state is supported (render-graph-redesign.md §7).
+    if (transparent_count > 0)
+    {
+        command_buffer->DrawIndirectRange(*buf, opaque_count, transparent_count);
+    }
+
+    command_buffer->EndRenderPass();
+}
+```
+
+---
+
+## 10. GPU-Side DrawData Layout
+
+`RenderDataBufferHandle` holds a flat array of `DrawData` records in sorted submission order.
+The array is indexed by `gl_InstanceIndex`, which Vulkan sets equal to `VkDrawIndirectCommand::firstInstance`
+for each draw. After `Flush`, slot `i` in the GPU array corresponds to the `i`-th sorted draw
+command.
+
+GLSL storage buffer definition (shared between `depth_prepass_scene` and `g_buffer` shaders):
+
+```glsl
+// shaders/include/draw_data.glsl
+
+struct DrawData {
+    uint TransformIndex;
+    uint MaterialIndex;
+    uint VertexOffset;
+    uint IndexOffset;
+    uint VertexCount;
+    uint IndexCount;
+};
+
+layout(set = 0, binding = 2, std430) readonly buffer DrawDataSB {
+    DrawData draws[];
+} draw_data_buf;
+```
+
+The binding number matches the existing `DrawDataSB` name used in `DepthPrePass::Compile` and
+`GbufferPass::Compile` via `(*output_pass)->SetInput("DrawDataSB", scene->RenderDataBufferHandle)`.
+The struct layout must be `std430` with no padding between fields; six consecutive `uint` fields
+with no vec3/vec4 alignment issues satisfy this constraint.
+
+Vertex shader usage:
+
+```glsl
+// shaders/depth_prepass_scene.vert (illustrative excerpt)
+
+layout(set = 0, binding = 0) uniform UBCamera {
+    mat4 View;
+    mat4 Projection;
+    vec3 CameraPosition;
+} ub_camera;
+
+layout(set = 0, binding = 1, std430) readonly buffer VertexSB {
+    float data[];
+} vertex_buf;
+
+layout(set = 0, binding = 2, std430) readonly buffer DrawDataSB {
+    DrawData draws[];
+} draw_data_buf;
+
+layout(set = 0, binding = 3, std430) readonly buffer TransformSB {
+    mat4 transforms[];
+} transform_buf;
+
+void main()
+{
+    DrawData draw      = draw_data_buf.draws[gl_InstanceIndex];
+    mat4     model     = transform_buf.transforms[draw.TransformIndex];
+
+    // Vertices are stored as interleaved floats; stride depends on vertex format.
+    // VertexOffset is a float-element offset into vertex_buf.data[].
+    uint   base        = draw.VertexOffset + gl_VertexIndex * VERTEX_STRIDE_FLOATS;
+    vec3   position    = vec3(vertex_buf.data[base],
+                              vertex_buf.data[base + 1],
+                              vertex_buf.data[base + 2]);
+
+    gl_Position = ub_camera.Projection * ub_camera.View * model * vec4(position, 1.0);
+}
+```
+
+The G-buffer vertex shader additionally reads `draw.MaterialIndex` to fetch the per-draw
+material from `MatSB` (bound as `scene->MaterialBufferHandle`):
+
+```glsl
+// shaders/g_buffer.vert (additional line after DrawData fetch)
+uint material_idx = draw_data_buf.draws[gl_InstanceIndex].MaterialIndex;
+// passed as flat varying to fragment shader:
+// flat out uint v_MaterialIndex;
+// v_MaterialIndex = material_idx;
+```
+
+---
+
+## 11. File Layout and Deliverables
+
+### New files
+
+- [ ] `ZEngine/ZEngine/Rendering/Scenes/DrawCommandBuffer.h` — `DrawData` struct (moved from
+  `GraphicScene.h` `#if 0`), `SortKey` namespace, `DrawCommand` struct, `DrawCommandBuffer`
+  struct declaration
+- [ ] `ZEngine/ZEngine/Rendering/Scenes/DrawCommandBuffer.cpp` — `RadixSort64` implementation,
+  `DrawCommandBuffer::Init`, `Build`, `Sort`, `Flush` implementations
+- [ ] `ZEngine/shaders/include/draw_data.glsl` — shared GLSL `DrawData` struct and
+  `DrawDataSB` binding definition, included by both `depth_prepass_scene.vert` and
+  `g_buffer.vert`
+
+### Modified files
+
+- [ ] `ZEngine/ZEngine/Rendering/Scenes/GraphicScene.h` — remove `DrawData` from the `#if 0`
+  block; add `DrawCommandsDirty[3]` to `RenderScene`; add `OpaqueDrawCount[3]` and
+  `TransparentDrawCount[3]` to `SceneData`; include `DrawCommandBuffer.h`
+- [ ] `ZEngine/ZEngine/Hardwares/VulkanDevice.h` — add `DrawIndirectRange` declaration to
+  `CommandBuffer`
+- [ ] `ZEngine/ZEngine/Hardwares/VulkanDevice.cpp` — implement `CommandBuffer::DrawIndirectRange`
+- [ ] `ZEngine/ZEngine/Applications/AppRenderPipeline.h` — add `DrawCommandBuffer DrawCmdBuffers[3]`
+  and `Core::Maths::Mat4f PreviousView[3]` members
+- [ ] `ZEngine/ZEngine/Applications/AppRenderPipeline.cpp` — `Initialize`: call
+  `DrawCmdBuffers[i].Init`; `RenderScene`: add camera-movement dirty check, add
+  `DrawCommandsDirty` branch that calls `Build` / `Sort` / `Flush`; propagate dirty flag
+  set-sites for mesh and transform changes
+- [ ] `ZEngine/ZEngine/Rendering/Renderers/RendererPasses.cpp` — replace single
+  `DrawIndirect` calls in `DepthPrePass::Execute` and `GbufferPass::Execute` with the
+  two-call `DrawIndirectRange` pattern from section 9
+- [ ] `ZEngine/shaders/depth_prepass_scene.vert` — include `draw_data.glsl`; switch from
+  current per-draw data source to `draw_data_buf.draws[gl_InstanceIndex]`
+- [ ] `ZEngine/shaders/g_buffer.vert` — same; add `flat out uint v_MaterialIndex` output
+
+### Tests
+
+- [ ] **Opaque sort order**: build a `DrawCommandBuffer` from a synthetic `RenderScene`
+  containing three opaque draws at view-space depths 10, 5, and 20. After `Build` and `Sort`,
+  assert `Opaque[0].Data` corresponds to depth 5, `Opaque[1]` to depth 10, `Opaque[2]` to
+  depth 20 (ascending depth key = front-to-back).
+
+- [ ] **Transparent sort order**: build a `DrawCommandBuffer` from a synthetic scene containing
+  three transparent draws at view-space depths 10, 5, and 20. After `Build` and `Sort`, assert
+  `Transparent[0]` corresponds to depth 20, `Transparent[1]` to depth 10, `Transparent[2]` to
+  depth 5 (NOT-encoded depth key ascending = back-to-front).
+
+- [ ] **Build idempotency when not dirty**: call `Build` once on a scene, record
+  `OpaqueCount` and the first sort key. Set `DrawCommandsDirty[fi] = false`. Confirm that
+  the `DrawCommandsDirty` guard in `AppRenderPipeline::RenderScene` skips the `Build` call
+  on the next frame tick; `OpaqueCount` and first key are unchanged.
+
+- [ ] **Flush byte layout**: after `Flush`, read back the raw bytes written to the
+  `IndirectBuffer` mock. Assert that bytes `[0, OpaqueCount * sizeof(VkDrawIndirectCommand))`
+  match the opaque `GpuCmd` array in sorted order, and that `GpuCmd.firstInstance` for the
+  i-th record equals `i`. Assert that bytes `[OpaqueCount * sizeof(VkDrawIndirectCommand), ...)`
+  match the transparent commands with `firstInstance` values starting at `OpaqueCount`.
+
+- [ ] **Pipeline batching**: build a scene with six draws — two pairs sharing the same pipeline
+  ID and two singletons — all opaque at the same depth. Assert that after `Sort`, the two draws
+  with matching pipeline ID are adjacent in `Opaque`.
+
+- [ ] **Camera-movement dirty**: construct a `DrawCommandBuffer`, call `Build`, confirm
+  `DrawCommandsDirty[fi]` is `false`. Move the camera (change `PreviousView[fi]` to differ from
+  `camera->GetView()`). Confirm that the dirty check in `AppRenderPipeline::RenderScene` sets
+  `DrawCommandsDirty[fi]` to `true` and triggers a `Build` on the next call.

--- a/ZEngine/docs/future-plan/gizmo-3d-pass.md
+++ b/ZEngine/docs/future-plan/gizmo-3d-pass.md
@@ -2,7 +2,7 @@
 
 **Priority:** P2 — Required to drop ImGuizmo and therefore ImGui entirely  
 **Status:** Design  
-**Depends on:** `ui-system.md` (UIContext, all 8 steps done), `editor-entity-selection.md`, `actor-ecs-architecture.md` (ECS + TransformComponent), `physics-system.md`  
+**Depends on:** `ui-system.md` (UIContext, all 8 steps done), `editor-entity-selection.md`, `actor-ecs-architecture.md` (ECS + TransformComponent), `physics-system.md`, `gpu-allocator-rearchitecture.md`  
 **Blocks:** Complete removal of `imgui` and `ImGuizmo` from `__externals/`
 
 ---
@@ -230,8 +230,11 @@ namespace ZEngine::Editor
         // Extra
         GizmoMeshRange CenterSphere;  // uniform scale / view-axis free rotate
 
+        // Allocated via GpuAllocator (GpuMemoryDomain::DeviceGeometry).
+        // Never use raw VkDeviceMemory — all memory is VMA-managed after
+        // gpu-allocator-rearchitecture.md lands.
         VkBuffer       Buffer     = VK_NULL_HANDLE;
-        VkDeviceMemory BufferMem  = VK_NULL_HANDLE;
+        VmaAllocation  Allocation = nullptr;
 
     private:
         void BuildArrow(Core::Memory::ArenaAllocator* scratch,
@@ -240,6 +243,9 @@ namespace ZEngine::Editor
         void BuildRing(Core::Memory::ArenaAllocator* scratch, uint32_t segments);
         void BuildScaleBox(Core::Memory::ArenaAllocator* scratch);
         void BuildCenterSphere(Core::Memory::ArenaAllocator* scratch, uint32_t stacks);
+        // Allocates Buffer via Device->GpuMem.AllocateBuffer(DeviceGeometry).
+        // Uploads via Device->GpuMem.Ring (StagingRing) + vkCmdCopyBuffer.
+        // Stores the resulting VkBuffer and VmaAllocation in this struct.
         void UploadToGPU(Core::Memory::ArenaAllocator* scratch,
                          Hardwares::VulkanDevice* device,
                          GizmoVertex* all_verts, uint32_t vert_count,
@@ -339,20 +345,23 @@ namespace ZEngine::Editor
         GizmoState*               m_gizmo_state  = nullptr;
         Core::Memory::ArenaAllocator* m_arena    = nullptr;
 
-        // R32_UINT picking texture (full viewport resolution)
-        VkImage        m_pick_img     = VK_NULL_HANDLE;
-        VkImageView    m_pick_view    = VK_NULL_HANDLE;
-        VkDeviceMemory m_pick_mem     = VK_NULL_HANDLE;
+        // R32_UINT picking texture (full viewport resolution).
+        // Allocated via GpuAllocator (GpuMemoryDomain::RenderTarget).
+        VkImage       m_pick_img     = VK_NULL_HANDLE;
+        VkImageView   m_pick_view    = VK_NULL_HANDLE;
+        VmaAllocation m_pick_alloc   = nullptr;
 
-        // D32_SFLOAT depth (reuse or create; same res as picking texture)
-        VkImage        m_depth_img    = VK_NULL_HANDLE;
-        VkImageView    m_depth_view   = VK_NULL_HANDLE;
-        VkDeviceMemory m_depth_mem    = VK_NULL_HANDLE;
+        // D32_SFLOAT depth (same resolution as picking texture).
+        VkImage       m_depth_img    = VK_NULL_HANDLE;
+        VkImageView   m_depth_view   = VK_NULL_HANDLE;
+        VmaAllocation m_depth_alloc  = nullptr;
 
-        // 1×1 host-visible readback buffer (4 bytes = one uint32_t)
-        VkBuffer       m_readback_buf = VK_NULL_HANDLE;
-        VkDeviceMemory m_readback_mem = VK_NULL_HANDLE;
-        void*          m_readback_ptr = nullptr;  // persistently mapped
+        // 1×1 host-visible readback buffer (4 bytes = one uint32_t).
+        // Allocated via GpuAllocator (GpuMemoryDomain::HostStaging).
+        // Persistently mapped — MappedPtr held here after Initialize.
+        VkBuffer      m_readback_buf = VK_NULL_HANDLE;
+        VmaAllocation m_readback_alloc = nullptr;
+        void*         m_readback_ptr = nullptr;  // persistently mapped
 
         // Pipeline for entity ID rendering
         VkPipeline            m_entity_pipeline = VK_NULL_HANDLE;

--- a/ZEngine/docs/future-plan/gpu-allocator-rearchitecture.md
+++ b/ZEngine/docs/future-plan/gpu-allocator-rearchitecture.md
@@ -1,0 +1,491 @@
+# GPU Allocator Rearchitecture — VMA Pools, Staging Ring, Timeline Drain
+
+**Priority:** P0 — Required before 4K resolution target; fixes confirmed correctness bugs  
+**Status:** Design  
+**Depends on:** Nothing — self-contained hardware layer change  
+**Blocks:** `per-frame-upload-heap.md` (needs clean allocator API first)
+
+**Goal:** Replace the current flat VMA usage in `VulkanDevice` with a `GpuAllocator` struct
+that owns segregated memory pools, a persistent staging ring, and a timeline-gated deferred
+free queue. Eliminates 8 confirmed gaps from the VMA analysis, fixes 2 correctness bugs,
+and provides the foundation for 4K resource budgets and cross-platform unified memory support.
+
+---
+
+## 1. Current State Problems
+
+| ID | Location | Problem |
+|---|---|---|
+| C1 | `VulkanDevice.cpp:1179` | `DEDICATED_MEMORY_BIT` hardcoded on every image — exhausts `VkDeviceMemory` object limit on large scenes |
+| C2 | `VulkanDevice.cpp:2501` | Texture staging uses `HOST_ACCESS_RANDOM` — wrong memory type for sequential writes |
+| C3 | `VulkanDevice.cpp:477` | `VmaAllocatorCreateInfo` has no flags — no BDA support, no driver budget signals |
+| C4 | Entire codebase | No `vmaGetHeapBudgets` call — engine is blind to VRAM pressure at 4K |
+| H1 | `VulkanDevice.cpp:1042` | All DEVICE_LOCAL allocations share one default pool — geometry holes fragment texture blocks |
+| H2 | `AsyncResourceLoader.cpp:237` | Per-upload `vmaCreateBuffer` / `vmaDestroyBuffer` — `vkAllocateMemory` storm on bulk scene loads |
+| H3 | `VulkanDevice.cpp:2183` | `UniformBuffer` missing `ALLOW_TRANSFER_INSTEAD` — overflows BAR window to slow system RAM |
+| H4 | `VulkanDevice.cpp:1337` | `DirtyCollector` polls idle frames — queue accumulates unboundedly during continuous rendering |
+| H5 | `AsyncResourceLoader.cpp:261` | `ClearBuffer` host-visible path skips `vmaFlushAllocation` — GPU reads stale data on non-coherent memory |
+| H6 | `VulkanDevice.cpp:1384` | `DirtyResources::BUFFER`/`BUFFERMEMORY` call raw `vkDestroyBuffer`/`vkFreeMemory` — VMA allocation leaks if wrong path is taken |
+
+---
+
+## 2. New Types
+
+### `GpuMemoryDomain`
+
+```cpp
+// ZEngine/Hardwares/GpuAllocator.h
+enum class GpuMemoryDomain : uint8_t {
+    DeviceGeometry,  // DEVICE_LOCAL — vertex, index, storage, indirect
+    DeviceTexture,   // DEVICE_LOCAL — sampled images, suballocated
+    RenderTarget,    // DEVICE_LOCAL — RT, depth, shadow maps; driver-advised dedicated
+    HostUniform,     // BAR window — uniforms, frequently-written storage
+    HostStaging,     // HOST_VISIBLE | HOST_COHERENT — staging ring source
+};
+```
+
+Callers declare what they need. `GpuAllocator` selects the pool, the VMA flags, and whether to dedicate. No VMA flags leak through the interface.
+
+### `GpuBudget` (compile-time, 4K target — from memory-budget.md §3)
+
+```cpp
+namespace ZEngine::Hardwares::GpuBudget {
+    constexpr uint64_t GeometryBytes     = 512ULL << 20;  // vertex + index + storage
+    constexpr uint64_t TextureBytes      = 512ULL << 20;  // BC7/BC5 atlas
+    constexpr uint64_t RenderTargetBytes = 172ULL << 20;  // shadow maps + post-process + thumbnails
+    constexpr uint64_t UniformBytes      =  64ULL << 20;  // per-frame UBOs + bone matrices
+    constexpr uint64_t StagingBytes      =  64ULL << 20;  // staging ring capacity
+    constexpr float    WarnPressure      = 0.90f;
+}
+```
+
+Derivation of `RenderTargetBytes` from memory-budget.md §3:
+- CSM shadow maps (4 × 2048×2048 × D32): 64 MB
+- Spot shadow maps (4 × 1024×1024 × D32): 16 MB
+- Point shadow maps (2 × cubemap × 512×512 × D32): 12 MB
+- Post-process RTs (HDR + bloom mips + SSAO + LUT): 48 MB
+- Thumbnail cache (512 × 128×128 × RGBA8): 32 MB
+- Total: 172 MB
+
+### `StagingRing`
+
+One 64 MB allocation, persistently mapped, reused for all uploads. Replaces per-upload
+`vmaCreateBuffer` / `vmaDestroyBuffer` in `AsyncResourceLoader`.
+
+```cpp
+struct StagingRing {
+    static constexpr uint32_t kCapacity  = GpuBudget::StagingBytes;
+    static constexpr uint32_t kMaxChunks = 256;
+
+    struct Chunk {
+        uint32_t Offset;
+        uint32_t Size;
+        uint64_t TimelineValue; // free when timeline semaphore completed >= this
+    };
+
+    VmaAllocation Allocation = nullptr;
+    VkBuffer      Handle     = VK_NULL_HANDLE;
+    void*         MappedPtr  = nullptr;
+    uint32_t      WritePos   = 0;
+    uint32_t      ReadPos    = 0;
+    Chunk         Chunks[kMaxChunks] = {};
+    uint32_t      ChunkHead  = 0;
+    uint32_t      ChunkTail  = 0;
+
+    void  Initialize(VmaAllocator allocator);
+    void  Shutdown(VmaAllocator allocator);
+
+    // Returns mapped pointer + VkBuffer byte offset. Returns nullptr when the ring is
+    // full — caller falls back to a one-shot staging buffer for oversized transfers.
+    void* Allocate(uint32_t size, uint32_t alignment, uint32_t* out_vk_offset);
+
+    // Record a submitted chunk so Drain() can release it.
+    void  Submit(uint32_t vk_offset, uint32_t size, uint64_t timeline_value);
+
+    // Advance ReadPos past all chunks whose TimelineValue <= completed. O(drained_count).
+    void  Drain(uint64_t completed_value);
+};
+```
+
+`Allocate` is a compare-and-advance on `WritePos` — no heap allocation, no lock.
+`Drain` linearly scans from `ChunkHead` and advances `ReadPos`. In steady state
+(no bulk load) the ring oscillates around a small write window; `ReadPos` catches up
+within one frame.
+
+### `DeferredFreeQueue`
+
+Replaces `HandleManager<DirtyResource>`, `HandleManager<BufferView>`,
+`HandleManager<BufferImage>`, `RunningDirtyCollector`, and the entire `DirtyCollector()`
+thread.
+
+```cpp
+// ZEngine/Hardwares/DeferredFreeQueue.h
+struct DeferredFreeEntry {
+    enum class Kind : uint8_t { Buffer, Image, VkHandle };
+    Kind     EntryKind;
+    uint64_t TimelineValue; // drain when render_timeline completed >= this value
+    union {
+        BufferView  Buffer;
+        BufferImage Image;
+        struct {
+            void*                         Handle;
+            Rendering::DeviceResourceType Type;
+            void*                         Extra; // used for DESCRIPTORSET pool pointer
+        } Vk;
+    };
+};
+
+struct DeferredFreeQueue {
+    static constexpr uint32_t kCapacity = 2048;
+
+    DeferredFreeEntry Entries[kCapacity] = {};
+    uint32_t          Head = 0;
+    uint32_t          Tail = 0;
+
+    void Enqueue(DeferredFreeEntry entry);
+    void Drain(GpuAllocator* alloc, VkDevice device, uint64_t completed_timeline_value);
+};
+```
+
+`Drain` walks from `Head` while `Entries[Head].TimelineValue <= completed_timeline_value`,
+calls `vmaDestroyBuffer` / `vmaDestroyImage` / `vkDestroy*`, advances `Head`. O(k) where
+k is the number of resources freed this frame — bounded by `MaxFramesInFlight * MaxResourcesDestroyedPerFrame` in steady state.
+
+### `GpuAllocator`
+
+Single owner of `VmaAllocator` and all `VmaPool` handles. Lives inside `VulkanDevice`
+as a value member.
+
+```cpp
+// ZEngine/Hardwares/GpuAllocator.h
+struct GpuAllocator {
+    VmaAllocator Allocator  = nullptr;
+    VmaPool      Pools[5]   = {};   // indexed by GpuMemoryDomain cast to uint8_t
+    StagingRing  Ring       = {};
+    VmaBudget    HeapBudgets[VK_MAX_MEMORY_HEAPS] = {};
+    uint32_t     HeapCount  = 0;
+    bool         HasBudgetExt = false;
+
+    void        Initialize(VkPhysicalDevice physical_device, VkDevice device,
+                           VkInstance instance, bool has_memory_budget_ext,
+                           bool has_buffer_device_address);
+    void        Shutdown();
+
+    BufferView  AllocateBuffer(VkDeviceSize size, VkBufferUsageFlags usage,
+                               GpuMemoryDomain domain, const char* debug_name = nullptr);
+    BufferImage AllocateImage(const VkImageCreateInfo& info, GpuMemoryDomain domain,
+                              VkDevice device, VkImageAspectFlagBits aspect,
+                              VkImageViewType view_type, uint32_t layer_count);
+    void        FreeBuffer(BufferView& view);
+    void        FreeImage(BufferImage& image, VkDevice device);
+
+    // Call once per frame. O(VK_MAX_MEMORY_HEAPS).
+    void        SampleBudgets();
+    float       HeapPressure(uint32_t heap_index) const;
+};
+```
+
+Internal flag mapping (inside `AllocateBuffer` — not exposed to callers):
+
+| Domain | VMA usage | VMA flags |
+|---|---|---|
+| `DeviceGeometry` | `AUTO_PREFER_DEVICE` | `SEQUENTIAL_WRITE \| ALLOW_TRANSFER_INSTEAD \| MAPPED` |
+| `DeviceTexture` | `AUTO_PREFER_DEVICE` | none (driver-queried dedicated when advised) |
+| `RenderTarget` | `AUTO_PREFER_DEVICE` | driver-queried dedicated only |
+| `HostUniform` | `AUTO_PREFER_DEVICE` | `SEQUENTIAL_WRITE \| ALLOW_TRANSFER_INSTEAD \| MAPPED` |
+| `HostStaging` | `AUTO_PREFER_DEVICE` | `SEQUENTIAL_WRITE \| MAPPED` |
+
+`AllocateImage` always calls `vkGetImageMemoryRequirements2` with `VkMemoryDedicatedRequirementsKHR`
+chained. `DEDICATED_MEMORY_BIT` is set only when `prefersDedicatedAllocation ||
+requiresDedicatedAllocation`. This replaces the hardcoded flag at `VulkanDevice.cpp:1179`.
+
+Pool `maxBlockCount` values derived from `GpuBudget`:
+```
+DeviceGeometry : GeometryBytes  / 256 MB = 2 blocks
+DeviceTexture  : TextureBytes   / 256 MB = 2 blocks
+RenderTarget   : 0 (unlimited, driver-dedicated)
+HostUniform    : UniformBytes   / 64 MB  = 1 block
+HostStaging    : 1 (the ring's single block)
+```
+
+When a pool's `maxBlockCount` is reached, `vmaCreateBuffer` returns
+`VK_ERROR_OUT_OF_DEVICE_MEMORY`. `AllocateBuffer` propagates this as a null `BufferView`
+so callers can trigger LRU eviction from `GlobalTextures` before retrying.
+
+---
+
+## 3. Changes to Existing Files
+
+### `VulkanDevice.h`
+
+Remove:
+- `VmaAllocator VmaAllocatorValue` (line 617)
+- `HandleManager<DirtyResource> DirtyResources` (line 641)
+- `HandleManager<BufferView> DirtyBuffers` (line 642)
+- `HandleManager<BufferImage> DirtyBufferImages` (line 643)
+- `std::atomic_bool RunningDirtyCollector` (line 644)
+- `void DirtyCollector()` declaration (line 676)
+- `void EnqueueBufferForDeletion(BufferView&)`, `void EnqueueBufferImageForDeletion(BufferImage&)`, `void EnqueueForDeletion(...)` (all overloads)
+
+Add:
+```cpp
+GpuAllocator      GpuMem      = {};
+DeferredFreeQueue PendingFree = {};
+void              TickMemory();   // call in AcquireNextImage
+void              DeferFree(DeferredFreeEntry entry);
+```
+
+Change `CreateBuffer` signature:
+```cpp
+// Before:
+BufferView CreateBuffer(VkDeviceSize size, VkBufferUsageFlags usage,
+                        VmaAllocationCreateFlags vma_create_flags = 0);
+// After:
+BufferView CreateBuffer(VkDeviceSize size, VkBufferUsageFlags usage,
+                        GpuMemoryDomain domain, const char* debug_name = nullptr);
+```
+
+Add `Domain` field to `BufferView` so `DeferredFreeQueue` knows which pool to return to:
+```cpp
+struct BufferView {
+    uint8_t         FrameIndex  = std::numeric_limits<uint8_t>::max();
+    BufferType      Type        = BufferType::UNKNOWN;
+    GpuMemoryDomain Domain      = GpuMemoryDomain::DeviceGeometry;
+    VkBuffer        Handle      = VK_NULL_HANDLE;
+    VmaAllocation   Allocation  = nullptr;
+    operator bool() const { return Handle != VK_NULL_HANDLE; }
+};
+```
+
+### `VulkanDevice.cpp`
+
+`Initialize()` — allocator setup (currently line 477):
+```cpp
+bool has_budget = /* VK_EXT_memory_budget in enabled device extensions */;
+bool has_bda    = /* VkPhysicalDeviceBufferDeviceAddressFeatures.bufferDeviceAddress */;
+GpuMem.Initialize(PhysicalDevice, LogicalDevice, Instance, has_budget, has_bda);
+```
+
+`GpuAllocator::Initialize` sets:
+```cpp
+VmaAllocatorCreateFlags flags = 0;
+if (has_budget) flags |= VMA_ALLOCATOR_CREATE_EXT_MEMORY_BUDGET_BIT;
+if (has_bda)    flags |= VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT;
+```
+
+`Deinitialize()` — replace three `__cleanup*` calls and `RunningDirtyCollector.store(false)`:
+```cpp
+// QueueWaitAll() already called above — GPU is idle
+PendingFree.Drain(&GpuMem, LogicalDevice, UINT64_MAX);
+GpuMem.Ring.Drain(UINT64_MAX);
+```
+
+`Dispose()` — replace `vmaDestroyAllocator(VmaAllocatorValue)` with `GpuMem.Shutdown()`.
+
+`CreateBuffer` — routes directly to `GpuMem.AllocateBuffer`. The entire current 40-line body collapses to one call.
+
+`CreateImage` — routes to `GpuMem.AllocateImage`. The hardcoded `DEDICATED_MEMORY_BIT` at line 1179 is removed.
+
+`WriteTextureData` (line 2501) — fix C2:
+```cpp
+// Before: HOST_ACCESS_RANDOM (wrong)
+BufferView staging = CreateBuffer(..., VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT);
+
+// After: use staging ring for sequential write
+uint32_t ring_offset = 0;
+void* ring_ptr = GpuMem.Ring.Allocate(resource->BufferSize, 4, &ring_offset);
+```
+
+`DeferFree` — replaces all three enqueue methods:
+```cpp
+void VulkanDevice::DeferFree(DeferredFreeEntry entry) {
+    entry.TimelineValue = SwapchainPtr->RenderTimelineNextValue;
+    PendingFree.Enqueue(entry);
+}
+```
+
+All 12 callsites (`Image2DBuffer::Dispose`, `IGraphicBuffer::CleanUpMemory`,
+`DeviceSwapchain::Clear`, `RendererPipeline::Deinitialize`, `Attachment::Dispose`,
+`Framebuffer::Dispose`, `Fence::~Fence`, `Semaphore::~Semaphore`, `Shader::Dispose`,
+`VulkanDevice::Deinitialize` × 4) switch to `DeferFree({...})`.
+
+`TickMemory()`:
+```cpp
+void VulkanDevice::TickMemory() {
+    uint64_t completed = 0;
+    vkGetSemaphoreCounterValue(LogicalDevice,
+        SwapchainPtr->RenderTimeline->GetHandle(), &completed);
+    PendingFree.Drain(&GpuMem, LogicalDevice, completed);
+    GpuMem.Ring.Drain(completed);
+    GpuMem.SampleBudgets(); // O(VK_MAX_MEMORY_HEAPS)
+}
+```
+
+Remove `DirtyCollector()` entirely: delete method body, delete `ThreadPoolHelper::Submit`
+call at line 663, delete `RunningDirtyCollector.store(false)` at line 670.
+
+Typed buffer `CreateBuffer()` callsites (lines 2162–2183) — new domain arguments:
+```cpp
+BufferView VertexBuffer::CreateBuffer() {
+    return m_device->CreateBuffer(m_total_size,
+        VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
+        GpuMemoryDomain::DeviceGeometry, "VertexBuffer");
+}
+BufferView UniformBuffer::CreateBuffer() {
+    return m_device->CreateBuffer(m_total_size,
+        VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+        GpuMemoryDomain::HostUniform, "UniformBuffer");
+}
+// StorageBuffer, IndexBuffer, IndirectBuffer: DeviceGeometry
+```
+
+### `AsyncResourceLoader.cpp`
+
+`UploadFromStagingBuffer` (line 216) — use staging ring:
+```cpp
+uint32_t ring_offset = 0;
+void* ring_ptr = Device->GpuMem.Ring.Allocate((uint32_t)byte_size, 4, &ring_offset);
+if (!ring_ptr) {
+    // Ring full (large burst load): fall back to one-shot staging buffer
+    ring_ptr = /* one-shot path, same as today */;
+} else {
+    memcpy(ring_ptr, data, byte_size);
+    // CopyBuffer uses Device->GpuMem.Ring.Handle as source at ring_offset
+    Device->GpuMem.Ring.Submit(ring_offset, (uint32_t)byte_size, signal_value);
+    // No RetireStagingBuffers slot — ring owns lifetime
+}
+```
+
+`RetireStagingBuffers` and `TransferRetireStagingBuffers` arrays become unused and are
+removed. The staging destroy loops in `ResetCommandBuffers` (lines 574–609) and
+`Shutdown` (lines 796–813) are removed.
+
+`ClearBuffer` host-visible path (line 261) — fix H5, add missing flush:
+```cpp
+// After secure_memset on pMappedData:
+if (!(mem_prop_flags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)) {
+    vmaFlushAllocation(Device->GpuMem.Allocator,
+                       buffer_view->Allocation, offset, byte_size);
+}
+```
+
+All 14 `Device->VmaAllocatorValue` references renamed to `Device->GpuMem.Allocator`.
+
+### `DeviceSwapchain.cpp`
+
+`AcquireNextImage` — add `TickMemory` call immediately after `vkAcquireNextImageKHR`:
+```cpp
+Device->TickMemory();
+```
+
+This is the single per-frame drain point. It fires after the GPU has advanced its
+timeline (previous frame completed) and before any new command buffers are recorded.
+
+---
+
+## 4. New Files
+
+### `ZEngine/Hardwares/GpuAllocator.h`
+
+Types: `GpuMemoryDomain`, `GpuBudget` constants, `StagingRing`, `GpuAllocator`.
+
+`VMA_IMPLEMENTATION` and `VMA_VULKAN_VERSION` move here from `VulkanDevice.cpp`.
+`VulkanDevice.cpp` no longer defines them. `VulkanDevice.h` replaces
+`#include <vk_mem_alloc.h>` at the top level with `#include <ZEngine/Hardwares/GpuAllocator.h>`.
+
+### `ZEngine/Hardwares/GpuAllocator.cpp`
+
+All `GpuAllocator` and `StagingRing` method bodies.
+
+### `ZEngine/Hardwares/DeferredFreeQueue.h`
+
+`DeferredFreeEntry` and `DeferredFreeQueue` — header-only, all methods inline.
+
+---
+
+## 5. Cross-Platform Notes
+
+### Unified memory (Apple Silicon via MoltenVK, Intel iGPU)
+
+`GpuAllocator::Initialize` probes whether `DeviceGeometry` and `HostStaging` resolve to
+the same memory type index via `vmaFindMemoryTypeIndexForBufferInfo`. When they match:
+
+```cpp
+if (geometry_mem_type == staging_mem_type) {
+    Pools[(uint8_t)GpuMemoryDomain::HostStaging] =
+        Pools[(uint8_t)GpuMemoryDomain::DeviceGeometry];
+    m_staging_shares_geometry_pool = true;
+}
+```
+
+On unified memory `UploadBuffer` takes the direct `vmaCopyMemoryToAllocation` path
+(geometry buffer is already host-visible) — the staging ring is bypassed entirely.
+
+### MoltenVK / macOS
+
+`VK_EXT_memory_budget` supported on MoltenVK 1.2+. `has_budget` is probed from the
+extension list at device creation; `VMA_ALLOCATOR_CREATE_EXT_MEMORY_BUDGET_BIT` is set
+only when present. `SampleBudgets` calls `vmaCalculateStatistics` as fallback when the
+extension is absent.
+
+### Mobile Vulkan (Adreno, Mali)
+
+BAR (`HostUniform` pool) may resolve to a plain `HOST_VISIBLE | HOST_COHERENT` type on
+Mali/PowerVR where the dedicated BAR window is absent. VMA handles this silently via
+`AUTO_PREFER_DEVICE`. `ALLOW_TRANSFER_INSTEAD` on uniform buffers ensures that when the
+small BAR fills up, data is staged to DEVICE_LOCAL rather than falling back to slow
+system RAM.
+
+---
+
+## 6. Budget Enforcement
+
+`SampleBudgets` in debug/profiling builds:
+```cpp
+void GpuAllocator::SampleBudgets() {
+    if (HasBudgetExt)
+        vmaGetHeapBudgets(Allocator, HeapBudgets);
+    else
+        /* vmaCalculateStatistics fallback */;
+
+    for (uint32_t i = 0; i < HeapCount; ++i) {
+        float p = (float)HeapBudgets[i].usage / (float)HeapBudgets[i].budget;
+        if (p > GpuBudget::WarnPressure)
+            ZENGINE_CORE_WARN("[GPU] Heap %u at %.0f%% (%zu / %zu MB)",
+                              i, p * 100.f,
+                              HeapBudgets[i].usage >> 20,
+                              HeapBudgets[i].budget >> 20);
+    }
+}
+```
+
+---
+
+## 7. Implementation Order
+
+Each step compiles and passes existing tests before the next begins.
+
+| Step | Files | Change | Risk |
+|---|---|---|---|
+| 1 | New `GpuAllocator.h/.cpp` | Define types, Initialize/Shutdown/Allocate/Free. Move `VMA_IMPLEMENTATION` here. | Low — additive |
+| 2 | New `DeferredFreeQueue.h` | Define `DeferredFreeEntry`, `DeferredFreeQueue`. | Low — additive |
+| 3 | `VulkanDevice.h` | Add `GpuMem`, `PendingFree`, `TickMemory`, `DeferFree`. Keep `VmaAllocatorValue` as alias temporarily. | Low |
+| 4 | `VulkanDevice.cpp` — `Initialize` | Wire `GpuMem.Initialize`. Keep old dirty queues alive. | Low |
+| 5 | `VulkanDevice.cpp` — `CreateBuffer` / `CreateImage` | Route through `GpuMem`. Update typed buffer `CreateBuffer()` to pass `GpuMemoryDomain`. | Medium |
+| 6 | `AsyncResourceLoader.cpp` — flush fix | Add `vmaFlushAllocation` to `ClearBuffer` host-visible path. | None |
+| 7 | `AsyncResourceLoader.cpp` — staging ring | Replace per-upload `CreateBuffer(TRANSFER_SRC)` with `GpuMem.Ring.Allocate`. Remove `RetireStagingBuffers`. | High — core upload path |
+| 8 | `VulkanDevice.cpp` — `DeferFree` | Implement `DeferFree`, migrate all 12 enqueue callsites. | Medium |
+| 9 | `DeviceSwapchain.cpp` — `TickMemory` | Add `Device->TickMemory()` in `AcquireNextImage`. | Low |
+| 10 | `VulkanDevice.cpp` — remove `DirtyCollector` | Delete thread, remove dirty HandleManagers, remove three `__cleanup*` methods. | Low — depends on step 8 |
+| 11 | `VulkanDevice.h` — cleanup | Remove old declarations and alias. | Low |
+
+---
+
+## 8. Verification
+
+1. Debug build with `VMA_DEBUG_DETECT_CORRUPTION=1`, `VMA_DEBUG_MARGIN=16` (already in CMakeLists). Run scene load + 100-frame render + unload. Zero corruption reports.
+2. Assert inside `GpuAllocator::FreeBuffer`: verify `vkGetSemaphoreCounterValue(RenderTimeline) >= entry.TimelineValue` at destruction time. Validates the timeline gate.
+3. After 1000 upload calls confirm `GpuMem.Ring.ReadPos == GpuMem.Ring.WritePos` (ring fully drained). Trace with `VK_LAYER_LUNARG_api_dump` — zero `vkAllocateMemory` calls during streaming after startup.
+4. RenderDoc before/after step 5: `VkDeviceMemory` object count drops from one-per-texture to one-per-256MB-block for suballocated textures.
+5. Write a test: clear a non-coherent buffer, GPU readback, assert zeroed. Validates the `ClearBuffer` flush fix.
+6. Build on macOS (MoltenVK): confirm `has_budget` is false when the extension is absent; no crash; `SampleBudgets` uses statistics fallback.

--- a/ZEngine/docs/future-plan/per-frame-upload-heap.md
+++ b/ZEngine/docs/future-plan/per-frame-upload-heap.md
@@ -1,0 +1,312 @@
+# Per-Frame Upload Heap — Replacing IBufferSet with a Linear Frame Heap
+
+**Priority:** P1 — Required for scalable 4K scene rendering (hundreds of draw calls)  
+**Status:** Design  
+**Depends on:** `gpu-allocator-rearchitecture.md` (needs `GpuAllocator` and `GpuMemoryDomain::HostUniform`)  
+**Blocks:** Nothing, but unlocks scalable per-draw-call UBO streaming and large bone matrix uploads
+
+**Goal:** Replace the current `IBufferSet<T>` pattern (one `VkBuffer` per resource type per
+frame) with a `PerFrameUploadHeap` — a single large persistently-mapped buffer per frame in
+flight into which all per-frame CPU data is bump-allocated. Descriptor access switches from
+per-buffer bindings to dynamic UBO offsets. Result: 3 `VkBuffer` objects total regardless of
+scene complexity, zero `VmaAllocation` calls per frame in steady state, and one cache-local
+write pass per frame for all per-draw data.
+
+---
+
+## 1. Current State Problems
+
+The current `IBufferSet<T>` pattern:
+
+```
+VertexBufferSet[3]:     one VkBuffer per frame × scene geometry
+StorageBufferSet[3]:    one VkBuffer per frame × storage type
+IndexBufferSet[3]:      one VkBuffer per frame × index data
+IndirectBufferSet[3]:   one VkBuffer per frame × draw call list
+UniformBufferSet[3]:    one VkBuffer per frame × UBO type
+```
+
+For a scene with 50 draw calls, each with a per-object UBO (transform, material),
+plus scene-global UBOs (camera, lights, skinning matrices):
+
+- At minimum: `(50 per-object + 3 global) × 3 frames = 159 VkBuffer objects` just for uniforms
+- 159 `VmaAllocation` objects in the `HostUniform` pool
+- 159 separate descriptor set writes at bind time
+- CPU writes are scattered across 159 non-contiguous mapped regions
+
+This approach also makes the 40 MB bone matrix budget from memory-budget.md §3 expensive:
+`10,000 entities × 256 bones × 16 bytes = 40 MB` as a single `StorageBuffer` works today,
+but growing the scene requires tracking more buffer set handles and more descriptor updates.
+
+### Comparison
+
+| | Current (`IBufferSet`) | `PerFrameUploadHeap` |
+|---|---|---|
+| `VkBuffer` objects for per-frame data | O(resource_count × frames) | 3 (one per frame in flight) |
+| `vmaCreateBuffer` calls per frame | 0 (pre-allocated) but one per new resource | 0 — bump pointer reset |
+| CPU write locality | Scattered — one mapped ptr per buffer | Contiguous — one mapped region |
+| Descriptor update per draw call | One full `vkUpdateDescriptorSets` per buffer | One `uint32_t` dynamic offset per draw |
+| BAR window fragmentation | Each buffer occupies its own VMA slot | One allocation per frame covers everything |
+
+---
+
+## 2. `PerFrameUploadHeap`
+
+One heap per frame in flight. The heap is a single `VkBuffer` in `GpuMemoryDomain::HostUniform`
+(persistently mapped, `ALLOW_TRANSFER_INSTEAD` for BAR overflow). At the start of each frame
+the bump pointer resets to zero — no `vmaDestroyBuffer`, no `vmaCreateBuffer`. The GPU has
+finished reading the previous use of this frame's buffer (timeline semaphore ensures it).
+
+```cpp
+// ZEngine/Hardwares/PerFrameUploadHeap.h
+struct PerFrameHeapAlloc {
+    uint32_t Offset;  // byte offset into the frame's VkBuffer
+    uint32_t Size;
+};
+
+struct PerFrameUploadHeap {
+    static constexpr uint32_t kCapacity = GpuBudget::UniformBytes; // 64 MB per frame
+
+    VkBuffer         Handle     = VK_NULL_HANDLE;
+    VmaAllocation    Allocation = nullptr;
+    void*            MappedPtr  = nullptr;
+    uint32_t         WritePos   = 0;
+    bool             Coherent   = false; // cached from VkMemoryPropertyFlags at init
+
+    // Initialized once per frame slot in VulkanDevice::Initialize
+    void Initialize(GpuAllocator* alloc, const char* debug_name);
+    void Shutdown(GpuAllocator* alloc);
+
+    // Reset at frame start — O(1), no GPU wait (timeline guarantees GPU is done)
+    void Reset();
+
+    // Push data into the heap. Returns the byte offset for use as a dynamic UBO offset.
+    // Returns UINT32_MAX if the heap is full (caller must assert — should never happen
+    // in a correctly budgeted scene).
+    PerFrameHeapAlloc Push(const void* data, uint32_t size, uint32_t alignment);
+
+    // Flush the written range if memory is not coherent. Called once per frame after
+    // all Push() calls, before command buffer recording begins.
+    void Flush(VmaAllocator allocator);
+};
+```
+
+`Push` implementation:
+```cpp
+PerFrameHeapAlloc PerFrameUploadHeap::Push(const void* data, uint32_t size, uint32_t alignment) {
+    uint32_t aligned_pos = (WritePos + alignment - 1) & ~(alignment - 1);
+    ZENGINE_VALIDATE_ASSERT(aligned_pos + size <= kCapacity, "PerFrameUploadHeap full")
+    memcpy((uint8_t*)MappedPtr + aligned_pos, data, size);
+    WritePos = aligned_pos + size;
+    return { aligned_pos, size };
+}
+```
+
+No branches, no locks, no allocation — a pointer bump and a `memcpy`.
+
+`Flush` is called once per frame after all `Push` calls complete, before the command buffer
+is recorded. It issues a single `vmaFlushAllocation` covering `[0, WritePos]`:
+```cpp
+void PerFrameUploadHeap::Flush(VmaAllocator allocator) {
+    if (!Coherent && WritePos > 0)
+        vmaFlushAllocation(allocator, Allocation, 0, WritePos);
+}
+```
+
+One flush per frame instead of one per buffer — reduces the number of cache-flush
+syscalls from O(resource_count) to O(1).
+
+---
+
+## 3. Integration with `VulkanDevice`
+
+`VulkanDevice` gains:
+
+```cpp
+// VulkanDevice.h
+PerFrameUploadHeap FrameHeaps[3] = {}; // one per BufferredFrameCount
+```
+
+Initialized in `VulkanDevice::Initialize` after `GpuMem`:
+```cpp
+for (uint32_t i = 0; i < SwapchainPtr->BufferredFrameCount; ++i) {
+    char name[64];
+    snprintf(name, sizeof(name), "FrameHeap[%u]", i);
+    FrameHeaps[i].Initialize(&GpuMem, name);
+}
+```
+
+`TickMemory()` resets the current frame's heap:
+```cpp
+void VulkanDevice::TickMemory() {
+    uint64_t completed = 0;
+    vkGetSemaphoreCounterValue(LogicalDevice,
+        SwapchainPtr->RenderTimeline->GetHandle(), &completed);
+    PendingFree.Drain(&GpuMem, LogicalDevice, completed);
+    GpuMem.Ring.Drain(completed);
+    GpuMem.SampleBudgets();
+
+    // Reset the heap for the frame we are about to record
+    FrameHeaps[SwapchainPtr->CurrentFrame->Index].Reset();
+}
+```
+
+The reset is a single `WritePos = 0` assignment — O(1).
+
+---
+
+## 4. New Per-Frame Data API
+
+### Before: per-type buffer set
+
+```cpp
+// Current usage in GraphicRenderer::DrawScene
+camera_buffer_set->At(frame_index).Write(frame_index, thread_index, &camera_data, sizeof(camera_data));
+// → calls AsyncResLoader->UploadBuffer → may allocate staging buffer
+// → VkDescriptorSet bound to one specific VkBuffer
+```
+
+### After: push into frame heap, bind with dynamic offset
+
+```cpp
+// Proposed usage
+uint8_t fi = Device->SwapchainPtr->CurrentFrame->Index;
+PerFrameUploadHeap& heap = Device->FrameHeaps[fi];
+
+auto camera_alloc = heap.Push(&camera_data, sizeof(CameraData),
+                              Device->MinUniformBufferOffsetAlignment());
+// camera_alloc.Offset is the dynamic offset for this draw
+
+auto lights_alloc = heap.Push(&lights_data, sizeof(LightsData),
+                              Device->MinUniformBufferOffsetAlignment());
+
+// One vkCmdBindDescriptorSets with dynamic offsets covers all per-frame data
+uint32_t offsets[] = { camera_alloc.Offset, lights_alloc.Offset, ... };
+vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                        pipeline_layout, SET_PER_FRAME,
+                        1, &per_frame_descriptor_set,
+                        ARRAY_COUNT(offsets), offsets);
+```
+
+The per-frame descriptor set is allocated once per frame in flight at startup and is
+never updated per-draw. It has a single binding per per-frame data type
+(`DYNAMIC_UNIFORM_BUFFER`). Only the dynamic offset changes per draw call.
+
+---
+
+## 5. Descriptor Set Layout Change
+
+Currently each buffer type has its own `VkDescriptorSetLayout` binding pointing to a
+specific `VkBuffer`. After the heap migration:
+
+```
+Set 0 — per-pass (render pass inputs: textures, samplers) — unchanged
+Set 1 — global bindless textures — unchanged (already in VulkanDevice)
+Set 2 — per-frame dynamic UBOs (one binding per per-frame data type, DYNAMIC_UNIFORM_BUFFER)
+Set 3 — per-draw push constants or storage buffer offsets
+```
+
+The per-frame set (set 2) is created once at `VulkanDevice::Initialize`. Its descriptor
+writes point to `FrameHeaps[i].Handle` for frame `i`. Dynamic offsets at bind time select
+the sub-region within the heap for each data type.
+
+`minUniformBufferOffsetAlignment` (queried from `VkPhysicalDeviceLimits`) governs the
+alignment passed to `PerFrameUploadHeap::Push`. Stored as:
+```cpp
+uint32_t VulkanDevice::MinUniformBufferOffsetAlignment() const {
+    return (uint32_t)PhysicalDeviceProperties.properties.limits.minUniformBufferOffsetAlignment;
+}
+```
+
+---
+
+## 6. Migration Path for `IBufferSet<T>`
+
+`IBufferSet<T>` and `IGraphicBuffer` are not deleted. They remain for vertex, index, and
+indirect buffers — resources that are long-lived, uploaded once, and read many times.
+These do not benefit from per-frame bump allocation.
+
+What is replaced:
+
+| Buffer type | Current approach | After migration |
+|---|---|---|
+| `UniformBuffer` (per-frame) | `UniformBufferSet[3]`, one `VkBuffer` per type per frame | `PerFrameUploadHeap::Push` per frame |
+| `StorageBuffer` (per-frame write) | `StorageBufferSet[3]` | `PerFrameUploadHeap::Push` for write-per-frame storage |
+| `StorageBuffer` (large, static) | `StorageBufferSet[3]` | Keep as `IGraphicBuffer` — `DeviceGeometry` pool |
+| `VertexBuffer` | `VertexBufferSet[3]` | Unchanged — long-lived geometry |
+| `IndexBuffer` | `IndexBufferSet[3]` | Unchanged — long-lived geometry |
+| `IndirectBuffer` | `IndirectBufferSet[3]` | Kept but indirect draw data pushed into heap each frame |
+
+The rule: if the data changes every frame and is consumed by the GPU in that same frame,
+it belongs in the heap. If the data is uploaded once and read across many frames
+(geometry, textures, static storage buffers), it stays in `IGraphicBuffer`.
+
+---
+
+## 7. Bone Matrix Storage
+
+The 40 MB bone matrix buffer (memory-budget.md §3: `10,000 entities × 256 bones × 16 bytes`)
+is a per-frame write — it is re-uploaded every frame for each animated entity. This is the
+primary motivation for a 64 MB heap:
+
+```cpp
+// Per frame, after skinning system runs:
+auto bone_alloc = heap.Push(skinning_system.BoneMatrices(),
+                            skinning_system.TotalBytes(),
+                            Device->MinStorageBufferOffsetAlignment());
+// Bind as storage buffer with dynamic offset into the skinning pass
+```
+
+Without the heap, bone matrices require a 40 MB `StorageBufferSet[3]` (120 MB total) with
+per-frame `vmaCopyMemoryToAllocation` calls. With the heap, the 40 MB sits inside the
+64 MB `PerFrameUploadHeap` — no separate allocation, no staging, one `memcpy` per frame.
+
+---
+
+## 8. Indirect Draw Buffer
+
+`IndirectBuffer` currently holds one `VkDrawIndirectCommand` per draw call, uploaded each
+frame. After migration, the indirect command array is pushed into the heap each frame:
+
+```cpp
+auto indirect_alloc = heap.Push(draw_commands.data(),
+                                draw_commands.size() * sizeof(VkDrawIndirectCommand),
+                                sizeof(VkDrawIndirectCommand));
+// vkCmdDrawIndirect uses heap.Handle at indirect_alloc.Offset
+vkCmdDrawIndirect(cmd, heap.Handle, indirect_alloc.Offset,
+                  (uint32_t)draw_commands.size(), sizeof(VkDrawIndirectCommand));
+```
+
+`IndirectBuffer` and `IndirectBufferSet` are then unused for per-frame indirect data and
+can be removed or repurposed for static multi-draw-indirect batches.
+
+---
+
+## 9. Implementation Order
+
+Depends on `gpu-allocator-rearchitecture.md` steps 1–5 being complete (GpuAllocator with
+`GpuMemoryDomain::HostUniform` pool functional).
+
+| Step | Files | Change | Risk |
+|---|---|---|---|
+| 1 | New `PerFrameUploadHeap.h` | Define struct; `Initialize`, `Shutdown`, `Reset`, `Push`, `Flush`. | Low — additive |
+| 2 | `VulkanDevice.h` | Add `FrameHeaps[3]`, `MinUniformBufferOffsetAlignment()`. | Low |
+| 3 | `VulkanDevice.cpp` — `Initialize` | Allocate and init 3 heaps. | Low |
+| 4 | `VulkanDevice.cpp` — `TickMemory` | Add `FrameHeaps[fi].Reset()`. | Low |
+| 5 | Shader / descriptor set layout | Add set 2 (`DYNAMIC_UNIFORM_BUFFER` per per-frame type) to shader reflection. Update `CreateDescriptorSets` in `Shader.cpp`. | Medium |
+| 6 | `GraphicRenderer.cpp` — camera, lights | Migrate camera and light UBOs to `heap.Push`. Update bind calls to pass dynamic offsets. | Medium |
+| 7 | `GraphicScene` — per-object transforms | Migrate per-draw transform UBOs to `heap.Push`. | Medium |
+| 8 | Skinning system (future) | Migrate bone matrix upload to `heap.Push`. | Low — new system |
+| 9 | `IndirectBuffer` | Push indirect commands into heap. Remove `IndirectBufferSet` per-frame path. | Low |
+| 10 | `UniformBufferSet` cleanup | Remove `UniformBuffer::CreateBuffer` and `UniformBufferSet` from `VulkanDevice`. | Low — after step 7 |
+
+---
+
+## 10. Verification
+
+1. Frame heap `WritePos` after all pushes must be less than `kCapacity`. Assert in Debug builds. Log peak `WritePos` via `MemoryProfiler` to validate budget sizing.
+2. One `vkFlushMappedMemoryRanges` call per frame (not per buffer). Verify with `VK_LAYER_LUNARG_api_dump` — count `vkFlushMappedMemoryRanges` invocations before and after migration.
+3. `vkCmdBindDescriptorSets` for per-frame set uses non-zero dynamic offsets and binds correctly. Verify with RenderDoc: capture a frame and inspect UBO bindings — data should match CPU-side values.
+4. `VkBuffer` object count for per-frame data in RenderDoc: 3 (one per frame in flight) vs. O(N) before.
+5. Scene stress test: 500 draw calls, 60 fps, 100 frames — no validation layer errors, no heap overflow asserts.
+6. macOS / MoltenVK: `PerFrameUploadHeap` uses `GpuMemoryDomain::HostUniform` which is backed by unified memory. Verify writes are visible to GPU without staging (host-visible fast path in `UploadBuffer`).

--- a/ZEngine/docs/future-plan/post-processing.md
+++ b/ZEngine/docs/future-plan/post-processing.md
@@ -2,7 +2,7 @@
 
 **Priority:** P3 — Required for visual polish; bloom, tone mapping, and color grading are standard
 **Status:** Design
-**Depends on:** `render-resource-manager.md`, `shader-asset-pipeline.md`
+**Depends on:** `render-resource-manager.md`, `shader-asset-pipeline.md`, `gpu-allocator-rearchitecture.md`, `per-frame-upload-heap.md`
 **Blocks:** Visual polish, final image quality
 
 **Goal**: Implement a fully data-driven, RenderGraph-integrated post-processing stack inside
@@ -283,21 +283,21 @@ namespace ZEngine::Rendering::PostProcessing {
     // PostProcessPassData::Params.
     struct BloomPassState {
         BloomParams             Params{};
-        VkBuffer                ParamsUBO = VK_NULL_HANDLE;
+        // ParamsUBO is NOT a persistent VkBuffer. Bloom parameters are pushed via
+        // PerFrameUploadHeap::Push each frame when dirty; at steady state (no param
+        // change) the heap write is skipped via a dirty flag.
         Textures::TextureHandle DownsampleChain[BLOOM_MIP_LEVELS] = {};
         Textures::TextureHandle UpsampleChain[BLOOM_MIP_LEVELS]   = {};
         VkPipeline              ThresholdPipeline  = VK_NULL_HANDLE;
         VkPipeline              DownsamplePipeline = VK_NULL_HANDLE;
         VkPipeline              UpsamplePipeline   = VK_NULL_HANDLE;
         VkPipeline              CompositePipeline  = VK_NULL_HANDLE;
-        VkPipelineLayout m_layout              = VK_NULL_HANDLE;
+        VkPipelineLayout        PipelineLayout     = VK_NULL_HANDLE;
+        bool                    ParamsDirty        = true;
 
         Core::Memory::ArenaAllocator* m_arena  = nullptr;
         Hardwares::VulkanDevice*      m_device = nullptr;
     };
-
-    Hardwares::VulkanDevice* Device = nullptr;
-};
 
 // Factory — allocates BloomPassState from arena, returns a ready-to-add entry.
 PostProcessPassEntry MakeBloomPass(Core::Memory::ArenaAllocator* arena,
@@ -502,34 +502,33 @@ struct ToneMappingParams {
 };
 ```
 
-### Full class declaration
+### State struct and free functions
+
+Tone mapping follows the same DOD pattern as `BloomPass` — a plain state struct
+plus two free functions registered in a `PostProcessPassVtable`. No inheritance,
+no virtual dispatch.
 
 ```cpp
-struct ToneMappingPass final : public PostProcessPass {
-    explicit ToneMappingPass(Core::Memory::ArenaAllocator* arena,
-                             Hardwares::VulkanDevice*     device);
-
-    StringHash GetName() const override;  // hash of "ToneMappingPass"
-
-    void SetIOHandles(Textures::TextureHandle input,
-                      Textures::TextureHandle output) override;
-
-    void SetParams(const ToneMappingParams& params);
-
-    void Setup(Graph::RenderGraphResourceBuilder& builder) override;
-    void Execute(VkCommandBuffer cmd, const Graph::RenderGraph& rg) override;
-
-private:
-    ToneMappingParams        m_params{};
-    VkBuffer                 m_params_ubo  = VK_NULL_HANDLE;
-    VkPipeline               m_pipeline    = VK_NULL_HANDLE;
-    VkPipelineLayout         m_layout      = VK_NULL_HANDLE;
-    Textures::TextureHandle  m_input       = {};
-    Textures::TextureHandle  m_output      = {};  // VK_FORMAT_R8G8B8A8_UNORM
+struct ToneMappingState {
+    ToneMappingParams        Params{};
+    // Parameters pushed via PerFrameUploadHeap when dirty; no persistent VkBuffer.
+    bool                     ParamsDirty   = true;
+    VkPipeline               Pipeline      = VK_NULL_HANDLE;
+    VkPipelineLayout         PipelineLayout= VK_NULL_HANDLE;
+    Textures::TextureHandle  Input         = {};
+    Textures::TextureHandle  Output        = {};  // VK_FORMAT_R8G8B8A8_UNORM
 
     Core::Memory::ArenaAllocator* m_arena  = nullptr;
     Hardwares::VulkanDevice*      m_device = nullptr;
 };
+
+// Factory — allocates ToneMappingState from arena, returns a ready-to-add entry.
+PostProcessPassEntry MakeToneMappingPass(Core::Memory::ArenaAllocator* arena,
+                                         Hardwares::VulkanDevice*      device,
+                                         const ToneMappingParams&      params);
+
+void ToneMappingPass_Setup  (PostProcessPassData&, Graph::RenderGraphResourceBuilder&);
+void ToneMappingPass_Execute(PostProcessPassData&, VkCommandBuffer, const Graph::RenderGraph&);
 ```
 
 ### Tone mapping shader (`tone_mapping.frag`)
@@ -652,45 +651,34 @@ struct ColorGradingParams {
 };
 ```
 
-### Full class declaration
+### State struct and free functions
 
 ```cpp
 // ZEngine/Rendering/PostProcessing/ColorGradingPass.h
-struct ColorGradingPass final : public PostProcessPass {
-    explicit ColorGradingPass(Core::Memory::ArenaAllocator* arena,
-                              Hardwares::VulkanDevice*     device);
-
-    StringHash GetName() const override;  // hash of "ColorGradingPass"
-
-    void SetIOHandles(Textures::TextureHandle input,
-                      Textures::TextureHandle output) override;
-
-    // Load a .cube LUT file from the VFS. Call after Initialize.
-    // Blocking: reads and uploads the LUT texture via RenderResourceManager.
-    // On failure logs the error and keeps the current LUT (identity at startup).
-    void LoadLUT(const VFS::VFSPath& cube_path);
-
-    // Replace with the identity LUT (no color change).
-    void ResetLUT();
-
-    void SetParams(const ColorGradingParams& params);
-
-    void Setup(Graph::RenderGraphResourceBuilder& builder) override;
-    void Execute(VkCommandBuffer cmd, const Graph::RenderGraph& rg) override;
-
-private:
-    ColorGradingParams       m_params{};
-    VkBuffer                 m_params_ubo    = VK_NULL_HANDLE;
-    Textures::TextureHandle  m_lut_texture   = {};
-    bool                     m_lut_is_identity = true;
-    VkPipeline               m_pipeline      = VK_NULL_HANDLE;
-    VkPipelineLayout         m_layout        = VK_NULL_HANDLE;
-    Textures::TextureHandle  m_input         = {};
-    Textures::TextureHandle  m_output        = {};
+struct ColorGradingState {
+    ColorGradingParams       Params{};
+    bool                     ParamsDirty    = true;
+    Textures::TextureHandle  LUTTexture     = {};
+    bool                     LUTIsIdentity  = true;
+    VkPipeline               Pipeline       = VK_NULL_HANDLE;
+    VkPipelineLayout         PipelineLayout = VK_NULL_HANDLE;
+    Textures::TextureHandle  Input          = {};
+    Textures::TextureHandle  Output         = {};
 
     Core::Memory::ArenaAllocator* m_arena  = nullptr;
     Hardwares::VulkanDevice*      m_device = nullptr;
 };
+
+PostProcessPassEntry MakeColorGradingPass(Core::Memory::ArenaAllocator* arena,
+                                           Hardwares::VulkanDevice*      device,
+                                           const ColorGradingParams&     params);
+
+// Load a .cube LUT file from the VFS. Safe to call any time after Initialize.
+// On failure logs the error and keeps the current LUT (identity at startup).
+void ColorGradingPass_LoadLUT  (ColorGradingState* state, const VFS::VFSPath& cube_path);
+void ColorGradingPass_ResetLUT (ColorGradingState* state);
+void ColorGradingPass_Setup    (PostProcessPassData&, Graph::RenderGraphResourceBuilder&);
+void ColorGradingPass_Execute  (PostProcessPassData&, VkCommandBuffer, const Graph::RenderGraph&);
 ```
 
 ### Color grading shader (`color_grading.frag`)
@@ -755,35 +743,28 @@ struct FXAAParams {
 };
 ```
 
-### Full class declaration
+### State struct and free functions
 
 ```cpp
 // ZEngine/Rendering/PostProcessing/FXAAPass.h
-struct FXAAPass final : public PostProcessPass {
-    explicit FXAAPass(Core::Memory::ArenaAllocator* arena,
-                      Hardwares::VulkanDevice*     device);
-
-    StringHash GetName() const override;  // hash of "FXAAPass"
-
-    void SetIOHandles(Textures::TextureHandle input,
-                      Textures::TextureHandle output) override;
-
-    void SetParams(const FXAAParams& params);
-
-    void Setup(Graph::RenderGraphResourceBuilder& builder) override;
-    void Execute(VkCommandBuffer cmd, const Graph::RenderGraph& rg) override;
-
-private:
-    FXAAParams               m_params{};
-    VkBuffer                 m_params_ubo = VK_NULL_HANDLE;
-    VkPipeline               m_pipeline   = VK_NULL_HANDLE;
-    VkPipelineLayout         m_layout     = VK_NULL_HANDLE;
-    Textures::TextureHandle  m_input      = {};
-    Textures::TextureHandle  m_output     = {};
+struct FXAAState {
+    FXAAParams               Params{};
+    bool                     ParamsDirty  = true;
+    VkPipeline               Pipeline     = VK_NULL_HANDLE;
+    VkPipelineLayout         PipelineLayout = VK_NULL_HANDLE;
+    Textures::TextureHandle  Input        = {};
+    Textures::TextureHandle  Output       = {};
 
     Core::Memory::ArenaAllocator* m_arena  = nullptr;
     Hardwares::VulkanDevice*      m_device = nullptr;
 };
+
+PostProcessPassEntry MakeFXAAPass(Core::Memory::ArenaAllocator* arena,
+                                   Hardwares::VulkanDevice*      device,
+                                   const FXAAParams&             params);
+
+void FXAAPass_Setup  (PostProcessPassData&, Graph::RenderGraphResourceBuilder&);
+void FXAAPass_Execute(PostProcessPassData&, VkCommandBuffer, const Graph::RenderGraph&);
 ```
 
 ### FXAA 3.11 shader (`fxaa.frag`)
@@ -889,35 +870,28 @@ struct ChromaticAberrationParams {
 };
 ```
 
-### Full class declaration
+### State struct and free functions
 
 ```cpp
 // ZEngine/Rendering/PostProcessing/ChromaticAberrationPass.h
-struct ChromaticAberrationPass final : public PostProcessPass {
-    explicit ChromaticAberrationPass(Core::Memory::ArenaAllocator* arena,
-                                     Hardwares::VulkanDevice*     device);
-
-    StringHash GetName() const override;  // hash of "ChromaticAberrationPass"
-
-    void SetIOHandles(Textures::TextureHandle input,
-                      Textures::TextureHandle output) override;
-
-    void SetParams(const ChromaticAberrationParams& params);
-
-    void Setup(Graph::RenderGraphResourceBuilder& builder) override;
-    void Execute(VkCommandBuffer cmd, const Graph::RenderGraph& rg) override;
-
-private:
-    ChromaticAberrationParams  m_params{};
-    VkBuffer                   m_params_ubo = VK_NULL_HANDLE;
-    VkPipeline                 m_pipeline   = VK_NULL_HANDLE;
-    VkPipelineLayout           m_layout     = VK_NULL_HANDLE;
-    Textures::TextureHandle    m_input      = {};
-    Textures::TextureHandle    m_output     = {};
+struct ChromaticAberrationState {
+    ChromaticAberrationParams Params{};
+    bool                      ParamsDirty  = true;
+    VkPipeline                Pipeline     = VK_NULL_HANDLE;
+    VkPipelineLayout          PipelineLayout = VK_NULL_HANDLE;
+    Textures::TextureHandle   Input        = {};
+    Textures::TextureHandle   Output       = {};
 
     Core::Memory::ArenaAllocator* m_arena  = nullptr;
     Hardwares::VulkanDevice*      m_device = nullptr;
 };
+
+PostProcessPassEntry MakeChromAberrationPass(Core::Memory::ArenaAllocator*         arena,
+                                              Hardwares::VulkanDevice*              device,
+                                              const ChromaticAberrationParams&      params);
+
+void ChromAberrationPass_Setup  (PostProcessPassData&, Graph::RenderGraphResourceBuilder&);
+void ChromAberrationPass_Execute(PostProcessPassData&, VkCommandBuffer, const Graph::RenderGraph&);
 ```
 
 ### Shader (`chromatic_aberration.frag`)
@@ -967,35 +941,28 @@ struct VignetteParams {
 };
 ```
 
-### Full class declaration
+### State struct and free functions
 
 ```cpp
 // ZEngine/Rendering/PostProcessing/VignettePass.h
-struct VignettePass final : public PostProcessPass {
-    explicit VignettePass(Core::Memory::ArenaAllocator* arena,
-                          Hardwares::VulkanDevice*     device);
-
-    StringHash GetName() const override;  // hash of "VignettePass"
-
-    void SetIOHandles(Textures::TextureHandle input,
-                      Textures::TextureHandle output) override;
-
-    void SetParams(const VignetteParams& params);
-
-    void Setup(Graph::RenderGraphResourceBuilder& builder) override;
-    void Execute(VkCommandBuffer cmd, const Graph::RenderGraph& rg) override;
-
-private:
-    VignetteParams           m_params{};
-    VkBuffer                 m_params_ubo = VK_NULL_HANDLE;
-    VkPipeline               m_pipeline   = VK_NULL_HANDLE;
-    VkPipelineLayout         m_layout     = VK_NULL_HANDLE;
-    Textures::TextureHandle  m_input      = {};
-    Textures::TextureHandle  m_output     = {};
+struct VignetteState {
+    VignetteParams           Params{};
+    bool                     ParamsDirty  = true;
+    VkPipeline               Pipeline     = VK_NULL_HANDLE;
+    VkPipelineLayout         PipelineLayout = VK_NULL_HANDLE;
+    Textures::TextureHandle  Input        = {};
+    Textures::TextureHandle  Output       = {};
 
     Core::Memory::ArenaAllocator* m_arena  = nullptr;
     Hardwares::VulkanDevice*      m_device = nullptr;
 };
+
+PostProcessPassEntry MakeVignettePass(Core::Memory::ArenaAllocator* arena,
+                                       Hardwares::VulkanDevice*      device,
+                                       const VignetteParams&         params);
+
+void VignettePass_Setup  (PostProcessPassData&, Graph::RenderGraphResourceBuilder&);
+void VignettePass_Execute(PostProcessPassData&, VkCommandBuffer, const Graph::RenderGraph&);
 ```
 
 ### Shader (`vignette.frag`)
@@ -1090,7 +1057,7 @@ A 4×4 tileable noise texture (`VK_FORMAT_R16G16_SFLOAT`, encoding random rotati
 the XY plane) is used to rotate the hemisphere kernel per-pixel, removing banding artefacts
 without extra samples.
 
-### Full class declaration
+### State struct and free functions
 
 ```cpp
 // ZEngine/Rendering/PostProcessing/SSAOPass.h
@@ -1102,44 +1069,33 @@ namespace ZEngine::Rendering::PostProcessing {
     static constexpr uint32_t SSAO_MAX_SAMPLES = 32;
     static constexpr uint32_t SSAO_NOISE_DIM   = 4;
 
-    struct SSAOPass final : public PostProcessPass {
-        explicit SSAOPass(Core::Memory::ArenaAllocator* arena,
-                          Hardwares::VulkanDevice*     device);
+    struct SSAOState {
+        SSAOParams               Params{};
+        bool                     ParamsDirty     = true;
+        Core::Maths::Vec3f       Kernel[SSAO_MAX_SAMPLES] = {};
+        // KernelUBO and NoiseTex are static after init — uploaded once via
+        // GpuAllocator staging ring, not re-uploaded each frame.
+        VkBuffer                 KernelUBO       = VK_NULL_HANDLE;
+        VmaAllocation            KernelAlloc     = nullptr;
+        Textures::TextureHandle  NoiseTex        = {};
+        Textures::TextureHandle  DepthInput      = {};
+        Textures::TextureHandle  NormalsInput    = {};
+        Textures::TextureHandle  OcclusionOut    = {};  // R8, half-res
 
-        StringHash GetName() const override;  // hash of "SSAOPass"
+        VkPipeline               SSAOPipeline    = VK_NULL_HANDLE;
+        VkPipeline               BlurPipeline    = VK_NULL_HANDLE;
+        VkPipelineLayout         PipelineLayout  = VK_NULL_HANDLE;
 
-        // SSAO reads depth and normals; output is an R8 occlusion texture.
-        void SetGBufferInputs(Textures::TextureHandle depth,
-                              Textures::TextureHandle view_normals);
-
-        void SetIOHandles(Textures::TextureHandle input,
-                          Textures::TextureHandle output) override;
-
-        void SetParams(const SSAOParams& params);
-
-        void Setup(Graph::RenderGraphResourceBuilder& builder) override;
-        void Execute(VkCommandBuffer cmd, const Graph::RenderGraph& rg) override;
-
-    private:
-        void GenerateKernel();
-        void GenerateNoiseTex();
-
-        SSAOParams               m_params{};
-        Core::Maths::Vec3f       m_kernel[SSAO_MAX_SAMPLES] = {};
-        VkBuffer                 m_kernel_ubo    = VK_NULL_HANDLE;
-        Textures::TextureHandle  m_noise_tex     = {};
-        Textures::TextureHandle  m_depth_input   = {};
-        Textures::TextureHandle  m_normals_input = {};
-        Textures::TextureHandle  m_occlusion_out = {};  // R8, half-res
-
-        // Blur pass resources (bilateral, to preserve edges)
-        VkPipeline               m_ssao_pipeline  = VK_NULL_HANDLE;
-        VkPipeline               m_blur_pipeline  = VK_NULL_HANDLE;
-        VkPipelineLayout         m_layout         = VK_NULL_HANDLE;
-
-        Core::Memory::ArenaAllocator* m_arena  = nullptr;
-        Hardwares::VulkanDevice*      m_device = nullptr;
+        Core::Memory::ArenaAllocator* m_arena    = nullptr;
+        Hardwares::VulkanDevice*      m_device   = nullptr;
     };
+
+    PostProcessPassEntry MakeSSAOPass(Core::Memory::ArenaAllocator* arena,
+                                       Hardwares::VulkanDevice*      device,
+                                       const SSAOParams&             params);
+
+    void SSAOPass_Setup  (PostProcessPassData&, Graph::RenderGraphResourceBuilder&);
+    void SSAOPass_Execute(PostProcessPassData&, VkCommandBuffer, const Graph::RenderGraph&);
 
 }  // namespace ZEngine::Rendering::PostProcessing
 ```
@@ -1328,7 +1284,7 @@ during stable frames.
 
 ```
 ZEngine/Rendering/PostProcessing/
-├── PostProcessPass.h              — abstract base type
+├── PostProcessPass.h              — DOD types (PostProcessPassData, PostProcessPassVtable, PostProcessPassEntry)
 ├── PostProcessStack.h/.cpp        — owns + orders all passes
 ├── BloomPass.h/.cpp               — dual kawase bloom
 ├── ToneMappingPass.h/.cpp         — ACES/Reinhard/Uncharted2/Neutral
@@ -1380,7 +1336,7 @@ assembly state.
 ## 14. Deliverables Checklist
 
 ### Core infrastructure
-- [ ] `ZEngine/Rendering/PostProcessing/PostProcessPass.h` — abstract base with `GetName()`, `SetEnabled()`, `SetIOHandles()`, `Setup()`, `Execute()`
+- [ ] `ZEngine/Rendering/PostProcessing/PostProcessPass.h` — DOD types: `PostProcessPassData` (name, I/O handles, enabled flag, order, void* params), `PostProcessPassVtable` (Setup/Execute free-function pointers), `PostProcessPassEntry` aggregate; no virtual inheritance
 - [ ] `ZEngine/Rendering/PostProcessing/PostProcessStack.h/.cpp` — `Initialize`, `AddPass`, `RemovePass`, `SetEnabled`, `Compile`, `Execute`; ping-pong resource allocation; sorted pass list via `order` field
 - [ ] `ZEngine/Assets/Shaders/PostProcessing/fullscreen_triangle.vert` — index-based full-screen triangle, no VBO
 

--- a/ZEngine/docs/future-plan/profiling.md
+++ b/ZEngine/docs/future-plan/profiling.md
@@ -582,26 +582,37 @@ macro is placed _after_ the pointer is computed so `ptr` is valid.
 
 ### Post-process passes
 
+Post-process passes use the DOD free-function pattern — `Execute` is a standalone function,
+not a class method. The profiling macros follow the same one-CPU-scope + one-GPU-scope rule:
+
 ```cpp
-// Each PostProcessPass::Execute implementation:
-void BloomPass::Execute(VkCommandBuffer cmd, const Graph::RenderGraph& rg) {
-    ZENGINE_PROFILE_SCOPE("BloomPass::Execute");
+// BloomPass_Execute — free function registered in PostProcessPassVtable.
+void BloomPass_Execute(PostProcessPassData& data,
+                       VkCommandBuffer      cmd,
+                       const Graph::RenderGraph& rg)
+{
+    ZENGINE_PROFILE_SCOPE("BloomPass_Execute");
     ZENGINE_PROFILE_GPU_SCOPE(cmd, "GPU::BloomPass");
     // ...
 }
 ```
 
-All post-process passes follow the same pattern: one CPU scope and one GPU scope per
-`Execute` call.
+All post-process Execute free functions follow the same pattern: one CPU scope and one GPU
+scope per call. The scope name matches the free-function name for easy Tracy lookup.
 
 ### Shadow passes
 
+Shadow passes use the same DOD free-function pattern:
+
 ```cpp
-void CascadedShadowPass::Execute(VkCommandBuffer cmd, const Graph::RenderGraph& rg) {
-    ZENGINE_PROFILE_SCOPE("CascadedShadowPass::Execute");
-    ZENGINE_PROFILE_GPU_SCOPE(cmd, "GPU::CascadedShadowPass");
-    for (uint32_t cascade = 0; cascade < m_cascade_count; ++cascade) {
-        ZENGINE_PROFILE_SCOPE("CascadedShadowPass::Cascade");
+void ShadowPassDir_Execute(PostProcessPassData& data,
+                           VkCommandBuffer      cmd,
+                           const Graph::RenderGraph& rg)
+{
+    ZENGINE_PROFILE_SCOPE("ShadowPassDir_Execute");
+    ZENGINE_PROFILE_GPU_SCOPE(cmd, "GPU::ShadowPassDir");
+    for (uint32_t cascade = 0; cascade < SHADOW_CASCADE_COUNT; ++cascade) {
+        ZENGINE_PROFILE_SCOPE("ShadowPassDir_Cascade");
         ZENGINE_PROFILE_GPU_SCOPE(cmd, "GPU::ShadowCascade");
         // ...
     }
@@ -634,8 +645,8 @@ void AudioEngine::Tick(float dt) {
 | `AssetManager::Load` | `ZENGINE_PROFILE_SCOPE` | |
 | `AssetManager::FlushPendingLoads` | `ZENGINE_PROFILE_SCOPE` | |
 | `ArenaAllocator::Allocate` | `ZENGINE_PROFILE_ALLOC` | After ptr is valid |
-| Each `PostProcessPass::Execute` | `ZENGINE_PROFILE_SCOPE` + `ZENGINE_PROFILE_GPU_SCOPE` | |
-| Each shadow pass `Execute` | `ZENGINE_PROFILE_SCOPE` + `ZENGINE_PROFILE_GPU_SCOPE` | |
+| Each `*Pass_Execute` free function (post-process) | `ZENGINE_PROFILE_SCOPE` + `ZENGINE_PROFILE_GPU_SCOPE` | |
+| Each shadow pass `*Pass_Execute` free function | `ZENGINE_PROFILE_SCOPE` + `ZENGINE_PROFILE_GPU_SCOPE` | |
 | `AudioEngine::Tick` | `ZENGINE_PROFILE_SCOPE` | |
 
 ---

--- a/ZEngine/docs/future-plan/render-graph-integration.md
+++ b/ZEngine/docs/future-plan/render-graph-integration.md
@@ -557,20 +557,20 @@ void GraphicRenderer::RegisterPasses(RenderGraphPtr render_graph)
     render_graph->AddCallbackPass("LightingPass",        ZNew(LightingPass));
 
     // Post-process chain.
-    render_graph->AddCallbackPass("SSAOPass",            ZNew(SSAOPass));
-    render_graph->AddCallbackPass("BloomThresholdPass",  ZNew(BloomThresholdPass));
-    render_graph->AddCallbackPass("BloomDownsample_0",   ZNew(BloomDownsamplePass, 0));
-    render_graph->AddCallbackPass("BloomDownsample_1",   ZNew(BloomDownsamplePass, 1));
-    render_graph->AddCallbackPass("BloomDownsample_2",   ZNew(BloomDownsamplePass, 2));
-    render_graph->AddCallbackPass("BloomDownsample_3",   ZNew(BloomDownsamplePass, 3));
-    render_graph->AddCallbackPass("BloomDownsample_4",   ZNew(BloomDownsamplePass, 4));
-    render_graph->AddCallbackPass("BloomUpsample_4",     ZNew(BloomUpsamplePass, 4));
-    render_graph->AddCallbackPass("BloomUpsample_3",     ZNew(BloomUpsamplePass, 3));
-    render_graph->AddCallbackPass("BloomUpsample_2",     ZNew(BloomUpsamplePass, 2));
-    render_graph->AddCallbackPass("BloomUpsample_1",     ZNew(BloomUpsamplePass, 1));
-    render_graph->AddCallbackPass("BloomUpsample_0",     ZNew(BloomUpsamplePass, 0));
-    render_graph->AddCallbackPass("ToneMappingPass",     ZNew(ToneMappingPass));
-    render_graph->AddCallbackPass("FXAAPass",            ZNew(FXAAPass));
+    // Passes are owned by PostProcessStack, not registered directly with the
+    // RenderGraph via AddCallbackPass. PostProcessStack::Compile() calls
+    // AddCallbackPass internally for each enabled pass in Order-sorted sequence.
+    // GraphicRenderer holds a PostProcessStack member (or pointer) initialised
+    // during engine startup.
+    m_post_process_stack.AddPass(MakeSSAOPass        (arena, device, SSAOParams{}));
+    m_post_process_stack.AddPass(MakeBloomPass        (arena, device, BloomParams{}));
+    m_post_process_stack.AddPass(MakeToneMappingPass  (arena, device, ToneMappingParams{}));
+    m_post_process_stack.AddPass(MakeFXAAPass         (arena, device, FXAAParams{}));
+    // Optional passes — disabled at startup; editor can enable at runtime.
+    m_post_process_stack.AddPass(MakeColorGradingPass        (arena, device, ColorGradingParams{}));
+    m_post_process_stack.AddPass(MakeChromaticAberrationPass (arena, device, ChromaticAberrationParams{}));
+    m_post_process_stack.AddPass(MakeVignettePass            (arena, device, VignetteParams{}));
+    m_post_process_stack.Compile();
 
     // UI, text, editor overlay.
     render_graph->AddCallbackPass("UIPass",              ZNew(UIPass));
@@ -595,21 +595,37 @@ represents a future migration of that code into the graph.
 
 ## 8. Pass Enable/Disable at Runtime
 
-`AddCallbackPass` accepts an optional `enabled` parameter (default `true`):
+Post-process passes are toggled through `PostProcessStack`, not directly through the
+`RenderGraph`. The stack owns pass lifetime and communicates enable state to the graph via
+the `PostProcessPassData::Enabled` flag, which `Compile()` propagates to the corresponding
+`AddCallbackPass` node.
+
+To disable a post-process pass at startup, set `Enabled = false` in the factory params or
+call `SetEnabled` before `Compile()`:
 
 ```cpp
-render_graph->AddCallbackPass("SSAOPass", ZNew(SSAOPass), false);  // disabled at startup
+// Option A — pass disabled params to the factory.
+auto entry = MakeSSAOPass(arena, device, SSAOParams{});
+entry.Data.Enabled = false;
+m_post_process_stack.AddPass(entry);
+
+// Option B — disable after AddPass, before Compile().
+m_post_process_stack.SetEnabled(StringHash("SSAOPass"), false);
 ```
 
-To toggle a pass after the graph is compiled:
+To toggle a post-process pass after the graph is compiled (runtime):
 
 ```cpp
-render_graph->ResourceInspector->GetNode("FXAAPass").Enabled = false;
-// or equivalently:
-render_graph->NodeMap["FXAAPass"].Enabled = false;
+m_post_process_stack.SetEnabled(StringHash("FXAAPass"), false);
+// Takes effect on the next PostProcessStack::Execute() call — no re-compile needed.
 ```
 
-The change takes effect on the next `Execute()` call — no re-compile needed.
+For non-post-process passes (geometry, shadow, UI) the RenderGraph node can be toggled
+directly via the node map:
+
+```cpp
+render_graph->NodeMap["DepthPrePass"].Enabled = false;
+```
 
 Disabled passes are skipped in `Execute()`: their barriers are not emitted and their
 `Execute()` callback is not called. Their resource producers still run normally. This means a

--- a/ZEngine/docs/future-plan/render-graph-redesign.md
+++ b/ZEngine/docs/future-plan/render-graph-redesign.md
@@ -1,0 +1,813 @@
+# Render Graph Redesign — Production-Grade Barrier Insertion and Memory Aliasing
+
+**Relates to:** `gpu-allocator-rearchitecture.md`, `per-frame-upload-heap.md`, `render-graph-integration.md`
+**Replaces:** `RenderGraph.h/.cpp`, `IRenderGraphCallbackPass`, `RenderGraphNode`, `RenderGraphResourceBuilder`, `RenderGraphResourceInspector`
+**Scope:** Full redesign of the render graph compile and execute paths to produce automatic pipeline barriers and alias transient render target memory.
+
+---
+
+## 1. What Is Wrong With the Current Design
+
+Reading `RenderGraph.cpp` directly:
+
+**Barrier insertion is manual and wrong.** `Execute()` emits one barrier per input texture
+(always `COLOR_ATTACHMENT_OUTPUT -> SHADER_READ_ONLY`) and one barrier per output attachment
+(always `TOP_OF_PIPE -> COLOR_ATTACHMENT / DEPTH_STENCIL`). The source stage is hardcoded
+regardless of what the previous pass actually was. This produces over-synchronisation every
+frame — every pass stalls the full pipeline before it starts, even when the previous pass was
+a compute dispatch or a transfer, not a color attachment write.
+
+**No transient resource lifetime tracking.** `Compile()` calls `Device->CreateTexture()` once
+per attachment resource with no record of when that resource is first written or last read.
+G-buffer normals at 4K (`R16G16B16A16_SFLOAT`) = 134 MB. That memory is allocated, held for
+the entire frame, and freed at graph teardown — even though the lighting pass is the last
+consumer and the resource is dead for the remaining 60%+ of the frame.
+
+**`UnorderedHashMap` on the hot path.** `Execute()` calls `NodeMap[node_name]` and
+`ResourceMap[input.Name]` inside the per-pass loop. Both are string-keyed hash map lookups.
+At 25 passes with 3-5 resources each that is 100+ hash lookups per frame on the critical path.
+
+**`Resize()` leaks.** Line 342: `Device->GlobalTextures.Create()` + `Device->GlobalTextures.Update()`
+copies the old texture descriptor into a temp slot, then enqueues the temp for disposal. The
+resize path allocates two texture slots per resource per resize event. Rapid viewport dragging
+creates a leak storm. The deferred free queue also never receives the VkImage memory — only
+the texture slot is enqueued.
+
+**`Compile()` rebuilds framebuffers unconditionally** even if the render area has not changed.
+`Resize()` also rebuilds all framebuffers for every node regardless of whether that node's
+outputs changed size.
+
+---
+
+## 2. Design Goals
+
+1. Automatic pipeline barriers — no pass implementation ever calls `vkCmdPipelineBarrier` directly.
+2. Transient attachment aliasing — non-overlapping transient resources share physical memory via VMA alias pools.
+3. `VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT` + `VMA_MEMORY_USAGE_GPU_LAZILY_ALLOCATED` for any
+   attachment consumed only within a single render pass (tile memory on Mali/Adreno/Apple GPU).
+4. Execute loop is array-indexed, not hash-keyed — zero string hashing on the hot path.
+5. Barrier batching — collect all barriers needed before a pass into one `vkCmdPipelineBarrier` call.
+6. Keep the existing `IRenderGraphCallbackPass` interface intact. Existing pass implementations
+   (`UploadPass`, `BasePass`, `DepthPrePass`, `SkyboxPass`, `GridPass`) require no changes.
+
+---
+
+## 3. Core Data Model
+
+### 3.1 ResourceHandle — typed index, no string on hot path
+
+```cpp
+struct RGResourceHandle {
+    uint32_t Index   = UINT32_MAX;
+    uint32_t Version = 0;           // incremented on each write to detect read-after-write
+
+    bool Valid() const { return Index != UINT32_MAX; }
+};
+```
+
+### 3.2 RGResource — flat struct, all state in one place
+
+```cpp
+enum class RGResourceKind : uint8_t {
+    Attachment,   // VkImage written as render target / depth target
+    Texture,      // VkImage read-only (external or imported)
+    Buffer,       // VkBuffer (external — per-frame heap, storage buffer set, etc.)
+};
+
+// Access describes how a pass uses a resource.
+// The compiler uses this to derive src/dst stage + access masks for barriers.
+enum class RGAccess : uint8_t {
+    None,
+    ColorWrite,           // vkCmdBeginRenderPass as color attachment
+    DepthWrite,           // vkCmdBeginRenderPass as depth attachment
+    DepthRead,            // input attachment, read-only depth
+    ShaderRead,           // sampler2D / combined image sampler
+    ShaderReadWrite,      // storage image read + write (compute)
+    TransferRead,
+    TransferWrite,
+    Present,
+};
+
+struct RGResourceState {
+    VkPipelineStageFlags Stage  = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+    VkAccessFlags        Access = 0;
+    VkImageLayout        Layout = VK_IMAGE_LAYOUT_UNDEFINED;
+};
+
+struct RGResource {
+    cstring              Name           = nullptr;
+    RGResourceKind       Kind           = RGResourceKind::Attachment;
+    bool                 External       = false;    // imported, not owned by the graph
+
+    // Transient physical backing — null for external resources.
+    // Set by the aliasing allocator during Compile().
+    Textures::TextureHandle  TextureHandle  = {};
+    RGResourceState          CurrentState   = {};
+
+    // Lifetime — filled by the lifetime analysis pass in Compile().
+    uint32_t             FirstPassIndex = UINT32_MAX;
+    uint32_t             LastPassIndex  = 0;
+
+    // For aliasing: physical memory can be reused after LastPassIndex.
+    bool                 Transient      = true;
+
+    // Spec used to (re-)allocate the physical backing on resize.
+    Specifications::TextureSpecification Spec = {};
+};
+```
+
+### 3.3 RGPassResource — a pass's declaration of one resource use
+
+```cpp
+struct RGPassResource {
+    RGResourceHandle Handle = {};
+    RGAccess         Access = RGAccess::None;
+    cstring          BindingKey = nullptr;  // descriptor slot name, for textures
+};
+```
+
+### 3.4 RGPass — compiled representation of one pass
+
+```cpp
+struct RGPass {
+    cstring                               Name       = nullptr;
+    bool                                  Enabled    = true;
+    IRenderGraphCallbackPass*             Callback   = nullptr;
+    RenderPasses::RenderPass*             Handle     = nullptr;
+    Buffers::FramebufferVNext*            Framebuffer = nullptr;
+
+    // Declared by the pass in Setup() via RGBuilder.
+    Core::Containers::Array<RGPassResource> Reads;   // inputs
+    Core::Containers::Array<RGPassResource> Writes;  // outputs
+
+    // Filled by Compile() — the full barrier batch to emit before Execute().
+    Core::Containers::Array<VkImageMemoryBarrier>  ImageBarriers;
+    VkPipelineStageFlags                           BarrierSrcStage = 0;
+    VkPipelineStageFlags                           BarrierDstStage = 0;
+};
+```
+
+### 3.5 RenderGraph — the new top-level struct
+
+```cpp
+struct RenderGraph {
+    Hardwares::VulkanDevicePtr   Device      = nullptr;
+    Scenes::SceneDataPtr         SceneData   = nullptr;
+
+    // Flat arrays — indexed by compile-time order.
+    // No hash map on the Execute hot path.
+    Core::Containers::Array<RGPass>     Passes;
+    Core::Containers::Array<RGResource> Resources;
+
+    // String -> index map used only during Setup/Compile, not Execute.
+    Core::Containers::UnorderedHashMap<cstring, uint32_t> ResourceIndex;
+    Core::Containers::UnorderedHashMap<cstring, uint32_t> PassIndex;
+
+    // Builder and inspector exposed to pass Setup() implementations.
+    // Same API surface as today so existing pass code compiles unchanged.
+    RGBuilder*    Builder    = nullptr;
+    RGInspector*  Inspector  = nullptr;
+
+    // Transient resource pool used by the aliasing allocator.
+    RGTransientPool TransientPool;
+
+    void Initialize(Hardwares::VulkanDevicePtr device, Scenes::SceneDataPtr scene);
+    void AddCallbackPass(cstring name, IRenderGraphCallbackPass* cb, bool enabled = true);
+    void Setup();
+    void Compile();
+    void Execute(Hardwares::CommandBufferPtr cb);
+    void Resize(uint32_t width, uint32_t height);
+    void Dispose();
+
+    RGResourceHandle ImportRenderTarget(cstring name, Textures::TextureHandle handle);
+    RGResourceHandle CreateTransientAttachment(cstring name, const Specifications::TextureSpecification& spec);
+};
+```
+
+---
+
+## 4. Lifetime Analysis
+
+This runs in `Compile()` after all passes have called `Setup()` and declared their reads and writes.
+
+```
+for i in 0..Passes.size():
+    pass = Passes[i]
+    for each write in pass.Writes:
+        resource = Resources[write.Handle.Index]
+        resource.FirstPassIndex = min(resource.FirstPassIndex, i)
+    for each read in pass.Reads:
+        resource = Resources[read.Handle.Index]
+        resource.LastPassIndex  = max(resource.LastPassIndex,  i)
+    // A pass that both reads and writes the same resource (read-modify-write)
+    // contributes to both.
+    for each write in pass.Writes where resource also in pass.Reads:
+        resource.LastPassIndex  = max(resource.LastPassIndex,  i)
+```
+
+After this loop every transient resource knows exactly when it is born (first write) and
+when it dies (last read).
+
+---
+
+## 5. Transient Aliasing Allocator
+
+### 5.1 RGTransientPool
+
+```cpp
+struct RGTransientSlot {
+    Textures::TextureHandle Handle         = {};
+    Specifications::TextureSpecification Spec = {};
+    uint32_t                FreeAfterPass  = 0;  // resource is dead after this pass index
+};
+
+struct RGTransientPool {
+    // Arena-backed flat list of all allocated slots.
+    Core::Containers::Array<RGTransientSlot> Slots;
+
+    // Try to find an existing slot compatible with `spec` that is free
+    // (FreeAfterPass < firstPassIndex). Returns invalid handle if none found.
+    Textures::TextureHandle TryAlias(
+        const Specifications::TextureSpecification& spec,
+        uint32_t firstPassIndex);
+
+    // Register a newly allocated slot into the pool.
+    void Register(Textures::TextureHandle handle,
+                  const Specifications::TextureSpecification& spec,
+                  uint32_t lastPassIndex);
+
+    // Update the free-after index when a slot is reused.
+    void MarkInUse(Textures::TextureHandle handle, uint32_t lastPassIndex);
+
+    void Clear();
+};
+```
+
+### 5.2 Alias compatibility
+
+Two texture specs are alias-compatible when:
+- Same `VkFormat`
+- Same width and height (or the slot's dimensions are >= the requested dimensions — exact match preferred)
+- Same or superset of `VkImageUsageFlags` — the slot must support at least everything the new resource needs
+- Same `layerCount` and `mipLevels`
+
+This is a conservative check. Two resources with non-overlapping lifetimes and compatible specs
+share one `VkImage` allocation. The Vulkan spec allows this as long as the aliased image is
+re-initialized (transition from `VK_IMAGE_LAYOUT_UNDEFINED`) before use — which the barrier
+system does automatically on every first write.
+
+### 5.3 Allocation path in Compile()
+
+```
+for each transient resource r in dependency order (FirstPassIndex ascending):
+
+    aliased = TransientPool.TryAlias(r.Spec, r.FirstPassIndex)
+
+    if aliased.Valid():
+        r.TextureHandle = aliased
+        TransientPool.MarkInUse(aliased, r.LastPassIndex)
+    else:
+        // Determine usage flags from all accesses declared against this resource.
+        usage = DeriveUsageFlags(r)  // see Section 5.4
+        r.Spec.UsageFlags = usage
+        r.TextureHandle = Device->CreateTexture(r.Spec)
+        TransientPool.Register(r.TextureHandle, r.Spec, r.LastPassIndex)
+```
+
+### 5.4 Deriving `VkImageUsageFlags`
+
+Walk all passes, collect every `RGAccess` declared against resource `r`:
+
+```cpp
+VkImageUsageFlags DeriveUsageFlags(const RGResource& r, const Array<RGPass>& passes)
+{
+    VkImageUsageFlags flags = 0;
+    bool wroteAsColor = false, wroteAsDepth = false;
+    bool readAsShader = false;
+
+    for (auto& pass : passes) {
+        for (auto& w : pass.Writes) {
+            if (w.Handle.Index != r.Index) continue;
+            if (w.Access == RGAccess::ColorWrite) { flags |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT; wroteAsColor = true; }
+            if (w.Access == RGAccess::DepthWrite) { flags |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT; wroteAsDepth = true; }
+        }
+        for (auto& rd : pass.Reads) {
+            if (rd.Handle.Index != r.Index) continue;
+            if (rd.Access == RGAccess::ShaderRead)      { flags |= VK_IMAGE_USAGE_SAMPLED_BIT; readAsShader = true; }
+            if (rd.Access == RGAccess::ShaderReadWrite)   flags |= VK_IMAGE_USAGE_STORAGE_BIT;
+            if (rd.Access == RGAccess::TransferRead)      flags |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+            if (rd.Access == RGAccess::TransferWrite)     flags |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+        }
+    }
+
+    // Transient attachment: written and read only as an attachment within a single pass
+    // (first and last pass are the same). Never sampled by a shader.
+    bool singlePassLifetime = (r.FirstPassIndex == r.LastPassIndex);
+    if (singlePassLifetime && !readAsShader && (wroteAsColor || wroteAsDepth)) {
+        flags |= VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
+        // Caller sets VMA_MEMORY_USAGE_GPU_LAZILY_ALLOCATED for this resource.
+        // On tiled GPUs the image never touches DRAM.
+    }
+
+    return flags;
+}
+```
+
+The `VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT` path covers:
+- SSAO blur intermediates (R8, half-res, written and blurred in a single compute pass)
+- Bloom downsample/upsample intermediates at each mip level
+- Shadow resolve buffer (depth-only, not sampled after the cascade pass resolves)
+- G-buffer normals/specular on hardware where the lighting pass uses input attachments (TBDR path)
+
+---
+
+## 6. Automatic Barrier Insertion
+
+### 6.1 State tracking
+
+Each `RGResource` carries a `CurrentState` (stage, access mask, image layout). The graph
+initialises all states to `{TOP_OF_PIPE, 0, UNDEFINED}` at the start of Compile. States are
+then advanced pass-by-pass during the barrier-building loop.
+
+### 6.2 Access -> stage + mask table
+
+```cpp
+struct RGAccessInfo {
+    VkPipelineStageFlags Stage;
+    VkAccessFlags        Access;
+    VkImageLayout        Layout;
+};
+
+constexpr RGAccessInfo kAccessTable[] = {
+    // None
+    { VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,                0,                                          VK_IMAGE_LAYOUT_UNDEFINED                     },
+    // ColorWrite
+    { VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,    VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,        VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL      },
+    // DepthWrite
+    { VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT
+      | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
+      VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT
+      | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT,
+      VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL                                                                                             },
+    // DepthRead
+    { VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT,       VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT, VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL },
+    // ShaderRead
+    { VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,            VK_ACCESS_SHADER_READ_BIT,                   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL      },
+    // ShaderReadWrite (compute)
+    { VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,             VK_ACCESS_SHADER_READ_BIT
+                                                        | VK_ACCESS_SHADER_WRITE_BIT,                VK_IMAGE_LAYOUT_GENERAL                       },
+    // TransferRead
+    { VK_PIPELINE_STAGE_TRANSFER_BIT,                   VK_ACCESS_TRANSFER_READ_BIT,                 VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL          },
+    // TransferWrite
+    { VK_PIPELINE_STAGE_TRANSFER_BIT,                   VK_ACCESS_TRANSFER_WRITE_BIT,                VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL          },
+    // Present
+    { VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,             0,                                           VK_IMAGE_LAYOUT_PRESENT_SRC_KHR               },
+};
+```
+
+### 6.3 Barrier build loop (runs once in Compile())
+
+```cpp
+for (uint32_t i = 0; i < Passes.size(); ++i) {
+    RGPass& pass = Passes[i];
+
+    VkPipelineStageFlags srcStage = 0;
+    VkPipelineStageFlags dstStage = 0;
+
+    // Collect all image barriers needed before this pass executes.
+    for (auto& rd : pass.Reads) {
+        RGResource& res  = Resources[rd.Handle.Index];
+        RGAccessInfo dst = kAccessTable[(int)rd.Access];
+
+        // Only emit a barrier if layout or access changes.
+        if (res.CurrentState.Layout == dst.Layout &&
+            res.CurrentState.Access == dst.Access)
+            continue;
+
+        VkImageMemoryBarrier barrier = {};
+        barrier.sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+        barrier.oldLayout           = res.CurrentState.Layout;
+        barrier.newLayout           = dst.Layout;
+        barrier.srcAccessMask       = res.CurrentState.Access;
+        barrier.dstAccessMask       = dst.Access;
+        // Aliased resources always transition from UNDEFINED on first use,
+        // discarding stale contents from the previous alias owner.
+        if (res.FirstPassIndex == i)
+            barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        barrier.image               = GetVkImage(res.TextureHandle);
+        barrier.subresourceRange    = FullSubresourceRange(res);
+
+        pass.ImageBarriers.push(barrier);
+        srcStage |= res.CurrentState.Stage;
+        dstStage |= dst.Stage;
+
+        res.CurrentState = { dst.Stage, dst.Access, dst.Layout };
+    }
+
+    for (auto& wr : pass.Writes) {
+        RGResource& res  = Resources[wr.Handle.Index];
+        RGAccessInfo dst = kAccessTable[(int)wr.Access];
+
+        if (res.CurrentState.Layout == dst.Layout &&
+            res.CurrentState.Access == dst.Access)
+            continue;
+
+        VkImageMemoryBarrier barrier = {};
+        barrier.sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+        barrier.oldLayout           = res.CurrentState.Layout;
+        barrier.newLayout           = dst.Layout;
+        barrier.srcAccessMask       = res.CurrentState.Access;
+        barrier.dstAccessMask       = dst.Access;
+        if (res.FirstPassIndex == i)
+            barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        barrier.image               = GetVkImage(res.TextureHandle);
+        barrier.subresourceRange    = FullSubresourceRange(res);
+
+        pass.ImageBarriers.push(barrier);
+        srcStage |= res.CurrentState.Stage;
+        dstStage |= dst.Stage;
+
+        res.CurrentState = { dst.Stage, dst.Access, dst.Layout };
+    }
+
+    // Fallback: if no barriers needed, stage masks remain zero.
+    // Guard against the degenerate case (TOP_OF_PIPE | 0).
+    if (srcStage == 0) srcStage = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+    if (dstStage == 0) dstStage = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+
+    pass.BarrierSrcStage = srcStage;
+    pass.BarrierDstStage = dstStage;
+}
+```
+
+The barrier arrays are arena-allocated once per Compile() call. Execute() just reads them.
+
+### 6.4 Execute loop — barrier emission
+
+```cpp
+void RenderGraph::Execute(Hardwares::CommandBufferPtr cb)
+{
+    for (uint32_t i = 0; i < Passes.size(); ++i) {
+        RGPass& pass = Passes[i];
+
+        if (!pass.Enabled) continue;
+
+        // Emit the pre-computed barrier batch — one vkCmdPipelineBarrier call.
+        if (!pass.ImageBarriers.empty()) {
+            vkCmdPipelineBarrier(
+                cb->Handle,
+                pass.BarrierSrcStage,
+                pass.BarrierDstStage,
+                0,
+                0, nullptr,       // memory barriers
+                0, nullptr,       // buffer barriers
+                pass.ImageBarriers.size(),
+                pass.ImageBarriers.data());
+        }
+
+        pass.Callback->Execute(
+            Device, Inspector, SceneData,
+            pass.Handle, pass.Framebuffer, cb);
+    }
+}
+```
+
+No hash lookups. No per-pass barrier computation. One `vkCmdPipelineBarrier` per pass,
+batching all image transitions for that pass. Total: O(N) where N = pass count.
+
+---
+
+## 7. RGBuilder API (replaces RenderGraphResourceBuilder)
+
+The `RGBuilder` is the same object as today's `RenderGraphResourceBuilder` from the pass's
+perspective, but returns `RGResourceHandle` instead of `RenderGraphResource&`. Pass
+implementations call it identically from `Setup()`.
+
+```cpp
+struct RGBuilder {
+    RenderGraph* Graph = nullptr;
+
+    // Declare that the current pass writes a transient color attachment.
+    // If the resource does not yet exist it is created.
+    RGResourceHandle WriteColorAttachment(cstring name,
+                                          const Specifications::TextureSpecification& spec);
+
+    // Declare that the current pass writes a transient depth attachment.
+    RGResourceHandle WriteDepthAttachment(cstring name,
+                                          const Specifications::TextureSpecification& spec);
+
+    // Declare that the current pass reads a resource as a shader texture.
+    RGResourceHandle ReadTexture(cstring name, cstring binding_key);
+
+    // Declare that the current pass reads a resource as a depth input attachment (read-only).
+    RGResourceHandle ReadDepth(cstring name);
+
+    // Import an externally-owned resource into the graph.
+    RGResourceHandle ImportRenderTarget(cstring name, Textures::TextureHandle handle);
+    RGResourceHandle ImportTexture(cstring name, Textures::TextureHandle handle);
+
+    // Buffer resources (vertex, index, storage, indirect) — identical to today.
+    RGResourceHandle AttachBuffer(cstring name, const Hardwares::StorageBufferSetHandle&);
+    RGResourceHandle AttachBuffer(cstring name, const Hardwares::VertexBufferSetHandle&);
+    RGResourceHandle AttachBuffer(cstring name, const Hardwares::IndexBufferSetHandle&);
+    RGResourceHandle AttachBuffer(cstring name, const Hardwares::IndirectBufferSetHandle&);
+    RGResourceHandle AttachBuffer(cstring name, const Hardwares::UniformBufferSetHandle&);
+};
+```
+
+Each `Write*` / `Read*` call:
+1. Creates or looks up the `RGResource` entry by name.
+2. Records the access type on the current pass's `Reads` or `Writes` array.
+3. Records `ProducerPassIndex` on the resource (for topology).
+4. Returns the `RGResourceHandle` — the pass can store it for use in `Execute()`.
+
+---
+
+## 8. Topology — Replacing the Hand-Written DFS
+
+The current topological sort walks `EdgeNodes` sets attached to each node. EdgeNodes are
+populated during Compile() from the resource producer map.
+
+The new design uses the same DFS but operates on indices, not strings:
+
+```
+// Build adjacency from resource producer/consumer declarations.
+for each pass i:
+    for each read r in pass.Reads:
+        res = Resources[r.Handle.Index]
+        if res.ProducerPassIndex is valid and != i:
+            // pass[res.ProducerPassIndex] must execute before pass[i]
+            Adjacency[res.ProducerPassIndex].insert(i)
+
+// DFS post-order topological sort on integer pass indices.
+// Cycle detection: same logic as current, but using index sets instead of string sets.
+// Result: SortedPassIndices[] — the execution order.
+```
+
+The sorted index array is filled once in Compile() and read back by Execute(). No string
+comparisons anywhere in the sort or the execution loop.
+
+---
+
+## 9. Resize Path
+
+The current resize path (lines 339-354 of RenderGraph.cpp) allocates two new texture slots
+per resource and leaks the VkImage. The new path:
+
+```cpp
+void RenderGraph::Resize(uint32_t width, uint32_t height)
+{
+    // Rebuild the transient pool with new dimensions.
+    TransientPool.Clear();
+
+    for (auto& res : Resources) {
+        if (res.External || !res.Transient) continue;
+
+        // Enqueue the old VkImage for deferred destruction.
+        if (res.TextureHandle.Valid())
+            Device->DeferFree({ .Kind = DeferredFreeEntry::Image,
+                                .Image = res.TextureHandle });
+
+        res.TextureHandle = {};
+        res.Spec.Width    = width;
+        res.Spec.Height   = height;
+        res.CurrentState  = { VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0, VK_IMAGE_LAYOUT_UNDEFINED };
+    }
+
+    // Re-run the aliasing allocator with the new dimensions.
+    // This re-allocates only transient resources, in FirstPassIndex order.
+    AllocateTransientResources();
+
+    // Rebuild framebuffers only for passes whose output dimensions changed.
+    for (auto& pass : Passes) {
+        if (OutputsResized(pass))
+            RebuildFramebuffer(pass, width, height);
+    }
+
+    // Notify the swapchain/bindless system about the new frame color RT.
+    for (auto& res : Resources) {
+        if (res.Name == RendererResourceName::FrameColorRenderTargetName)
+            Device->TextureHandleToUpdates.Enqueue(res.TextureHandle);
+    }
+}
+```
+
+`Device->DeferFree` is the timeline-semaphore-gated path from `gpu-allocator-rearchitecture.md`.
+`vmaDestroyImage` is called by `DeferredFreeQueue::Drain` in `TickMemory` — the resize path
+never calls it directly.
+
+---
+
+## 10. Compute Pass Support
+
+The redesigned graph supports compute passes with no special registration path. A compute pass
+calls `AddCallbackPass` identically to a graphics pass. The barrier system handles it automatically
+via `RGAccess::ShaderReadWrite` which maps to `VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT` in
+`kAccessTable`. The only structural differences are in `Compile()` and in how `RenderPass`
+creates its pipeline.
+
+### 10.1 Framebuffer skip
+
+`Compile()` creates a `FramebufferVNext` for every pass after building pipelines. Compute passes
+have no render pass object and no framebuffer — the guard is:
+
+```cpp
+for (auto& pass : Passes) {
+    if (!pass.Handle) continue;
+    if (pass.Handle->Specification.Type == RenderPassType::COMPUTE) continue;
+
+    Specifications::FrameBufferSpecificationVNext fb_spec = {
+        .Width         = pass.Handle->RenderAreaWidth,
+        .Height        = pass.Handle->RenderAreaHeight,
+        .RenderTargets = pass.Handle->RenderTargets,
+        .Attachment    = pass.Handle->Attachment,
+    };
+    pass.Framebuffer = ZPushStructCtorArgs(Device->Arena, Buffers::FramebufferVNext, Device, fb_spec);
+}
+```
+
+`pass.Framebuffer` remains null for compute passes. The `Execute()` loop passes it as-is to
+`Callback->Execute` — compute pass implementations receive a null framebuffer and must not
+call `BeginRenderPass`.
+
+### 10.2 Compute pipeline creation in RenderPass
+
+`RenderPass::Initialize` is split on `Specification.Type`:
+
+```cpp
+void RenderPass::Initialize(VulkanDevice* device, const RenderPassSpecification& spec)
+{
+    m_device      = device;
+    Specification = spec;
+
+    if (spec.Type == RenderPassType::COMPUTE) {
+        // No attachment, no VkRenderPass object.
+        ComputePipeline = ZPushStructCtorArgs(device->Arena, Pipelines::ComputePipeline);
+        ComputePipeline->Initialize(device, spec.PipelineSpecification.ShaderSpecificationValue.Name);
+        return;
+    }
+
+    if (spec.Type != RenderPassType::GRAPHIC) return;
+
+    // ... existing graphics path unchanged ...
+}
+
+void RenderPass::Bake()
+{
+    if (Specification.Type == RenderPassType::COMPUTE) {
+        ComputePipeline->Bake();  // calls vkCreateComputePipelines
+        return;
+    }
+    if (Specification.Type != RenderPassType::GRAPHIC) return;
+    Pipeline->Bake();
+}
+```
+
+`RenderPass` gains a `ComputePipeline* ComputePipeline = nullptr` field alongside
+`GraphicPipeline* Pipeline`. Exactly one is non-null depending on pass type.
+
+### 10.3 Execute path for compute passes
+
+A compute pass `Execute()` implementation follows this pattern:
+
+```cpp
+void SSAOComputePass::Execute(
+    VulkanDevicePtr device, RGInspector* inspector, SceneDataPtr,
+    RenderPass* pass, FramebufferVNext* /*null*/, CommandBufferPtr cb)
+{
+    VkCommandBuffer cmd = cb->GetHandle();
+
+    // Bind the compute pipeline.
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE,
+                      pass->ComputePipeline->Handle);
+
+    // Bind descriptor sets (device global bindless set + pass-local set).
+    // vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, ...)
+
+    // Push dispatch size as a push constant if the shader needs it.
+    // vkCmdPushConstants(...)
+
+    uint32_t gx = (m_width  + 7) / 8;
+    uint32_t gy = (m_height + 7) / 8;
+    vkCmdDispatch(cmd, gx, gy, 1);
+}
+```
+
+`CommandBuffer::Dispatch` is a new method added in `compute-pipeline.md`:
+```cpp
+void CommandBuffer::Dispatch(uint32_t x, uint32_t y, uint32_t z) {
+    vkCmdDispatch(m_command_buffer, x, y, z);
+}
+```
+
+Barriers before the dispatch are pre-built by the graph's barrier loop in `Compile()` and
+emitted automatically in `Execute()` — the pass implementation never calls
+`vkCmdPipelineBarrier` directly.
+
+---
+
+## 11. Migration from the Current Design
+
+The current pass implementations (`UploadPass`, `BasePass`, `DepthPrePass`, `SkyboxPass`,
+`GridPass`) call `res_builder->CreateBufferSet`, `CreateRenderTarget`, `CreateRenderPassNode`,
+and `res_inspector->GetVertexBufferSet` etc. These APIs are preserved with identical
+signatures on `RGBuilder` and `RGInspector`. Migration is mechanical:
+
+| Current call | New call | Notes |
+|---|---|---|
+| `res_builder->CreateRenderTarget(name, spec)` | `builder->WriteColorAttachment(name, spec)` | Returns `RGResourceHandle` instead of `RenderGraphResource&` |
+| `res_builder->AttachRenderTarget(name, handle)` | `builder->ImportRenderTarget(name, handle)` | Same |
+| `res_builder->AttachTexture(name, handle)` | `builder->ImportTexture(name, handle)` | Same |
+| `res_builder->CreateBufferSet(name, type)` | `builder->AttachBuffer(name, ...)` | Typed overloads |
+| `res_builder->CreateRenderPassNode(creation)` | Removed — each `Write*/Read*` call registers the node implicitly | |
+| `res_inspector->GetRenderTarget(name)` | `inspector->GetTextureHandle(handle)` | Handle-indexed, no string |
+| `res_inspector->GetVertexBufferSet(name)` | `inspector->GetVertexBufferSet(handle)` | Handle-indexed |
+| `NodeMap[name].Enabled = false` | `graph->SetPassEnabled(name, false)` | String lookup only at setup time |
+
+The `IRenderGraphCallbackPass` interface signatures are unchanged. Existing `Setup`, `Compile`,
+and `Execute` implementations compile without modification after the builder/inspector API swap.
+
+---
+
+## 12. Memory Budget Impact at 4K
+
+Based on the `GpuMemoryDomain::RenderTarget` pool from `gpu-allocator-rearchitecture.md`
+(172 MB budget). With aliasing and transient bit:
+
+| Resource | Format | Size (4K) | Aliasable with | Lazy alloc? |
+|---|---|---|---|---|
+| FrameDepthRT | D32_SFLOAT | 33 MB | — | No (persists frame-to-frame) |
+| FrameColorRT (HDR) | R16G16B16A16_SFLOAT | 134 MB | — | No (read by ImGui) |
+| G-buffer normals | R16G16B16A16_SFLOAT | 134 MB | Bloom ping (lifetime gap) | No |
+| G-buffer albedo | R8G8B8A8_UNORM | 33 MB | Bloom pong | No |
+| SSAO occlusion | R8_UNORM, half-res | 8 MB | Any half-res R8 | Yes |
+| Bloom threshold | R16G16B16A16_SFLOAT | 134 MB | G-buffer normals (dead) | No |
+| Bloom ping/pong × 5 levels | R16G16B16A16_SFLOAT | ~42 MB total | Each other (alternating) | No |
+| Shadow depth (per cascade) | D32_SFLOAT, 2K | 16 MB | Other shadow maps | Yes |
+
+Without aliasing: ~534 MB transient RT memory.
+With aliasing (normals aliased with bloom threshold, ping aliases pong per-level, lazy SSAO/shadow): ~205 MB.
+Net saving: ~329 MB — comfortably within the 172 MB budget when the two persistent RTs (depth + HDR color) are subtracted (167 MB combined), leaving 5 MB for small temporaries.
+
+If the 172 MB budget proves tight, increase `GpuBudget::RenderTarget` or use `VK_EXT_memory_budget`
+to query device headroom dynamically at runtime.
+
+---
+
+## 13. Deliverables Checklist
+
+### Core graph
+
+- [ ] `ZEngine/Rendering/Renderers/RenderGraph.h` — `RGResourceHandle`, `RGResource`, `RGResourceKind`, `RGAccess`, `RGAccessInfo`, `RGResourceState`, `RGPassResource`, `RGPass`, `RenderGraph`; remove `IRenderGraphCallbackPass*` raw pointer from `RenderGraphNode` (it moves to `RGPass.Callback`)
+- [ ] `ZEngine/Rendering/Renderers/RenderGraph.cpp` — `Initialize`, `Setup`, `Compile` (lifetime analysis + aliasing allocator + barrier build), `Execute` (index loop + pre-built barriers), `Resize` (DeferFree + re-allocate + partial framebuffer rebuild), `Dispose`
+- [ ] Keep `IRenderGraphCallbackPass` interface unchanged — `Setup`, `Compile`, `Execute` virtual methods; existing pass structs compile without changes
+
+### Builder and inspector
+
+- [ ] `ZEngine/Rendering/Renderers/RGBuilder.h/.cpp` — `WriteColorAttachment`, `WriteDepthAttachment`, `ReadTexture`, `ReadDepth`, `ImportRenderTarget`, `ImportTexture`, `AttachBuffer` (typed overloads); each call registers read/write on current pass and returns `RGResourceHandle`
+- [ ] `ZEngine/Rendering/Renderers/RGInspector.h/.cpp` — all `Get*` methods indexed by `RGResourceHandle`; string-keyed overloads preserved for pass `Execute()` callsites that use names
+
+### Aliasing allocator
+
+- [ ] `ZEngine/Rendering/Renderers/RGTransientPool.h/.cpp` — `TryAlias`, `Register`, `MarkInUse`, `Clear`; alias compatibility check: format + dimensions + usage superset + layer/mip count
+- [ ] `DeriveUsageFlags(RGResource, passes)` free function — derives `VkImageUsageFlags` and sets `VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT` for single-pass-lifetime resources
+- [ ] VMA allocation path: transient bit resources use `VMA_MEMORY_USAGE_GPU_LAZILY_ALLOCATED`; all others use `GpuMemoryDomain::RenderTarget` segregated pool
+
+### Barrier system
+
+- [ ] `kAccessTable` constexpr array — stage + access + layout for every `RGAccess` value
+- [ ] Barrier build loop in `Compile()` — one `VkImageMemoryBarrier` per resource state transition, stored in `RGPass.ImageBarriers`; transitions from `UNDEFINED` for aliased/first-use resources
+- [ ] Execute loop emits `vkCmdPipelineBarrier` once per pass from pre-built arrays; no per-frame barrier construction
+
+### Topology
+
+- [ ] Index-based DFS topological sort; integer adjacency sets (no string sets in sort); cycle detection preserved; result stored in `SortedPassIndices: Array<uint32_t>`
+
+### Compute pass
+
+- [ ] `ZEngine/Rendering/Renderers/RenderPasses/RenderPass.h/.cpp` — add `ComputePipeline* ComputePipeline = nullptr` field; split `Initialize` and `Bake` on `RenderPassType::COMPUTE`; compute path creates `ComputePipeline`, skips `Attachment` and `VkRenderPass`
+- [ ] `Compile()` framebuffer loop — guard: skip `FramebufferVNext` creation for `RenderPassType::COMPUTE` passes
+- [ ] `Execute()` loop — pass null `Framebuffer` to compute callbacks; no `BeginRenderPass` call
+- [ ] See `compute-pipeline.md` for `ComputePipeline`, `CommandBuffer::Dispatch`, `ShaderType::COMPUTE`, and `IComputeCallbackPass` deliverables
+
+### Migration
+
+- [ ] `UploadPass`, `BasePass`, `DepthPrePass`, `SkyboxPass`, `GridPass` updated to use new `RGBuilder`/`RGInspector` API — builder call sites only; `Execute()` bodies unchanged
+- [ ] `GraphicRenderer::Initialize` updated — `RGBuilder::ImportRenderTarget` for `FrameColorRenderTarget` and `FrameDepthRenderTarget`; remove `ResourceBuilder->AttachRenderTarget` calls
+- [ ] `GbufferPass::Setup` and `LightingPass::Setup` updated to use `WriteColorAttachment` and `ReadTexture` — these are currently commented out; enable them as part of this migration
+
+### Tests
+
+- [ ] `tests/Rendering/RenderGraphTest.cpp`:
+  - Test 1 — linear chain A -> B -> C produces correct barrier sequence (A COLOR_WRITE -> B SHADER_READ has `COLOR_ATTACHMENT_OUTPUT -> FRAGMENT_SHADER` barrier)
+  - Test 2 — diamond dependency A -> {B, C} -> D; B and C have no barrier between them; D waits on both
+  - Test 3 — aliasing: resources X (lives pass 0-1) and Y (lives pass 3-4) with identical specs share one `VkImage`; confirmed via `TextureHandle` equality
+  - Test 4 — transient bit: resource live only in pass 2 gets `VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT`
+  - Test 5 — resize: old handles enqueued in `DeferFree`, new handles allocated, state reset to UNDEFINED
+  - All tests pass under AddressSanitizer and UBSanitizer
+
+### Manual smoke test
+
+- [ ] Profile with RenderDoc: open a capture, confirm that all image transitions between passes match the expected layouts (no validation layer errors, no redundant full-pipeline stalls)
+- [ ] Profile with Tracy: `ZENGINE_PROFILE_SCOPE("RenderGraph::Execute")` should show linear per-pass cost with no hash lookup spikes
+- [ ] Measure RT memory with `vmaCalculateStatistics` before and after; confirm transient pool reduces peak allocation by at least 40% vs the baseline at 1440p

--- a/ZEngine/docs/future-plan/render-resource-manager.md
+++ b/ZEngine/docs/future-plan/render-resource-manager.md
@@ -2,7 +2,7 @@
 
 **Priority:** P3 — Implement alongside import-pipeline.md  
 **Status:** Design  
-**Depends on:** `import-pipeline.md`, `vfs-ticket6-asset-registry.md`  
+**Depends on:** `import-pipeline.md`, `vfs-ticket6-asset-registry.md`, `gpu-allocator-rearchitecture.md`  
 **Blocks:** `animation-system.md` (SkinningUploadSystem), `shader-asset-pipeline.md`
 
 **Goal**: Implement `ZEngine::Rendering::RenderResourceManager` (RRM), a single authority
@@ -228,22 +228,24 @@ namespace ZEngine::Rendering {
         void EnqueueDeletion(VkImage image, VkImageView view, VmaAllocation allocation);
 
     private:
-        static constexpr uint32_t FRAMES_IN_FLIGHT = 2;
-
-        // ... HandleManager-backed pools for GPUBuffer, GPUImage ...
-
-        // IMPORTANT: Slot recycling delay must be FRAMES_IN_FLIGHT + 1 frames, NOT FRAMES_IN_FLIGHT.
+        // IMPORTANT: FRAMES_IN_FLIGHT = 3 (triple-buffered swapchain, matching
+        // SwapchainPtr->BufferredFrameCount in VulkanDevice).
+        //
+        // Slot recycling delay must be FRAMES_IN_FLIGHT frames, not FRAMES_IN_FLIGHT - 1.
         //
         // Reasoning:
-        // - Frame N submits GPU work referencing resource R.
-        // - Frame N+1 submits more GPU work (pipelining).
-        // - Frame N+2 begins. GPU work from frame N is still potentially in flight
-        //   because the frame fence for N has not yet been waited on by N+2.
-        // - Only in frame N + (FRAMES_IN_FLIGHT + 1) is it guaranteed that ALL
-        //   command buffers referencing R have retired.
+        // - Frame N submits GPU work referencing resource R; signal timeline value N.
+        // - Frames N+1 and N+2 also run concurrently (pipeline depth = 3).
+        // - Frame N+3 begins. GPU work for frame N is guaranteed retired because
+        //   TickMemory queries vkGetSemaphoreCounterValue and only drains entries
+        //   whose TimelineValue <= completed. The DeferredFreeQueue in GpuAllocator
+        //   enforces the same timeline gate, so the RRM delegates safe-frame
+        //   computation to the timeline value stored at enqueue time.
         //
-        // Using only FRAMES_IN_FLIGHT allows slot reuse one frame too early → GPU use-after-free.
-        static constexpr uint32_t RECYCLE_DELAY = FRAMES_IN_FLIGHT + 1;
+        // The m_deletion_queues ring therefore needs FRAMES_IN_FLIGHT slots.
+        static constexpr uint32_t FRAMES_IN_FLIGHT = 3;
+
+        // ... HandleManager-backed pools for GPUBuffer, GPUImage ...
     };
 
 }  // namespace ZEngine::Rendering
@@ -277,53 +279,59 @@ signal a fence. The final GPU resource is `DEVICE_LOCAL` (not CPU-visible).
 
 ### Step-by-step
 
-**1. Create staging buffer**
+**1. Acquire staging memory from the StagingRing**
+
+After `gpu-allocator-rearchitecture.md` lands, the RRM does not call `vmaCreateBuffer`
+for staging. All uploads go through `GpuAllocator::Ring` (the 64 MB persistent ring
+inside `VulkanDevice::GpuMem`). For assets larger than the ring can serve in one chunk,
+a one-shot `GpuMemoryDomain::HostStaging` allocation is used as fallback.
 
 ```cpp
-VmaAllocationCreateInfo staging_alloc_info{};
-staging_alloc_info.usage = VMA_MEMORY_USAGE_CPU_ONLY;
-staging_alloc_info.flags = VMA_ALLOCATION_CREATE_MAPPED_BIT;
+uint32_t ring_offset = 0;
+void* ring_ptr = Device->GpuMem.Ring.Allocate(
+    (uint32_t)asset_byte_size, 4, &ring_offset);
 
-VkBufferCreateInfo staging_buf_info{};
-staging_buf_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-staging_buf_info.size  = asset_byte_size;
-staging_buf_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-staging_buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-
-GPUBuffer staging{};
-vmaCreateBuffer(m_allocator,
-                &staging_buf_info, &staging_alloc_info,
-                &staging.Buffer, &staging.Allocation, nullptr);
+if (!ring_ptr) {
+    // Oversized asset (> ring capacity): fall back to a one-shot HostStaging buffer.
+    BufferView one_shot = Device->GpuMem.AllocateBuffer(
+        asset_byte_size,
+        VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+        GpuMemoryDomain::HostStaging,
+        "RRM::StagingFallback");
+    // ... use one_shot.Handle as transfer source, then DeferFree after submit ...
+}
 ```
 
-**2. Map and copy**
+**2. Copy into staging memory**
 
 ```cpp
-VmaAllocationInfo staging_info{};
-vmaGetAllocationInfo(m_allocator, staging.Allocation, &staging_info);
-std::memcpy(staging_info.pMappedData, asset_bytes, asset_byte_size);
-vmaFlushAllocation(m_allocator, staging.Allocation, 0, VK_WHOLE_SIZE);
+std::memcpy(ring_ptr, asset_bytes, asset_byte_size);
+// Flush only if the HostStaging pool is not HOST_COHERENT.
+// GpuAllocator caches this flag at init time.
+if (!Device->GpuMem.StagingIsCoherent()) {
+    vmaFlushAllocation(Device->GpuMem.Allocator,
+                       Device->GpuMem.Ring.Allocation,
+                       ring_offset, asset_byte_size);
+}
 ```
 
-**3. Create device-local destination buffer**
+**3. Allocate device-local destination buffer**
 
 ```cpp
-VmaAllocationCreateInfo dst_alloc_info{};
-dst_alloc_info.usage = VMA_MEMORY_USAGE_GPU_ONLY;
+// Route through GpuAllocator — no direct vmaCreateBuffer call.
+BufferView dst = Device->GpuMem.AllocateBuffer(
+    asset_byte_size,
+    VK_BUFFER_USAGE_VERTEX_BUFFER_BIT
+        | VK_BUFFER_USAGE_INDEX_BUFFER_BIT
+        | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+    GpuMemoryDomain::DeviceGeometry,
+    debug_name);
 
-VkBufferCreateInfo dst_buf_info{};
-dst_buf_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-dst_buf_info.size  = asset_byte_size;
-dst_buf_info.usage = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT
-                   | VK_BUFFER_USAGE_INDEX_BUFFER_BIT
-                   | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-dst_buf_info.sharingMode = VK_SHARING_MODE_CONCURRENT;  // transfer + graphics families
-// (or EXCLUSIVE with explicit queue-family ownership transfer — see below)
-
-GPUBuffer dst{};
-vmaCreateBuffer(m_allocator,
-                &dst_buf_info, &dst_alloc_info,
-                &dst.Buffer, &dst.Allocation, nullptr);
+GPUBuffer gpu_buf{};
+gpu_buf.Buffer     = dst.Handle;
+gpu_buf.Allocation = dst.Allocation;
+gpu_buf.Size       = asset_byte_size;
+gpu_buf.Usage      = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
 ```
 
 **4. Record copy command**
@@ -433,20 +441,28 @@ vkCmdPipelineBarrier(m_transfer_cmd,
     0, 0, nullptr, 0, nullptr, 1, &post_copy_barrier);
 ```
 
-**8. Staging buffer cleanup**
+**8. Staging memory retirement**
 
-The staging buffer is added to the deletion queue for the current frame:
+The ring chunk is retired via the timeline semaphore — no deletion queue entry needed:
 
 ```cpp
-DeferredRelease entry{};
-entry.FrameTarget = m_current_frame + FRAMES_IN_FLIGHT;
-entry.Kind        = ResourceKind::Buffer;
-entry.Buffer      = staging;
-m_deletion_queues[m_current_frame % FRAMES_IN_FLIGHT].push_back(entry);
+// signal_value is the timeline value that will be signalled when the
+// vkQueueSubmit for this transfer completes.
+uint64_t signal_value = Device->SwapchainPtr->RenderTimelineNextValue;
+Device->GpuMem.Ring.Submit(ring_offset, (uint32_t)asset_byte_size, signal_value);
+// GpuAllocator::Ring.Drain(completed) inside TickMemory reclaims the chunk
+// once the GPU signals that timeline value.
 ```
 
-The staging buffer is therefore freed `FRAMES_IN_FLIGHT` frames after the copy
-completes, by which time the GPU has certainly finished reading it.
+For one-shot fallback buffers, enqueue via `Device->DeferFree`:
+
+```cpp
+Device->DeferFree({
+    DeferredFreeEntry::Kind::Buffer,
+    .Buffer = one_shot  // the BufferView returned by AllocateBuffer
+    // TimelineValue is set by DeferFree from RenderTimelineNextValue
+});
+```
 
 ---
 
@@ -510,7 +526,15 @@ void RenderResourceManager::EndFrame(uint32_t frame_index) {
             // Safe to swap: all in-flight frames that referenced the old resource have retired.
             if (it->Kind == ResourceKind::Buffer) {
                 GPUBuffer* slot = GetBufferMutable(it->OldBuffer);
-                EnqueueDeletion(it->OldBuffer.Index, *slot, frame_index);
+                // Enqueue the old GPU resource for timeline-gated destruction via
+                // VulkanDevice::DeferFree. Do NOT call vmaDestroyBuffer here —
+                // the GPU may still be reading from this buffer in in-flight frames.
+                Device->DeferFree({
+                    DeferredFreeEntry::Kind::Buffer,
+                    /* TimelineValue set by DeferFree from RenderTimelineNextValue */
+                    .Buffer = BufferView{.Handle = slot->Buffer, .Allocation = slot->Allocation}
+                });
+                // Swap: the handle now points to the new GPU resource.
                 *slot = it->NewBuffer;
             }
             it = m_pending_swaps.erase(it);
@@ -560,20 +584,30 @@ Core::Containers::Array<DeferredRelease>
 
 ### BeginFrame drain
 
+The RRM does not call `vmaDestroyBuffer` / `vmaDestroyImage` directly. After
+`gpu-allocator-rearchitecture.md` lands, all GPU memory is owned by `GpuAllocator` inside
+`VulkanDevice`. The RRM enqueues resources with `Device->DeferFree(entry)` and the
+`DeferredFreeQueue::Drain` call inside `TickMemory` performs the actual destruction once
+the timeline semaphore confirms the GPU has retired those command buffers.
+
+The RRM's `BeginFrame` therefore only needs to advance the ring slot and flush pending
+uploads — it does not call any VMA or Vulkan destroy functions itself.
+
 ```cpp
 void RenderResourceManager::BeginFrame(uint32_t frame_index) {
+    // Flush uploads queued from the asset thread.
+    FlushPendingUploads();
+
+    // Release handle pool slots for resources whose timeline gate has passed.
+    // Actual GPU memory is freed by DeferredFreeQueue::Drain inside TickMemory,
+    // which has already run in AcquireNextImage before this call.
     uint32_t drain_slot = frame_index % FRAMES_IN_FLIGHT;
     for (auto& entry : m_deletion_queues[drain_slot]) {
-        if (entry.Kind == ResourceKind::Buffer) {
-            vmaDestroyBuffer(m_allocator,
-                             entry.Buffer.Buffer,
-                             entry.Buffer.Allocation);
-        } else {
-            vkDestroyImageView(m_device, entry.Image.View, nullptr);
-            vmaDestroyImage(m_allocator,
-                            entry.Image.Image,
-                            entry.Image.Allocation);
-        }
+        // Invalidate the handle pool slot so GetBuffer/GetImage return nullptr.
+        if (entry.Kind == ResourceKind::Buffer)
+            m_buffer_pool.Free(entry.Buffer.PoolIndex, entry.Buffer.Generation);
+        else
+            m_image_pool.Free(entry.Image.PoolIndex, entry.Image.Generation);
     }
     m_deletion_queues[drain_slot].Clear();
 }
@@ -581,17 +615,19 @@ void RenderResourceManager::BeginFrame(uint32_t frame_index) {
 
 **Design notes**:
 
-- The ring has exactly `FRAMES_IN_FLIGHT` slots. A resource enqueued in frame `F` is
-  freed in `BeginFrame(F + FRAMES_IN_FLIGHT)` — by that time the GPU has finished all
-  work submitted in frame `F`.
+- The ring has exactly `FRAMES_IN_FLIGHT` (3) slots. A resource enqueued in frame `F`
+  has its handle pool slot invalidated in `BeginFrame(F + FRAMES_IN_FLIGHT)`. The actual
+  GPU memory was already destroyed by `DeferredFreeQueue::Drain` inside `TickMemory`
+  once the timeline semaphore confirmed the GPU had retired all work for that frame.
 - `Clear()` resets the `Array` size to zero without releasing the heap allocation.
   The underlying memory is reused each period, so steady-state operation produces no
   allocator traffic.
-- `vmaDestroyBuffer` destroys both the `VkBuffer` and the `VmaAllocation` in one call.
-  For images, `vkDestroyImageView` must precede `vmaDestroyImage` because the view
-  borrows the image handle.
-- Handle pool slots are **not** recycled here. Slot recycling is a separate concern
-  managed by the `HandleManager`. The deletion queue purely drives GPU memory release.
+- `vmaDestroyBuffer` / `vmaDestroyImage` are called exclusively from
+  `DeferredFreeQueue::Drain` inside `VulkanDevice::TickMemory`, not from the RRM.
+  The RRM's deletion queue only tracks which handle pool slots to invalidate.
+- Handle pool slots are **not** recycled in `BeginFrame`. Slot recycling is a separate
+  concern managed by the `HandleManager`; it recycles the slot only after the generation
+  counter has advanced, preventing ABA collisions on reused slots.
 
 ---
 
@@ -840,12 +876,12 @@ TEST(RRM, GetBufferOnReleasedHandleReturnsNullptr)
 
 - [ ] `ZEngine/Rendering/RenderHandle.h` — `RenderHandle<Tag>` generational handle template + four `using` aliases (`BufferHandle`, `ImageHandle`, `SamplerHandle`, `PipelineHandle`)
 - [ ] `ZEngine/Rendering/GPUResource.h` — `GPUBuffer` and `GPUImage` plain aggregates; zero-initialised sentinel values; no RAII
-- [ ] `ZEngine/Rendering/RenderResourceManager.h` — public API (`UploadMesh`, `UploadTexture`, `ScheduleSwap`, `Release`, `BeginFrame`, `EndFrame`, `GetBuffer`, `GetImage` (const), `GetImageMutable`); `FRAMES_IN_FLIGHT = 2` constant
+- [ ] `ZEngine/Rendering/RenderResourceManager.h` — public API (`UploadMesh`, `UploadTexture`, `ScheduleSwap`, `Release`, `BeginFrame`, `EndFrame`, `GetBuffer`, `GetImage` (const), `GetImageMutable`); `FRAMES_IN_FLIGHT = 3` constant
 - [ ] `ZEngine/Rendering/RenderResourceManager.cpp` — `Init`, `FlushPendingUploads`, upload path with staging buffer, barrier structs, queue-family ownership transfer for transfer-to-graphics handoff
-- [ ] Staging buffer path: `VMA_MEMORY_USAGE_CPU_ONLY` → `memcpy` → `vmaFlushAllocation` → `vkCmdCopyBuffer` → release barrier on transfer queue → acquire barrier on graphics queue
+- [ ] Staging buffer path: `GpuAllocator::Ring.Allocate()` → `memcpy` → `Ring.Submit(signal_val)` → `vkCmdCopyBuffer` → release barrier on transfer queue → acquire barrier on graphics queue
 - [ ] Texture path: `VK_IMAGE_LAYOUT_UNDEFINED` → `VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL` → `vkCmdCopyBufferToImage` → `VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL`; barrier covers all mip levels
 - [ ] `SwapEntry` struct: old handle union + new resource union + `SwapSafeFrame`; `EndFrame` drains entries where `frame_index >= SwapSafeFrame`, swaps slot in-place, enqueues old resource for deferred deletion
-- [ ] `DeferredRelease` ring: `m_deletion_queues[FRAMES_IN_FLIGHT]`; `BeginFrame` drains `frame_index % FRAMES_IN_FLIGHT` slot; `vmaDestroyBuffer` / `vkDestroyImageView` + `vmaDestroyImage` called only from render thread
+- [ ] `DeferredRelease` ring: `m_deletion_queues[FRAMES_IN_FLIGHT]`; `BeginFrame` invalidates the handle pool slot for `frame_index % FRAMES_IN_FLIGHT`; actual GPU memory freed by `DeferredFreeQueue::Drain` in `VulkanDevice::TickMemory` once the timeline semaphore confirms the GPU is done
 - [ ] `AssetRegistry::OnAssetReady` → `m_pending_uploads` (mutex-protected); flushed in `BeginFrame` on render thread via `FlushPendingUploads`
 - [ ] `AssetRegistry::OnAssetStale` → `ScheduleSwap` using `m_uuid_to_buffer` / `m_uuid_to_image` maps
 - [ ] `ReleaseChecked(handle)` returns `VFS::VFSResult<void>` with `VFSError::InvalidHandle` on double-free; `Release(handle)` asserts in debug, no-ops in release

--- a/ZEngine/docs/future-plan/rendering-flow.md
+++ b/ZEngine/docs/future-plan/rendering-flow.md
@@ -1,0 +1,335 @@
+# Rendering Flow — Engine + Editor (Post-Rearchitecture)
+
+**Relates to:** `gpu-allocator-rearchitecture.md`, `per-frame-upload-heap.md`
+**Scope:** Full per-frame rendering pipeline from user interaction to GPU submission, covering both the runtime engine and the Tetragrama editor.
+
+---
+
+## 1. Two-Thread Architecture
+
+The engine splits work across two threads. This is fixed — not configurable.
+
+```
++------------------------------------------------------+
+|                    MAIN THREAD                        |
+|                                                       |
+|  PollEvent  ->  Update  ->  OnRenderUI  ->  PrepareScene |
+|                             (ImGui)      (payload)    |
+|                                              |        |
+|                               MailBoxBuffer.store()   |
++------------------------------------------------------+
+                                      |
+                              double-buffer handoff
+                                      |
++------------------------------------------------------+
+|                   RENDER THREAD                       |
+|                                                       |
+|  BeginFrame  ->  RenderScene  ->  RenderOverlay  ->  EndFrame |
+|  (acquire)     (3D scene)       (ImGui)           (submit+present) |
++------------------------------------------------------+
+```
+
+The two threads never share a mutex on the hot path. The handoff is a single atomic
+store/load on `MailBoxBufferHead`. The main thread builds ImGui draw lists and scene
+payload; the render thread consumes them and touches Vulkan exclusively.
+
+---
+
+## 2. Per-Frame Lifecycle — Step by Step
+
+Frame index `fi` = `SwapchainPtr->CurrentFrame->Index` (0, 1, or 2 in a triple-buffered setup).
+
+### MAIN THREAD
+
+```
+[1] PollEvent()
+    GLFW events -> window resize flag, input state
+
+[2] g_app->Update(dt)
+    Editor::OnUpdate()
+      UILayer->Update(dt)
+        HierarchyViewUIComponent::Update()
+          Pop PendingOnLoadHierarchies
+          CreateOrGetMeshAllocation()     <- memcpy vertices/indices into CPU arrays
+          MeshAllocationDirty[0,1,2] = true
+          TransformBufferDirty[0,1,2] = true
+        other panels (InspectorView, etc.) -- pure CPU
+
+[3] pipeline->BeginOverlayFrame()
+    ImGui_ImplGlfw_NewFrame()
+    ImGui::NewFrame()
+    ImGuizmo::BeginFrame()
+
+[4] g_app->OnRenderUI()
+    Editor::OnRenderUI()
+      UILayer->Render()
+        DockspaceUIComponent::Render()    <- docking layout, menu bar
+        SceneViewportUIComponent::Render()
+          ImGui::Image(FrameColorRenderTarget.Index, ...)  <- bindless handle
+          ImGuizmo::Manipulate() -> mutates GlobalTransforms[selected]
+          [BUG] TransformBufferDirty NOT set here (known TODO)
+        HierarchyViewUIComponent::Render()  <- scene tree, selection
+        InspectorViewUIComponent::Render()  <- property editor (no GPU)
+
+[5] pipeline->EndOverlayFrame()
+    ImGui::Render()           <- finalises draw lists
+    FillOverlayPayload()      <- copies ImDrawData ptr into payload struct
+
+[6] g_app->PrepareScene(payload)
+    sets payload.Scene = current_scene, payload.Camera = editor_camera
+
+[7] MailBoxBufferHead.store(next_slot)    <- render thread sees new frame payload
+```
+
+### RENDER THREAD
+
+```
+[1] BeginFrame()
+    swapchain->AcquireNextImage(mailbox_head)
+      vkAcquireNextImageKHR
+      Device->TickMemory()                  <- NEW (post-rearchitecture)
+        vkGetSemaphoreCounterValue(RenderTimeline)
+        PendingFree.Drain(completed)        <- free GPU resources GPU is done with
+        GpuMem.Ring.Drain(completed)        <- reclaim staging ring chunks
+        GpuMem.SampleBudgets()              <- per-heap pressure check
+        FrameHeaps[fi].Reset()              <- bump pointer = 0, O(1)
+    CommandBufferMgr->ResetPool(fi, thread)
+    AsyncResLoader->CompleteDeferrals()
+    GetCommandBuffer(GRAPHIC, fi, thread)
+    CurrentCmdBuf->Begin()
+
+[2] RenderScene(payload)
+
+    [RESIZE CHECK]  if RenderTargetResizeRequests not empty:
+      RenderGraph->Resize()
+        Device->DeferFree({old FrameColorRT, old FrameDepthRT})
+        // vmaDestroyImage is called by DeferredFreeQueue::Drain once the timeline
+        // confirms the GPU is done with those images — the caller only enqueues.
+        GpuMem.AllocateImage(new size, RenderTarget)
+        Device->TextureHandleToUpdates.Push(new_handle)
+        Rebuild all VkFramebuffer objects
+
+    [MESH DIRTY]  if MeshAllocationDirty[fi]:
+      vtx_buffer_set->At(fi).Write(fi, 0, scene->Vertices)
+        AsyncResLoader->UploadBuffer()
+          vmaGetAllocationMemoryProperties -> HOST_VISIBLE?
+          YES: vmaCopyMemoryToAllocation + vmaFlushAllocation (if !coherent)
+          NO:  GpuMem.Ring.Allocate() -> vkCmdCopyBuffer -> Ring.Submit(signal_val)
+      idx_buffer_set->At(fi).Write(...)       <- same path
+      rd_buffer_set->At(fi).Write(...)        <- SubMeshAllocations
+      indirect_buffer_set->At(fi).Write(...)  <- VkDrawIndirectCommands
+      [POST-REARCHITECTURE: all 4 writes push into FrameHeaps[fi] instead]
+
+    [TRANSFORM DIRTY]  if TransformBufferDirty[fi]:
+      transform_buffer_set->At(fi).Write(fi, 0, scene->GlobalTransforms)
+      [POST-REARCHITECTURE: heap.Push(GlobalTransforms, ...)]
+
+    GraphicRenderer::DrawScene(fi, thread, cmd, camera)
+      camera_buf->Write(fi, thread, &UBOCameraLayout)    <- view/proj/pos
+      material_buf->Write(fi, thread, GPUMeshMaterials)  <- full material array
+      RenderGraph->Execute(cmd)
+
+        [UploadPass]
+          skybox VB/IB write (write-once per frame-in-flight)
+          grid VB/IB write
+
+        // Passes below reflect the current live implementation.
+        // Shadow, post-process, and gizmo passes are added by their
+        // respective future-plan docs and are not listed here.
+
+        [DepthPrePass]
+          TransitionImageLayout(FrameDepthRT -> DEPTH_STENCIL_ATTACHMENT)
+          BeginRenderPass(DepthOnlyFramebuffer)
+          BindPipeline(depth_prepass_pipeline)
+          BindDescriptorSets(fi)  <- UBCamera, VertexSB, IndexSB, TransformSB, DrawDataSB
+          DrawIndirect(indirect_buffer, 0, draw_count)
+          EndRenderPass
+
+        [BasePass]  (deferred lighting / fullscreen triangle)
+          TransitionImageLayout(FrameColorRT -> COLOR_ATTACHMENT)
+          BeginRenderPass(OffscreenFramebuffer)
+          BindPipeline(base_pipeline)
+          BindDescriptorSets(fi)  <- all SBs + MatSB + TextureArray (bindless) + EnvMap
+          Draw(3, 1, 0, 0)        <- fullscreen triangle
+          EndRenderPass
+
+        [SkyboxPass]
+          BindVertexBuffer / BindIndexBuffer (cube, 36 indices)
+          BindDescriptorSets(fi)
+          DrawIndexed(36, 1, 0, 0, 0)
+
+        [GridPass]
+          BindVertexBuffer / BindIndexBuffer (quad, 6 indices)
+          PushConstants(grid_params)
+          DrawIndexed(6, 1, 0, 0, 0)
+
+[3] RenderOverlay(payload)   <- ImGui on swapchain framebuffer
+    TransitionImageLayout(SwapchainImage -> COLOR_ATTACHMENT)
+    BeginRenderPass(SwapchainFramebuffer[image_index], UIPass)
+    Write per-frame ImGui geometry:
+      imgui_vtx_buf->Write(fi, 0, ImDrawData->Vertices)  <- VkBuffer in HOST_VISIBLE
+      imgui_idx_buf->Write(fi, 0, ImDrawData->Indices)
+    Secondary command buffer per ImGui viewport:
+      BindPipeline(imgui_pipeline)
+      BindVertexBuffer(imgui_vtx_buf)
+      BindIndexBuffer(imgui_idx_buf)
+      BindDescriptorSets(fi)   <- bindless TextureArray (ImGui font + scene textures)
+      for each ImDrawCmd:
+        SetScissor(clip_rect)
+        PushConstants(scale, translate, texture_id)
+        DrawIndexed(elem_count, 1, idx_offset, vtx_offset, 0)
+    EndRenderPass
+
+[4] EndFrame()
+    AsyncResLoader->SubmitAsyncJobs()       <- flush timeline semaphore job queue
+    CommandBufferMgr->EndEnqueuedBuffers()
+    SwapchainPtr->Present()
+      3-submit timeline pattern (acquire bridge -> render -> present bridge)
+      vkQueuePresentKHR
+      IdleFrameCount++ (if no work submitted)
+```
+
+---
+
+## 3. GPU Memory Timeline — One Frame
+
+```
+CPU                                          GPU
+----------------------------------------------------------------------
+AcquireNextImage
+  vkGetSemaphoreCounterValue(timeline N-2)
+  PendingFree.Drain()      ----free N-2 resources---->  (already idle)
+  Ring.Drain()             ----reclaim N-2 chunks---->
+  FrameHeaps[fi].Reset()
+
+  [HOST_VISIBLE buffers]
+  vmaCopyMemoryToAllocation ----write-------------->  (not started)
+  vmaFlushAllocation
+
+  [DEVICE_LOCAL buffers]
+  Ring.Allocate(chunk)
+  memcpy -> ring mapped ptr
+  vkCmdCopyBuffer (staged)  ----will copy---------->  (queued)
+
+  vkCmdDrawIndirect         ----draw-------------->   (queued after copy)
+  vkCmdDraw (fullscreen tri) ---draw-------------->   (queued)
+  ...
+
+EndFrame
+  vkQueueSubmit (signal N)                             <- GPU starts
+                                       ...executing...
+                            <---signal N signalled---  GPU done with frame N
+```
+
+Frame `fi` resources are safe to destroy when `timeline_completed >= N` (the signal value
+recorded when they were enqueued in `DeferFree`).
+
+---
+
+## 4. Editor User Actions — GPU Impact Map
+
+| User Action | CPU Side | GPU Side | Frames Until Visible |
+|---|---|---|---|
+| Open `.zemesh` file | `secure_memcpy` vertices/indices into `EditorScene::Vertices`, set `MeshAllocationDirty[0,1,2]` | All 3 frame buffer sets re-written on their respective frames | 1-3 frames (each frame slot catches up) |
+| Move object (ImGuizmo) | Mutates `GlobalTransforms[node]` in place | Nothing -- `TransformBufferDirty` NOT set (known bug) | Never (until another dirty event fires) |
+| Select object | Sets `SelectedSceneNode` | Nothing | Immediate (CPU-only highlight) |
+| Resize viewport | Pushes `RenderTargetResizeRequest` | `vmaDestroyImage` + `GpuMem.AllocateImage` for color+depth RT, rebuild framebuffers, update bindless descriptor slot | 1 frame |
+| Change material property | Inspector writes to `EditorScene::Materials` CPU array | `MaterialBufferHandle->Write()` fires next frame (storage buffer re-upload) | 1 frame |
+| Add/remove light | Updates CPU light array | `LightBufferHandle->Write()` next frame | 1 frame |
+| Camera move (WASD/mouse) | `FlyCamera` updates `ViewMatrix`, `ProjectionMatrix` | `UBOCameraLayout` written into `camera_buffer->At(fi)` each frame (always dirty) | 0 -- same frame |
+
+---
+
+## 5. Post-Rearchitecture Flow Changes
+
+With `gpu-allocator-rearchitecture.md` and `per-frame-upload-heap.md` landed, the
+`RenderScene` upload section simplifies significantly.
+
+### Before
+
+```
+MeshAllocationDirty[fi] == true
+  vtx_buffer_set->At(fi).Write()    -> AsyncResLoader->UploadBuffer
+    -> vmaGetAllocationMemoryProperties
+    -> HOST_VISIBLE? vmaCopyMemoryToAllocation
+    -> else: Device->CreateBuffer(TRANSFER_SRC, HOST_ACCESS_SEQUENTIAL_WRITE)
+                     ^ vkAllocateMemory per upload
+            RetireStagingBuffers[pool][slot] = staging_buffer
+```
+
+### After
+
+```
+MeshAllocationDirty[fi] == true
+  heap = Device->FrameHeaps[fi]
+
+  vtx_alloc      = heap.Push(scene->Vertices.data(), vtx_byte_size, 4)
+  idx_alloc      = heap.Push(scene->Indices.data(), idx_byte_size, 4)
+  rd_alloc       = heap.Push(SubMeshAllocations.data(), rd_byte_size, 4)
+  indirect_alloc = heap.Push(DrawCommands.data(), indirect_byte_size, sizeof(VkDrawIndirectCommand))
+
+  heap.Flush(GpuMem.Allocator)   <- one flush covering all 4 uploads
+
+  vkCmdBindDescriptorSets(..., {vtx_alloc.Offset, idx_alloc.Offset, ...})
+```
+
+No `vkAllocateMemory`. No staging buffer lifecycle. No `RetireStagingBuffers` array.
+The GPU reads the data directly from the frame heap buffer using dynamic offsets.
+
+---
+
+## 6. Known Gaps and Bugs in Current Flow
+
+| Type | Location | Issue |
+|---|---|---|
+| BUG | `HierarchyViewUIComponent.cpp:252` | ImGuizmo manipulate mutates `GlobalTransforms` but does NOT set `TransformBufferDirty`. Transform change never reaches GPU. |
+| GAP | `AppRenderPipeline.cpp` | `MeshAllocationDirty` is set for all 3 frames when a mesh loads, but only cleared for `fi`. Frames fi+1, fi+2 will re-upload the same data redundantly. |
+| GAP | `RenderScene()` | No LRU eviction path when `GpuMem.AllocateBuffer` returns null (pool full). Engine would assert rather than gracefully degrade. |
+| GAP | `SceneViewportUIComponent.cpp` | Viewport resize request is not rate-limited. Rapid window dragging fires one `RenderGraph::Resize()` per render frame during the drag, each resize allocates and frees render targets. |
+| NOTE | `AppRenderPipeline.cpp` | `camera_buffer->Write()` fires every frame unconditionally even when the camera has not moved. Post-heap migration this is free (just a `memcpy` into the frame heap). Before migration it submits a timeline job every frame. |
+
+---
+
+## 7. Full Dependency Graph — Frame N
+
+```
+MAIN THREAD                         RENDER THREAD
+------------------                  -----------------------------------------
+PollEvent
+  |
+Update(dt)
+  |- ImGuizmo -> GlobalTransforms
+  `- MeshAllocationDirty = true
+                                    AcquireNextImage(N)
+  BeginOverlayFrame                   TickMemory()
+  OnRenderUI -> ImDrawData               PendingFree.Drain(completed N-2)
+  EndOverlayFrame                        Ring.Drain(completed N-2)
+  PrepareScene -> payload                FrameHeaps[fi].Reset()
+  MailBox.store(N)  ------------->    CommandPool reset
+                                      CompleteDeferrals
+                                      cmd->Begin()
+
+                                      RenderScene(payload)
+                                        dirty uploads -> heap.Push or Ring
+                                        heap.Flush()
+                                        GraphicRenderer::DrawScene()
+                                          camera_buf write
+                                          material_buf write
+                                          RenderGraph::Execute()
+                                            DepthPrePass
+                                            BasePass
+                                            SkyboxPass
+                                            GridPass
+
+                                      RenderOverlay(payload)
+                                        imgui vtx/idx write
+                                        secondary CB
+                                        DrawIndexed x N
+
+                                      EndFrame()
+                                        SubmitAsyncJobs()
+                                        EndEnqueuedBuffers()
+                                        Present()
+                                          vkQueueSubmit -> signal timeline N
+                                          vkQueuePresentKHR
+```

--- a/ZEngine/docs/future-plan/shadows.md
+++ b/ZEngine/docs/future-plan/shadows.md
@@ -2,7 +2,7 @@
 
 **Priority:** P2 — Required for visual quality in any 3D game
 **Status:** Design
-**Depends on:** `render-resource-manager.md`, `actor-ecs-architecture.md` (LightComponent), `vfs-design.md` (Ticket 1)
+**Depends on:** `gpu-allocator-rearchitecture.md`, `per-frame-upload-heap.md`, `actor-ecs-architecture.md` (LightComponent), `vfs-design.md` (Ticket 1)
 **Blocks:** Visual quality, night/indoor scenes
 
 **Goal**: Implement a multi-technique shadow system for ZEngine that covers the three
@@ -682,9 +682,14 @@ namespace ZEngine::Rendering::Shadows {
 } // namespace ZEngine::Rendering::Shadows
 ```
 
-This buffer is uploaded once per frame via a `VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT` buffer
-managed by the RRM. The `ShadowSystem` fills it on the CPU side, then the RRM transfers
-it to the GPU-visible range before the lighting pass executes.
+This buffer is uploaded once per frame via `PerFrameUploadHeap::Push`. The
+`ShadowSystem` fills it on the CPU side each frame and pushes it into the current
+frame's heap. The resulting dynamic offset is passed to `vkCmdBindDescriptorSets` at the
+lighting pass bind point.
+
+The RRM is not involved in `ShadowUniformBuffer` upload. The RRM manages static asset
+lifetime (textures, meshes); per-frame CPU-written data always goes through
+`PerFrameUploadHeap`.
 
 ---
 


### PR DESCRIPTION
New documents:
- gpu-allocator-rearchitecture.md: VMA v3.3.0 redesign with segregated pools, StagingRing, DeferredFreeQueue, and GpuMemoryDomain budget
- per-frame-upload-heap.md: single 64 MB bump-pointer frame heap replacing per-upload vkAllocateMemory
- rendering-flow.md: full per-frame pipeline from main thread to GPU submission, post-rearchitecture flow changes and known gaps
- render-graph-redesign.md: production-grade render graph with automatic barrier insertion, transient memory aliasing, RGTransientPool, kAccessTable, and compute pass support
- draw-call-sorting.md: 64-bit sort key, LSD radix sort, opaque front-to-back and transparent back-to-front split, DrawCommandBuffer
- compute-pipeline.md: ComputePipeline struct, CommandBuffer::Dispatch, ShaderType::COMPUTE, IComputeCallbackPass, three concrete examples

Correctness fixes to existing documents:
- render-resource-manager.md: FRAMES_IN_FLIGHT 2->3 in checklist, staging path updated to Ring.Allocate, DeferredRelease description corrected, EndFrame DeferFree call fixed
- gizmo-3d-pass.md: raw VkDeviceMemory fields replaced with VmaAllocation
- shadows.md: ShadowUniformBuffer upload attributed to PerFrameUploadHeap
- post-processing.md: all passes converted to DOD vtable pattern, SSAOPass converted, checklist and file layout updated
- render-graph-integration.md: post-process registration updated to PostProcessStack::AddPass factory pattern, enable/disable section updated to PostProcessStack::SetEnabled
- profiling.md: Execute examples updated to free-function signatures