### PR TITLE
feat(vfs): vfsfilewatcher

### DIFF
--- a/ZEngine/ZEngine/CMakeLists.txt
+++ b/ZEngine/ZEngine/CMakeLists.txt
@@ -76,6 +76,9 @@ if(APPLE)
     list(APPEND ZENGINE_SOURCES_CRASH_HANDLERS
         ${CMAKE_CURRENT_SOURCE_DIR}/CrashHandlers/CrashHandlerMacOS.mm
     )
+    list(APPEND ZENGINE_SOURCES_CORE
+        ${CMAKE_CURRENT_SOURCE_DIR}/Core/VFS/Platform/VFSFSEventsWatcher.mm
+    )
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     list(APPEND ZENGINE_SOURCES_CRASH_HANDLERS
         ${CMAKE_CURRENT_SOURCE_DIR}/CrashHandlers/CrashHandlerWindows.cpp
@@ -165,6 +168,6 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_link_libraries(zEngineLib PUBLIC stdc++fs dl)
     target_compile_definitions(zEngineLib PUBLIC GLFW_EXPOSE_NATIVE_WAYLAND)
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    target_link_libraries(zEngineLib PRIVATE "-lobjc" "-framework AppKit" "-framework CoreGraphics")
+    target_link_libraries(zEngineLib PRIVATE "-lobjc" "-framework AppKit" "-framework CoreGraphics" "-framework CoreServices")
     target_compile_definitions(zEngineLib PUBLIC GLFW_EXPOSE_NATIVE_COCOA)
 endif()

--- a/ZEngine/ZEngine/Core/VFS/IVFSPlatformWatcher.h
+++ b/ZEngine/ZEngine/Core/VFS/IVFSPlatformWatcher.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <ZEngine/Core/VFS/VFSWatchEvent.h>
+#include <cstdint>
+
+namespace ZEngine::Core::VFS
+{
+    using RawEventCallback                     = void (*)(void* ctx, const VFSWatchEvent&);
+    using WatchHandle                          = uint32_t;
+    constexpr WatchHandle INVALID_WATCH_HANDLE = 0xFFFF'FFFFu;
+
+    class IVFSPlatformWatcher
+    {
+    public:
+        virtual ~IVFSPlatformWatcher()                                        = default;
+
+        virtual WatchHandle AddWatch(const char* native_path, bool recursive) = 0;
+        virtual void        RemoveWatch(WatchHandle handle)                   = 0;
+
+        virtual void        Poll(RawEventCallback cb, void* ctx)              = 0;
+
+        virtual void        StartThread()                                     = 0;
+        virtual void        StopThread()                                      = 0;
+    };
+} // namespace ZEngine::Core::VFS

--- a/ZEngine/ZEngine/Core/VFS/Platform/VFSFSEventsWatcher.h
+++ b/ZEngine/ZEngine/Core/VFS/Platform/VFSFSEventsWatcher.h
@@ -1,0 +1,71 @@
+#pragma once
+#if defined(__APPLE__)
+#include <CoreServices/CoreServices.h>
+#include <ZEngine/Core/Containers/Array.h>
+#include <ZEngine/Core/Containers/UnorderedHashMap.h>
+#include <ZEngine/Core/Memory/Allocator.h>
+#include <ZEngine/Core/VFS/IVFSPlatformWatcher.h>
+#include <ZEngine/ZEngineDef.h>
+#include <mutex>
+#include <thread>
+
+namespace ZEngine::Core::VFS
+{
+    class VFSFSEventsWatcher final : public IVFSPlatformWatcher
+    {
+    public:
+        VFSFSEventsWatcher();
+        ~VFSFSEventsWatcher() override;
+
+        VFSFSEventsWatcher(const VFSFSEventsWatcher&)            = delete;
+        VFSFSEventsWatcher& operator=(const VFSFSEventsWatcher&) = delete;
+
+        void                Initialize(Memory::ArenaAllocator* arena, size_t capacity = 64);
+
+        WatchHandle         AddWatch(const char* native_path, bool recursive) override;
+        void                RemoveWatch(WatchHandle handle) override;
+        void                Poll(RawEventCallback cb, void* ctx) override;
+        void                StartThread() override;
+        void                StopThread() override;
+
+        bool                IsValid() const
+        {
+            return m_arena != nullptr;
+        }
+
+        size_t WatchCount() const;
+
+    private:
+        struct WatchEntry
+        {
+            char Path[MAX_FILE_PATH_COUNT] = {};
+            bool Recursive                 = false;
+        };
+
+        static void                                           FSEventsCallback(ConstFSEventStreamRef stream, void* context, size_t count, void* paths, const FSEventStreamEventFlags* flags, const FSEventStreamEventId* ids);
+        void                                                  RebuildStream();
+        void                                                  TeardownStream();
+        void                                                  PushEvent(const VFSWatchEvent& ev);
+
+        static VFSWatchEvent                                  MakeEvent(const char* path, WatchEventKind kind, bool is_directory);
+        static size_t                                         ClampedLength(const char* text);
+
+        Memory::ArenaAllocator*                               m_arena = nullptr;
+
+        mutable std::mutex                                    m_watch_mutex;
+        Containers::UnorderedHashMap<WatchHandle, WatchEntry> m_watches;
+        WatchHandle                                           m_next_handle    = 1;
+
+        FSEventStreamRef                                      m_stream         = nullptr;
+        bool                                                  m_stream_started = false;
+        CFRunLoopRef                                          m_run_loop       = nullptr;
+        std::thread                                           m_thread;
+        PaddedAtomic<bool>                                    m_running = {};
+
+        std::mutex                                            m_queue_mutex;
+        Containers::Array<VFSWatchEvent>                      m_queue;
+        Containers::Array<VFSWatchEvent>                      m_drain;
+    };
+
+} // namespace ZEngine::Core::VFS
+#endif // __APPLE__

--- a/ZEngine/ZEngine/Core/VFS/Platform/VFSFSEventsWatcher.mm
+++ b/ZEngine/ZEngine/Core/VFS/Platform/VFSFSEventsWatcher.mm
@@ -1,0 +1,254 @@
+#include <ZEngine/Core/VFS/Platform/VFSFSEventsWatcher.h>
+#if defined(__APPLE__)
+#include <ZEngine/Helpers/MemoryOperations.h>
+#include <sys/stat.h>
+
+namespace ZEngine::Core::VFS
+{
+
+    static constexpr CFAbsoluteTime STREAM_LATENCY_SECONDS = 0.05;
+
+    size_t                   VFSFSEventsWatcher::ClampedLength(const char* text)
+    {
+        const size_t length = Helpers::secure_strlen(text);
+        return length < MAX_FILE_PATH_COUNT ? length : MAX_FILE_PATH_COUNT - 1;
+    }
+
+    VFSWatchEvent VFSFSEventsWatcher::MakeEvent(const char* path, WatchEventKind kind, bool is_directory)
+    {
+        VFSWatchEvent ev{};
+        Helpers::secure_strncpy(ev.Path, sizeof(ev.Path), path, ClampedLength(path));
+        ev.Kind        = kind;
+        ev.IsDirectory = is_directory;
+        return ev;
+    }
+
+    VFSFSEventsWatcher::VFSFSEventsWatcher() = default;
+
+    VFSFSEventsWatcher::~VFSFSEventsWatcher()
+    {
+        StopThread();
+
+        std::lock_guard<std::mutex> lock(m_watch_mutex);
+        TeardownStream();
+    }
+
+    void VFSFSEventsWatcher::Initialize(Memory::ArenaAllocator* arena, size_t capacity)
+    {
+        m_arena = arena;
+        m_watches.init(arena, capacity);
+        m_queue.init(arena, capacity);
+        m_drain.init(arena, capacity);
+    }
+
+    void VFSFSEventsWatcher::PushEvent(const VFSWatchEvent& ev)
+    {
+        std::lock_guard<std::mutex> lock(m_queue_mutex);
+        m_queue.push(ev);
+    }
+
+    void VFSFSEventsWatcher::FSEventsCallback(ConstFSEventStreamRef, void* context, size_t count, void* paths, const FSEventStreamEventFlags* flags, const FSEventStreamEventId*)
+    {
+        VFSFSEventsWatcher* self       = static_cast<VFSFSEventsWatcher*>(context);
+        const char**        path_array = static_cast<const char**>(paths);
+
+        for (size_t i = 0; i < count; ++i)
+        {
+            const FSEventStreamEventFlags flag = flags[i];
+
+            if (flag & (kFSEventStreamEventFlagUserDropped | kFSEventStreamEventFlagKernelDropped | kFSEventStreamEventFlagMustScanSubDirs))
+            {
+                VFSWatchEvent overflow{};
+                overflow.Kind = WatchEventKind::Overflow;
+                self->PushEvent(overflow);
+                continue;
+            }
+
+            const bool     is_directory = (flag & kFSEventStreamEventFlagItemIsDir) != 0;
+
+            struct stat    st           = {};
+            WatchEventKind kind;
+            if (stat(path_array[i], &st) != 0)
+            {
+                kind = WatchEventKind::Deleted;
+            }
+            else if (flag & kFSEventStreamEventFlagItemCreated)
+            {
+                kind = WatchEventKind::Created;
+            }
+            else
+            {
+                kind = WatchEventKind::Modified;
+            }
+
+            self->PushEvent(MakeEvent(path_array[i], kind, is_directory));
+        }
+    }
+
+    void VFSFSEventsWatcher::TeardownStream()
+    {
+        if (!m_stream)
+        {
+            return;
+        }
+
+        if (m_stream_started)
+        {
+            FSEventStreamStop(m_stream);
+            FSEventStreamInvalidate(m_stream);
+            m_stream_started = false;
+        }
+        FSEventStreamRelease(m_stream);
+        m_stream = nullptr;
+    }
+
+    void VFSFSEventsWatcher::RebuildStream()
+    {
+        TeardownStream();
+
+        if (m_watches.size() == 0)
+        {
+            return;
+        }
+
+        CFMutableArrayRef path_list = CFArrayCreateMutable(nullptr, 0, &kCFTypeArrayCallBacks);
+        for (auto it = m_watches.begin(); it != m_watches.end(); ++it)
+        {
+            CFStringRef path = CFStringCreateWithCString(nullptr, (*it).second.Path, kCFStringEncodingUTF8);
+            CFArrayAppendValue(path_list, path);
+            CFRelease(path);
+        }
+
+        FSEventStreamContext context = {0, this, nullptr, nullptr, nullptr};
+        m_stream                     = FSEventStreamCreate(nullptr, &FSEventsCallback, &context, path_list, kFSEventStreamEventIdSinceNow, STREAM_LATENCY_SECONDS,
+                                                           kFSEventStreamCreateFlagFileEvents | kFSEventStreamCreateFlagNoDefer);
+        CFRelease(path_list);
+
+        if (m_stream && m_run_loop)
+        {
+            FSEventStreamScheduleWithRunLoop(m_stream, m_run_loop, kCFRunLoopDefaultMode);
+            FSEventStreamStart(m_stream);
+            m_stream_started = true;
+        }
+    }
+
+    WatchHandle VFSFSEventsWatcher::AddWatch(const char* native_path, bool recursive)
+    {
+        if (!IsValid() || !native_path || native_path[0] == '\0')
+        {
+            return INVALID_WATCH_HANDLE;
+        }
+
+        std::lock_guard<std::mutex> lock(m_watch_mutex);
+
+        const WatchHandle           handle = m_next_handle++;
+        WatchEntry                  entry;
+        Helpers::secure_strncpy(entry.Path, sizeof(entry.Path), native_path, ClampedLength(native_path));
+        entry.Recursive   = recursive;
+
+        m_watches[handle] = entry;
+
+        if (m_run_loop)
+        {
+            CFRunLoopRef run_loop = m_run_loop;
+            CFRunLoopPerformBlock(run_loop, kCFRunLoopDefaultMode, ^{
+                std::lock_guard<std::mutex> rebuild_lock(m_watch_mutex);
+                RebuildStream();
+            });
+            CFRunLoopWakeUp(run_loop);
+        }
+        return handle;
+    }
+
+    void VFSFSEventsWatcher::RemoveWatch(WatchHandle handle)
+    {
+        std::lock_guard<std::mutex> lock(m_watch_mutex);
+
+        if (!m_watches.find(handle))
+        {
+            return;
+        }
+
+        m_watches.remove(handle);
+
+        if (m_run_loop)
+        {
+            CFRunLoopRef run_loop = m_run_loop;
+            CFRunLoopPerformBlock(run_loop, kCFRunLoopDefaultMode, ^{
+                std::lock_guard<std::mutex> rebuild_lock(m_watch_mutex);
+                RebuildStream();
+            });
+            CFRunLoopWakeUp(run_loop);
+        }
+    }
+
+    void VFSFSEventsWatcher::Poll(RawEventCallback cb, void* ctx)
+    {
+        if (!m_arena)
+        {
+            return;
+        }
+
+        m_drain.clear();
+        {
+            std::lock_guard<std::mutex> lock(m_queue_mutex);
+            for (size_t i = 0; i < m_queue.size(); ++i)
+            {
+                m_drain.push(m_queue[i]);
+            }
+            m_queue.clear();
+        }
+
+        for (size_t i = 0; i < m_drain.size(); ++i)
+        {
+            cb(ctx, m_drain[i]);
+        }
+    }
+
+    void VFSFSEventsWatcher::StartThread()
+    {
+        if (!IsValid() || m_running.value.exchange(true, std::memory_order_acq_rel))
+        {
+            return;
+        }
+
+        m_thread = std::thread([this] {
+            m_run_loop = CFRunLoopGetCurrent();
+            {
+                std::lock_guard<std::mutex> lock(m_watch_mutex);
+                RebuildStream();
+            }
+            CFRunLoopRun();
+        });
+    }
+
+    void VFSFSEventsWatcher::StopThread()
+    {
+        if (!m_running.value.exchange(false, std::memory_order_acq_rel))
+        {
+            return;
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(m_watch_mutex);
+            if (m_run_loop)
+            {
+                CFRunLoopStop(m_run_loop);
+            }
+        }
+        if (m_thread.joinable())
+        {
+            m_thread.join();
+        }
+        std::lock_guard<std::mutex> lock(m_watch_mutex);
+        m_run_loop = nullptr;
+    }
+
+    size_t VFSFSEventsWatcher::WatchCount() const
+    {
+        std::lock_guard<std::mutex> lock(m_watch_mutex);
+        return m_watches.size();
+    }
+
+} // namespace ZEngine::Core::VFS
+#endif // __APPLE__

--- a/ZEngine/ZEngine/Core/VFS/Platform/VFSInotifyWatcher.cpp
+++ b/ZEngine/ZEngine/Core/VFS/Platform/VFSInotifyWatcher.cpp
@@ -1,0 +1,465 @@
+#include <ZEngine/Core/VFS/Platform/VFSInotifyWatcher.h>
+#if defined(__linux__)
+#include <ZEngine/Helpers/MemoryOperations.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <sys/inotify.h>
+#include <unistd.h>
+#include <filesystem>
+
+namespace ZEngine::Core::VFS
+{
+    static constexpr uint32_t WATCH_MASK = IN_CREATE | IN_MODIFY | IN_CLOSE_WRITE | IN_ATTRIB | IN_DELETE | IN_MOVED_FROM | IN_MOVED_TO | IN_DELETE_SELF | IN_MOVE_SELF | IN_ONLYDIR;
+
+    size_t                    VFSInotifyWatcher::ClampedLength(const char* text)
+    {
+        const size_t length = Helpers::secure_strlen(text);
+        return length < MAX_FILE_PATH_COUNT ? length : MAX_FILE_PATH_COUNT - 1;
+    }
+
+    void VFSInotifyWatcher::JoinPath(char* out, size_t out_size, const char* directory, const char* name)
+    {
+        if (!out || out_size == 0)
+        {
+            return;
+        }
+        Helpers::secure_memset(out, 0, out_size, out_size);
+
+        const size_t directory_length = Helpers::secure_strlen(directory);
+        size_t       length           = directory_length < out_size - 1 ? directory_length : out_size - 1;
+        if (length > 0)
+        {
+            Helpers::secure_strncpy(out, out_size, directory, length);
+        }
+
+        if (!name || name[0] == '\0')
+        {
+            return;
+        }
+
+        const bool has_separator = (length > 0 && out[length - 1] == '/');
+        if (!has_separator && length + 1 < out_size)
+        {
+            out[length++] = '/';
+            out[length]   = '\0';
+        }
+
+        const size_t name_length = Helpers::secure_strlen(name);
+        const size_t room        = (out_size - 1) - length;
+        const size_t copied      = name_length < room ? name_length : room;
+        if (copied > 0)
+        {
+            Helpers::secure_strncpy(out + length, out_size - length, name, copied);
+        }
+    }
+
+    VFSWatchEvent VFSInotifyWatcher::MakeEvent(const char* path, WatchEventKind kind, bool is_directory)
+    {
+        VFSWatchEvent ev{};
+        Helpers::secure_strncpy(ev.Path, sizeof(ev.Path), path, ClampedLength(path));
+        ev.Kind        = kind;
+        ev.IsDirectory = is_directory;
+        return ev;
+    }
+
+    VFSInotifyWatcher::VFSInotifyWatcher()
+    {
+        m_inotify_fd = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
+
+        if (pipe2(m_wake_pipe, O_NONBLOCK | O_CLOEXEC) != 0)
+        {
+            m_wake_pipe[0] = -1;
+            m_wake_pipe[1] = -1;
+        }
+    }
+
+    VFSInotifyWatcher::~VFSInotifyWatcher()
+    {
+        StopThread();
+
+        if (m_inotify_fd >= 0)
+        {
+            close(m_inotify_fd);
+            m_inotify_fd = -1;
+        }
+        for (int& fd : m_wake_pipe)
+        {
+            if (fd >= 0)
+            {
+                close(fd);
+                fd = -1;
+            }
+        }
+    }
+
+    void VFSInotifyWatcher::Initialize(Memory::ArenaAllocator* arena, size_t capacity)
+    {
+        std::lock_guard<std::mutex> lock(m_watch_mutex);
+
+        m_arena = arena;
+        m_wd_to_entry.init(arena, capacity);
+        m_roots.init(arena, capacity);
+
+        m_queue.init(arena, capacity);
+        m_batch.init(arena, capacity);
+        m_drain.init(arena, capacity);
+        m_pending_moves.init(arena, 8);
+    }
+
+    int VFSInotifyWatcher::AddDirectory(WatchHandle handle, const char* directory)
+    {
+        const int wd = inotify_add_watch(m_inotify_fd, directory, WATCH_MASK);
+        if (wd < 0)
+        {
+            VFSWatchEvent overflow{};
+            overflow.Kind = WatchEventKind::Overflow;
+            PushEvent(overflow);
+            return -1;
+        }
+
+        WatchDescriptor descriptor;
+        Helpers::secure_strncpy(descriptor.Path, sizeof(descriptor.Path), directory, ClampedLength(directory));
+        descriptor.Owner  = handle;
+        m_wd_to_entry[wd] = descriptor;
+
+        if (WatchRoot* root = m_roots.find(handle))
+        {
+            root->Descriptors.push(wd);
+        }
+        return wd;
+    }
+
+    void VFSInotifyWatcher::AddSubtree(WatchHandle handle, const char* directory)
+    {
+        std::error_code ec;
+        auto            options = std::filesystem::directory_options::skip_permission_denied;
+        for (auto it = std::filesystem::recursive_directory_iterator(directory, options, ec); it != std::filesystem::recursive_directory_iterator(); it.increment(ec))
+        {
+            if (ec)
+            {
+                break;
+            }
+            if (it->is_directory(ec) && !ec)
+            {
+                AddDirectory(handle, it->path().c_str());
+            }
+        }
+    }
+
+    WatchHandle VFSInotifyWatcher::AddWatch(const char* native_path, bool recursive)
+    {
+        if (!IsValid() || !native_path || native_path[0] == '\0')
+        {
+            return INVALID_WATCH_HANDLE;
+        }
+
+        std::lock_guard<std::mutex> lock(m_watch_mutex);
+
+        const WatchHandle           handle = m_next_handle++;
+        WatchRoot                   root;
+        Helpers::secure_strncpy(root.Root, sizeof(root.Root), native_path, ClampedLength(native_path));
+        root.Recursive = recursive;
+        root.Descriptors.init(m_arena, 8);
+        m_roots[handle] = std::move(root);
+
+        if (AddDirectory(handle, native_path) < 0)
+        {
+            m_roots.remove(handle);
+            return INVALID_WATCH_HANDLE;
+        }
+
+        if (recursive)
+        {
+            AddSubtree(handle, native_path);
+        }
+        return handle;
+    }
+
+    void VFSInotifyWatcher::RemoveWatch(WatchHandle handle)
+    {
+        std::lock_guard<std::mutex> lock(m_watch_mutex);
+
+        WatchRoot*                  root = m_roots.find(handle);
+        if (!root)
+        {
+            return;
+        }
+
+        for (size_t i = 0; i < root->Descriptors.size(); ++i)
+        {
+            const int wd = root->Descriptors[i];
+            inotify_rm_watch(m_inotify_fd, wd);
+            m_wd_to_entry.remove(wd);
+        }
+        m_roots.remove(handle);
+    }
+
+    void VFSInotifyWatcher::DropDescriptor(int wd)
+    {
+        WatchDescriptor* entry = m_wd_to_entry.find(wd);
+        if (!entry)
+        {
+            return;
+        }
+
+        if (WatchRoot* root = m_roots.find(entry->Owner))
+        {
+            for (size_t i = 0; i < root->Descriptors.size(); ++i)
+            {
+                if (root->Descriptors[i] == wd)
+                {
+                    root->Descriptors.erase(i);
+                    break;
+                }
+            }
+        }
+        m_wd_to_entry.remove(wd);
+    }
+
+    void VFSInotifyWatcher::PushEvent(const VFSWatchEvent& ev)
+    {
+        std::lock_guard<std::mutex> lock(m_queue_mutex);
+        m_queue.push(ev);
+    }
+
+    void VFSInotifyWatcher::TranslateBuffer(const char* buffer, size_t length)
+    {
+        m_batch.clear();
+        m_pending_moves.clear();
+
+        size_t offset = 0;
+        while (offset + sizeof(inotify_event) <= length)
+        {
+            const inotify_event* raw  = reinterpret_cast<const inotify_event*>(buffer + offset);
+            offset                   += sizeof(inotify_event) + raw->len;
+
+            if (raw->mask & IN_Q_OVERFLOW)
+            {
+                VFSWatchEvent overflow{};
+                overflow.Kind = WatchEventKind::Overflow;
+                m_batch.push(overflow);
+                continue;
+            }
+
+            if (raw->mask & IN_IGNORED)
+            {
+                std::lock_guard<std::mutex> lock(m_watch_mutex);
+                DropDescriptor(raw->wd);
+                continue;
+            }
+
+            char        path[MAX_FILE_PATH_COUNT];
+            WatchHandle owner     = INVALID_WATCH_HANDLE;
+            bool        recursive = false;
+            {
+                std::lock_guard<std::mutex> lock(m_watch_mutex);
+
+                WatchDescriptor*            descriptor = m_wd_to_entry.find(raw->wd);
+                if (!descriptor)
+                {
+                    continue;
+                }
+
+                owner                 = descriptor->Owner;
+                const WatchRoot* root = m_roots.find(owner);
+                recursive             = root && root->Recursive;
+
+                JoinPath(path, sizeof(path), descriptor->Path, raw->len ? raw->name : "");
+            }
+
+            const bool is_directory = (raw->mask & IN_ISDIR) != 0;
+
+            if (raw->mask & (IN_DELETE_SELF | IN_MOVE_SELF))
+            {
+                m_batch.push(MakeEvent(path, WatchEventKind::Deleted, true));
+                continue;
+            }
+
+            if (raw->mask & IN_CREATE)
+            {
+                if (is_directory && recursive)
+                {
+                    std::lock_guard<std::mutex> lock(m_watch_mutex);
+                    AddDirectory(owner, path);
+                    AddSubtree(owner, path);
+                }
+                m_batch.push(MakeEvent(path, WatchEventKind::Created, is_directory));
+            }
+            else if (raw->mask & (IN_MODIFY | IN_CLOSE_WRITE | IN_ATTRIB))
+            {
+                m_batch.push(MakeEvent(path, WatchEventKind::Modified, is_directory));
+            }
+            else if (raw->mask & IN_DELETE)
+            {
+                m_batch.push(MakeEvent(path, WatchEventKind::Deleted, is_directory));
+            }
+            else if (raw->mask & IN_MOVED_FROM)
+            {
+                PendingMove move;
+                move.Cookie = raw->cookie;
+                move.Event  = MakeEvent(path, WatchEventKind::Deleted, is_directory);
+                m_pending_moves.push(move);
+            }
+            else if (raw->mask & IN_MOVED_TO)
+            {
+                bool paired = false;
+                for (size_t i = 0; i < m_pending_moves.size(); ++i)
+                {
+                    if (m_pending_moves[i].Cookie != raw->cookie)
+                    {
+                        continue;
+                    }
+
+                    VFSWatchEvent renamed = MakeEvent(path, WatchEventKind::Renamed, is_directory);
+                    Helpers::secure_strcpy(renamed.OldPath, sizeof(renamed.OldPath), m_pending_moves[i].Event.Path);
+                    m_batch.push(renamed);
+                    m_pending_moves.erase(i);
+                    paired = true;
+                    break;
+                }
+
+                if (!paired)
+                {
+                    m_batch.push(MakeEvent(path, WatchEventKind::Created, is_directory));
+                }
+
+                if (is_directory && recursive)
+                {
+                    std::lock_guard<std::mutex> lock(m_watch_mutex);
+                    AddDirectory(owner, path);
+                    AddSubtree(owner, path);
+                }
+            }
+        }
+
+        for (size_t i = 0; i < m_pending_moves.size(); ++i)
+        {
+            m_batch.push(m_pending_moves[i].Event);
+        }
+        m_pending_moves.clear();
+
+        if (m_batch.size() > 0)
+        {
+            std::lock_guard<std::mutex> lock(m_queue_mutex);
+            for (size_t i = 0; i < m_batch.size(); ++i)
+            {
+                m_queue.push(m_batch[i]);
+            }
+        }
+        m_batch.clear();
+    }
+
+    void VFSInotifyWatcher::ReadPendingEvents()
+    {
+        if (m_inotify_fd < 0)
+        {
+            return;
+        }
+
+        alignas(inotify_event) char buffer[ZKilo(64)];
+        for (;;)
+        {
+            const ssize_t bytes = read(m_inotify_fd, buffer, sizeof(buffer));
+            if (bytes <= 0)
+            {
+                break;
+            }
+            TranslateBuffer(buffer, static_cast<size_t>(bytes));
+        }
+    }
+
+    void VFSInotifyWatcher::Poll(RawEventCallback cb, void* ctx)
+    {
+        if (!m_arena)
+        {
+            return;
+        }
+
+        if (!m_running.value.load(std::memory_order_acquire))
+        {
+            ReadPendingEvents();
+        }
+
+        m_drain.clear();
+        {
+            std::lock_guard<std::mutex> lock(m_queue_mutex);
+            for (size_t i = 0; i < m_queue.size(); ++i)
+            {
+                m_drain.push(m_queue[i]);
+            }
+            m_queue.clear();
+        }
+
+        for (size_t i = 0; i < m_drain.size(); ++i)
+        {
+            cb(ctx, m_drain[i]);
+        }
+    }
+
+    void VFSInotifyWatcher::ThreadMain()
+    {
+        pollfd fds[2];
+        fds[0].fd     = m_inotify_fd;
+        fds[0].events = POLLIN;
+        fds[1].fd     = m_wake_pipe[0];
+        fds[1].events = POLLIN;
+
+        while (m_running.value.load(std::memory_order_acquire))
+        {
+            const int ready = ::poll(fds, 2, -1);
+            if (ready < 0)
+            {
+                continue;
+            }
+
+            if (fds[1].revents & POLLIN)
+            {
+                char discard[64];
+                while (read(m_wake_pipe[0], discard, sizeof(discard)) > 0)
+                {
+                }
+                break;
+            }
+
+            if (fds[0].revents & POLLIN)
+            {
+                ReadPendingEvents();
+            }
+        }
+    }
+
+    void VFSInotifyWatcher::StartThread()
+    {
+        if (!IsValid() || m_running.value.exchange(true, std::memory_order_acq_rel))
+        {
+            return;
+        }
+        m_thread = std::thread([this] { ThreadMain(); });
+    }
+
+    void VFSInotifyWatcher::StopThread()
+    {
+        if (!m_running.value.exchange(false, std::memory_order_acq_rel))
+        {
+            return;
+        }
+
+        if (m_wake_pipe[1] >= 0)
+        {
+            const char            wake    = 1;
+            [[maybe_unused]] auto ignored = write(m_wake_pipe[1], &wake, 1);
+        }
+        if (m_thread.joinable())
+        {
+            m_thread.join();
+        }
+    }
+
+    size_t VFSInotifyWatcher::DescriptorCount() const
+    {
+        std::lock_guard<std::mutex> lock(m_watch_mutex);
+        return m_wd_to_entry.size();
+    }
+
+} // namespace ZEngine::Core::VFS
+#endif // __linux__

--- a/ZEngine/ZEngine/Core/VFS/Platform/VFSInotifyWatcher.h
+++ b/ZEngine/ZEngine/Core/VFS/Platform/VFSInotifyWatcher.h
@@ -1,0 +1,91 @@
+#pragma once
+#if defined(__linux__)
+#include <ZEngine/Core/Containers/Array.h>
+#include <ZEngine/Core/Containers/UnorderedHashMap.h>
+#include <ZEngine/Core/Memory/Allocator.h>
+#include <ZEngine/Core/VFS/IVFSPlatformWatcher.h>
+#include <ZEngine/ZEngineDef.h>
+#include <mutex>
+#include <thread>
+
+namespace ZEngine::Core::VFS
+{
+    class VFSInotifyWatcher final : public IVFSPlatformWatcher
+    {
+    public:
+        VFSInotifyWatcher();
+        ~VFSInotifyWatcher() override;
+
+        VFSInotifyWatcher(const VFSInotifyWatcher&)            = delete;
+        VFSInotifyWatcher& operator=(const VFSInotifyWatcher&) = delete;
+
+        void               Initialize(Memory::ArenaAllocator* arena, size_t capacity = 64);
+
+        WatchHandle        AddWatch(const char* native_path, bool recursive) override;
+        void               RemoveWatch(WatchHandle handle) override;
+        void               Poll(RawEventCallback cb, void* ctx) override;
+        void               StartThread() override;
+        void               StopThread() override;
+
+        bool               IsValid() const
+        {
+            return m_inotify_fd >= 0 && m_arena != nullptr;
+        }
+
+        size_t DescriptorCount() const;
+
+    private:
+        struct WatchDescriptor
+        {
+            char        Path[MAX_FILE_PATH_COUNT] = {};
+            WatchHandle Owner                     = INVALID_WATCH_HANDLE;
+        };
+
+        struct WatchRoot
+        {
+            char                   Root[MAX_FILE_PATH_COUNT] = {};
+            bool                   Recursive                 = false;
+            Containers::Array<int> Descriptors               = {};
+        };
+
+        struct PendingMove
+        {
+            uint32_t      Cookie = 0;
+            VFSWatchEvent Event  = {};
+        };
+
+        int                                                  AddDirectory(WatchHandle handle, const char* directory);
+        void                                                 AddSubtree(WatchHandle handle, const char* directory);
+        void                                                 DropDescriptor(int wd);
+
+        void                                                 ReadPendingEvents();
+        void                                                 TranslateBuffer(const char* buffer, size_t length);
+        void                                                 ThreadMain();
+        void                                                 PushEvent(const VFSWatchEvent& ev);
+
+        static VFSWatchEvent                                 MakeEvent(const char* path, WatchEventKind kind, bool is_directory);
+        static void                                          JoinPath(char* out, size_t out_size, const char* directory, const char* name);
+        static size_t                                        ClampedLength(const char* text);
+
+        Memory::ArenaAllocator*                              m_arena        = nullptr;
+
+        int                                                  m_inotify_fd   = -1;
+        int                                                  m_wake_pipe[2] = {-1, -1};
+
+        mutable std::mutex                                   m_watch_mutex;
+        Containers::UnorderedHashMap<int, WatchDescriptor>   m_wd_to_entry;
+        Containers::UnorderedHashMap<WatchHandle, WatchRoot> m_roots;
+        WatchHandle                                          m_next_handle = 1;
+
+        std::mutex                                           m_queue_mutex;
+        Containers::Array<VFSWatchEvent>                     m_queue;
+        Containers::Array<VFSWatchEvent>                     m_batch;
+        Containers::Array<PendingMove>                       m_pending_moves;
+        Containers::Array<VFSWatchEvent>                     m_drain;
+
+        std::thread                                          m_thread;
+        PaddedAtomic<bool>                                   m_running = {};
+    };
+
+} // namespace ZEngine::Core::VFS
+#endif // __linux__

--- a/ZEngine/ZEngine/Core/VFS/Platform/VFSRDCWatcher.cpp
+++ b/ZEngine/ZEngine/Core/VFS/Platform/VFSRDCWatcher.cpp
@@ -1,0 +1,351 @@
+#include <ZEngine/Core/VFS/Platform/VFSRDCWatcher.h>
+#if defined(_WIN32)
+#include <ZEngine/Helpers/MemoryOperations.h>
+
+namespace ZEngine::Core::VFS
+{
+    static constexpr DWORD     NOTIFY_FILTER       = FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_DIR_NAME | FILE_NOTIFY_CHANGE_LAST_WRITE | FILE_NOTIFY_CHANGE_SIZE;
+    static constexpr ULONG_PTR COMPLETION_KEY_STOP = 1;
+
+    size_t                     VFSRDCWatcher::ClampedLength(const char* text)
+    {
+        const size_t length = Helpers::secure_strlen(text);
+        return length < MAX_FILE_PATH_COUNT ? length : MAX_FILE_PATH_COUNT - 1;
+    }
+
+    void VFSRDCWatcher::AppendWideName(char* out, size_t out_size, const char* root, const wchar_t* name, DWORD name_bytes)
+    {
+        char      narrow[MAX_FILE_PATH_COUNT] = {};
+
+        const int wide_length                 = static_cast<int>(name_bytes / sizeof(wchar_t));
+        const int written                     = WideCharToMultiByte(CP_UTF8, 0, name, wide_length, narrow, sizeof(narrow) - 1, nullptr, nullptr);
+        narrow[written > 0 ? written : 0]     = '\0';
+
+        for (char* c = narrow; *c != '\0'; ++c)
+        {
+            if (*c == '\\')
+            {
+                *c = '/';
+            }
+        }
+
+        if (!out || out_size == 0)
+        {
+            return;
+        }
+
+        const size_t root_length   = Helpers::secure_strlen(root);
+        const bool   has_separator = (root_length > 0 && (root[root_length - 1] == '/' || root[root_length - 1] == '\\'));
+
+        out[0]                     = '\0';
+        Helpers::secure_strncpy(out, out_size, root, root_length < out_size ? root_length : out_size - 1);
+
+        size_t pos = Helpers::secure_strlen(out);
+        if (!has_separator && pos + 1 < out_size)
+        {
+            out[pos++] = '/';
+            out[pos]   = '\0';
+        }
+
+        if (pos < out_size - 1)
+        {
+            const size_t remaining   = out_size - pos - 1;
+            const size_t name_length = Helpers::secure_strlen(narrow);
+            Helpers::secure_strncpy(out + pos, out_size - pos, narrow, name_length < remaining ? name_length : remaining);
+        }
+    }
+
+    VFSWatchEvent VFSRDCWatcher::MakeEvent(const char* path, WatchEventKind kind)
+    {
+        VFSWatchEvent ev{};
+        Helpers::secure_strncpy(ev.Path, sizeof(ev.Path), path, ClampedLength(path));
+        ev.Kind = kind;
+        return ev;
+    }
+
+    VFSRDCWatcher::VFSRDCWatcher()
+    {
+        m_iocp = CreateIoCompletionPort(INVALID_HANDLE_VALUE, nullptr, 0, 1);
+    }
+
+    VFSRDCWatcher::~VFSRDCWatcher()
+    {
+        StopThread();
+
+        std::lock_guard<std::mutex> lock(m_watch_mutex);
+        for (auto it = m_entries.begin(); it != m_entries.end(); ++it)
+        {
+            WatchEntry* entry = (*it).second;
+            if (entry && entry->DirHandle != INVALID_HANDLE_VALUE)
+            {
+                CancelIoEx(entry->DirHandle, &entry->Overlapped);
+                CloseHandle(entry->DirHandle);
+                entry->DirHandle = INVALID_HANDLE_VALUE;
+            }
+        }
+        m_entries.clear();
+
+        if (m_iocp)
+        {
+            CloseHandle(m_iocp);
+            m_iocp = nullptr;
+        }
+    }
+
+    void VFSRDCWatcher::Initialize(Memory::ArenaAllocator* arena, size_t capacity)
+    {
+        std::lock_guard<std::mutex> lock(m_watch_mutex);
+
+        m_arena = arena;
+        m_entries.init(arena, capacity);
+        m_queue.init(arena, capacity);
+        m_batch.init(arena, capacity);
+        m_drain.init(arena, capacity);
+    }
+
+    bool VFSRDCWatcher::ReissueRead(WatchEntry* entry)
+    {
+        Helpers::secure_memset(&entry->Overlapped, 0, sizeof(entry->Overlapped), sizeof(entry->Overlapped));
+        return ReadDirectoryChangesW(entry->DirHandle, entry->Buffer, sizeof(entry->Buffer), entry->Recursive ? TRUE : FALSE, NOTIFY_FILTER, nullptr, &entry->Overlapped, nullptr) != FALSE;
+    }
+
+    WatchHandle VFSRDCWatcher::AddWatch(const char* native_path, bool recursive)
+    {
+        if (!IsValid() || !native_path || native_path[0] == '\0')
+        {
+            return INVALID_WATCH_HANDLE;
+        }
+
+        const HANDLE dir = CreateFileA(native_path, FILE_LIST_DIRECTORY, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED, nullptr);
+        if (dir == INVALID_HANDLE_VALUE)
+        {
+            return INVALID_WATCH_HANDLE;
+        }
+
+        std::lock_guard<std::mutex> lock(m_watch_mutex);
+
+        void*                       storage = ZAlloc(m_arena, sizeof(WatchEntry), ZAlignof(WatchEntry));
+        if (!storage)
+        {
+            CloseHandle(dir);
+            return INVALID_WATCH_HANDLE;
+        }
+
+        WatchEntry*       entry  = new (storage) WatchEntry();
+        const WatchHandle handle = m_next_handle++;
+        entry->DirHandle         = dir;
+        entry->Handle            = handle;
+        entry->Recursive         = recursive;
+        Helpers::secure_strncpy(entry->Root, sizeof(entry->Root), native_path, ClampedLength(native_path));
+
+        if (!CreateIoCompletionPort(dir, m_iocp, reinterpret_cast<ULONG_PTR>(entry), 0) || !ReissueRead(entry))
+        {
+            CloseHandle(dir);
+            entry->DirHandle = INVALID_HANDLE_VALUE;
+            return INVALID_WATCH_HANDLE;
+        }
+
+        m_entries[handle] = entry;
+        return handle;
+    }
+
+    void VFSRDCWatcher::RemoveWatch(WatchHandle handle)
+    {
+        std::lock_guard<std::mutex> lock(m_watch_mutex);
+
+        WatchEntry**                slot = m_entries.find(handle);
+        if (!slot || !*slot)
+        {
+            return;
+        }
+
+        WatchEntry* entry = *slot;
+        CancelIoEx(entry->DirHandle, &entry->Overlapped);
+        CloseHandle(entry->DirHandle);
+        entry->DirHandle = INVALID_HANDLE_VALUE;
+
+        m_entries.remove(handle);
+    }
+
+    void VFSRDCWatcher::ProcessNotifications(WatchEntry* entry, DWORD bytes)
+    {
+        if (bytes == 0)
+        {
+            VFSWatchEvent overflow{};
+            overflow.Kind = WatchEventKind::Overflow;
+            PushEvent(overflow);
+            return;
+        }
+
+        m_batch.clear();
+
+        char  pending_rename[MAX_FILE_PATH_COUNT] = {};
+        bool  has_pending_rename                  = false;
+
+        DWORD offset                              = 0;
+        for (;;)
+        {
+            const FILE_NOTIFY_INFORMATION* info                      = reinterpret_cast<const FILE_NOTIFY_INFORMATION*>(entry->Buffer + offset);
+
+            char                           path[MAX_FILE_PATH_COUNT] = {};
+            AppendWideName(path, sizeof(path), entry->Root, info->FileName, info->FileNameLength);
+
+            switch (info->Action)
+            {
+                case FILE_ACTION_ADDED:
+                    m_batch.push(MakeEvent(path, WatchEventKind::Created));
+                    break;
+                case FILE_ACTION_REMOVED:
+                    m_batch.push(MakeEvent(path, WatchEventKind::Deleted));
+                    break;
+                case FILE_ACTION_MODIFIED:
+                    m_batch.push(MakeEvent(path, WatchEventKind::Modified));
+                    break;
+                case FILE_ACTION_RENAMED_OLD_NAME:
+                    Helpers::secure_strcpy(pending_rename, sizeof(pending_rename), path);
+                    has_pending_rename = true;
+                    break;
+                case FILE_ACTION_RENAMED_NEW_NAME:
+                {
+                    VFSWatchEvent renamed = MakeEvent(path, has_pending_rename ? WatchEventKind::Renamed : WatchEventKind::Created);
+                    if (has_pending_rename)
+                    {
+                        Helpers::secure_strcpy(renamed.OldPath, sizeof(renamed.OldPath), pending_rename);
+                        has_pending_rename = false;
+                    }
+                    m_batch.push(renamed);
+                    break;
+                }
+                default:
+                    break;
+            }
+
+            if (info->NextEntryOffset == 0)
+            {
+                break;
+            }
+            offset += info->NextEntryOffset;
+        }
+
+        if (m_batch.size() > 0)
+        {
+            std::lock_guard<std::mutex> lock(m_queue_mutex);
+            for (size_t i = 0; i < m_batch.size(); ++i)
+            {
+                m_queue.push(m_batch[i]);
+            }
+        }
+        m_batch.clear();
+    }
+
+    void VFSRDCWatcher::PushEvent(const VFSWatchEvent& ev)
+    {
+        std::lock_guard<std::mutex> lock(m_queue_mutex);
+        m_queue.push(ev);
+    }
+
+    void VFSRDCWatcher::DrainCompletions(DWORD timeout_ms)
+    {
+        for (;;)
+        {
+            DWORD       bytes      = 0;
+            ULONG_PTR   key        = 0;
+            OVERLAPPED* overlapped = nullptr;
+
+            if (!GetQueuedCompletionStatus(m_iocp, &bytes, &key, &overlapped, timeout_ms))
+            {
+                return;
+            }
+            if (key == COMPLETION_KEY_STOP)
+            {
+                return;
+            }
+
+            WatchEntry* entry = reinterpret_cast<WatchEntry*>(key);
+            if (!entry)
+            {
+                continue;
+            }
+
+            {
+                std::lock_guard<std::mutex> lock(m_watch_mutex);
+                WatchEntry**                slot = m_entries.find(entry->Handle);
+                if (!slot || *slot != entry)
+                {
+                    continue;
+                }
+            }
+
+            ProcessNotifications(entry, bytes);
+            ReissueRead(entry);
+
+            timeout_ms = 0;
+        }
+    }
+
+    void VFSRDCWatcher::Poll(RawEventCallback cb, void* ctx)
+    {
+        if (!m_arena)
+        {
+            return;
+        }
+
+        if (!m_running.value.load(std::memory_order_acquire))
+        {
+            DrainCompletions(0);
+        }
+        m_drain.clear();
+        {
+            std::lock_guard<std::mutex> lock(m_queue_mutex);
+            for (size_t i = 0; i < m_queue.size(); ++i)
+            {
+                m_drain.push(m_queue[i]);
+            }
+            m_queue.clear();
+        }
+
+        for (size_t i = 0; i < m_drain.size(); ++i)
+        {
+            cb(ctx, m_drain[i]);
+        }
+    }
+
+    void VFSRDCWatcher::ThreadMain()
+    {
+        while (m_running.value.load(std::memory_order_acquire))
+        {
+            DrainCompletions(INFINITE);
+        }
+    }
+
+    void VFSRDCWatcher::StartThread()
+    {
+        if (!IsValid() || m_running.value.exchange(true, std::memory_order_acq_rel))
+        {
+            return;
+        }
+        m_thread = std::thread([this] { ThreadMain(); });
+    }
+
+    void VFSRDCWatcher::StopThread()
+    {
+        if (!m_running.value.exchange(false, std::memory_order_acq_rel))
+        {
+            return;
+        }
+
+        PostQueuedCompletionStatus(m_iocp, 0, COMPLETION_KEY_STOP, nullptr);
+        if (m_thread.joinable())
+        {
+            m_thread.join();
+        }
+    }
+
+    size_t VFSRDCWatcher::WatchCount() const
+    {
+        std::lock_guard<std::mutex> lock(m_watch_mutex);
+        return m_entries.size();
+    }
+
+} // namespace ZEngine::Core::VFS
+#endif // _WIN32

--- a/ZEngine/ZEngine/Core/VFS/Platform/VFSRDCWatcher.h
+++ b/ZEngine/ZEngine/Core/VFS/Platform/VFSRDCWatcher.h
@@ -1,0 +1,78 @@
+#pragma once
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#include <ZEngine/Core/Containers/Array.h>
+#include <ZEngine/Core/Containers/UnorderedHashMap.h>
+#include <ZEngine/Core/Memory/Allocator.h>
+#include <ZEngine/Core/VFS/IVFSPlatformWatcher.h>
+#include <ZEngine/ZEngineDef.h>
+#include <windows.h>
+#include <mutex>
+#include <thread>
+
+namespace ZEngine::Core::VFS
+{
+    class VFSRDCWatcher final : public IVFSPlatformWatcher
+    {
+    public:
+        VFSRDCWatcher();
+        ~VFSRDCWatcher() override;
+
+        VFSRDCWatcher(const VFSRDCWatcher&)            = delete;
+        VFSRDCWatcher& operator=(const VFSRDCWatcher&) = delete;
+
+        void           Initialize(Memory::ArenaAllocator* arena, size_t capacity = 64);
+
+        WatchHandle    AddWatch(const char* native_path, bool recursive) override;
+        void           RemoveWatch(WatchHandle handle) override;
+        void           Poll(RawEventCallback cb, void* ctx) override;
+        void           StartThread() override;
+        void           StopThread() override;
+
+        bool           IsValid() const
+        {
+            return m_iocp != nullptr && m_arena != nullptr;
+        }
+
+        size_t WatchCount() const;
+
+    private:
+        struct WatchEntry
+        {
+            OVERLAPPED  Overlapped                = {};
+            HANDLE      DirHandle                 = INVALID_HANDLE_VALUE;
+            WatchHandle Handle                    = INVALID_WATCH_HANDLE;
+            bool        Recursive                 = false;
+            char        Root[MAX_FILE_PATH_COUNT] = {};
+            alignas(DWORD) BYTE Buffer[ZKilo(32)] = {};
+        };
+
+        bool                                                   ReissueRead(WatchEntry* entry);
+        void                                                   ProcessNotifications(WatchEntry* entry, DWORD bytes);
+        void                                                   DrainCompletions(DWORD timeout_ms);
+        void                                                   ThreadMain();
+        void                                                   PushEvent(const VFSWatchEvent& ev);
+
+        static VFSWatchEvent                                   MakeEvent(const char* path, WatchEventKind kind);
+        static void                                            AppendWideName(char* out, size_t out_size, const char* root, const wchar_t* name, DWORD name_bytes);
+        static size_t                                          ClampedLength(const char* text);
+
+        Memory::ArenaAllocator*                                m_arena = nullptr;
+        HANDLE                                                 m_iocp  = nullptr;
+
+        mutable std::mutex                                     m_watch_mutex;
+        Containers::UnorderedHashMap<WatchHandle, WatchEntry*> m_entries;
+        WatchHandle                                            m_next_handle = 1;
+
+        std::mutex                                             m_queue_mutex;
+        Containers::Array<VFSWatchEvent>                       m_queue;
+
+        Containers::Array<VFSWatchEvent>                       m_batch;
+        Containers::Array<VFSWatchEvent>                       m_drain;
+
+        std::thread                                            m_thread;
+        PaddedAtomic<bool>                                     m_running = {};
+    };
+
+} // namespace ZEngine::Core::VFS
+#endif // _WIN32

--- a/ZEngine/ZEngine/Core/VFS/VFSContext.cpp
+++ b/ZEngine/ZEngine/Core/VFS/VFSContext.cpp
@@ -1,5 +1,15 @@
 #include <ZEngine/Core/VFS/VFSContext.h>
+#include <ZEngine/Core/VFS/VFSScanner.h>
 #include <ZEngine/Helpers/MemoryOperations.h>
+#include <ZEngine/Logging/LoggerDefinition.h>
+
+#if defined(__APPLE__)
+#include <ZEngine/Core/VFS/Platform/VFSFSEventsWatcher.h>
+#elif defined(__linux__)
+#include <ZEngine/Core/VFS/Platform/VFSInotifyWatcher.h>
+#elif defined(_WIN32)
+#include <ZEngine/Core/VFS/Platform/VFSRDCWatcher.h>
+#endif
 
 namespace ZEngine::Core::VFS
 {
@@ -7,6 +17,166 @@ namespace ZEngine::Core::VFS
     {
         m_arena = arena;
         m_mount_table.Initialize(m_arena, mount_table_capacity);
+    }
+
+    void VFSContext::InitWatcher(const char* project_root_native, VFSDirectoryCache* cache, VFSScanner* scanner)
+    {
+        if (!m_arena)
+        {
+            ZENGINE_LOG_VFS_ERR("InitWatcher: arena is null");
+            return;
+        }
+        if (!project_root_native || project_root_native[0] == '\0')
+        {
+            ZENGINE_LOG_VFS_ERR("InitWatcher: project_root_native is null or empty");
+            return;
+        }
+
+        m_directory_cache   = cache;
+        m_scanner           = scanner;
+
+        const size_t length = Helpers::secure_strlen(project_root_native);
+        Helpers::secure_strncpy(m_project_root_native, sizeof(m_project_root_native), project_root_native, length < MAX_FILE_PATH_COUNT ? length : MAX_FILE_PATH_COUNT - 1);
+
+#if defined(__APPLE__)
+        {
+            void* storage = ZAlloc(m_arena, sizeof(VFSFSEventsWatcher), ZAlignof(VFSFSEventsWatcher));
+            if (!storage)
+            {
+                ZENGINE_LOG_VFS_ERR("InitWatcher: arena allocation failed for VFSFSEventsWatcher");
+                return;
+            }
+            auto* fsevents = new (storage) VFSFSEventsWatcher();
+            fsevents->Initialize(m_arena);
+            if (!fsevents->IsValid())
+            {
+                ZENGINE_LOG_VFS_ERR("InitWatcher: VFSFSEventsWatcher failed to initialize");
+                fsevents->~VFSFSEventsWatcher();
+                return;
+            }
+            m_platform_watcher = fsevents;
+        }
+#elif defined(__linux__)
+        {
+            void* storage = ZAlloc(m_arena, sizeof(VFSInotifyWatcher), ZAlignof(VFSInotifyWatcher));
+            if (!storage)
+            {
+                ZENGINE_LOG_VFS_ERR("InitWatcher: arena allocation failed for VFSInotifyWatcher");
+                return;
+            }
+            auto* inotify = new (storage) VFSInotifyWatcher();
+            inotify->Initialize(m_arena);
+            if (!inotify->IsValid())
+            {
+                ZENGINE_LOG_VFS_ERR("InitWatcher: VFSInotifyWatcher failed to initialize");
+                inotify->~VFSInotifyWatcher();
+                return;
+            }
+            m_platform_watcher = inotify;
+        }
+#elif defined(_WIN32)
+        {
+            void* storage = ZAlloc(m_arena, sizeof(VFSRDCWatcher), ZAlignof(VFSRDCWatcher));
+            if (!storage)
+            {
+                ZENGINE_LOG_VFS_ERR("InitWatcher: arena allocation failed for VFSRDCWatcher");
+                return;
+            }
+            auto* rdc = new (storage) VFSRDCWatcher();
+            rdc->Initialize(m_arena);
+            if (!rdc->IsValid())
+            {
+                ZENGINE_LOG_VFS_ERR("InitWatcher: VFSRDCWatcher failed to initialize");
+                rdc->~VFSRDCWatcher();
+                return;
+            }
+            m_platform_watcher = rdc;
+        }
+#else
+        ZENGINE_LOG_VFS_ERR("InitWatcher: unsupported platform");
+        return;
+#endif
+
+        void* fw_storage = ZAlloc(m_arena, sizeof(VFSFileWatcher), ZAlignof(VFSFileWatcher));
+        if (!fw_storage)
+        {
+            ZENGINE_LOG_VFS_ERR("InitWatcher: arena allocation failed for VFSFileWatcher");
+            m_platform_watcher->~IVFSPlatformWatcher();
+            m_platform_watcher = nullptr;
+            return;
+        }
+        m_file_watcher = new (fw_storage) VFSFileWatcher(m_platform_watcher);
+        m_file_watcher->Initialize(m_arena);
+
+        const WatchHandle root_handle = m_file_watcher->Watch(m_project_root_native, /*recursive=*/true, [this](const VFSWatchEvent& ev) {
+            const bool         full_rescan = (ev.Kind == WatchEventKind::Overflow);
+
+            VFSResult<VFSPath> path        = full_rescan ? VFSPath::FromNative(m_project_root_native) : VFSPath::FromNative(ev.Path);
+            if (path.Failed())
+            {
+                return;
+            }
+
+            const VFSPath target = (ev.IsDirectory || full_rescan) ? path.Value() : path.Value().Parent();
+
+            if (m_directory_cache)
+            {
+                m_directory_cache->Invalidate(target);
+                if (ev.Kind == WatchEventKind::Renamed && ev.OldPath[0] != '\0')
+                {
+                    VFSResult<VFSPath> old_path = VFSPath::FromNative(ev.OldPath);
+                    if (old_path.Succeeded())
+                    {
+                        m_directory_cache->Invalidate(ev.IsDirectory ? old_path.Value() : old_path.Value().Parent());
+                    }
+                }
+            }
+
+            if (m_scanner && m_directory_cache && !m_scanner->IsScanning())
+            {
+                m_scanner->Scan(this, target, m_directory_cache);
+            }
+        });
+
+        if (root_handle == INVALID_WATCH_HANDLE)
+        {
+            ZENGINE_LOG_VFS_ERR("InitWatcher: failed to watch root path '{}'", m_project_root_native);
+            m_file_watcher->~VFSFileWatcher();
+            m_file_watcher = nullptr;
+            m_platform_watcher->~IVFSPlatformWatcher();
+            m_platform_watcher = nullptr;
+            return;
+        }
+
+        m_platform_watcher->StartThread();
+    }
+
+    void VFSContext::Tick()
+    {
+        if (m_file_watcher)
+        {
+            m_file_watcher->Tick();
+        }
+    }
+
+    void VFSContext::ShutdownWatcher()
+    {
+        if (m_platform_watcher)
+        {
+            m_platform_watcher->StopThread();
+        }
+        if (m_file_watcher)
+        {
+            m_file_watcher->~VFSFileWatcher();
+            m_file_watcher = nullptr;
+        }
+        if (m_platform_watcher)
+        {
+            m_platform_watcher->~IVFSPlatformWatcher();
+            m_platform_watcher = nullptr;
+        }
+        m_directory_cache = nullptr;
+        m_scanner         = nullptr;
     }
 
     VFSResult<IVFSFile*> VFSContext::Open(const VFSPath& absolute_path, VFSOpenFlags flags)

--- a/ZEngine/ZEngine/Core/VFS/VFSContext.h
+++ b/ZEngine/ZEngine/Core/VFS/VFSContext.h
@@ -1,13 +1,22 @@
 #pragma once
 #include <ZEngine/Core/VFS/IVFSContext.h>
+#include <ZEngine/Core/VFS/VFSDirectoryCache.h>
+#include <ZEngine/Core/VFS/VFSFileWatcher.h>
 #include <ZEngine/Core/VFS/VFSMountTable.h>
 #include <mutex>
 
 namespace ZEngine::Core::VFS
 {
+    struct VFSScanner;
+
     struct VFSContext : IVFSContext
     {
         void                                                    Initialize(Memory::ArenaAllocator* arena, size_t mount_table_capacity = 16);
+
+        void                                                    InitWatcher(const char* project_root_native, VFSDirectoryCache* cache, VFSScanner* scanner);
+        void                                                    Tick();
+
+        void                                                    ShutdownWatcher();
 
         [[nodiscard]] VFSResult<IVFSFile*>                      Open(const VFSPath& absolute_path, VFSOpenFlags flags) override;
         void                                                    Close(IVFSFile* file) override;
@@ -36,6 +45,12 @@ namespace ZEngine::Core::VFS
         VFSMountTable                          m_mount_table = {};
         Memory::ArenaAllocator*                m_arena       = nullptr;
         mutable std::mutex                     m_arena_mutex;
+
+        IVFSPlatformWatcher*                   m_platform_watcher                         = nullptr;
+        VFSFileWatcher*                        m_file_watcher                             = nullptr;
+        VFSDirectoryCache*                     m_directory_cache                          = nullptr;
+        VFSScanner*                            m_scanner                                  = nullptr;
+        char                                   m_project_root_native[MAX_FILE_PATH_COUNT] = {};
     };
 
 } // namespace ZEngine::Core::VFS

--- a/ZEngine/ZEngine/Core/VFS/VFSFileWatcher.cpp
+++ b/ZEngine/ZEngine/Core/VFS/VFSFileWatcher.cpp
@@ -1,0 +1,205 @@
+#include <ZEngine/Core/Containers/Array.h>
+#include <ZEngine/Core/VFS/VFSFileWatcher.h>
+#include <ZEngine/Helpers/MemoryOperations.h>
+
+namespace ZEngine::Core::VFS
+{
+
+    VFSFileWatcher::VFSFileWatcher(IVFSPlatformWatcher* platform, std::chrono::milliseconds debounce_window) : m_platform(platform), m_window(debounce_window) {}
+
+    VFSFileWatcher::~VFSFileWatcher()
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_platform)
+        {
+            for (const auto& [handle, entry] : m_callbacks)
+            {
+                m_platform->RemoveWatch(handle);
+            }
+        }
+        m_callbacks.clear();
+        m_pending.clear();
+    }
+
+    void VFSFileWatcher::Initialize(Memory::ArenaAllocator* arena, size_t pending_capacity)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_arena = arena;
+        m_pending.init(arena, pending_capacity);
+        m_callbacks.init(arena, pending_capacity);
+
+        // Dedicated sub arena for per tick temporaries
+        arena->CreateSubArena(ZKilo(512), &m_local_arena);
+    }
+
+    WatchHandle VFSFileWatcher::Watch(const char* native_path, bool recursive, WatchCallback cb)
+    {
+        if (!m_platform || !native_path || native_path[0] == '\0')
+        {
+            return INVALID_WATCH_HANDLE;
+        }
+
+        const WatchHandle handle = m_platform->AddWatch(native_path, recursive);
+        if (handle == INVALID_WATCH_HANDLE)
+        {
+            return INVALID_WATCH_HANDLE;
+        }
+
+        WatchEntry entry;
+        entry.RootLength = Helpers::secure_strlen(native_path);
+        if (entry.RootLength >= MAX_FILE_PATH_COUNT)
+        {
+            entry.RootLength = MAX_FILE_PATH_COUNT - 1;
+        }
+        Helpers::secure_memcpy(entry.Root, MAX_FILE_PATH_COUNT, native_path, entry.RootLength);
+        entry.Root[entry.RootLength] = '\0';
+
+        while (entry.RootLength > 1 && entry.Root[entry.RootLength - 1] == '/')
+        {
+            entry.Root[--entry.RootLength] = '\0';
+        }
+        entry.Callback = std::move(cb);
+
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_callbacks[handle] = std::move(entry);
+        return handle;
+    }
+
+    void VFSFileWatcher::Unwatch(WatchHandle handle)
+    {
+        if (handle == INVALID_WATCH_HANDLE)
+        {
+            return;
+        }
+
+        if (m_platform)
+        {
+            m_platform->RemoveWatch(handle);
+        }
+
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_callbacks.remove(handle);
+
+        for (auto it = m_pending.begin(); it != m_pending.end(); ++it)
+        {
+            if ((*it).second.Owner == handle)
+            {
+                m_pending.remove((*it).first);
+            }
+        }
+    }
+
+    void VFSFileWatcher::Tick()
+    {
+        if (m_platform)
+        {
+            m_platform->Poll([](void* ctx, const VFSWatchEvent& ev) { reinterpret_cast<VFSFileWatcher*>(ctx)->OnRawEvent(ev); }, this);
+        }
+
+        EmitReady(std::chrono::steady_clock::now());
+    }
+
+    void VFSFileWatcher::OnRawEvent(const VFSWatchEvent& ev)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+
+        const bool                  is_overflow = (ev.Kind == WatchEventKind::Overflow);
+        const WatchHandle           owner       = is_overflow ? INVALID_WATCH_HANDLE : ResolveOwner(ev.Path);
+        if (!is_overflow && owner == INVALID_WATCH_HANDLE)
+        {
+            return;
+        }
+
+        DebounceEntry& entry = m_pending[VFSWatchPathKey{ev.Path}];
+        entry.Event          = ev;
+        entry.Owner          = owner;
+        entry.LastSeen       = std::chrono::steady_clock::now();
+    }
+
+    void VFSFileWatcher::EmitReady(std::chrono::steady_clock::time_point now)
+    {
+        auto                             scratch = ZGetScratch(&m_local_arena);
+
+        Containers::Array<DebounceEntry> ready;
+        ready.init(scratch.Arena, 16);
+
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            for (auto it = m_pending.begin(); it != m_pending.end(); ++it)
+            {
+                const DebounceEntry& entry = (*it).second;
+                if ((now - entry.LastSeen) >= m_window)
+                {
+                    ready.push(entry);
+                    m_pending.remove((*it).first);
+                }
+            }
+        }
+
+        Containers::Array<WatchCallback> targets;
+        targets.init(scratch.Arena, 4);
+
+        for (const DebounceEntry& entry : ready)
+        {
+            targets.clear();
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                if (entry.Event.Kind == WatchEventKind::Overflow)
+                {
+                    for (const auto& [handle, watch] : m_callbacks)
+                    {
+                        targets.push(watch.Callback);
+                    }
+                }
+                else if (const WatchEntry* watch = m_callbacks.find(entry.Owner))
+                {
+                    targets.push(watch->Callback);
+                }
+            }
+
+            for (const WatchCallback& cb : targets)
+            {
+                if (cb)
+                {
+                    cb(entry.Event);
+                }
+            }
+        }
+
+        ZReleaseScratch(scratch);
+    }
+
+    WatchHandle VFSFileWatcher::ResolveOwner(const char* native_path) const
+    {
+        if (!native_path || native_path[0] == '\0')
+        {
+            return INVALID_WATCH_HANDLE;
+        }
+
+        const size_t path_length = Helpers::secure_strlen(native_path);
+        WatchHandle  best        = INVALID_WATCH_HANDLE;
+        size_t       best_length = 0;
+
+        for (const auto& [handle, entry] : m_callbacks)
+        {
+            if (entry.RootLength > path_length || Helpers::secure_memcmp(native_path, path_length, entry.Root, entry.RootLength, entry.RootLength) != 0)
+            {
+                continue;
+            }
+            const bool boundary_ok = (path_length == entry.RootLength) || (native_path[entry.RootLength] == '/') || (entry.RootLength == 1 && entry.Root[0] == '/');
+            if (boundary_ok && (best == INVALID_WATCH_HANDLE || entry.RootLength > best_length))
+            {
+                best        = handle;
+                best_length = entry.RootLength;
+            }
+        }
+        return best;
+    }
+
+    size_t VFSFileWatcher::PendingCount() const
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_pending.size();
+    }
+
+} // namespace ZEngine::Core::VFS

--- a/ZEngine/ZEngine/Core/VFS/VFSFileWatcher.h
+++ b/ZEngine/ZEngine/Core/VFS/VFSFileWatcher.h
@@ -1,0 +1,88 @@
+#pragma once
+#include <ZEngine/Core/Containers/UnorderedHashMap.h>
+#include <ZEngine/Core/Memory/Allocator.h>
+#include <ZEngine/Core/VFS/IVFSPlatformWatcher.h>
+#include <ZEngine/Core/VFS/VFSWatchEvent.h>
+#include <ZEngine/Helpers/MemoryOperations.h>
+#include <chrono>
+#include <functional>
+#include <mutex>
+
+namespace ZEngine::Core::VFS
+{
+    using WatchCallback = std::function<void(const VFSWatchEvent&)>;
+
+    struct VFSWatchPathKey
+    {
+        char Data[MAX_FILE_PATH_COUNT] = {};
+
+        VFSWatchPathKey()              = default;
+
+        explicit VFSWatchPathKey(const char* path)
+        {
+            Helpers::secure_memset(Data, 0, sizeof(Data), sizeof(Data));
+
+            size_t length = Helpers::secure_strlen(path);
+            if (length >= MAX_FILE_PATH_COUNT)
+            {
+                length = MAX_FILE_PATH_COUNT - 1;
+            }
+            if (length > 0)
+            {
+                Helpers::secure_strncpy(Data, sizeof(Data), path, length);
+            }
+        }
+
+        bool operator==(const VFSWatchPathKey& other) const
+        {
+            return Helpers::secure_memcmp(Data, sizeof(Data), other.Data, sizeof(other.Data), sizeof(Data)) == 0;
+        }
+    };
+
+    struct DebounceEntry
+    {
+        VFSWatchEvent                         Event    = {};
+        std::chrono::steady_clock::time_point LastSeen = {};
+        WatchHandle                           Owner    = INVALID_WATCH_HANDLE;
+    };
+
+    struct VFSFileWatcher
+    {
+        explicit VFSFileWatcher(IVFSPlatformWatcher* platform, std::chrono::milliseconds debounce_window = std::chrono::milliseconds{80});
+        ~VFSFileWatcher();
+
+        VFSFileWatcher(const VFSFileWatcher&)            = delete;
+        VFSFileWatcher& operator=(const VFSFileWatcher&) = delete;
+
+        void            Initialize(Memory::ArenaAllocator* arena, size_t pending_capacity = 64);
+
+        WatchHandle     Watch(const char* native_path, bool recursive, WatchCallback cb);
+        void            Unwatch(WatchHandle handle);
+
+        void            Tick();
+
+        size_t          PendingCount() const;
+
+    private:
+        struct WatchEntry
+        {
+            char          Root[MAX_FILE_PATH_COUNT] = {};
+            size_t        RootLength                = 0;
+            WatchCallback Callback                  = {};
+        };
+
+        void                                                         OnRawEvent(const VFSWatchEvent& ev);
+        void                                                         EmitReady(std::chrono::steady_clock::time_point now);
+        WatchHandle                                                  ResolveOwner(const char* native_path) const;
+
+        IVFSPlatformWatcher*                                         m_platform = nullptr;
+        std::chrono::milliseconds                                    m_window   = std::chrono::milliseconds{80};
+        Memory::ArenaAllocator*                                      m_arena    = nullptr;
+        Memory::ArenaAllocator                                       m_local_arena;
+
+        mutable std::mutex                                           m_mutex;
+        Containers::UnorderedHashMap<VFSWatchPathKey, DebounceEntry> m_pending;
+        Containers::UnorderedHashMap<WatchHandle, WatchEntry>        m_callbacks;
+    };
+
+} // namespace ZEngine::Core::VFS

--- a/ZEngine/ZEngine/Core/VFS/VFSWatchEvent.h
+++ b/ZEngine/ZEngine/Core/VFS/VFSWatchEvent.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <ZEngine/ZEngineDef.h>
+
+namespace ZEngine::Core::VFS
+{
+    enum class WatchEventKind : uint8_t
+    {
+        Created  = 0,
+        Modified = 1,
+        Deleted  = 2,
+        Renamed  = 3,
+        Overflow = 4,
+    };
+
+    struct VFSWatchEvent
+    {
+        char           Path[MAX_FILE_PATH_COUNT]    = {};
+        char           OldPath[MAX_FILE_PATH_COUNT] = {};
+        WatchEventKind Kind                         = WatchEventKind::Created;
+        bool           IsDirectory                  = false;
+    };
+} // namespace ZEngine::Core::VFS

--- a/ZEngine/tests/VFS/VFSFileWatcherTest.cpp
+++ b/ZEngine/tests/VFS/VFSFileWatcherTest.cpp
@@ -1,0 +1,408 @@
+#include <ZEngine/Core/Memory/MemoryManager.h>
+#include <ZEngine/Core/VFS/VFSFileWatcher.h>
+#include <ZEngine/Helpers/MemoryOperations.h>
+#include <gtest/gtest.h>
+#include <chrono>
+#include <mutex>
+#include <thread>
+
+using namespace ZEngine::Core::VFS;
+using ZEngine::Core::Memory::MemoryManager;
+
+namespace
+{
+    class MockPlatformWatcher final : public IVFSPlatformWatcher
+    {
+    public:
+        WatchHandle AddWatch(const char* native_path, bool recursive) override
+        {
+            (void) native_path;
+            (void) recursive;
+            return m_next_handle++;
+        }
+
+        void RemoveWatch(WatchHandle handle) override
+        {
+            m_removed.push_back(handle);
+        }
+
+        void Poll(RawEventCallback cb, void* ctx) override
+        {
+            std::vector<VFSWatchEvent> drained;
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                drained.swap(m_queue);
+            }
+
+            ++m_poll_count;
+            for (const VFSWatchEvent& ev : drained)
+            {
+                cb(ctx, ev);
+            }
+        }
+
+        void StartThread() override {}
+        void StopThread() override {}
+
+        void InjectEvent(const VFSWatchEvent& ev)
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_queue.push_back(ev);
+        }
+
+        bool WasRemoved(WatchHandle handle) const
+        {
+            for (WatchHandle h : m_removed)
+            {
+                if (h == handle)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        int PollCount() const
+        {
+            return m_poll_count;
+        }
+
+    private:
+        std::mutex                 m_mutex;
+        std::vector<VFSWatchEvent> m_queue;
+        std::vector<WatchHandle>   m_removed;
+        WatchHandle                m_next_handle = 1;
+        int                        m_poll_count  = 0;
+    };
+
+    VFSWatchEvent MakeEvent(const char* path, WatchEventKind kind, bool is_directory = false)
+    {
+        VFSWatchEvent ev{};
+        ZEngine::Helpers::secure_strcpy(ev.Path, sizeof(ev.Path), path);
+        ev.Kind        = kind;
+        ev.IsDirectory = is_directory;
+        return ev;
+    }
+} // namespace
+
+class VFSFileWatcherTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        m_manager.Initialize(ZMega(2), {});
+    }
+
+    void TearDown() override
+    {
+        m_manager.Shutdown();
+    }
+
+    MemoryManager m_manager;
+};
+
+TEST_F(VFSFileWatcherTest, DebounceBurstCollapses)
+{
+    MockPlatformWatcher mock;
+    VFSFileWatcher      watcher(&mock, std::chrono::milliseconds{50});
+    watcher.Initialize(&m_manager.MainArena);
+
+    int fired = 0;
+    watcher.Watch("/project", true, [&](const VFSWatchEvent&) { ++fired; });
+
+    for (int i = 0; i < 10; ++i)
+    {
+        mock.InjectEvent(MakeEvent("/project/foo.glb", WatchEventKind::Modified));
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds{20});
+    watcher.Tick();
+    EXPECT_EQ(fired, 0);
+    EXPECT_EQ(watcher.PendingCount(), 1u);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds{60});
+    watcher.Tick();
+    EXPECT_EQ(fired, 1);
+    EXPECT_EQ(watcher.PendingCount(), 0u);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds{60});
+    watcher.Tick();
+    EXPECT_EQ(fired, 1);
+}
+
+TEST_F(VFSFileWatcherTest, TwoDistinctFilesFireTwice)
+{
+    MockPlatformWatcher mock;
+    VFSFileWatcher      watcher(&mock, std::chrono::milliseconds{50});
+    watcher.Initialize(&m_manager.MainArena);
+
+    int fired = 0;
+    watcher.Watch("/project", true, [&](const VFSWatchEvent&) { ++fired; });
+
+    mock.InjectEvent(MakeEvent("/project/a.glb", WatchEventKind::Modified));
+    mock.InjectEvent(MakeEvent("/project/b.glb", WatchEventKind::Modified));
+
+    watcher.Tick();
+    EXPECT_EQ(watcher.PendingCount(), 2u);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds{60});
+    watcher.Tick();
+    EXPECT_EQ(fired, 2);
+}
+
+TEST_F(VFSFileWatcherTest, UnwatchStopsEvents)
+{
+    MockPlatformWatcher mock;
+    VFSFileWatcher      watcher(&mock, std::chrono::milliseconds{10});
+    watcher.Initialize(&m_manager.MainArena);
+
+    int               fired = 0;
+    const WatchHandle h     = watcher.Watch("/project", true, [&](const VFSWatchEvent&) { ++fired; });
+
+    watcher.Unwatch(h);
+    EXPECT_TRUE(mock.WasRemoved(h));
+
+    mock.InjectEvent(MakeEvent("/project/foo.glb", WatchEventKind::Created));
+    std::this_thread::sleep_for(std::chrono::milliseconds{20});
+    watcher.Tick();
+    EXPECT_EQ(fired, 0);
+}
+
+TEST_F(VFSFileWatcherTest, UnwatchDiscardsAlreadyPendingEvents)
+{
+    MockPlatformWatcher mock;
+    VFSFileWatcher      watcher(&mock, std::chrono::milliseconds{50});
+    watcher.Initialize(&m_manager.MainArena);
+
+    int               fired = 0;
+    const WatchHandle h     = watcher.Watch("/project", true, [&](const VFSWatchEvent&) { ++fired; });
+
+    mock.InjectEvent(MakeEvent("/project/foo.glb", WatchEventKind::Modified));
+    watcher.Tick();
+    EXPECT_EQ(watcher.PendingCount(), 1u);
+
+    watcher.Unwatch(h);
+    EXPECT_EQ(watcher.PendingCount(), 0u);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds{60});
+    watcher.Tick();
+    EXPECT_EQ(fired, 0);
+}
+
+TEST_F(VFSFileWatcherTest, OverflowSetsKind)
+{
+    MockPlatformWatcher mock;
+    VFSFileWatcher      watcher(&mock, std::chrono::milliseconds{10});
+    watcher.Initialize(&m_manager.MainArena);
+
+    WatchEventKind received = WatchEventKind::Created;
+    watcher.Watch("/project", true, [&](const VFSWatchEvent& ev) { received = ev.Kind; });
+
+    mock.InjectEvent(MakeEvent("", WatchEventKind::Overflow));
+
+    watcher.Tick();
+    std::this_thread::sleep_for(std::chrono::milliseconds{20});
+    watcher.Tick();
+    EXPECT_EQ(received, WatchEventKind::Overflow);
+}
+
+TEST_F(VFSFileWatcherTest, OverflowBroadcastsToEveryWatch)
+{
+    MockPlatformWatcher mock;
+    VFSFileWatcher      watcher(&mock, std::chrono::milliseconds{10});
+    watcher.Initialize(&m_manager.MainArena);
+
+    int fired_a = 0, fired_b = 0;
+    watcher.Watch("/projectA", false, [&](const VFSWatchEvent&) { ++fired_a; });
+    watcher.Watch("/projectB", false, [&](const VFSWatchEvent&) { ++fired_b; });
+
+    mock.InjectEvent(MakeEvent("", WatchEventKind::Overflow));
+
+    watcher.Tick();
+    std::this_thread::sleep_for(std::chrono::milliseconds{20});
+    watcher.Tick();
+
+    EXPECT_EQ(fired_a, 1);
+    EXPECT_EQ(fired_b, 1);
+}
+
+TEST_F(VFSFileWatcherTest, RenamePreservesOldPath)
+{
+    MockPlatformWatcher mock;
+    VFSFileWatcher      watcher(&mock, std::chrono::milliseconds{10});
+    watcher.Initialize(&m_manager.MainArena);
+
+    VFSWatchEvent received{};
+    watcher.Watch("/project", true, [&](const VFSWatchEvent& ev) { received = ev; });
+
+    VFSWatchEvent ev = MakeEvent("/project/new.glb", WatchEventKind::Renamed);
+    ZEngine::Helpers::secure_strcpy(ev.OldPath, sizeof(ev.OldPath), "/project/old.glb");
+    mock.InjectEvent(ev);
+
+    watcher.Tick();
+    std::this_thread::sleep_for(std::chrono::milliseconds{20});
+    watcher.Tick();
+
+    EXPECT_STREQ(received.OldPath, "/project/old.glb");
+    EXPECT_STREQ(received.Path, "/project/new.glb");
+    EXPECT_EQ(received.Kind, WatchEventKind::Renamed);
+}
+
+TEST_F(VFSFileWatcherTest, MultipleWatchesRouteCorrectly)
+{
+    MockPlatformWatcher mock;
+    VFSFileWatcher      watcher(&mock, std::chrono::milliseconds{10});
+    watcher.Initialize(&m_manager.MainArena);
+
+    int fired_a = 0, fired_b = 0;
+    watcher.Watch("/projectA", false, [&](const VFSWatchEvent&) { ++fired_a; });
+    watcher.Watch("/projectB", false, [&](const VFSWatchEvent&) { ++fired_b; });
+
+    mock.InjectEvent(MakeEvent("/projectA/x.png", WatchEventKind::Created));
+    mock.InjectEvent(MakeEvent("/projectB/y.png", WatchEventKind::Created));
+
+    watcher.Tick();
+    std::this_thread::sleep_for(std::chrono::milliseconds{20});
+    watcher.Tick();
+
+    EXPECT_EQ(fired_a, 1);
+    EXPECT_EQ(fired_b, 1);
+}
+
+TEST_F(VFSFileWatcherTest, RoutingRespectsPathBoundariesAndPrefersNestedRoot)
+{
+    MockPlatformWatcher mock;
+    VFSFileWatcher      watcher(&mock, std::chrono::milliseconds{10});
+    watcher.Initialize(&m_manager.MainArena);
+
+    int fired_a = 0, fired_ab = 0, fired_nested = 0;
+    watcher.Watch("/projectA", true, [&](const VFSWatchEvent&) { ++fired_a; });
+    watcher.Watch("/projectAB", true, [&](const VFSWatchEvent&) { ++fired_ab; });
+    watcher.Watch("/projectA/assets", true, [&](const VFSWatchEvent&) { ++fired_nested; });
+
+    mock.InjectEvent(MakeEvent("/projectAB/x.png", WatchEventKind::Created));
+    mock.InjectEvent(MakeEvent("/projectA/assets/y.png", WatchEventKind::Created));
+    mock.InjectEvent(MakeEvent("/elsewhere/z.png", WatchEventKind::Created));
+
+    watcher.Tick();
+    std::this_thread::sleep_for(std::chrono::milliseconds{20});
+    watcher.Tick();
+
+    EXPECT_EQ(fired_ab, 1);
+    EXPECT_EQ(fired_nested, 1);
+    EXPECT_EQ(fired_a, 0);
+}
+
+TEST_F(VFSFileWatcherTest, NoTickNoFire)
+{
+    MockPlatformWatcher mock;
+    VFSFileWatcher      watcher(&mock, std::chrono::milliseconds{10});
+    watcher.Initialize(&m_manager.MainArena);
+
+    int fired = 0;
+    watcher.Watch("/project", true, [&](const VFSWatchEvent&) { ++fired; });
+
+    mock.InjectEvent(MakeEvent("/project/foo.glb", WatchEventKind::Modified));
+    std::this_thread::sleep_for(std::chrono::milliseconds{20});
+
+    EXPECT_EQ(fired, 0);
+    EXPECT_EQ(mock.PollCount(), 0);
+    EXPECT_EQ(watcher.PendingCount(), 0u);
+}
+
+TEST_F(VFSFileWatcherTest, IsDirectoryFlagPropagated)
+{
+    MockPlatformWatcher mock;
+    VFSFileWatcher      watcher(&mock, std::chrono::milliseconds{10});
+    watcher.Initialize(&m_manager.MainArena);
+
+    bool got_dir = false;
+    watcher.Watch("/project", true, [&](const VFSWatchEvent& ev) { got_dir = ev.IsDirectory; });
+
+    mock.InjectEvent(MakeEvent("/project/newfolder", WatchEventKind::Created, /*is_directory=*/true));
+
+    watcher.Tick(); // absorb
+    std::this_thread::sleep_for(std::chrono::milliseconds{20});
+    watcher.Tick(); // emit
+
+    EXPECT_TRUE(got_dir);
+}
+
+TEST_F(VFSFileWatcherTest, LatestEventWinsWithinWindow)
+{
+    MockPlatformWatcher mock;
+    VFSFileWatcher      watcher(&mock, std::chrono::milliseconds{50});
+    watcher.Initialize(&m_manager.MainArena);
+
+    WatchEventKind received = WatchEventKind::Overflow;
+    watcher.Watch("/project", true, [&](const VFSWatchEvent& ev) { received = ev.Kind; });
+
+    mock.InjectEvent(MakeEvent("/project/foo.glb", WatchEventKind::Created));
+    mock.InjectEvent(MakeEvent("/project/foo.glb", WatchEventKind::Modified));
+    mock.InjectEvent(MakeEvent("/project/foo.glb", WatchEventKind::Deleted));
+
+    watcher.Tick();
+    std::this_thread::sleep_for(std::chrono::milliseconds{60});
+    watcher.Tick();
+    EXPECT_EQ(received, WatchEventKind::Deleted);
+}
+
+TEST_F(VFSFileWatcherTest, ContinuousActivityKeepsResettingTheTimer)
+{
+    MockPlatformWatcher mock;
+    VFSFileWatcher      watcher(&mock, std::chrono::milliseconds{100});
+    watcher.Initialize(&m_manager.MainArena);
+
+    int fired = 0;
+    watcher.Watch("/project", true, [&](const VFSWatchEvent&) { ++fired; });
+
+    for (int i = 0; i < 5; ++i)
+    {
+        mock.InjectEvent(MakeEvent("/project/main.cpp", WatchEventKind::Modified));
+        watcher.Tick();
+        std::this_thread::sleep_for(std::chrono::milliseconds{10});
+    }
+    watcher.Tick();
+    EXPECT_EQ(fired, 0);
+
+    // Editor pauses.
+    std::this_thread::sleep_for(std::chrono::milliseconds{160});
+    watcher.Tick();
+    EXPECT_EQ(fired, 1);
+}
+
+TEST_F(VFSFileWatcherTest, EventOutsideAllRootsIsDropped)
+{
+    MockPlatformWatcher mock;
+    VFSFileWatcher      watcher(&mock, std::chrono::milliseconds{10});
+    watcher.Initialize(&m_manager.MainArena);
+
+    int fired = 0;
+    watcher.Watch("/project", true, [&](const VFSWatchEvent&) { ++fired; });
+
+    mock.InjectEvent(MakeEvent("/somewhere/else/foo.glb", WatchEventKind::Modified));
+    watcher.Tick();
+    EXPECT_EQ(watcher.PendingCount(), 0u);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds{20});
+    watcher.Tick();
+    EXPECT_EQ(fired, 0);
+}
+
+TEST_F(VFSFileWatcherTest, TrailingSlashRootStillMatches)
+{
+    MockPlatformWatcher mock;
+    VFSFileWatcher      watcher(&mock, std::chrono::milliseconds{10});
+    watcher.Initialize(&m_manager.MainArena);
+
+    int fired = 0;
+    watcher.Watch("/project/", true, [&](const VFSWatchEvent&) { ++fired; });
+
+    mock.InjectEvent(MakeEvent("/project/foo.glb", WatchEventKind::Modified));
+
+    watcher.Tick(); // absorb
+    std::this_thread::sleep_for(std::chrono::milliseconds{20});
+    watcher.Tick(); // emit
+
+    EXPECT_EQ(fired, 1);
+}

--- a/ZEngine/tests/VFS/vfs_fsevents_test.cpp
+++ b/ZEngine/tests/VFS/vfs_fsevents_test.cpp
@@ -1,0 +1,277 @@
+#if defined(__APPLE__)
+#include <ZEngine/Core/Containers/Array.h>
+#include <ZEngine/Core/Memory/MemoryManager.h>
+#include <ZEngine/Core/VFS/Platform/VFSFSEventsWatcher.h>
+#include <ZEngine/Helpers/MemoryOperations.h>
+#include <gtest/gtest.h>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <thread>
+
+using namespace ZEngine::Core::VFS;
+using ZEngine::Core::Containers::Array;
+using ZEngine::Core::Memory::MemoryManager;
+using ZEngine::Helpers::secure_strcmp;
+
+namespace
+{
+    class VFSFSEventsWatcherTest : public ::testing::Test
+    {
+    protected:
+        void SetUp() override
+        {
+            m_manager.Initialize(ZMega(2), {});
+            m_events.init(&m_manager.MainArena, 32);
+
+            std::error_code ec;
+            m_root = std::filesystem::temp_directory_path() / "zengine_vfs_fsevents_tests";
+            std::filesystem::remove_all(m_root, ec);
+            std::filesystem::create_directories(m_root, ec);
+            m_root = std::filesystem::canonical(m_root, ec);
+        }
+
+        void TearDown() override
+        {
+            std::error_code ec;
+            std::filesystem::remove_all(m_root, ec);
+
+            m_manager.Shutdown();
+        }
+
+        void Init(VFSFSEventsWatcher& watcher)
+        {
+            watcher.Initialize(&m_manager.MainArena);
+        }
+
+        void WriteFile(const std::filesystem::path& path, const char* contents)
+        {
+            std::ofstream out(path);
+            out << contents;
+        }
+
+        void Drain(VFSFSEventsWatcher& watcher)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds{400});
+
+            m_events.clear();
+            watcher.Poll([](void* ctx, const VFSWatchEvent& ev) { reinterpret_cast<VFSFSEventsWatcherTest*>(ctx)->m_events.push(ev); }, this);
+        }
+
+        bool Contains(const char* path, WatchEventKind kind) const
+        {
+            for (size_t i = 0; i < m_events.size(); ++i)
+            {
+                if (m_events[i].Kind == kind && secure_strcmp(m_events[i].Path, path) == 0)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        bool ContainsPath(const char* path) const
+        {
+            for (size_t i = 0; i < m_events.size(); ++i)
+            {
+                if (secure_strcmp(m_events[i].Path, path) == 0)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        size_t EventCount() const
+        {
+            return m_events.size();
+        }
+
+        MemoryManager         m_manager;
+        Array<VFSWatchEvent>  m_events;
+        std::filesystem::path m_root;
+    };
+} // namespace
+
+TEST_F(VFSFSEventsWatcherTest, ReportsFileCreation)
+{
+    VFSFSEventsWatcher watcher;
+    Init(watcher);
+    ASSERT_TRUE(watcher.IsValid());
+
+    const WatchHandle handle = watcher.AddWatch(m_root.c_str(), /*recursive=*/true);
+    ASSERT_NE(handle, INVALID_WATCH_HANDLE);
+    EXPECT_EQ(watcher.WatchCount(), 1u);
+
+    watcher.StartThread();
+
+    const auto file = m_root / "created.glb";
+    WriteFile(file, "x");
+
+    Drain(watcher);
+    watcher.StopThread();
+
+    EXPECT_TRUE(ContainsPath(file.c_str()));
+}
+
+TEST_F(VFSFSEventsWatcherTest, ReportsFileModification)
+{
+    VFSFSEventsWatcher watcher;
+    Init(watcher);
+
+    const auto file = m_root / "existing.glb";
+    WriteFile(file, "first");
+
+    ASSERT_NE(watcher.AddWatch(m_root.c_str(), true), INVALID_WATCH_HANDLE);
+    watcher.StartThread();
+    Drain(watcher);
+
+    WriteFile(file, "second");
+
+    Drain(watcher);
+    watcher.StopThread();
+
+    EXPECT_TRUE(ContainsPath(file.c_str()));
+}
+
+TEST_F(VFSFSEventsWatcherTest, DeletionIsClassifiedByStat)
+{
+    VFSFSEventsWatcher watcher;
+    Init(watcher);
+
+    const auto file = m_root / "doomed.glb";
+    WriteFile(file, "x");
+
+    ASSERT_NE(watcher.AddWatch(m_root.c_str(), true), INVALID_WATCH_HANDLE);
+    watcher.StartThread();
+    Drain(watcher);
+
+    std::error_code ec;
+    std::filesystem::remove(file, ec);
+
+    Drain(watcher);
+    watcher.StopThread();
+
+    EXPECT_TRUE(Contains(file.c_str(), WatchEventKind::Deleted));
+}
+
+TEST_F(VFSFSEventsWatcherTest, RenameArrivesAsTwoSeparateEvents)
+{
+    VFSFSEventsWatcher watcher;
+    Init(watcher);
+
+    const auto original = m_root / "old.glb";
+    const auto renamed  = m_root / "new.glb";
+    WriteFile(original, "x");
+
+    ASSERT_NE(watcher.AddWatch(m_root.c_str(), true), INVALID_WATCH_HANDLE);
+    watcher.StartThread();
+    Drain(watcher);
+
+    std::error_code ec;
+    std::filesystem::rename(original, renamed, ec);
+    ASSERT_FALSE(ec);
+
+    Drain(watcher);
+    watcher.StopThread();
+
+    EXPECT_TRUE(Contains(original.c_str(), WatchEventKind::Deleted));
+    EXPECT_TRUE(ContainsPath(renamed.c_str()));
+
+    for (size_t i = 0; i < EventCount(); ++i)
+    {
+        EXPECT_NE(m_events[i].Kind, WatchEventKind::Renamed) << "FSEvents cannot pair renames";
+    }
+}
+
+TEST_F(VFSFSEventsWatcherTest, SubtreeIsCoveredIncludingNewDirectories)
+{
+    std::error_code ec;
+    std::filesystem::create_directories(m_root / "assets" / "meshes", ec);
+
+    VFSFSEventsWatcher watcher;
+    Init(watcher);
+    ASSERT_NE(watcher.AddWatch(m_root.c_str(), /*recursive=*/true), INVALID_WATCH_HANDLE);
+    EXPECT_EQ(watcher.WatchCount(), 1u);
+
+    watcher.StartThread();
+
+    const auto nested = m_root / "assets" / "meshes" / "deep.glb";
+    WriteFile(nested, "x");
+    Drain(watcher);
+    EXPECT_TRUE(ContainsPath(nested.c_str()));
+
+    std::filesystem::create_directory(m_root / "late", ec);
+    Drain(watcher);
+
+    const auto late_file = m_root / "late" / "inside.glb";
+    WriteFile(late_file, "x");
+    Drain(watcher);
+    watcher.StopThread();
+
+    EXPECT_TRUE(ContainsPath(late_file.c_str()));
+}
+
+TEST_F(VFSFSEventsWatcherTest, RemoveWatchStopsEvents)
+{
+    VFSFSEventsWatcher watcher;
+    Init(watcher);
+
+    const WatchHandle handle = watcher.AddWatch(m_root.c_str(), true);
+    ASSERT_NE(handle, INVALID_WATCH_HANDLE);
+    watcher.StartThread();
+    Drain(watcher);
+
+    watcher.RemoveWatch(handle);
+    EXPECT_EQ(watcher.WatchCount(), 0u);
+
+    WriteFile(m_root / "ignored.glb", "x");
+    Drain(watcher);
+    watcher.StopThread();
+
+    EXPECT_EQ(EventCount(), 0u);
+}
+
+TEST_F(VFSFSEventsWatcherTest, TwoRootsBothStayLiveAcrossStreamRebuild)
+{
+    std::error_code ec;
+    const auto      first  = m_root / "first";
+    const auto      second = m_root / "second";
+    std::filesystem::create_directories(first, ec);
+    std::filesystem::create_directories(second, ec);
+
+    VFSFSEventsWatcher watcher;
+    Init(watcher);
+    ASSERT_NE(watcher.AddWatch(first.c_str(), true), INVALID_WATCH_HANDLE);
+    ASSERT_NE(watcher.AddWatch(second.c_str(), true), INVALID_WATCH_HANDLE);
+    EXPECT_EQ(watcher.WatchCount(), 2u);
+
+    watcher.StartThread();
+
+    const auto a = first / "a.glb";
+    const auto b = second / "b.glb";
+    WriteFile(a, "x");
+    WriteFile(b, "x");
+
+    Drain(watcher);
+    watcher.StopThread();
+
+    EXPECT_TRUE(ContainsPath(a.c_str()));
+    EXPECT_TRUE(ContainsPath(b.c_str()));
+}
+
+TEST_F(VFSFSEventsWatcherTest, AddWatchBeforeInitializeFails)
+{
+    VFSFSEventsWatcher watcher;
+    EXPECT_FALSE(watcher.IsValid());
+    EXPECT_EQ(watcher.AddWatch(m_root.c_str(), true), INVALID_WATCH_HANDLE);
+}
+
+TEST_F(VFSFSEventsWatcherTest, StopThreadIsSafeWithoutStart)
+{
+    VFSFSEventsWatcher watcher;
+    Init(watcher);
+    watcher.StopThread();
+    SUCCEED();
+}
+#endif // __APPLE__

--- a/ZEngine/tests/VFS/vfs_inotify_test.cpp
+++ b/ZEngine/tests/VFS/vfs_inotify_test.cpp
@@ -1,0 +1,305 @@
+#if defined(__linux__)
+#include <ZEngine/Core/Containers/Array.h>
+#include <ZEngine/Core/Memory/MemoryManager.h>
+#include <ZEngine/Core/VFS/Platform/VFSInotifyWatcher.h>
+#include <ZEngine/Helpers/MemoryOperations.h>
+#include <gtest/gtest.h>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <thread>
+
+using namespace ZEngine::Core::VFS;
+using ZEngine::Core::Containers::Array;
+using ZEngine::Core::Memory::MemoryManager;
+using ZEngine::Helpers::secure_strcmp;
+
+namespace
+{
+    class VFSInotifyWatcherTest : public ::testing::Test
+    {
+    protected:
+        void SetUp() override
+        {
+            m_manager.Initialize(ZMega(2), {});
+            m_events.init(&m_manager.MainArena, 32);
+
+            std::error_code ec;
+            m_root = std::filesystem::temp_directory_path() / "zengine_vfs_inotify_tests";
+            std::filesystem::remove_all(m_root, ec);
+            std::filesystem::create_directories(m_root, ec);
+        }
+
+        void TearDown() override
+        {
+            std::error_code ec;
+            std::filesystem::remove_all(m_root, ec);
+
+            m_manager.Shutdown();
+        }
+
+        void Init(VFSInotifyWatcher& watcher)
+        {
+            watcher.Initialize(&m_manager.MainArena);
+        }
+
+        void WriteFile(const std::filesystem::path& path, const char* contents)
+        {
+            std::ofstream out(path);
+            out << contents;
+        }
+
+        void Drain(VFSInotifyWatcher& watcher)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds{120});
+
+            m_events.clear();
+            watcher.Poll([](void* ctx, const VFSWatchEvent& ev) { reinterpret_cast<VFSInotifyWatcherTest*>(ctx)->m_events.push(ev); }, this);
+        }
+
+        bool Contains(const char* path, WatchEventKind kind) const
+        {
+            for (size_t i = 0; i < m_events.size(); ++i)
+            {
+                if (m_events[i].Kind == kind && secure_strcmp(m_events[i].Path, path) == 0)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        bool ContainsPath(const char* path) const
+        {
+            for (size_t i = 0; i < m_events.size(); ++i)
+            {
+                if (secure_strcmp(m_events[i].Path, path) == 0)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        size_t EventCount() const
+        {
+            return m_events.size();
+        }
+
+        MemoryManager         m_manager;
+        Array<VFSWatchEvent>  m_events;
+        std::filesystem::path m_root;
+    };
+} // namespace
+
+TEST_F(VFSInotifyWatcherTest, ReportsFileCreation)
+{
+    VFSInotifyWatcher watcher;
+    Init(watcher);
+    ASSERT_TRUE(watcher.IsValid());
+
+    const WatchHandle handle = watcher.AddWatch(m_root.c_str(), /*recursive=*/false);
+    ASSERT_NE(handle, INVALID_WATCH_HANDLE);
+
+    const auto file = m_root / "created.glb";
+    WriteFile(file, "x");
+
+    Drain(watcher);
+    EXPECT_TRUE(Contains(file.c_str(), WatchEventKind::Created));
+}
+
+TEST_F(VFSInotifyWatcherTest, ReportsFileModification)
+{
+    VFSInotifyWatcher watcher;
+    Init(watcher);
+
+    const auto file = m_root / "existing.glb";
+    WriteFile(file, "first");
+
+    ASSERT_NE(watcher.AddWatch(m_root.c_str(), false), INVALID_WATCH_HANDLE);
+
+    WriteFile(file, "second");
+
+    Drain(watcher);
+    EXPECT_TRUE(Contains(file.c_str(), WatchEventKind::Modified));
+}
+
+TEST_F(VFSInotifyWatcherTest, ReportsFileDeletion)
+{
+    VFSInotifyWatcher watcher;
+    Init(watcher);
+
+    const auto file = m_root / "doomed.glb";
+    WriteFile(file, "x");
+
+    ASSERT_NE(watcher.AddWatch(m_root.c_str(), false), INVALID_WATCH_HANDLE);
+
+    std::error_code ec;
+    std::filesystem::remove(file, ec);
+
+    Drain(watcher);
+    EXPECT_TRUE(Contains(file.c_str(), WatchEventKind::Deleted));
+}
+
+TEST_F(VFSInotifyWatcherTest, RenameWithinRootFusesIntoSingleEvent)
+{
+    VFSInotifyWatcher watcher;
+    Init(watcher);
+
+    const auto original = m_root / "old.glb";
+    const auto renamed  = m_root / "new.glb";
+    WriteFile(original, "x");
+
+    ASSERT_NE(watcher.AddWatch(m_root.c_str(), false), INVALID_WATCH_HANDLE);
+
+    std::error_code ec;
+    std::filesystem::rename(original, renamed, ec);
+    ASSERT_FALSE(ec);
+
+    Drain(watcher);
+
+    bool found = false;
+    for (size_t i = 0; i < EventCount(); ++i)
+    {
+        if (m_events[i].Kind == WatchEventKind::Renamed)
+        {
+            EXPECT_STREQ(renamed.c_str(), m_events[i].Path);
+            EXPECT_STREQ(original.c_str(), m_events[i].OldPath);
+            found = true;
+        }
+    }
+    EXPECT_TRUE(found) << "no Renamed event produced";
+}
+
+TEST_F(VFSInotifyWatcherTest, MoveOutOfRootBecomesDelete)
+{
+    VFSInotifyWatcher watcher;
+    Init(watcher);
+
+    const auto inside  = m_root / "leaving.glb";
+    const auto outside = std::filesystem::temp_directory_path() / "zengine_vfs_inotify_outside.glb";
+    WriteFile(inside, "x");
+
+    ASSERT_NE(watcher.AddWatch(m_root.c_str(), false), INVALID_WATCH_HANDLE);
+
+    std::error_code ec;
+    std::filesystem::rename(inside, outside, ec);
+
+    Drain(watcher);
+    EXPECT_TRUE(Contains(inside.c_str(), WatchEventKind::Deleted));
+
+    std::filesystem::remove(outside, ec);
+}
+
+TEST_F(VFSInotifyWatcherTest, RecursiveWatchCoversExistingSubdirectories)
+{
+    std::error_code ec;
+    std::filesystem::create_directories(m_root / "assets" / "meshes", ec);
+
+    VFSInotifyWatcher watcher;
+    Init(watcher);
+    ASSERT_NE(watcher.AddWatch(m_root.c_str(), /*recursive=*/true), INVALID_WATCH_HANDLE);
+    EXPECT_EQ(watcher.DescriptorCount(), 3u);
+
+    const auto nested = m_root / "assets" / "meshes" / "deep.glb";
+    WriteFile(nested, "x");
+
+    Drain(watcher);
+    EXPECT_TRUE(Contains(nested.c_str(), WatchEventKind::Created));
+}
+
+TEST_F(VFSInotifyWatcherTest, NonRecursiveWatchIgnoresSubdirectories)
+{
+    std::error_code ec;
+    std::filesystem::create_directories(m_root / "assets", ec);
+
+    VFSInotifyWatcher watcher;
+    Init(watcher);
+    ASSERT_NE(watcher.AddWatch(m_root.c_str(), /*recursive=*/false), INVALID_WATCH_HANDLE);
+    EXPECT_EQ(watcher.DescriptorCount(), 1u);
+
+    const auto nested = m_root / "assets" / "hidden.glb";
+    WriteFile(nested, "x");
+
+    Drain(watcher);
+    EXPECT_FALSE(ContainsPath(nested.c_str()));
+}
+
+TEST_F(VFSInotifyWatcherTest, NewDirectoryGetsWatchedAutomatically)
+{
+    VFSInotifyWatcher watcher;
+    Init(watcher);
+    ASSERT_NE(watcher.AddWatch(m_root.c_str(), /*recursive=*/true), INVALID_WATCH_HANDLE);
+    EXPECT_EQ(watcher.DescriptorCount(), 1u);
+
+    std::error_code ec;
+    std::filesystem::create_directory(m_root / "late", ec);
+    Drain(watcher);
+
+    EXPECT_EQ(watcher.DescriptorCount(), 2u);
+
+    const auto nested = m_root / "late" / "inside.glb";
+    WriteFile(nested, "x");
+
+    Drain(watcher);
+    EXPECT_TRUE(Contains(nested.c_str(), WatchEventKind::Created));
+}
+
+TEST_F(VFSInotifyWatcherTest, RemoveWatchReleasesEveryDescriptorInTheSubtree)
+{
+    std::error_code ec;
+    std::filesystem::create_directories(m_root / "a" / "b", ec);
+
+    VFSInotifyWatcher watcher;
+    Init(watcher);
+    const WatchHandle handle = watcher.AddWatch(m_root.c_str(), /*recursive=*/true);
+    ASSERT_NE(handle, INVALID_WATCH_HANDLE);
+    EXPECT_EQ(watcher.DescriptorCount(), 3u);
+
+    watcher.RemoveWatch(handle);
+    EXPECT_EQ(watcher.DescriptorCount(), 0u);
+
+    WriteFile(m_root / "ignored.glb", "x");
+    Drain(watcher);
+    EXPECT_EQ(EventCount(), 0u);
+}
+
+TEST_F(VFSInotifyWatcherTest, AddWatchOnMissingDirectoryFails)
+{
+    VFSInotifyWatcher watcher;
+    Init(watcher);
+    EXPECT_EQ(watcher.AddWatch((m_root / "does_not_exist").c_str(), false), INVALID_WATCH_HANDLE);
+}
+
+TEST_F(VFSInotifyWatcherTest, AddWatchBeforeInitializeFails)
+{
+    VFSInotifyWatcher watcher;
+    EXPECT_FALSE(watcher.IsValid());
+    EXPECT_EQ(watcher.AddWatch(m_root.c_str(), false), INVALID_WATCH_HANDLE);
+}
+
+TEST_F(VFSInotifyWatcherTest, BackgroundThreadDeliversEvents)
+{
+    VFSInotifyWatcher watcher;
+    Init(watcher);
+    ASSERT_NE(watcher.AddWatch(m_root.c_str(), /*recursive=*/true), INVALID_WATCH_HANDLE);
+
+    watcher.StartThread();
+
+    const auto file = m_root / "threaded.glb";
+    WriteFile(file, "x");
+
+    Drain(watcher);
+    watcher.StopThread();
+
+    EXPECT_TRUE(Contains(file.c_str(), WatchEventKind::Created));
+}
+
+TEST_F(VFSInotifyWatcherTest, StopThreadIsSafeWithoutStart)
+{
+    VFSInotifyWatcher watcher;
+    Init(watcher);
+    watcher.StopThread();
+    SUCCEED();
+}
+#endif // __linux__

--- a/ZEngine/tests/VFS/vfs_rdc_test.cpp
+++ b/ZEngine/tests/VFS/vfs_rdc_test.cpp
@@ -1,0 +1,327 @@
+#if defined(_WIN32)
+#include <ZEngine/Core/Containers/Array.h>
+#include <ZEngine/Core/Memory/MemoryManager.h>
+#include <ZEngine/Core/VFS/Platform/VFSRDCWatcher.h>
+#include <ZEngine/Helpers/MemoryOperations.h>
+#include <gtest/gtest.h>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <thread>
+
+using namespace ZEngine::Core::VFS;
+using ZEngine::Core::Containers::Array;
+using ZEngine::Core::Memory::MemoryManager;
+using ZEngine::Helpers::secure_strcmp;
+
+namespace
+{
+    struct ExpectedPath
+    {
+        char Value[MAX_FILE_PATH_COUNT] = {};
+
+        explicit ExpectedPath(const std::filesystem::path& path)
+        {
+            const int written = WideCharToMultiByte(CP_UTF8, 0, path.c_str(), -1, Value, sizeof(Value) - 1, nullptr, nullptr);
+            if (written <= 0)
+            {
+                Value[0] = '\0';
+            }
+
+            for (char* c = Value; *c != '\0'; ++c)
+            {
+                if (*c == '\\')
+                {
+                    *c = '/';
+                }
+            }
+        }
+
+        const char* Get() const
+        {
+            return Value;
+        }
+    };
+
+    class VFSRDCWatcherTest : public ::testing::Test
+    {
+    protected:
+        void SetUp() override
+        {
+            m_manager.Initialize(ZMega(2), {});
+            m_events.init(&m_manager.MainArena, 32);
+
+            std::error_code ec;
+            m_root = std::filesystem::temp_directory_path() / "zengine_vfs_rdc_tests";
+            std::filesystem::remove_all(m_root, ec);
+            std::filesystem::create_directories(m_root, ec);
+
+            const ExpectedPath root{m_root};
+            ZEngine::Helpers::secure_strcpy(m_root_native, sizeof(m_root_native), root.Get());
+        }
+
+        void TearDown() override
+        {
+            std::error_code ec;
+            std::filesystem::remove_all(m_root, ec);
+
+            m_manager.Shutdown();
+        }
+
+        void Init(VFSRDCWatcher& watcher)
+        {
+            watcher.Initialize(&m_manager.MainArena);
+        }
+
+        void WriteFile(const std::filesystem::path& path, const char* contents)
+        {
+            std::ofstream out(path);
+            out << contents;
+        }
+
+        const char* RootPath() const
+        {
+            return m_root_native;
+        }
+
+        void Drain(VFSRDCWatcher& watcher)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds{200});
+
+            m_events.clear();
+            watcher.Poll([](void* ctx, const VFSWatchEvent& ev) { reinterpret_cast<VFSRDCWatcherTest*>(ctx)->m_events.push(ev); }, this);
+        }
+
+        bool Contains(const char* path, WatchEventKind kind) const
+        {
+            for (size_t i = 0; i < m_events.size(); ++i)
+            {
+                if (m_events[i].Kind == kind && secure_strcmp(m_events[i].Path, path) == 0)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        bool ContainsPath(const char* path) const
+        {
+            for (size_t i = 0; i < m_events.size(); ++i)
+            {
+                if (secure_strcmp(m_events[i].Path, path) == 0)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        size_t EventCount() const
+        {
+            return m_events.size();
+        }
+
+        MemoryManager         m_manager;
+        Array<VFSWatchEvent>  m_events;
+        std::filesystem::path m_root;
+        char                  m_root_native[MAX_FILE_PATH_COUNT] = {};
+    };
+} // namespace
+
+TEST_F(VFSRDCWatcherTest, ReportsFileCreation)
+{
+    VFSRDCWatcher watcher;
+    Init(watcher);
+    ASSERT_TRUE(watcher.IsValid());
+
+    const WatchHandle handle = watcher.AddWatch(RootPath(), /*recursive=*/false);
+    ASSERT_NE(handle, INVALID_WATCH_HANDLE);
+    EXPECT_EQ(watcher.WatchCount(), 1u);
+
+    const auto         file = m_root / "created.glb";
+    const ExpectedPath expected{file};
+    WriteFile(file, "x");
+
+    Drain(watcher);
+    EXPECT_TRUE(Contains(expected.Get(), WatchEventKind::Created));
+}
+
+TEST_F(VFSRDCWatcherTest, ReportsFileModification)
+{
+    VFSRDCWatcher watcher;
+    Init(watcher);
+
+    const auto         file = m_root / "existing.glb";
+    const ExpectedPath expected{file};
+    WriteFile(file, "first");
+
+    ASSERT_NE(watcher.AddWatch(RootPath(), false), INVALID_WATCH_HANDLE);
+
+    WriteFile(file, "second");
+
+    Drain(watcher);
+    EXPECT_TRUE(Contains(expected.Get(), WatchEventKind::Modified));
+}
+
+TEST_F(VFSRDCWatcherTest, ReportsFileDeletion)
+{
+    VFSRDCWatcher watcher;
+    Init(watcher);
+
+    const auto         file = m_root / "doomed.glb";
+    const ExpectedPath expected{file};
+    WriteFile(file, "x");
+
+    ASSERT_NE(watcher.AddWatch(RootPath(), false), INVALID_WATCH_HANDLE);
+
+    std::error_code ec;
+    std::filesystem::remove(file, ec);
+
+    Drain(watcher);
+    EXPECT_TRUE(Contains(expected.Get(), WatchEventKind::Deleted));
+}
+
+TEST_F(VFSRDCWatcherTest, RenameFusesIntoSingleEvent)
+{
+    VFSRDCWatcher watcher;
+    Init(watcher);
+
+    const auto         original = m_root / "old.glb";
+    const auto         renamed  = m_root / "new.glb";
+    const ExpectedPath expected_original{original};
+    const ExpectedPath expected_renamed{renamed};
+    WriteFile(original, "x");
+
+    ASSERT_NE(watcher.AddWatch(RootPath(), false), INVALID_WATCH_HANDLE);
+
+    std::error_code ec;
+    std::filesystem::rename(original, renamed, ec);
+    ASSERT_FALSE(ec);
+
+    Drain(watcher);
+
+    bool found = false;
+    for (size_t i = 0; i < EventCount(); ++i)
+    {
+        if (m_events[i].Kind == WatchEventKind::Renamed)
+        {
+            EXPECT_STREQ(expected_renamed.Get(), m_events[i].Path);
+            EXPECT_STREQ(expected_original.Get(), m_events[i].OldPath);
+            found = true;
+        }
+    }
+    EXPECT_TRUE(found) << "no Renamed event produced";
+}
+
+TEST_F(VFSRDCWatcherTest, RecursiveWatchIsASingleHandleAndSeesNestedFiles)
+{
+    std::error_code ec;
+    std::filesystem::create_directories(m_root / "assets" / "meshes", ec);
+
+    VFSRDCWatcher watcher;
+    Init(watcher);
+    ASSERT_NE(watcher.AddWatch(RootPath(), /*recursive=*/true), INVALID_WATCH_HANDLE);
+    EXPECT_EQ(watcher.WatchCount(), 1u);
+
+    const auto         nested = m_root / "assets" / "meshes" / "deep.glb";
+    const ExpectedPath expected{nested};
+    WriteFile(nested, "x");
+
+    Drain(watcher);
+    EXPECT_TRUE(Contains(expected.Get(), WatchEventKind::Created));
+}
+
+TEST_F(VFSRDCWatcherTest, NonRecursiveWatchIgnoresSubdirectories)
+{
+    std::error_code ec;
+    std::filesystem::create_directories(m_root / "assets", ec);
+
+    VFSRDCWatcher watcher;
+    Init(watcher);
+    ASSERT_NE(watcher.AddWatch(RootPath(), /*recursive=*/false), INVALID_WATCH_HANDLE);
+
+    const auto         nested = m_root / "assets" / "hidden.glb";
+    const ExpectedPath expected{nested};
+    WriteFile(nested, "x");
+
+    Drain(watcher);
+    EXPECT_FALSE(ContainsPath(expected.Get()));
+}
+
+TEST_F(VFSRDCWatcherTest, NewDirectoryIsCoveredWithoutReregistering)
+{
+    VFSRDCWatcher watcher;
+    Init(watcher);
+    ASSERT_NE(watcher.AddWatch(RootPath(), /*recursive=*/true), INVALID_WATCH_HANDLE);
+
+    std::error_code ec;
+    std::filesystem::create_directory(m_root / "late", ec);
+    Drain(watcher);
+
+    const auto         nested = m_root / "late" / "inside.glb";
+    const ExpectedPath expected{nested};
+    WriteFile(nested, "x");
+
+    Drain(watcher);
+    EXPECT_TRUE(Contains(expected.Get(), WatchEventKind::Created));
+}
+
+TEST_F(VFSRDCWatcherTest, RemoveWatchStopsEvents)
+{
+    VFSRDCWatcher watcher;
+    Init(watcher);
+
+    const WatchHandle handle = watcher.AddWatch(RootPath(), /*recursive=*/true);
+    ASSERT_NE(handle, INVALID_WATCH_HANDLE);
+    EXPECT_EQ(watcher.WatchCount(), 1u);
+
+    watcher.RemoveWatch(handle);
+    EXPECT_EQ(watcher.WatchCount(), 0u);
+
+    WriteFile(m_root / "ignored.glb", "x");
+    Drain(watcher);
+    EXPECT_EQ(EventCount(), 0u);
+}
+
+TEST_F(VFSRDCWatcherTest, AddWatchOnMissingDirectoryFails)
+{
+    VFSRDCWatcher watcher;
+    Init(watcher);
+
+    const ExpectedPath missing{m_root / "does_not_exist"};
+    EXPECT_EQ(watcher.AddWatch(missing.Get(), false), INVALID_WATCH_HANDLE);
+}
+
+TEST_F(VFSRDCWatcherTest, AddWatchBeforeInitializeFails)
+{
+    VFSRDCWatcher watcher;
+    EXPECT_FALSE(watcher.IsValid());
+    EXPECT_EQ(watcher.AddWatch(RootPath(), false), INVALID_WATCH_HANDLE);
+}
+
+TEST_F(VFSRDCWatcherTest, BackgroundThreadDeliversEvents)
+{
+    VFSRDCWatcher watcher;
+    Init(watcher);
+    ASSERT_NE(watcher.AddWatch(RootPath(), /*recursive=*/true), INVALID_WATCH_HANDLE);
+
+    watcher.StartThread();
+
+    const auto         file = m_root / "threaded.glb";
+    const ExpectedPath expected{file};
+    WriteFile(file, "x");
+
+    Drain(watcher);
+    watcher.StopThread();
+
+    EXPECT_TRUE(Contains(expected.Get(), WatchEventKind::Created));
+}
+
+TEST_F(VFSRDCWatcherTest, StopThreadIsSafeWithoutStart)
+{
+    VFSRDCWatcher watcher;
+    Init(watcher);
+    watcher.StopThread();
+    SUCCEED();
+}
+#endif // _WIN32


### PR DESCRIPTION
Implements **Ticket 4** from [`ZEngine/docs/vfs-ticket4-filewatcher.md`](https://github.com/JeanPhilippeKernel/RendererEngine/blob/develop/ZEngine/docs/vfs-ticket4-filewatcher.md) — VFSFileWatcher: Platform File-Watch + Debounce.

Depends on Ticket 3 (`vfs-ticket3-scanner-memory-backend.md`). Blocks Ticket 5, Ticket 6, and the import pipeline OnStale hook.

## What ships

**Platform backends**
- `VFSFSEventsWatcher` (macOS) — FSEvents run-loop thread, stream rebuilt on the run loop thread via `CFRunLoopPerformBlock`, events classified by `stat()`
- `VFSInotifyWatcher` (Linux) — inotify with `poll` + wake pipe, recursive subtree support, `IN_MOVED_FROM`/`IN_MOVED_TO` cookie pairing for `Renamed`
- `VFSRDCWatcher` (Windows) — `ReadDirectoryChangesW` over an IOCP, `FILE_ACTION_RENAMED_*` coalesced into `Renamed`

**Debounce layer — `VFSFileWatcher`**
- 80 ms debounce window (configurable); last-write-wins within the window
- Path-prefix routing to per-watch callbacks; longest-prefix match wins
- `Overflow` events broadcast to all registered watchers

**VFSContext integration**
- `InitWatcher(project_root_native, cache, scanner)` — arena-allocates the platform and file watcher (ZAlloc + placement new), registers a root watch that calls `VFSDirectoryCache::Invalidate` and `VFSScanner::Scan` on each event
- `Tick()` — drives the debounce flush each frame
- `ShutdownWatcher()` — stops the background thread, calls destructors explicitly
- All failure paths log via `ZENGINE_LOG_VFS_ERR`

**API**
- `IVFSPlatformWatcher::Poll` uses `void(*)(void*, const VFSWatchEvent&)` instead of `std::function` — zero heap allocation on the hot poll path

**CMake**
- `VFSFSEventsWatcher.mm` added explicitly to `ZENGINE_SOURCES_CORE` on Apple
- `CoreServices` framework linked on Darwin

**Tests**
- `VFSFileWatcherTest.cpp` — 14 mock-based tests covering debounce, routing, overflow, rename, unwatch, path boundary disambiguation
- `vfs_fsevents_test.cpp`, `vfs_inotify_test.cpp`, `vfs_rdc_test.cpp` — integration tests against the real OS APIs using a temp directory

## Deliverables checklist

- [x] `VFSWatchEvent.h`
- [x] `IVFSPlatformWatcher.h`
- [x] `VFSFileWatcher.h` + `VFSFileWatcher.cpp`
- [x] `Platform/VFSFSEventsWatcher.h` + `VFSFSEventsWatcher.mm`
- [x] `Platform/VFSInotifyWatcher.h` + `VFSInotifyWatcher.cpp`
- [x] `Platform/VFSRDCWatcher.h` + `VFSRDCWatcher.cpp`
- [x] CMake: `-framework CoreServices`, `.mm` explicit source entry
- [x] `VFSContext::InitWatcher()` and `VFSContext::Tick()` wired up
- [x] Tests: 14 unit tests + platform integration tests per OS