### PR TITLE
feat(memory): introduce GpuAllocator with VMA segregated pool foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -423,3 +423,4 @@ CMakeSettings.json
 
 # MacOS files
 .DS_Store
+SampleProject/

--- a/Tetragrama/Components/DockspaceUIComponent.cpp
+++ b/Tetragrama/Components/DockspaceUIComponent.cpp
@@ -552,7 +552,7 @@ namespace Tetragrama::Components
 
         auto config      = ZPushStruct(arena, ZEngine::Importers::ImportConfiguration);
         config->OutputWorkingSpacePath.init(arena, app->Configuration->WorkingSpacePath.c_str());
-        config->OutputAssetsPath.init(arena, "Settings/EnvironmentMaps");
+        config->OutputAssetsPath.init(arena, app->Configuration->EnvironmentMapImportPath.c_str());
         config->AssetName.init(arena, asset_name.c_str());
         config->OutputAssetFile.init(arena, output_file.c_str());
 

--- a/Tetragrama/Components/DockspaceUIComponent.cpp
+++ b/Tetragrama/Components/DockspaceUIComponent.cpp
@@ -804,7 +804,7 @@ namespace Tetragrama::Components
 
         auto        config            = ZPushStruct(arena, ZEngine::Importers::ImportConfiguration);
         config->OutputWorkingSpacePath.init(arena, editor_config.WorkingSpacePath.c_str());
-        config->OutputTextureFilesPath.init(arena, editor_config.DefaultImportTexturePath.c_str());
+        config->OutputTextureFilesPath.init(arena, editor_config.TexturePath.c_str());
         config->OutputAssetsPath.init(arena, editor_config.SceneDataPath.c_str());
         config->AssetName.init(arena, asset_name.c_str());
         config->OutputAssetFile.init(arena, output_asset_file.c_str());

--- a/Tetragrama/Components/DockspaceUIComponent.cpp
+++ b/Tetragrama/Components/DockspaceUIComponent.cpp
@@ -720,6 +720,17 @@ namespace Tetragrama::Components
 
         current_scene->Name = app->Configuration->ActiveSceneName.c_str();
 
+        // Copy sky config from deserialized scene; resolve env map filename to absolute path
+        current_scene->Sky.Mode.init(&current_scene->LocalArena, scene.Sky.Mode.empty() ? "atmosphere" : scene.Sky.Mode.c_str());
+        if (!scene.Sky.EnvironmentMap.empty() && !app->Configuration->EnvironmentMapImportPath.empty())
+        {
+            auto abs_env = fmt::format("{}/{}", app->Configuration->EnvironmentMapImportPath.c_str(), scene.Sky.EnvironmentMap.c_str());
+            current_scene->Sky.EnvironmentMap.init(&current_scene->LocalArena, abs_env.c_str());
+        }
+        current_scene->SkyDirty[0].store(true, std::memory_order_release);
+        current_scene->SkyDirty[1].store(true, std::memory_order_release);
+        current_scene->SkyDirty[2].store(true, std::memory_order_release);
+
         current_scene->MarkDirty(false);
 
         {

--- a/Tetragrama/Editor.cpp
+++ b/Tetragrama/Editor.cpp
@@ -47,13 +47,6 @@ namespace Tetragrama
         WindowCfg.Title.init(&Memory->MainArena, title.c_str());
     }
 
-    const char* Editor::GetActiveEnvironmentMapPath()
-    {
-        if (!Configuration || Configuration->ActiveEnvironmentMapPath.empty())
-            return nullptr;
-        return Configuration->ActiveEnvironmentMapPath.c_str();
-    }
-
     void Editor::OnInitialized()
     {
         if (WorkingSpacePath && WorkingSpacePath[0] != '\0')
@@ -166,20 +159,6 @@ namespace Tetragrama
         MaterialPath.init(arena, asset_path("materialDir", nullptr, nullptr, "/Assets/Materials").c_str());
         SpritePath.init(arena, asset_path("spriteDir", nullptr, nullptr, "/Assets/Sprites").c_str());
         EnvironmentMapImportPath.init(arena, asset_path("environmentMapDir", nullptr, nullptr, "/Assets/EnvironmentMaps").c_str());
-
-        // Active environment map: optional — read from "sky.environmentMap" (filename only)
-        // Resolved against EnvironmentMapImportPath at runtime.
-        std::string env_map_file;
-        if (config.contains("sky") && config["sky"].contains("environmentMap"))
-            env_map_file = config["sky"]["environmentMap"].get<std::string>();
-        else if (config.contains("environmentMap"))
-            env_map_file = config["environmentMap"].get<std::string>(); // legacy fallback
-
-        if (!env_map_file.empty())
-        {
-            auto abs_path = fmt::format("{}/{}", EnvironmentMapImportPath.c_str(), env_map_file);
-            ActiveEnvironmentMapPath.init(arena, abs_path.c_str());
-        }
 
         /*
          * Retreiving the Active Scene

--- a/Tetragrama/Editor.cpp
+++ b/Tetragrama/Editor.cpp
@@ -128,33 +128,44 @@ namespace Tetragrama
         std::string working_space_path = config["workingSpace"];
         if (working_space_path == ".")
         {
-            expand_nested(config, "defaultImportDir", "textureDir");
-            expand_nested(config, "defaultImportDir", "soundDir");
             expand(config, "sceneDir");
             expand(config, "sceneDataDir");
-            if (config.contains("environmentMapDir"))
-                expand(config, "environmentMapDir");
+            // Expand all fields inside assetDirs (new format)
+            if (config.contains("assetDirs"))
+            {
+                for (auto& [key, val] : config["assetDirs"].items())
+                    expand_nested(config, "assetDirs", key);
+            }
+            // Backward compat: old defaultImportDir format
+            if (config.contains("defaultImportDir"))
+            {
+                expand_nested(config, "defaultImportDir", "textureDir");
+                expand_nested(config, "defaultImportDir", "soundDir");
+            }
             config["workingSpace"] = root_project_dir;
         }
 
+        auto ws = config["workingSpace"].get<std::string>();
         ProjectName.init(arena, config["projectName"].get<std::string>().c_str());
-        WorkingSpacePath.init(arena, config["workingSpace"].get<std::string>().c_str());
-        DefaultImportTexturePath.init(arena, config["defaultImportDir"]["textureDir"].get<std::string>().c_str());
-        DefaultImportSoundPath.init(arena, config["defaultImportDir"]["soundDir"].get<std::string>().c_str());
+        WorkingSpacePath.init(arena, ws.c_str());
         ScenePath.init(arena, config["sceneDir"].get<std::string>().c_str());
         SceneDataPath.init(arena, config["sceneDataDir"].get<std::string>().c_str());
 
-        // Environment map import directory (where .zenvmap files are written)
-        if (config.contains("environmentMapDir"))
-        {
-            EnvironmentMapImportPath.init(arena, config["environmentMapDir"].get<std::string>().c_str());
-        }
-        else
-        {
-            // Default: <project>/Assets/EnvironmentMaps
-            auto default_env_dir = fmt::format("{}/Assets/EnvironmentMaps", config["workingSpace"].get<std::string>());
-            EnvironmentMapImportPath.init(arena, default_env_dir.c_str());
-        }
+        // Asset directories — new assetDirs format, fall back to defaultImportDir
+        auto asset_path = [&](const char* asset_key, const char* legacy_section, const char* legacy_key, const char* default_suffix) -> std::string {
+            if (config.contains("assetDirs") && config["assetDirs"].contains(asset_key))
+                return config["assetDirs"][asset_key].get<std::string>();
+            if (legacy_section && config.contains(legacy_section) && config[legacy_section].contains(legacy_key))
+                return config[legacy_section][legacy_key].get<std::string>();
+            return fmt::format("{}{}", ws, default_suffix);
+        };
+
+        TexturePath.init(arena, asset_path("textureDir", "defaultImportDir", "textureDir", "/Assets/Textures").c_str());
+        SoundPath.init(arena, asset_path("soundDir", "defaultImportDir", "soundDir", "/Assets/Sounds").c_str());
+        MeshPath.init(arena, asset_path("meshDir", nullptr, nullptr, "/Assets/Meshes").c_str());
+        MaterialPath.init(arena, asset_path("materialDir", nullptr, nullptr, "/Assets/Materials").c_str());
+        SpritePath.init(arena, asset_path("spriteDir", nullptr, nullptr, "/Assets/Sprites").c_str());
+        EnvironmentMapImportPath.init(arena, asset_path("environmentMapDir", nullptr, nullptr, "/Assets/EnvironmentMaps").c_str());
 
         // Active environment map: optional — read from "sky.environmentMap" (filename only)
         // Resolved against EnvironmentMapImportPath at runtime.

--- a/Tetragrama/Editor.cpp
+++ b/Tetragrama/Editor.cpp
@@ -47,6 +47,13 @@ namespace Tetragrama
         WindowCfg.Title.init(&Memory->MainArena, title.c_str());
     }
 
+    const char* Editor::GetActiveEnvironmentMapPath()
+    {
+        if (!Configuration || Configuration->ActiveEnvironmentMapPath.empty())
+            return nullptr;
+        return Configuration->ActiveEnvironmentMapPath.c_str();
+    }
+
     void Editor::OnInitialized()
     {
         if (WorkingSpacePath && WorkingSpacePath[0] != '\0')
@@ -99,40 +106,34 @@ namespace Tetragrama
     void EditorConfiguration::ReadConfig(ZEngine::Core::Memory::ArenaAllocator* arena, const char* file)
     {
         std::ifstream  f(file);
-        nlohmann::json config             = nlohmann::json::parse(f);
-        std::string    root_project_dir   = std::filesystem::path(file).parent_path().string();
+        nlohmann::json config           = nlohmann::json::parse(f);
+        std::string    root_project_dir = std::filesystem::path(file).parent_path().string();
 
-        std::string    working_space_path = config["workingSpace"];
+        // Helper: expand $(workingSpace) token in a json string field
+        auto           expand           = [&](nlohmann::json& node, std::string_view key) {
+            std::string_view lookup("$(workingSpace)");
+            auto             s = node[key].get<std::string>();
+            auto             p = s.find(lookup);
+            if (p != std::string::npos)
+                node[key] = s.replace(p, lookup.size(), "");
+        };
+        auto expand_nested = [&](nlohmann::json& node, std::string_view section, std::string_view key) {
+            std::string_view lookup("$(workingSpace)");
+            auto             s = node[section][key].get<std::string>();
+            auto             p = s.find(lookup);
+            if (p != std::string::npos)
+                node[section][key] = s.replace(p, lookup.size(), "");
+        };
+
+        std::string working_space_path = config["workingSpace"];
         if (working_space_path == ".")
         {
-            std::string_view lookup_key("$(workingSpace)");
-            size_t           length          = lookup_key.size();
-
-            auto&            texture_path    = config["defaultImportDir"]["textureDir"];
-            auto&            sound_path      = config["defaultImportDir"]["soundDir"];
-            auto&            scene_path      = config["sceneDir"];
-            auto&            scene_data_path = config["sceneDataDir"];
-
-            if (texture_path.get<std::string>().find(lookup_key) != std::string::npos)
-            {
-                config["defaultImportDir"]["textureDir"] = texture_path.get<std::string>().replace(texture_path.get<std::string>().find(lookup_key), length, "");
-            }
-
-            if (sound_path.get<std::string>().find(lookup_key) != std::string::npos)
-            {
-                config["defaultImportDir"]["soundDir"] = sound_path.get<std::string>().replace(sound_path.get<std::string>().find(lookup_key), length, "");
-            }
-
-            if (scene_path.get<std::string>().find(lookup_key) != std::string::npos)
-            {
-                config["sceneDir"] = scene_path.get<std::string>().replace(scene_path.get<std::string>().find(lookup_key), length, "");
-            }
-
-            if (scene_data_path.get<std::string>().find(lookup_key) != std::string::npos)
-            {
-                config["sceneDataDir"] = scene_data_path.get<std::string>().replace(scene_data_path.get<std::string>().find(lookup_key), length, "");
-            }
-
+            expand_nested(config, "defaultImportDir", "textureDir");
+            expand_nested(config, "defaultImportDir", "soundDir");
+            expand(config, "sceneDir");
+            expand(config, "sceneDataDir");
+            if (config.contains("environmentMapDir"))
+                expand(config, "environmentMapDir");
             config["workingSpace"] = root_project_dir;
         }
 
@@ -142,6 +143,32 @@ namespace Tetragrama
         DefaultImportSoundPath.init(arena, config["defaultImportDir"]["soundDir"].get<std::string>().c_str());
         ScenePath.init(arena, config["sceneDir"].get<std::string>().c_str());
         SceneDataPath.init(arena, config["sceneDataDir"].get<std::string>().c_str());
+
+        // Environment map import directory (where .zenvmap files are written)
+        if (config.contains("environmentMapDir"))
+        {
+            EnvironmentMapImportPath.init(arena, config["environmentMapDir"].get<std::string>().c_str());
+        }
+        else
+        {
+            // Default: <project>/Assets/EnvironmentMaps
+            auto default_env_dir = fmt::format("{}/Assets/EnvironmentMaps", config["workingSpace"].get<std::string>());
+            EnvironmentMapImportPath.init(arena, default_env_dir.c_str());
+        }
+
+        // Active environment map: optional — read from "sky.environmentMap" (filename only)
+        // Resolved against EnvironmentMapImportPath at runtime.
+        std::string env_map_file;
+        if (config.contains("sky") && config["sky"].contains("environmentMap"))
+            env_map_file = config["sky"]["environmentMap"].get<std::string>();
+        else if (config.contains("environmentMap"))
+            env_map_file = config["environmentMap"].get<std::string>(); // legacy fallback
+
+        if (!env_map_file.empty())
+        {
+            auto abs_path = fmt::format("{}/{}", EnvironmentMapImportPath.c_str(), env_map_file);
+            ActiveEnvironmentMapPath.init(arena, abs_path.c_str());
+        }
 
         /*
          * Retreiving the Active Scene

--- a/Tetragrama/Editor.h
+++ b/Tetragrama/Editor.h
@@ -21,6 +21,9 @@ namespace Tetragrama
         ZEngine::Core::Containers::String DefaultImportSoundPath   = {};
         ZEngine::Core::Containers::String ScenePath                = {};
         ZEngine::Core::Containers::String SceneDataPath            = {};
+        ZEngine::Core::Containers::String EnvironmentMapImportPath = {};
+        // Absolute path to the active .zenvmap file; empty if none configured
+        ZEngine::Core::Containers::String ActiveEnvironmentMapPath = {};
         ZEngine::Core::Containers::String ProjectName              = {};
         ZEngine::Core::Containers::String ActiveSceneName          = {};
 
@@ -42,6 +45,7 @@ namespace Tetragrama
         virtual void                       OnInitializing() override;
         virtual void                       OverrideWindowConfiguration() override;
         virtual void                       OnInitialized() override;
+        virtual const char*                GetActiveEnvironmentMapPath() override;
 
         virtual void                       OnUpdate(float dt) override;
         virtual void                       OnEvent(ZEngine::Core::CoreEvent&) override;

--- a/Tetragrama/Editor.h
+++ b/Tetragrama/Editor.h
@@ -17,10 +17,14 @@ namespace Tetragrama
     struct EditorConfiguration
     {
         ZEngine::Core::Containers::String WorkingSpacePath         = {};
-        ZEngine::Core::Containers::String DefaultImportTexturePath = {};
-        ZEngine::Core::Containers::String DefaultImportSoundPath   = {};
         ZEngine::Core::Containers::String ScenePath                = {};
         ZEngine::Core::Containers::String SceneDataPath            = {};
+        // Asset import directories (all under Assets/)
+        ZEngine::Core::Containers::String TexturePath              = {};
+        ZEngine::Core::Containers::String SoundPath                = {};
+        ZEngine::Core::Containers::String MeshPath                 = {};
+        ZEngine::Core::Containers::String MaterialPath             = {};
+        ZEngine::Core::Containers::String SpritePath               = {};
         ZEngine::Core::Containers::String EnvironmentMapImportPath = {};
         // Absolute path to the active .zenvmap file; empty if none configured
         ZEngine::Core::Containers::String ActiveEnvironmentMapPath = {};

--- a/Tetragrama/Editor.h
+++ b/Tetragrama/Editor.h
@@ -26,8 +26,6 @@ namespace Tetragrama
         ZEngine::Core::Containers::String MaterialPath             = {};
         ZEngine::Core::Containers::String SpritePath               = {};
         ZEngine::Core::Containers::String EnvironmentMapImportPath = {};
-        // Absolute path to the active .zenvmap file; empty if none configured
-        ZEngine::Core::Containers::String ActiveEnvironmentMapPath = {};
         ZEngine::Core::Containers::String ProjectName              = {};
         ZEngine::Core::Containers::String ActiveSceneName          = {};
 
@@ -49,7 +47,6 @@ namespace Tetragrama
         virtual void                       OnInitializing() override;
         virtual void                       OverrideWindowConfiguration() override;
         virtual void                       OnInitialized() override;
-        virtual const char*                GetActiveEnvironmentMapPath() override;
 
         virtual void                       OnUpdate(float dt) override;
         virtual void                       OnEvent(ZEngine::Core::CoreEvent&) override;

--- a/Tetragrama/EditorScene.cpp
+++ b/Tetragrama/EditorScene.cpp
@@ -15,6 +15,7 @@ namespace Tetragrama
         arena->CreateSubArena(ZMega(200), &LocalArena);
 
         Name                     = name;
+        Sky.Mode.init(&LocalArena, "atmosphere");
 
         PendingOnLoadHierarchies = CreateRef<ThreadSafeQueue<AssetManager::AssetHandle>>();
 

--- a/Tetragrama/EditorScene.cpp
+++ b/Tetragrama/EditorScene.cpp
@@ -14,7 +14,7 @@ namespace Tetragrama
     {
         arena->CreateSubArena(ZMega(200), &LocalArena);
 
-        Name                     = name;
+        Name = name;
         Sky.Mode.init(&LocalArena, "atmosphere");
 
         PendingOnLoadHierarchies = CreateRef<ThreadSafeQueue<AssetManager::AssetHandle>>();

--- a/Tetragrama/Serializers/EditorSceneSerializer.cpp
+++ b/Tetragrama/Serializers/EditorSceneSerializer.cpp
@@ -152,7 +152,7 @@ namespace Tetragrama::Serializers
 
             char buf[DEFAULT_STR_BUFFER] = {0};
             ReadBinaryCString(&Arena, in_stream, buf);
-            scene.Name = buf;
+            scene.Name                            = buf;
 
             // Sky configuration
             char sky_mode_buf[DEFAULT_STR_BUFFER] = {0};

--- a/Tetragrama/Serializers/EditorSceneSerializer.cpp
+++ b/Tetragrama/Serializers/EditorSceneSerializer.cpp
@@ -56,6 +56,11 @@ namespace Tetragrama::Serializers
             }
 
             WriteBinaryString(out, scene->Name);
+
+            // Sky configuration
+            WriteBinaryString(out, scene->Sky.Mode.empty() ? "atmosphere" : scene->Sky.Mode.c_str());
+            WriteBinaryString(out, scene->Sky.EnvironmentMap.empty() ? "" : scene->Sky.EnvironmentMap.c_str());
+
             WriteBinaryArray(out, ArrayView{scene->Names});
             WriteBinaryArray(out, ArrayView{scene->Hierarchies});
             WriteBinaryArray(out, ArrayView{scene->LocalTransforms});
@@ -148,6 +153,15 @@ namespace Tetragrama::Serializers
             char buf[DEFAULT_STR_BUFFER] = {0};
             ReadBinaryCString(&Arena, in_stream, buf);
             scene.Name = buf;
+
+            // Sky configuration
+            char sky_mode_buf[DEFAULT_STR_BUFFER] = {0};
+            char sky_env_buf[DEFAULT_STR_BUFFER]  = {0};
+            ReadBinaryCString(&Arena, in_stream, sky_mode_buf);
+            ReadBinaryCString(&Arena, in_stream, sky_env_buf);
+            scene.Sky.Mode.init(&Arena, sky_mode_buf);
+            if (sky_env_buf[0] != '\0')
+                scene.Sky.EnvironmentMap.init(&Arena, sky_env_buf);
 
             REPORT_LOG(Context, "Extracting scene's hierarchies info...")
 

--- a/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp
+++ b/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp
@@ -91,13 +91,10 @@ namespace ZEngine::Applications
             auto  transform_buffer_set = Device->StorageBufferSetManager.Access(gpu_scene_data->TransformBufferHandle);
             auto  rd_buffer_set        = Device->StorageBufferSetManager.Access(gpu_scene_data->RenderDataBufferHandle);
 
-            auto  indirect_buffer_set  = Device->IndirectBufferSetManager.Access(gpu_scene_data->IndirectBufferHandle);
-
             auto  vtx_buffer           = vtx_buffer_set->At(Device->SwapchainPtr->CurrentFrame->Index);
             auto  idx_buffer           = idx_buffer_set->At(Device->SwapchainPtr->CurrentFrame->Index);
             auto  transform_buffer     = transform_buffer_set->At(Device->SwapchainPtr->CurrentFrame->Index);
             auto  rd_buffer            = rd_buffer_set->At(Device->SwapchainPtr->CurrentFrame->Index);
-            auto  indirect_buffer      = indirect_buffer_set->At(Device->SwapchainPtr->CurrentFrame->Index);
 
             auto& suballocs            = scene->NodeSubMeshesAllocations;
 
@@ -142,7 +139,11 @@ namespace ZEngine::Applications
 
                 rd_buffer->Write(frame_index, thread_index, sub_mesh_alloc_view);
 
-                indirect_buffer->Write(frame_index, thread_index, indirect_commands_view);
+                // Push indirect commands into the per-frame heap
+                auto& heap                           = Device->FrameHeaps[frame_index];
+                auto  indirect_alloc                 = heap.Push(DrawIndirectCommands.data(), DrawIndirectCommands.size() * sizeof(VkDrawIndirectCommand), sizeof(VkDrawIndirectCommand));
+                gpu_scene_data->IndirectHeapOffset   = indirect_alloc.Offset;
+                gpu_scene_data->IndirectCommandCount = static_cast<uint32_t>(DrawIndirectCommands.size());
 
                 ZReleaseScratch(scratch);
             }

--- a/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp
+++ b/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp
@@ -13,9 +13,10 @@ namespace ZEngine::Applications
         UICommandBufferIndex    = RenderMainThreadIndex + 1u;
         Device->Arena->CreateSubArena(ZMega(30), &LocalArena);
 
-        SceneRenderer = ZPushStructCtor(Device->Arena, Rendering::Renderers::GraphicRenderer);
-        ImguiRenderer = ZPushStructCtor(Device->Arena, Rendering::Renderers::ImGUIRenderer);
+        SceneRenderer                           = ZPushStructCtor(Device->Arena, Rendering::Renderers::GraphicRenderer);
+        ImguiRenderer                           = ZPushStructCtor(Device->Arena, Rendering::Renderers::ImGUIRenderer);
 
+        SceneRenderer->ActiveEnvironmentMapPath = ActiveEnvironmentMapPath;
         SceneRenderer->Initialize(Device);
         ImguiRenderer->Initialize(Device);
 

--- a/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp
+++ b/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp
@@ -13,10 +13,9 @@ namespace ZEngine::Applications
         UICommandBufferIndex    = RenderMainThreadIndex + 1u;
         Device->Arena->CreateSubArena(ZMega(30), &LocalArena);
 
-        SceneRenderer                           = ZPushStructCtor(Device->Arena, Rendering::Renderers::GraphicRenderer);
-        ImguiRenderer                           = ZPushStructCtor(Device->Arena, Rendering::Renderers::ImGUIRenderer);
+        SceneRenderer = ZPushStructCtor(Device->Arena, Rendering::Renderers::GraphicRenderer);
+        ImguiRenderer = ZPushStructCtor(Device->Arena, Rendering::Renderers::ImGUIRenderer);
 
-        SceneRenderer->ActiveEnvironmentMapPath = ActiveEnvironmentMapPath;
         SceneRenderer->Initialize(Device);
         ImguiRenderer->Initialize(Device);
 
@@ -82,6 +81,11 @@ namespace ZEngine::Applications
         auto swpachain    = Device->SwapchainPtr;
         auto frame_index  = swpachain->CurrentFrame->Index;
         auto thread_index = RenderMainThreadIndex;
+
+        if (scene->SkyDirty[Device->SwapchainPtr->CurrentFrame->Index].exchange(false, std::memory_order_acquire))
+        {
+            SceneRenderer->ApplySkyConfig(scene->Sky);
+        }
 
         if (scene->TransformBufferDirty[Device->SwapchainPtr->CurrentFrame->Index].load(std::memory_order_acquire) || scene->MeshAllocationDirty[Device->SwapchainPtr->CurrentFrame->Index].load(std::memory_order_acquire))
         {

--- a/ZEngine/ZEngine/Applications/AppRenderPipeline.h
+++ b/ZEngine/ZEngine/Applications/AppRenderPipeline.h
@@ -31,9 +31,6 @@ namespace ZEngine::Applications
         Rendering::Renderers::GraphicRendererPtr SceneRenderer            = nullptr;
         Rendering::Renderers::ImGUIRendererPtr   ImguiRenderer            = nullptr;
         Hardwares::CommandBufferPtr              CurrentCmdBuf            = nullptr;
-        // Set by the application before Initialize() is called.
-        // Null = no env map configured; SkyboxPass will be disabled.
-        const char*                              ActiveEnvironmentMapPath = nullptr;
 
         void                                     Initialize(Hardwares::VulkanDevicePtr device);
         void                                     Shutdown();

--- a/ZEngine/ZEngine/Applications/AppRenderPipeline.h
+++ b/ZEngine/ZEngine/Applications/AppRenderPipeline.h
@@ -31,6 +31,9 @@ namespace ZEngine::Applications
         Rendering::Renderers::GraphicRendererPtr SceneRenderer            = nullptr;
         Rendering::Renderers::ImGUIRendererPtr   ImguiRenderer            = nullptr;
         Hardwares::CommandBufferPtr              CurrentCmdBuf            = nullptr;
+        // Set by the application before Initialize() is called.
+        // Null = no env map configured; SkyboxPass will be disabled.
+        const char*                              ActiveEnvironmentMapPath = nullptr;
 
         void                                     Initialize(Hardwares::VulkanDevicePtr device);
         void                                     Shutdown();

--- a/ZEngine/ZEngine/Applications/GameApplication.cpp
+++ b/ZEngine/ZEngine/Applications/GameApplication.cpp
@@ -17,8 +17,7 @@ namespace ZEngine::Applications
 
         // Step 22 — AppRenderPipeline: must follow Engine::Initialize (device live) and
         // precede OnInitialized so the game DLL sees a fully constructed pipeline
-        RenderPipeline                           = ZPushStructCtor(&Memory->MainArena, AppRenderPipeline);
-        RenderPipeline->ActiveEnvironmentMapPath = GetActiveEnvironmentMapPath();
+        RenderPipeline = ZPushStructCtor(&Memory->MainArena, AppRenderPipeline);
         RenderPipeline->Initialize(Engine::GetContext()->Device);
 
         OnInitialized();

--- a/ZEngine/ZEngine/Applications/GameApplication.cpp
+++ b/ZEngine/ZEngine/Applications/GameApplication.cpp
@@ -17,7 +17,8 @@ namespace ZEngine::Applications
 
         // Step 22 — AppRenderPipeline: must follow Engine::Initialize (device live) and
         // precede OnInitialized so the game DLL sees a fully constructed pipeline
-        RenderPipeline = ZPushStructCtor(&Memory->MainArena, AppRenderPipeline);
+        RenderPipeline                           = ZPushStructCtor(&Memory->MainArena, AppRenderPipeline);
+        RenderPipeline->ActiveEnvironmentMapPath = GetActiveEnvironmentMapPath();
         RenderPipeline->Initialize(Engine::GetContext()->Device);
 
         OnInitialized();

--- a/ZEngine/ZEngine/Applications/GameApplication.h
+++ b/ZEngine/ZEngine/Applications/GameApplication.h
@@ -50,12 +50,6 @@ namespace ZEngine::Applications
 
         virtual void                      OnInitializing()              = 0;
         virtual void                      OnInitialized()               = 0;
-        // Override to supply the active environment map path to the render pipeline.
-        // Return null if no env map is configured for this project.
-        virtual const char*               GetActiveEnvironmentMapPath()
-        {
-            return nullptr;
-        }
 
         virtual void OnEvent(Core::CoreEvent&) = 0;
         virtual void OnUpdate(float dt)        = 0;

--- a/ZEngine/ZEngine/Applications/GameApplication.h
+++ b/ZEngine/ZEngine/Applications/GameApplication.h
@@ -51,15 +51,15 @@ namespace ZEngine::Applications
         virtual void                      OnInitializing()              = 0;
         virtual void                      OnInitialized()               = 0;
 
-        virtual void OnEvent(Core::CoreEvent&) = 0;
-        virtual void OnUpdate(float dt)        = 0;
+        virtual void                      OnEvent(Core::CoreEvent&)     = 0;
+        virtual void                      OnUpdate(float dt)            = 0;
 
-        virtual void OnPreRender()             = 0;
-        virtual void OnPostRender()            = 0;
-        virtual void OnRenderUI()              = 0;
+        virtual void                      OnPreRender()                 = 0;
+        virtual void                      OnPostRender()                = 0;
+        virtual void                      OnRenderUI()                  = 0;
 
-        virtual void OnClosing()               = 0;
-        virtual void OnClosed()                = 0;
+        virtual void                      OnClosing()                   = 0;
+        virtual void                      OnClosed()                    = 0;
     };
     ZDEFINE_PTR(GameApplication);
 

--- a/ZEngine/ZEngine/Applications/GameApplication.h
+++ b/ZEngine/ZEngine/Applications/GameApplication.h
@@ -50,16 +50,22 @@ namespace ZEngine::Applications
 
         virtual void                      OnInitializing()              = 0;
         virtual void                      OnInitialized()               = 0;
+        // Override to supply the active environment map path to the render pipeline.
+        // Return null if no env map is configured for this project.
+        virtual const char*               GetActiveEnvironmentMapPath()
+        {
+            return nullptr;
+        }
 
-        virtual void                      OnEvent(Core::CoreEvent&)     = 0;
-        virtual void                      OnUpdate(float dt)            = 0;
+        virtual void OnEvent(Core::CoreEvent&) = 0;
+        virtual void OnUpdate(float dt)        = 0;
 
-        virtual void                      OnPreRender()                 = 0;
-        virtual void                      OnPostRender()                = 0;
-        virtual void                      OnRenderUI()                  = 0;
+        virtual void OnPreRender()             = 0;
+        virtual void OnPostRender()            = 0;
+        virtual void OnRenderUI()              = 0;
 
-        virtual void                      OnClosing()                   = 0;
-        virtual void                      OnClosed()                    = 0;
+        virtual void OnClosing()               = 0;
+        virtual void OnClosed()                = 0;
     };
     ZDEFINE_PTR(GameApplication);
 

--- a/ZEngine/ZEngine/Core/Memory/Allocator.cpp
+++ b/ZEngine/ZEngine/Core/Memory/Allocator.cpp
@@ -179,7 +179,12 @@ namespace ZEngine::Core::Memory
 
     void ArenaAllocator::CreateSubArena(size_t size, ArenaAllocator* out_arena)
     {
-        out_arena->m_memory                  = reinterpret_cast<uint8_t*>(Allocate(size));
+        ZENGINE_VALIDATE_ASSERT(out_arena != nullptr, "ArenaAllocator::CreateSubArena: out_arena must not be null")
+        ZENGINE_VALIDATE_ASSERT(size > 0, "ArenaAllocator::CreateSubArena: size must be > 0")
+        ZENGINE_VALIDATE_ASSERT((m_current_offset + size) <= m_total_size, "ArenaAllocator::CreateSubArena: not enough space in parent arena")
+
+        out_arena->m_memory = reinterpret_cast<uint8_t*>(Allocate(size));
+        ZENGINE_VALIDATE_ASSERT(out_arena->m_memory != nullptr, "ArenaAllocator::CreateSubArena: failed to allocate sub-arena memory")
         out_arena->m_is_sub_arena            = true;
         out_arena->m_initial_previous_offset = 0;
         out_arena->m_initial_current_offset  = 0;

--- a/ZEngine/ZEngine/Core/Memory/GpuAllocator.cpp
+++ b/ZEngine/ZEngine/Core/Memory/GpuAllocator.cpp
@@ -1,0 +1,268 @@
+#define VMA_IMPLEMENTATION
+#define VMA_VULKAN_VERSION           1003000 // Vulkan 1.3
+#define VMA_STATIC_VULKAN_FUNCTIONS  1
+#define VMA_DYNAMIC_VULKAN_FUNCTIONS 0
+
+#include <ZEngine/Core/Memory/GpuAllocator.h>
+#include <ZEngine/Helpers/MemoryOperations.h>
+#include <ZEngine/Logging/LoggerDefinition.h>
+#include <ZEngine/ZEngineDef.h>
+
+#ifdef VMA_DEBUG_DETECT_CORRUPTION
+#include <cstdio>
+#ifdef _WIN32
+#include <windows.h>
+#define VMA_DEBUG_LOG_FORMAT(format, ...)                                          \
+    do                                                                             \
+    {                                                                              \
+        char __vma_buf[512];                                                       \
+        snprintf(__vma_buf, sizeof(__vma_buf), "[VMA] " format "\n", __VA_ARGS__); \
+        OutputDebugStringA(__vma_buf);                                             \
+        fputs(__vma_buf, stderr);                                                  \
+    } while (0)
+#else
+#define VMA_DEBUG_LOG_FORMAT(format, ...) fprintf(stderr, "[VMA] " format "\n", __VA_ARGS__)
+#endif
+#endif
+
+namespace ZEngine::Core::Memory
+{
+    void GpuAllocator::Initialize(VkPhysicalDevice physical_device, VkDevice device, VkInstance instance, bool has_memory_budget_ext, bool has_buffer_device_address_ext)
+    {
+        VmaAllocatorCreateInfo allocator_info = {.flags = VMA_ALLOCATOR_CREATE_KHR_DEDICATED_ALLOCATION_BIT};
+        allocator_info.physicalDevice         = physical_device;
+        allocator_info.device                 = device;
+        allocator_info.instance               = instance;
+        allocator_info.vulkanApiVersion       = VK_API_VERSION_1_3;
+
+        VmaAllocatorCreateFlags flags         = 0;
+        if (has_buffer_device_address_ext)
+        {
+            flags |= VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT;
+        }
+        if (has_memory_budget_ext)
+        {
+            flags |= VMA_ALLOCATOR_CREATE_EXT_MEMORY_BUDGET_BIT;
+        }
+        allocator_info.flags |= flags;
+
+        ZENGINE_VALIDATE_ASSERT(vmaCreateAllocator(&allocator_info, &Allocator) == VK_SUCCESS, "Failed to create VMA Allocator");
+
+        HasBudgetExt = has_memory_budget_ext;
+
+        if (HasBudgetExt)
+        {
+            const VkPhysicalDeviceMemoryProperties* memory_properties = nullptr;
+            vmaGetHeapBudgets(Allocator, HeapBudgets);
+            vmaGetMemoryProperties(Allocator, &memory_properties);
+            HeapCount = memory_properties->memoryHeapCount;
+        }
+
+        Ring.Initialize(Allocator);
+    }
+
+    void GpuAllocator::Shutdown()
+    {
+        Ring.Shutdown(Allocator);
+
+        VmaTotalStatistics stats = {};
+        vmaCalculateStatistics(Allocator, &stats);
+        if (stats.total.statistics.allocationCount > 0)
+        {
+            ZENGINE_CORE_WARN("[GPU] VMA shutdown: {} allocation(s) still live ({} MB)", stats.total.statistics.allocationCount, stats.total.statistics.allocationBytes >> 20);
+        }
+
+        vmaDestroyAllocator(Allocator);
+    }
+
+    BufferView GpuAllocator::AllocateBuffer(VkDeviceSize size, VkBufferUsageFlags usage, GpuMemoryDomain domain, const char* debug_name)
+    {
+        VkBufferCreateInfo buffer_create_info          = {.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+        buffer_create_info.size                        = size;
+        buffer_create_info.usage                       = usage;
+        buffer_create_info.sharingMode                 = VK_SHARING_MODE_EXCLUSIVE;
+
+        VmaAllocationCreateInfo allocation_create_info = {.flags = 0};
+        if (domain == GpuMemoryDomain::DeviceGeometry || domain == GpuMemoryDomain::DeviceTexture || domain == GpuMemoryDomain::RenderTarget || domain == GpuMemoryDomain::HostUniform || domain == GpuMemoryDomain::HostStaging)
+        {
+            allocation_create_info.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+        }
+
+        if (domain == GpuMemoryDomain::HostUniform)
+        {
+            allocation_create_info.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_ALLOW_TRANSFER_INSTEAD_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT;
+        }
+
+        if (domain == GpuMemoryDomain::HostStaging)
+        {
+            allocation_create_info.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT;
+        }
+
+        BufferView buffer_view = {.DebugName = debug_name, .Domain = domain};
+        ZENGINE_VALIDATE_ASSERT(vmaCreateBuffer(Allocator, &buffer_create_info, &allocation_create_info, &buffer_view.Handle, &buffer_view.Allocation, nullptr) == VK_SUCCESS, "Failed to allocate buffer");
+        vmaSetAllocationName(Allocator, buffer_view.Allocation, debug_name);
+        return buffer_view;
+    }
+
+    BufferImage GpuAllocator::AllocateImage(VkImageCreateInfo& image_info, GpuMemoryDomain domain, VkDevice device, VkImageAspectFlagBits aspect, VkImageViewType view_type, uint32_t layer_count, const char* debug_name)
+    {
+        VmaAllocationCreateInfo allocation_create_info = {.flags = 0};
+        if (domain == GpuMemoryDomain::DeviceGeometry || domain == GpuMemoryDomain::DeviceTexture || domain == GpuMemoryDomain::RenderTarget || domain == GpuMemoryDomain::HostUniform || domain == GpuMemoryDomain::HostStaging)
+        {
+            allocation_create_info.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+        }
+
+        BufferImage buffer_image = {.DebugName = debug_name, .Domain = domain};
+        ZENGINE_VALIDATE_ASSERT(vmaCreateImage(Allocator, &image_info, &allocation_create_info, &buffer_image.Handle, &buffer_image.Allocation, nullptr) == VK_SUCCESS, "Failed to allocate image");
+        vmaSetAllocationName(Allocator, buffer_image.Allocation, debug_name);
+
+        VkImageViewCreateInfo view_create_info           = {.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
+        view_create_info.image                           = buffer_image.Handle;
+        view_create_info.viewType                        = view_type;
+        view_create_info.format                          = image_info.format;
+        view_create_info.subresourceRange.aspectMask     = aspect;
+        view_create_info.subresourceRange.baseMipLevel   = 0;
+        view_create_info.subresourceRange.levelCount     = 1;
+        view_create_info.subresourceRange.baseArrayLayer = 0;
+        view_create_info.subresourceRange.layerCount     = layer_count;
+        ZENGINE_VALIDATE_ASSERT(vkCreateImageView(device, &view_create_info, nullptr, &buffer_image.ViewHandle) == VK_SUCCESS, "Failed to create image view");
+
+        return buffer_image;
+    }
+
+    void GpuAllocator::FreeBuffer(BufferView& buffer)
+    {
+        vmaDestroyBuffer(Allocator, buffer.Handle, buffer.Allocation);
+        buffer.Handle     = VK_NULL_HANDLE;
+        buffer.Allocation = nullptr;
+    }
+
+    void GpuAllocator::FreeImage(BufferImage& image, VkDevice device)
+    {
+        if (image.ViewHandle != VK_NULL_HANDLE)
+        {
+            vkDestroyImageView(device, image.ViewHandle, nullptr);
+            image.ViewHandle = VK_NULL_HANDLE;
+        }
+        vmaDestroyImage(Allocator, image.Handle, image.Allocation);
+        image.Handle     = VK_NULL_HANDLE;
+        image.Allocation = nullptr;
+    }
+
+    void GpuAllocator::SampleBudgets()
+    {
+        if (HasBudgetExt)
+        {
+            vmaGetHeapBudgets(Allocator, HeapBudgets);
+        }
+        else
+        {
+            VmaTotalStatistics                      stats             = {};
+            const VkPhysicalDeviceMemoryProperties* memory_properties = nullptr;
+            vmaCalculateStatistics(Allocator, &stats);
+            vmaGetMemoryProperties(Allocator, &memory_properties);
+            HeapCount = memory_properties->memoryHeapCount;
+
+            for (uint32_t i = 0; i < HeapCount; ++i)
+            {
+                HeapBudgets[i].statistics = stats.memoryHeap[i].statistics;
+                HeapBudgets[i].usage      = stats.memoryHeap[i].statistics.blockBytes;
+                HeapBudgets[i].budget     = memory_properties->memoryHeaps[i].size;
+            }
+        }
+
+        for (uint32_t i = 0; i < HeapCount; ++i)
+        {
+            float p = (float) HeapBudgets[i].usage / (float) HeapBudgets[i].budget;
+            if (p > WarnPressure)
+            {
+                ZENGINE_LOG_ENGINE_WARN("[GPU] Heap %u at %.0f%% (%zu / %zu MB)", i, p * 100.0f, HeapBudgets[i].usage >> 20, HeapBudgets[i].budget >> 20);
+            }
+        }
+    }
+
+    float GpuAllocator::HeapPressure(uint32_t heap_index) const
+    {
+        if (heap_index >= HeapCount)
+        {
+            return 0.0f;
+        }
+        return (float) HeapBudgets[heap_index].usage / (float) HeapBudgets[heap_index].budget;
+    }
+
+    void StagingRingBuffer::Initialize(VmaAllocator alloc)
+    {
+        VkBufferCreateInfo buffer_create_info          = {.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+        buffer_create_info.size                        = kCapacity;
+        buffer_create_info.usage                       = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+        buffer_create_info.sharingMode                 = VK_SHARING_MODE_EXCLUSIVE;
+
+        VmaAllocationCreateInfo allocation_create_info = {.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT};
+        allocation_create_info.usage                   = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+        VmaAllocationInfo result                       = {};
+        ZENGINE_VALIDATE_ASSERT(vmaCreateBuffer(alloc, &buffer_create_info, &allocation_create_info, &Buffer, &Allocation, &result) == VK_SUCCESS, "Failed to allocate buffer");
+        vmaSetAllocationName(alloc, Allocation, DebugName);
+
+        MappedPtr = result.pMappedData;
+    }
+
+    void StagingRingBuffer::Shutdown(VmaAllocator alloc)
+    {
+        vmaDestroyBuffer(alloc, Buffer, Allocation);
+    }
+
+    void* StagingRingBuffer::Allocate(uint32_t size, uint32_t alignment, uint32_t* out_vk_offset)
+    {
+        if (!MappedPtr)
+        {
+            return nullptr;
+        }
+
+        uint32_t offset = static_cast<uint32_t>(Helpers::memory_align_size_t(WritePos, alignment));
+
+        if (WritePos >= ReadPos)
+        {
+            if ((offset + size) < static_cast<uint32_t>(kCapacity))
+            {
+                *out_vk_offset = offset;
+                WritePos       = offset + size;
+                return reinterpret_cast<uint8_t*>(MappedPtr) + offset;
+            }
+
+            // this causes a buffer wrapping
+            if (size < ReadPos)
+            {
+                *out_vk_offset = 0;
+                WritePos       = size;
+                return MappedPtr;
+            }
+            return nullptr;
+        }
+        else
+        {
+            if ((offset + size) < ReadPos)
+            {
+                *out_vk_offset = offset;
+                WritePos       = offset + size;
+                return reinterpret_cast<uint8_t*>(MappedPtr) + offset;
+            }
+            return nullptr;
+        }
+    }
+
+    void StagingRingBuffer::Submit(uint32_t vk_offset, uint32_t size, uint64_t timeline_value)
+    {
+        Chunks[ChunkTail] = {vk_offset, size, timeline_value};
+        ChunkTail         = (ChunkTail + 1) % kMaxChunks;
+    }
+
+    void StagingRingBuffer::Drain(uint64_t completed_value)
+    {
+        while (ChunkHead != ChunkTail && Chunks[ChunkHead].TimelineValue <= completed_value)
+        {
+            ReadPos   = Chunks[ChunkHead].Offset + Chunks[ChunkHead].Size;
+            ChunkHead = (ChunkHead + 1) % kMaxChunks;
+        }
+    }
+
+} // namespace ZEngine::Core::Memory

--- a/ZEngine/ZEngine/Core/Memory/GpuAllocator.cpp
+++ b/ZEngine/ZEngine/Core/Memory/GpuAllocator.cpp
@@ -120,6 +120,10 @@ namespace ZEngine::Core::Memory
         view_create_info.image                           = buffer_image.Handle;
         view_create_info.viewType                        = view_type;
         view_create_info.format                          = image_info.format;
+        view_create_info.components.r                    = VK_COMPONENT_SWIZZLE_IDENTITY;
+        view_create_info.components.g                    = VK_COMPONENT_SWIZZLE_IDENTITY;
+        view_create_info.components.b                    = VK_COMPONENT_SWIZZLE_IDENTITY;
+        view_create_info.components.a                    = VK_COMPONENT_SWIZZLE_IDENTITY;
         view_create_info.subresourceRange.aspectMask     = aspect;
         view_create_info.subresourceRange.baseMipLevel   = 0;
         view_create_info.subresourceRange.levelCount     = 1;

--- a/ZEngine/ZEngine/Core/Memory/GpuAllocator.h
+++ b/ZEngine/ZEngine/Core/Memory/GpuAllocator.h
@@ -1,0 +1,127 @@
+#pragma once
+#include <vk_mem_alloc.h>
+#include <vulkan/vulkan.h>
+#include <cstdint>
+#include <limits>
+
+namespace ZEngine::Core::Memory
+{
+    constexpr uint64_t GeometryBytes     = 512ULL << 20; // 512 MB vertex/index/storage
+    constexpr uint64_t TextureBytes      = 512ULL << 20; // 512 MB BC7/BC5 atlas
+    constexpr uint64_t RenderTargetBytes = 172ULL << 20; // 172 MB shadow maps + post-process + thumbnails
+    constexpr uint64_t UniformBytes      = 64ULL << 20;  // per-frame UBOs + bone matrices
+    constexpr uint64_t StagingBytes      = 64ULL << 20;  // staging ring capacity
+    constexpr float    WarnPressure      = 0.90f;
+
+    enum class GpuMemoryDomain : uint8_t
+    {
+        DeviceGeometry = 0, // DEVICE_LOCAL - Geometry buffers, vertex/index buffers, etc.
+        DeviceTexture  = 1, // DEVICE_LOCAL - Texture buffers, image buffers, etc.
+        RenderTarget   = 2, // DEVICE_LOCAL - RT, depth, shadow maps
+        HostUniform    = 3, // BAR window - uniforms, frenquently updated data
+        HostStaging    = 4, // HOST_VISIBLE | HOST_COHERENT - Staging buffers for uploading data to the GPU
+        Count          = 5
+    };
+
+    enum BufferType : uint8_t
+    {
+        UNKNOWN  = 0,
+        VERTEX   = 1,
+        INDEX    = 2,
+        UNIFORM  = 3,
+        STORAGE  = 4,
+        INDIRECT = 5
+    };
+
+    struct BufferView
+    {
+        const char*     DebugName  = nullptr;
+        uint8_t         FrameIndex = std::numeric_limits<uint8_t>::max();
+        BufferType      Type       = BufferType::UNKNOWN;
+        GpuMemoryDomain Domain     = GpuMemoryDomain::DeviceGeometry;
+        VkBuffer        Handle     = VK_NULL_HANDLE;
+        VmaAllocation   Allocation = nullptr;
+        // clang-format off
+        operator bool() const
+        {
+            return (Handle != VK_NULL_HANDLE);
+        }
+        // clang-format on
+    };
+
+    struct BufferImage
+    {
+        const char*     DebugName  = nullptr;
+        uint8_t         FrameIndex = std::numeric_limits<uint8_t>::max();
+        GpuMemoryDomain Domain     = GpuMemoryDomain::DeviceTexture;
+        VkImage         Handle     = VK_NULL_HANDLE;
+        VkImageView     ViewHandle = VK_NULL_HANDLE;
+        VkSampler       Sampler    = VK_NULL_HANDLE;
+        VmaAllocation   Allocation = nullptr;
+        // clang-format off
+        operator bool() const
+        {
+            return (Handle != VK_NULL_HANDLE);
+        }
+        // clang-format on
+    };
+
+    struct StagingRingBuffer
+    {
+        static constexpr uint64_t kCapacity  = StagingBytes;
+        static constexpr uint64_t kMaxChunks = 256;
+
+        struct Chunk
+        {
+            uint32_t Offset        = 0;
+            uint32_t Size          = 0;
+            uint64_t TimelineValue = std::numeric_limits<uint64_t>::max(); // Timeline semaphore completion value when this chunk is safe to reuse
+        };
+
+        const char*   DebugName          = "ZStagingBuffer";
+        VmaAllocation Allocation         = nullptr;
+        VkBuffer      Buffer             = VK_NULL_HANDLE;
+        void*         MappedPtr          = nullptr;
+        uint32_t      WritePos           = 0;
+        uint32_t      ReadPos            = 0;
+        Chunk         Chunks[kMaxChunks] = {};
+        uint32_t      ChunkHead          = 0;
+        uint32_t      ChunkTail          = 0;
+
+        void          Initialize(VmaAllocator alloc);
+        void          Shutdown(VmaAllocator alloc);
+
+        // Returns mapped pointer + VkBuffer byte offset. Returns nullptr when the ring is
+        // full � caller falls back to a one-shot staging buffer for oversized transfers.
+        // alignment has possible value as follow:
+        void*         Allocate(uint32_t size, uint32_t alignment, uint32_t* out_vk_offset);
+
+        // Record a submitted chunk so Drain() can release it.
+        void          Submit(uint32_t vk_offset, uint32_t size, uint64_t timeline_value);
+
+        // Advance ReadPos past all chunks whose TimelineValue <= completed. O(drained_count).
+        void          Drain(uint64_t completed_value);
+    };
+
+    struct GpuAllocator
+    {
+        VmaAllocator      Allocator                                           = nullptr;
+        VmaPool           Pools[static_cast<uint8_t>(GpuMemoryDomain::Count)] = {nullptr};
+        StagingRingBuffer Ring                                                = {};
+        VmaBudget         HeapBudgets[VK_MAX_MEMORY_HEAPS]                    = {};
+        uint32_t          HeapCount                                           = 0;
+        bool              HasBudgetExt                                        = false;
+
+        void              Initialize(VkPhysicalDevice physical_device, VkDevice device, VkInstance instance, bool has_memory_budget_ext, bool has_buffer_device_address_ext);
+        void              Shutdown();
+
+        BufferView        AllocateBuffer(VkDeviceSize size, VkBufferUsageFlags usage, GpuMemoryDomain domain, const char* debug_name = nullptr);
+        BufferImage       AllocateImage(VkImageCreateInfo& image_info, GpuMemoryDomain domain, VkDevice device, VkImageAspectFlagBits aspect, VkImageViewType view_type, uint32_t layer_count, const char* debug_name = nullptr);
+        void              FreeBuffer(BufferView& buffer);
+        void              FreeImage(BufferImage& image, VkDevice device = VK_NULL_HANDLE);
+
+        void              SampleBudgets();
+        float             HeapPressure(uint32_t heap_index) const;
+    };
+
+} // namespace ZEngine::Core::Memory

--- a/ZEngine/ZEngine/Hardwares/AsyncResourceLoader.cpp
+++ b/ZEngine/ZEngine/Hardwares/AsyncResourceLoader.cpp
@@ -130,43 +130,43 @@ namespace ZEngine::Hardwares
         }
 
         VkMemoryPropertyFlags mem_prop_flags;
-        vmaGetAllocationMemoryProperties(Device->VmaAllocatorValue, buffer_view->Allocation, &mem_prop_flags);
+        vmaGetAllocationMemoryProperties(Device->GpuMem.Allocator, buffer_view->Allocation, &mem_prop_flags);
 
         if (mem_prop_flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
         {
-            ZENGINE_VALIDATE_ASSERT(vmaCopyMemoryToAllocation(Device->VmaAllocatorValue, data, buffer_view->Allocation, offset, byte_size) == VK_SUCCESS, "Failed to perform memory copy operation")
+            ZENGINE_VALIDATE_ASSERT(vmaCopyMemoryToAllocation(Device->GpuMem.Allocator, data, buffer_view->Allocation, offset, byte_size) == VK_SUCCESS, "Failed to perform memory copy operation")
 
             // flushing the allocation so the GPU can see it
             if (!(mem_prop_flags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT))
             {
-                vmaFlushAllocation(Device->VmaAllocatorValue, buffer_view->Allocation, offset, byte_size);
+                vmaFlushAllocation(Device->GpuMem.Allocator, buffer_view->Allocation, offset, byte_size);
             }
 
             VkAccessFlags        dst_access_mask    = VK_ACCESS_NONE;
             VkPipelineStageFlags dst_pipeline_stage = VK_PIPELINE_STAGE_TRANSFER_BIT;
             switch (buffer_view->Type)
             {
-                case BufferType::VERTEX:
+                case Core::Memory::BufferType::VERTEX:
                     dst_access_mask    = VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT;
                     dst_pipeline_stage = VK_PIPELINE_STAGE_VERTEX_INPUT_BIT;
                     break;
 
-                case BufferType::INDEX:
+                case Core::Memory::BufferType::INDEX:
                     dst_access_mask    = VK_ACCESS_INDEX_READ_BIT;
                     dst_pipeline_stage = VK_PIPELINE_STAGE_VERTEX_INPUT_BIT;
                     break;
 
-                case BufferType::UNIFORM:
+                case Core::Memory::BufferType::UNIFORM:
                     dst_access_mask    = VK_ACCESS_UNIFORM_READ_BIT;
                     dst_pipeline_stage = VK_PIPELINE_STAGE_VERTEX_SHADER_BIT;
                     break;
 
-                case BufferType::STORAGE:
+                case Core::Memory::BufferType::STORAGE:
                     dst_access_mask    = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;
                     dst_pipeline_stage = VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
                     break;
 
-                case BufferType::INDIRECT:
+                case Core::Memory::BufferType::INDIRECT:
                     dst_access_mask    = VK_ACCESS_INDIRECT_COMMAND_READ_BIT;
                     dst_pipeline_stage = VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT;
                     break;
@@ -232,19 +232,37 @@ namespace ZEngine::Hardwares
             }
         }
 
-        auto       command_buffer = Device->CommandBufferMgr->GetInstantCommandBuffer(QueueType::GRAPHIC_QUEUE, frame_index, thread_index, i);
+        auto                 command_buffer = Device->CommandBufferMgr->GetInstantCommandBuffer(QueueType::GRAPHIC_QUEUE, frame_index, thread_index, i);
 
-        BufferView staging_buffer = Device->CreateBuffer(static_cast<VkDeviceSize>(byte_size), VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT);
+        uint32_t             ring_offset    = 0;
+        void*                ring_ptr       = Device->GpuMem.Ring.Allocate(static_cast<uint32_t>(byte_size), 4, &ring_offset);
 
-        ZENGINE_VALIDATE_ASSERT(vmaCopyMemoryToAllocation(Device->VmaAllocatorValue, data, staging_buffer.Allocation, offset, byte_size) == VK_SUCCESS, "Failed to perform memory copy operation")
+        uint64_t             signal_value   = NextValues[pool_index].fetch_add(1, std::memory_order_acq_rel);
 
-        auto dst_pipeline_stage = Device->CopyBuffer(command_buffer, staging_buffer, *destination, byte_size, 0u, offset);
+        VkPipelineStageFlags dst_pipeline_stage;
+        if (ring_ptr)
+        {
+            Helpers::secure_memmove(ring_ptr, byte_size, data, byte_size);
+            // Borrow a temporary BufferView over the ring buffer so CopyBuffer can use it.
+            BufferView ring_view = {};
+            ring_view.Handle     = Device->GpuMem.Ring.Buffer;
+            ring_view.Allocation = Device->GpuMem.Ring.Allocation;
+            dst_pipeline_stage   = Device->CopyBuffer(command_buffer, ring_view, *destination, byte_size, ring_offset, offset);
+            command_buffer->End();
+            retire_values[i] = signal_value;
+            Device->GpuMem.Ring.Submit(ring_offset, static_cast<uint32_t>(byte_size), signal_value);
+        }
+        else
+        {
+            // Ring full (burst load) — fall back to one-shot staging buffer.
+            BufferView staging_buffer = Device->CreateBuffer(static_cast<VkDeviceSize>(byte_size), VK_BUFFER_USAGE_TRANSFER_SRC_BIT, Core::Memory::GpuMemoryDomain::HostStaging);
+            ZENGINE_VALIDATE_ASSERT(vmaCopyMemoryToAllocation(Device->GpuMem.Allocator, data, staging_buffer.Allocation, offset, byte_size) == VK_SUCCESS, "Failed to perform memory copy operation")
+            dst_pipeline_stage = Device->CopyBuffer(command_buffer, staging_buffer, *destination, byte_size, 0u, offset);
+            command_buffer->End();
+            retire_values[i]                    = signal_value;
+            RetireStagingBuffers[pool_index][i] = staging_buffer;
+        }
 
-        command_buffer->End();
-
-        uint64_t signal_value               = NextValues[pool_index].fetch_add(1, std::memory_order_acq_rel);
-        retire_values[i]                    = signal_value;
-        RetireStagingBuffers[pool_index][i] = staging_buffer;
         AsyncTimelineJobQueue.Enqueue({command_buffer, Timelines[pool_index], nullptr, dst_pipeline_stage, signal_value});
     }
 
@@ -256,56 +274,78 @@ namespace ZEngine::Hardwares
         }
 
         VkMemoryPropertyFlags mem_prop_flags;
-        vmaGetAllocationMemoryProperties(Device->VmaAllocatorValue, buffer_view->Allocation, &mem_prop_flags);
+        vmaGetAllocationMemoryProperties(Device->GpuMem.Allocator, buffer_view->Allocation, &mem_prop_flags);
 
         if (mem_prop_flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
         {
             VmaAllocationInfo allocation_info = {};
-            vmaGetAllocationInfo(Device->VmaAllocatorValue, buffer_view->Allocation, &allocation_info);
+            vmaGetAllocationInfo(Device->GpuMem.Allocator, buffer_view->Allocation, &allocation_info);
             if (allocation_info.pMappedData)
             {
                 auto mapped_buf = reinterpret_cast<uint8_t*>(allocation_info.pMappedData);
                 ZENGINE_VALIDATE_ASSERT(Helpers::secure_memset((mapped_buf + offset), clear_value, allocation_info.size, byte_size) == Helpers::MEMORY_OP_SUCCESS, "Failed to perform memory copy operation")
+                // H5 fix: flush so GPU sees the zeroed data on non-coherent memory
+                if (!(mem_prop_flags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT))
+                {
+                    vmaFlushAllocation(Device->GpuMem.Allocator, buffer_view->Allocation, offset, byte_size);
+                }
             }
         }
         else
         {
-            BufferView        staging_buffer  = Device->CreateBuffer(static_cast<VkDeviceSize>(byte_size), VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT);
+            uint32_t i             = 0;
+            uint32_t pool_index    = (frame_index * Device->CommandBufferMgr->TotalThreadCount) + thread_index;
+            auto&    retire_values = RetireValues[pool_index];
 
-            VmaAllocationInfo allocation_info = {};
-            vmaGetAllocationInfo(Device->VmaAllocatorValue, staging_buffer.Allocation, &allocation_info);
-
-            if (allocation_info.pMappedData)
+            for (; i < retire_values.size(); ++i)
             {
-
-                uint32_t i             = 0;
-                uint32_t pool_index    = (frame_index * Device->CommandBufferMgr->TotalThreadCount) + thread_index;
-                auto&    retire_values = RetireValues[pool_index];
-
-                for (; i < retire_values.size(); ++i)
+                if (retire_values[i] == 0)
                 {
-                    if (retire_values[i] == 0)
-                    {
-                        break;
-                    }
+                    break;
                 }
+            }
 
-                auto command_buffer = Device->CommandBufferMgr->GetInstantCommandBuffer(QueueType::GRAPHIC_QUEUE, frame_index, thread_index, i);
-                ZENGINE_VALIDATE_ASSERT(Helpers::secure_memset(allocation_info.pMappedData, clear_value, allocation_info.size, byte_size) == Helpers::MEMORY_OP_SUCCESS, "Failed to perform memory copy operation")
-                ZENGINE_VALIDATE_ASSERT(vmaFlushAllocation(Device->VmaAllocatorValue, staging_buffer.Allocation, 0, byte_size) == VK_SUCCESS, "Failed to flush allocation")
+            auto                 command_buffer = Device->CommandBufferMgr->GetInstantCommandBuffer(QueueType::GRAPHIC_QUEUE, frame_index, thread_index, i);
+            uint32_t             ring_offset    = 0;
+            void*                ring_ptr       = Device->GpuMem.Ring.Allocate(static_cast<uint32_t>(byte_size), 4, &ring_offset);
 
-                auto dst_pipeline_stage = Device->CopyBuffer(command_buffer, staging_buffer, *buffer_view, byte_size, 0u, offset);
+            uint64_t             signal_value   = NextValues[pool_index].fetch_add(1, std::memory_order_acq_rel);
+            VkPipelineStageFlags dst_pipeline_stage;
 
+            if (ring_ptr)
+            {
+                Helpers::secure_memset(ring_ptr, clear_value, byte_size, byte_size);
+                BufferView ring_view = {};
+                ring_view.Handle     = Device->GpuMem.Ring.Buffer;
+                ring_view.Allocation = Device->GpuMem.Ring.Allocation;
+                dst_pipeline_stage   = Device->CopyBuffer(command_buffer, ring_view, *buffer_view, byte_size, ring_offset, offset);
                 command_buffer->End();
-                uint64_t signal_value               = NextValues[pool_index].fetch_add(1, std::memory_order_acq_rel);
-                retire_values[i]                    = signal_value;
-                RetireStagingBuffers[pool_index][i] = staging_buffer;
-                AsyncTimelineJobQueue.Enqueue({command_buffer, Timelines[pool_index], nullptr, dst_pipeline_stage, signal_value});
+                retire_values[i] = signal_value;
+                Device->GpuMem.Ring.Submit(ring_offset, static_cast<uint32_t>(byte_size), signal_value);
             }
             else
             {
-                vmaDestroyBuffer(Device->VmaAllocatorValue, staging_buffer.Handle, staging_buffer.Allocation);
+                // Ring full — fall back to one-shot staging buffer.
+                BufferView        staging_buffer  = Device->CreateBuffer(static_cast<VkDeviceSize>(byte_size), VK_BUFFER_USAGE_TRANSFER_SRC_BIT, Core::Memory::GpuMemoryDomain::HostStaging);
+                VmaAllocationInfo allocation_info = {};
+                vmaGetAllocationInfo(Device->GpuMem.Allocator, staging_buffer.Allocation, &allocation_info);
+                if (allocation_info.pMappedData)
+                {
+                    ZENGINE_VALIDATE_ASSERT(Helpers::secure_memset(allocation_info.pMappedData, clear_value, allocation_info.size, byte_size) == Helpers::MEMORY_OP_SUCCESS, "Failed to perform memory copy operation")
+                    ZENGINE_VALIDATE_ASSERT(vmaFlushAllocation(Device->GpuMem.Allocator, staging_buffer.Allocation, 0, byte_size) == VK_SUCCESS, "Failed to flush allocation")
+                    dst_pipeline_stage = Device->CopyBuffer(command_buffer, staging_buffer, *buffer_view, byte_size, 0u, offset);
+                    command_buffer->End();
+                    retire_values[i]                    = signal_value;
+                    RetireStagingBuffers[pool_index][i] = staging_buffer;
+                }
+                else
+                {
+                    Device->GpuMem.FreeBuffer(staging_buffer);
+                    return;
+                }
             }
+
+            AsyncTimelineJobQueue.Enqueue({command_buffer, Timelines[pool_index], nullptr, dst_pipeline_stage, signal_value});
         }
     }
 
@@ -372,9 +412,10 @@ namespace ZEngine::Hardwares
             img_buf->Layout = release.NewLayout;
             transfer_cmd->End();
 
-            uint64_t transfer_val                       = TransferNextValues[pool_index].fetch_add(1, std::memory_order_acq_rel);
-            TransferRetireValues[pool_index][i]         = transfer_val;
-            TransferRetireStagingBuffers[pool_index][i] = transfer_staging;
+            uint64_t transfer_val               = TransferNextValues[pool_index].fetch_add(1, std::memory_order_acq_rel);
+            TransferRetireValues[pool_index][i] = transfer_val;
+            if (transfer_staging)
+                TransferRetireStagingBuffers[pool_index][i] = transfer_staging;
 
             AsyncTimelineJobQueue.Enqueue({
                 transfer_cmd,
@@ -461,9 +502,10 @@ namespace ZEngine::Hardwares
             cmd->TransitionImageLayout(ImageMemoryBarrier{to_final});
             cmd->End();
 
-            uint64_t signal_value               = NextValues[pool_index].fetch_add(1, std::memory_order_acq_rel);
-            retire_values[i]                    = signal_value;
-            RetireStagingBuffers[pool_index][i] = single_queue_staging;
+            uint64_t signal_value = NextValues[pool_index].fetch_add(1, std::memory_order_acq_rel);
+            retire_values[i]      = signal_value;
+            if (single_queue_staging)
+                RetireStagingBuffers[pool_index][i] = single_queue_staging;
             AsyncTimelineJobQueue.Enqueue({cmd, Timelines[pool_index], nullptr, (uint32_t) to_final.DestinationStageMask, signal_value, UINT64_MAX});
             img_buf->Layout = to_final.NewLayout;
         }
@@ -574,9 +616,7 @@ namespace ZEngine::Hardwares
                 auto& sb         = RetireStagingBuffers[pool_index][i];
                 if (sb.Handle != VK_NULL_HANDLE)
                 {
-                    vmaDestroyBuffer(Device->VmaAllocatorValue, sb.Handle, sb.Allocation);
-                    sb.Handle     = VK_NULL_HANDLE;
-                    sb.Allocation = VK_NULL_HANDLE;
+                    Device->GpuMem.FreeBuffer(sb);
                 }
             }
         }
@@ -600,9 +640,7 @@ namespace ZEngine::Hardwares
                     auto& tsb          = TransferRetireStagingBuffers[pool_index][i];
                     if (tsb.Handle != VK_NULL_HANDLE)
                     {
-                        vmaDestroyBuffer(Device->VmaAllocatorValue, tsb.Handle, tsb.Allocation);
-                        tsb.Handle     = VK_NULL_HANDLE;
-                        tsb.Allocation = VK_NULL_HANDLE;
+                        Device->GpuMem.FreeBuffer(tsb);
                     }
                 }
             }
@@ -796,18 +834,14 @@ namespace ZEngine::Hardwares
                 auto& sb = RetireStagingBuffers[p][i];
                 if (sb.Handle != VK_NULL_HANDLE)
                 {
-                    vmaDestroyBuffer(Device->VmaAllocatorValue, sb.Handle, sb.Allocation);
-                    sb.Handle     = VK_NULL_HANDLE;
-                    sb.Allocation = VK_NULL_HANDLE;
+                    Device->GpuMem.FreeBuffer(sb);
                 }
                 if (Device->HasSeperateTransfertQueueFamily)
                 {
                     auto& tsb = TransferRetireStagingBuffers[p][i];
                     if (tsb.Handle != VK_NULL_HANDLE)
                     {
-                        vmaDestroyBuffer(Device->VmaAllocatorValue, tsb.Handle, tsb.Allocation);
-                        tsb.Handle     = VK_NULL_HANDLE;
-                        tsb.Allocation = VK_NULL_HANDLE;
+                        Device->GpuMem.FreeBuffer(tsb);
                     }
                 }
             }

--- a/ZEngine/ZEngine/Hardwares/AsyncResourceLoader.h
+++ b/ZEngine/ZEngine/Hardwares/AsyncResourceLoader.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <ZEngine/Core/Memory/GpuAllocator.h>
 #include <ZEngine/Helpers/ThreadSafeQueue.h>
 #include <ZEngine/Rendering/Primitives/Semaphore.h>
 #include <ZEngine/Rendering/Textures/Texture.h>
@@ -7,9 +8,12 @@
 
 namespace ZEngine::Hardwares
 {
+    using Core::Memory::BufferImage;
+    using Core::Memory::BufferView;
+    using Core::Memory::GpuMemoryDomain;
+
     struct VulkanDevice;
     struct AsyncGPUOperation;
-    struct BufferView;
     struct CommandBuffer;
 
     struct TextureFileRequest

--- a/ZEngine/ZEngine/Hardwares/DeferredFreeQueue.h
+++ b/ZEngine/ZEngine/Hardwares/DeferredFreeQueue.h
@@ -1,0 +1,116 @@
+#pragma once
+#include <ZEngine/Core/Memory/GpuAllocator.h>
+#include <ZEngine/Rendering/ResourceTypes.h>
+
+namespace ZEngine::Hardwares
+{
+    struct DeferredFreeEntry
+    {
+        enum class Kind : uint8_t
+        {
+            Buffer   = 0,
+            Image    = 1,
+            VkHandle = 2,
+        };
+        Kind     EntryKind     = Kind::VkHandle;
+        uint64_t TimelineValue = 0;
+        union Payload
+        {
+            Core::Memory::BufferView  Buffer;
+            Core::Memory::BufferImage Image;
+            struct
+            {
+                void*                         Handle;
+                Rendering::DeviceResourceType Type;
+                void*                         Extra; // used for DESCRIPTORSET pool pointer
+            } Vk;
+
+            Payload() : Vk{} {}
+            ~Payload() {}
+        } Data;
+    };
+
+    struct DeferredFreeQueue
+    {
+        static constexpr uint32_t kCapacity          = 2048;
+
+        DeferredFreeEntry         Entries[kCapacity] = {};
+        uint32_t                  Head               = 0;
+        uint32_t                  Tail               = 0;
+
+        void                      Enqueue(DeferredFreeEntry entry)
+        {
+            Entries[Tail] = entry;
+            Tail          = (Tail + 1) % kCapacity;
+        }
+
+        void Drain(Core::Memory::GpuAllocator* alloc, VkDevice device, uint64_t completed_timeline_value)
+        {
+            while (Head != Tail && Entries[Head].TimelineValue <= completed_timeline_value)
+            {
+                DeferredFreeEntry& e = Entries[Head];
+
+                switch (e.EntryKind)
+                {
+                    case DeferredFreeEntry::Kind::Buffer:
+                        alloc->FreeBuffer(e.Data.Buffer);
+                        break;
+
+                    case DeferredFreeEntry::Kind::Image:
+                        alloc->FreeImage(e.Data.Image, device);
+                        break;
+
+                    case DeferredFreeEntry::Kind::VkHandle:
+                        switch (e.Data.Vk.Type)
+                        {
+                            case Rendering::DeviceResourceType::SAMPLER:
+                                // vkDestroySampler(device, reinterpret_cast<VkSampler>(e.Data.Vk.Handle), nullptr);
+                                break;
+                            case Rendering::DeviceResourceType::FRAMEBUFFER:
+                                vkDestroyFramebuffer(device, reinterpret_cast<VkFramebuffer>(e.Data.Vk.Handle), nullptr);
+                                break;
+                            case Rendering::DeviceResourceType::IMAGEVIEW:
+                                vkDestroyImageView(device, reinterpret_cast<VkImageView>(e.Data.Vk.Handle), nullptr);
+                                break;
+                            case Rendering::DeviceResourceType::RENDERPASS:
+                                vkDestroyRenderPass(device, reinterpret_cast<VkRenderPass>(e.Data.Vk.Handle), nullptr);
+                                break;
+                            case Rendering::DeviceResourceType::PIPELINE_LAYOUT:
+                                vkDestroyPipelineLayout(device, reinterpret_cast<VkPipelineLayout>(e.Data.Vk.Handle), nullptr);
+                                break;
+                            case Rendering::DeviceResourceType::PIPELINE:
+                                vkDestroyPipeline(device, reinterpret_cast<VkPipeline>(e.Data.Vk.Handle), nullptr);
+                                break;
+                            case Rendering::DeviceResourceType::DESCRIPTORSETLAYOUT:
+                                vkDestroyDescriptorSetLayout(device, reinterpret_cast<VkDescriptorSetLayout>(e.Data.Vk.Handle), nullptr);
+                                break;
+                            case Rendering::DeviceResourceType::DESCRIPTORPOOL:
+                                vkDestroyDescriptorPool(device, reinterpret_cast<VkDescriptorPool>(e.Data.Vk.Handle), nullptr);
+                                break;
+                            case Rendering::DeviceResourceType::SEMAPHORE:
+                                vkDestroySemaphore(device, reinterpret_cast<VkSemaphore>(e.Data.Vk.Handle), nullptr);
+                                break;
+                            case Rendering::DeviceResourceType::FENCE:
+                                vkDestroyFence(device, reinterpret_cast<VkFence>(e.Data.Vk.Handle), nullptr);
+                                break;
+                            case Rendering::DeviceResourceType::DESCRIPTORSET:
+                            {
+                                auto ds = reinterpret_cast<VkDescriptorSet>(e.Data.Vk.Handle);
+                                vkFreeDescriptorSets(device, reinterpret_cast<VkDescriptorPool>(e.Data.Vk.Extra), 1, &ds);
+                                break;
+                            }
+                            case Rendering::DeviceResourceType::BUFFER:
+                            case Rendering::DeviceResourceType::BUFFERMEMORY:
+                            case Rendering::DeviceResourceType::IMAGE:
+                            case Rendering::DeviceResourceType::RESOURCE_COUNT:
+                                break;
+                        }
+                        break;
+                }
+
+                e    = {};
+                Head = (Head + 1) % kCapacity;
+            }
+        }
+    };
+} // namespace ZEngine::Hardwares

--- a/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
+++ b/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
@@ -152,8 +152,14 @@ namespace ZEngine::Hardwares
     {
         for (uint32_t i = 0; i < SwapchainImageCount; ++i)
         {
-            Device->EnqueueForDeletion(DeviceResourceType::IMAGEVIEW, SwapchainImageViews[i]);
-            Device->EnqueueForDeletion(DeviceResourceType::FRAMEBUFFER, SwapchainFramebuffers[i]);
+            DeferredFreeEntry iv = {};
+            iv.EntryKind         = DeferredFreeEntry::Kind::VkHandle;
+            iv.Data.Vk           = {SwapchainImageViews[i], DeviceResourceType::IMAGEVIEW, nullptr};
+            Device->DeferFree(iv);
+            DeferredFreeEntry fb = {};
+            fb.EntryKind         = DeferredFreeEntry::Kind::VkHandle;
+            fb.Data.Vk           = {SwapchainFramebuffers[i], DeviceResourceType::FRAMEBUFFER, nullptr};
+            Device->DeferFree(fb);
             SwapchainImageViews[i]   = VK_NULL_HANDLE;
             SwapchainFramebuffers[i] = VK_NULL_HANDLE;
         }
@@ -246,6 +252,7 @@ namespace ZEngine::Hardwares
         uint32_t image_idx            = 0;
         VkResult acquire_image_result = vkAcquireNextImageKHR(Device->LogicalDevice, SwapchainHandle, UINT64_MAX, frame.Acquired->GetHandle(), VK_NULL_HANDLE, &(image_idx));
         frame.Acquired->SetState(Primitives::SemaphoreState::Submitted);
+        Device->TickMemory();
 
         if (PresentCompletes[image_idx]->GetState() == Rendering::Primitives::FenceState::Submitted)
         {

--- a/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
+++ b/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
@@ -463,6 +463,8 @@ namespace ZEngine::Hardwares
             .pSignalSemaphores    = work_signal_semaphores,
         };
 
+        Device->FrameHeaps[CurrentFrame->Index].Flush(&Device->GpuMem);
+
         auto submit = vkQueueSubmit(queue.Handle, 1, &(submit_info_1), CurrentFrame->Fence->GetHandle());
         ZENGINE_VALIDATE_ASSERT(submit == VK_SUCCESS, "Failed to submit queue")
 

--- a/ZEngine/ZEngine/Hardwares/PerFrameUploadHeap.h
+++ b/ZEngine/ZEngine/Hardwares/PerFrameUploadHeap.h
@@ -1,0 +1,72 @@
+#pragma once
+#include <ZEngine/Core/Memory/GpuAllocator.h>
+#include <ZEngine/Helpers/MemoryOperations.h>
+#include <ZEngine/ZEngineDef.h>
+
+namespace ZEngine::Hardwares
+{
+    struct PerFrameHeapAlloc
+    {
+        uint32_t Offset;
+        uint32_t Size;
+    };
+
+    struct PerFrameUploadHeap
+    {
+        static constexpr uint32_t kCapacity  = static_cast<uint32_t>(Core::Memory::UniformBytes); // 64 MB per frame
+
+        VkBuffer                  Handle     = VK_NULL_HANDLE;
+        VmaAllocation             Allocation = nullptr;
+        void*                     MappedPtr  = nullptr;
+        uint32_t                  WritePos   = 0;
+        bool                      Coherent   = false;
+
+        void                      Initialize(Core::Memory::GpuAllocator* alloc, const char* debug_name)
+        {
+            Core::Memory::BufferView view = alloc->AllocateBuffer(kCapacity, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, Core::Memory::GpuMemoryDomain::HostUniform, debug_name);
+            Handle                        = view.Handle;
+            Allocation                    = view.Allocation;
+            MappedPtr                     = nullptr;
+
+            VmaAllocationInfo info        = {};
+            vmaGetAllocationInfo(alloc->Allocator, Allocation, &info);
+            MappedPtr                       = info.pMappedData;
+
+            VkMemoryPropertyFlags mem_flags = 0;
+            vmaGetAllocationMemoryProperties(alloc->Allocator, Allocation, &mem_flags);
+            Coherent = (mem_flags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) != 0;
+        }
+
+        void Shutdown(Core::Memory::GpuAllocator* alloc)
+        {
+            Core::Memory::BufferView view = {};
+            view.Handle                   = Handle;
+            view.Allocation               = Allocation;
+            alloc->FreeBuffer(view);
+            Handle     = VK_NULL_HANDLE;
+            Allocation = nullptr;
+            MappedPtr  = nullptr;
+        }
+
+        void Reset()
+        {
+            WritePos = 0;
+        }
+
+        PerFrameHeapAlloc Push(const void* data, uint32_t size, uint32_t alignment)
+        {
+            uint32_t aligned_pos = (WritePos + alignment - 1) & ~(alignment - 1);
+            ZENGINE_VALIDATE_ASSERT(aligned_pos + size <= kCapacity, "PerFrameUploadHeap full")
+            Helpers::secure_memcpy(reinterpret_cast<uint8_t*>(MappedPtr) + aligned_pos, size, data, size);
+            WritePos = aligned_pos + size;
+            return {aligned_pos, size};
+        }
+
+        void Flush(Core::Memory::GpuAllocator* alloc)
+        {
+            if (!Coherent && WritePos > 0)
+                vmaFlushAllocation(alloc->Allocator, Allocation, 0, WritePos);
+        }
+    };
+
+} // namespace ZEngine::Hardwares

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
@@ -45,9 +45,7 @@ namespace ZEngine::Hardwares
         ShaderManager.Initialize(arena, 300);
         VertexBufferSetManager.Initialize(arena, 300);
         StorageBufferSetManager.Initialize(arena, 300);
-        IndirectBufferSetManager.Initialize(arena, 300);
         IndexBufferSetManager.Initialize(arena, 300);
-        UniformBufferSetManager.Initialize(arena, 300);
 
         ShaderCaches.init(arena, 10);
         m_queue_map.init(arena, 4);
@@ -474,6 +472,16 @@ namespace ZEngine::Hardwares
         CommandBufferMgr->Initialize(this, SwapchainPtr->BufferredFrameCount);
 
         /*
+         * Creating Per-Frame Upload Heaps
+         */
+        for (uint32_t i = 0; i < SwapchainPtr->BufferredFrameCount; ++i)
+        {
+            char name[32];
+            snprintf(name, sizeof(name), "FrameHeap[%u]", i);
+            FrameHeaps[i].Initialize(&GpuMem, name);
+        }
+
+        /*
          * Creating Global Descriptor Pool for : Textures, Samplers
          */
         VkSamplerCreateInfo linear_sampler_create_info                   = {};
@@ -677,9 +685,7 @@ namespace ZEngine::Hardwares
         Image2DBufferManager.Dispose();
         VertexBufferSetManager.Dispose();
         StorageBufferSetManager.Dispose();
-        IndirectBufferSetManager.Dispose();
         IndexBufferSetManager.Dispose();
-        UniformBufferSetManager.Dispose();
         ShaderManager.Dispose();
 
         SwapchainPtr->Dispose();
@@ -708,6 +714,11 @@ namespace ZEngine::Hardwares
         {
             vkDestroyDescriptorPool(LogicalDevice, GlobalDescriptorPoolHandle, nullptr);
             GlobalDescriptorPoolHandle = VK_NULL_HANDLE;
+        }
+
+        for (uint32_t i = 0; i < SwapchainPtr->BufferredFrameCount; ++i)
+        {
+            FrameHeaps[i].Shutdown(&GpuMem);
         }
 
         ZENGINE_DESTROY_VULKAN_HANDLE(Instance, vkDestroySurfaceKHR, Surface, nullptr)
@@ -1102,20 +1113,6 @@ namespace ZEngine::Hardwares
         return handle;
     }
 
-    IndirectBufferSetHandle VulkanDevice::CreateIndirectBufferSet()
-    {
-        auto handle = IndirectBufferSetManager.Create();
-        auto buffer = IndirectBufferSetManager.Access(handle);
-        buffer->set.init(Arena, SwapchainPtr->BufferredFrameCount, SwapchainPtr->BufferredFrameCount);
-
-        for (unsigned i = 0; i < SwapchainPtr->BufferredFrameCount; ++i)
-        {
-            buffer->set[i] = ZPushStructCtorArgs(Arena, IndirectBuffer, this);
-        }
-
-        return handle;
-    }
-
     IndexBufferSetHandle VulkanDevice::CreateIndexBufferSet()
     {
         auto handle = IndexBufferSetManager.Create();
@@ -1125,20 +1122,6 @@ namespace ZEngine::Hardwares
         for (unsigned i = 0; i < SwapchainPtr->BufferredFrameCount; ++i)
         {
             buffer->set[i] = ZPushStructCtorArgs(Arena, IndexBuffer, this);
-        }
-
-        return handle;
-    }
-
-    UniformBufferSetHandle VulkanDevice::CreateUniformBufferSet()
-    {
-        auto handle = UniformBufferSetManager.Create();
-        auto buffer = UniformBufferSetManager.Access(handle);
-        buffer->set.init(Arena, SwapchainPtr->BufferredFrameCount, SwapchainPtr->BufferredFrameCount);
-
-        for (unsigned i = 0; i < SwapchainPtr->BufferredFrameCount; ++i)
-        {
-            buffer->set[i] = ZPushStructCtorArgs(Arena, UniformBuffer, this);
         }
 
         return handle;
@@ -1403,7 +1386,7 @@ namespace ZEngine::Hardwares
         }
     }
 
-    void CommandBuffer::BindDescriptorSets(uint32_t frame_index)
+    void CommandBuffer::BindDescriptorSets(uint32_t frame_index, const uint32_t* dynamic_offsets, uint32_t dynamic_offset_count)
     {
         ZENGINE_VALIDATE_ASSERT(m_command_buffer != nullptr, "Command buffer can't be null")
 
@@ -1419,8 +1402,6 @@ namespace ZEngine::Hardwares
             Array<VkDescriptorSet> frame_sets         = {};
             frame_sets.init(scratch.Arena, 5);
 
-            // Since SetLayout is ordered by defined Set in shader source
-            // We're safe to use index as Set
             for (uint32_t i = 0; i < set_layout.size(); ++i)
             {
                 if (descriptor_set_map.contains(i))
@@ -1429,9 +1410,25 @@ namespace ZEngine::Hardwares
                 }
             }
 
-            if(!frame_sets.empty())
+            if (!frame_sets.empty())
             {
-                vkCmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, frame_sets.size(), frame_sets.data(), 0, nullptr);
+                // Count actual dynamic bindings in this shader to avoid validation errors
+                uint32_t actual_dynamic_count = 0;
+                for (const auto& lbs : shader->LayoutBindingSpecificationMap)
+                {
+                    for (uint32_t i = 0; i < lbs.second.size(); ++i)
+                    {
+                        if (lbs.second[i].DescriptorTypeValue == Rendering::Specifications::DescriptorType::UNIFORM_BUFFER_DYNAMIC ||
+                            lbs.second[i].DescriptorTypeValue == Rendering::Specifications::DescriptorType::STORAGE_BUFFER_DYNAMIC)
+                        {
+                            ++actual_dynamic_count;
+                        }
+                    }
+                }
+
+                const uint32_t* offsets = (actual_dynamic_count > 0) ? dynamic_offsets : nullptr;
+                uint32_t        count   = (actual_dynamic_count > 0) ? actual_dynamic_count : 0;
+                vkCmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, frame_sets.size(), frame_sets.data(), count, offsets);
             }
             ZReleaseScratch(scratch);
         }
@@ -1459,22 +1456,21 @@ namespace ZEngine::Hardwares
         vkCmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline->Handle);
     }
 
-    void CommandBuffer::DrawIndirect(const Hardwares::IndirectBuffer& buffer)
+    void CommandBuffer::DrawIndirect(VkBuffer buffer, uint32_t offset, uint32_t draw_count)
     {
         ZENGINE_VALIDATE_ASSERT(m_command_buffer != nullptr, "Command buffer can't be null")
-        if (buffer.GetNativeBufferHandle())
+        if (buffer != VK_NULL_HANDLE && draw_count > 0)
         {
-            vkCmdDrawIndirect(m_command_buffer, reinterpret_cast<VkBuffer>(buffer.GetNativeBufferHandle()), 0, buffer.CommandCount, sizeof(VkDrawIndirectCommand));
+            vkCmdDrawIndirect(m_command_buffer, buffer, offset, draw_count, sizeof(VkDrawIndirectCommand));
         }
     }
 
-    void CommandBuffer::DrawIndexedIndirect(const Hardwares::IndirectBuffer& buffer, uint32_t count)
+    void CommandBuffer::DrawIndexedIndirect(VkBuffer buffer, uint32_t offset, uint32_t count)
     {
         ZENGINE_VALIDATE_ASSERT(m_command_buffer != nullptr, "Command buffer can't be null")
-
-        if (buffer.GetNativeBufferHandle())
+        if (buffer != VK_NULL_HANDLE && count > 0)
         {
-            vkCmdDrawIndexedIndirect(m_command_buffer, reinterpret_cast<VkBuffer>(buffer.GetNativeBufferHandle()), 0, count, sizeof(VkDrawIndexedIndirectCommand));
+            vkCmdDrawIndexedIndirect(m_command_buffer, buffer, offset, count, sizeof(VkDrawIndexedIndirectCommand));
         }
     }
 
@@ -1848,54 +1844,6 @@ namespace ZEngine::Hardwares
         return m_device->CreateBuffer(m_total_size, VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT, Core::Memory::GpuMemoryDomain::DeviceGeometry, "IndexBuffer");
     }
 
-    BufferView IndirectBuffer::CreateBuffer()
-    {
-        return m_device->CreateBuffer(static_cast<VkDeviceSize>(m_total_size), VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, Core::Memory::GpuMemoryDomain::DeviceGeometry, "IndirectBuffer");
-    }
-
-    BufferView UniformBuffer::CreateBuffer()
-    {
-        return m_device->CreateBuffer(static_cast<VkDeviceSize>(m_total_size), VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, Core::Memory::GpuMemoryDomain::HostUniform, "UniformBuffer");
-    }
-
-    void IndirectBuffer::Upload(uint8_t frame_index, uint8_t thread_index, const VkDrawIndirectCommand* data, size_t byte_size)
-    {
-        if (byte_size == 0)
-        {
-            return;
-        }
-
-        CommandCount = byte_size / sizeof(VkDrawIndirectCommand);
-        IGraphicBuffer::Upload(frame_index, thread_index, data, byte_size);
-    }
-
-    void IndirectBuffer::Write(uint8_t frame_index, uint8_t thread_index, const void* data, size_t byte_size)
-    {
-        IGraphicBuffer::Write(frame_index, thread_index, data, byte_size);
-        CommandCount = byte_size / sizeof(VkDrawIndirectCommand);
-    }
-
-    void IndirectBuffer::CleanUpMemory()
-    {
-        CommandCount = 0;
-        IGraphicBuffer::CleanUpMemory();
-    }
-
-    void UniformBuffer::Allocate(uint64_t byte_size, const char* debug_name)
-    {
-        if (m_total_size < byte_size || (!m_uniform_buffer_mapped))
-        {
-            IGraphicBuffer::Allocate(byte_size, debug_name);
-            m_uniform_buffer_mapped = true;
-        }
-    }
-
-    void UniformBuffer::CleanUpMemory()
-    {
-        IGraphicBuffer::CleanUpMemory();
-        m_uniform_buffer_mapped = false;
-    }
-
     void Image2DBuffer::Construct(Hardwares::VulkanDevice* device)
     {
         Device = device;
@@ -2213,6 +2161,19 @@ namespace ZEngine::Hardwares
         PendingFree.Drain(&GpuMem, LogicalDevice, completed);
         GpuMem.Ring.Drain(completed);
         GpuMem.SampleBudgets();
+
+        uint32_t fi = SwapchainPtr->CurrentFrame == nullptr ? 0u : SwapchainPtr->CurrentFrame->Index;
+        FrameHeaps[fi].Reset();
+    }
+
+    uint32_t VulkanDevice::MinUniformBufferOffsetAlignment() const
+    {
+        return static_cast<uint32_t>(PhysicalDeviceProperties.properties.limits.minUniformBufferOffsetAlignment);
+    }
+
+    uint32_t VulkanDevice::MinStorageBufferOffsetAlignment() const
+    {
+        return static_cast<uint32_t>(PhysicalDeviceProperties.properties.limits.minStorageBufferOffsetAlignment);
     }
 
     void VulkanDevice::DeferFree(DeferredFreeEntry entry)

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
@@ -71,9 +71,10 @@ namespace ZEngine::Hardwares
 
         Array<const char*> validation_layer_name_collection;
         validation_layer_name_collection.init(scratch.Arena, 4);
-        validation_layer_name_collection.push("VK_LAYER_LUNARG_api_dump");
         validation_layer_name_collection.push("VK_LAYER_KHRONOS_validation");
         validation_layer_name_collection.push("VK_LAYER_LUNARG_monitor");
+        // api_dump intentionally excluded — enable via VK_INSTANCE_LAYERS=VK_LAYER_LUNARG_api_dump
+        // when inspecting a specific failing call. Leaving it in floods logs at 50+ MB/run.
 #ifndef __APPLE__
         validation_layer_name_collection.push("VK_LAYER_LUNARG_screenshot");
 #endif

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
@@ -1,26 +1,3 @@
-/*
- * We define those Macros before inclusion of VulkanDevice.h so we can enable impl from VMA header
- */
-#define VMA_IMPLEMENTATION
-#define VMA_VULKAN_VERSION 1003000 // Vulkan 1.3
-
-#ifdef VMA_DEBUG_DETECT_CORRUPTION
-#include <cstdio>
-#ifdef _WIN32
-#include <windows.h>
-#define VMA_DEBUG_LOG_FORMAT(format, ...)                                          \
-    do                                                                             \
-    {                                                                              \
-        char __vma_buf[512];                                                       \
-        snprintf(__vma_buf, sizeof(__vma_buf), "[VMA] " format "\n", __VA_ARGS__); \
-        OutputDebugStringA(__vma_buf);                                             \
-        fputs(__vma_buf, stderr);                                                  \
-    } while (0)
-#else
-#define VMA_DEBUG_LOG_FORMAT(format, ...) fprintf(stderr, "[VMA] " format "\n", __VA_ARGS__)
-#endif
-#endif
-
 #include <ZEngine/Hardwares/VulkanDevice.h>
 #include <ZEngine/Helpers/MemoryOperations.h>
 #include <ZEngine/Helpers/ThreadPool.h>
@@ -71,9 +48,7 @@ namespace ZEngine::Hardwares
         IndirectBufferSetManager.Initialize(arena, 300);
         IndexBufferSetManager.Initialize(arena, 300);
         UniformBufferSetManager.Initialize(arena, 300);
-        DirtyResources.Initialize(arena, 300);
-        DirtyBuffers.Initialize(arena, 500);
-        DirtyBufferImages.Initialize(arena, 300);
+
         ShaderCaches.init(arena, 10);
         m_queue_map.init(arena, 4);
 
@@ -469,13 +444,23 @@ namespace ZEngine::Hardwares
             }
         }
 
+        bool has_budget = false;
+        bool has_bda    = false;
+        for (uint32_t ext_i = 0; ext_i < requested_device_extension_layer_name_collection.size(); ++ext_i)
+        {
+            const char* ext = requested_device_extension_layer_name_collection[ext_i];
+            if (strcmp(ext, VK_EXT_MEMORY_BUDGET_EXTENSION_NAME) == 0)
+                has_budget = true;
+            if (strcmp(ext, VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME) == 0)
+                has_bda = true;
+        }
+
         ZReleaseScratch(scratch);
 
         /*
          * Creating VMA Allocators
          */
-        VmaAllocatorCreateInfo vma_allocator_create_info = {.physicalDevice = PhysicalDevice, .device = LogicalDevice, .instance = Instance, .vulkanApiVersion = VK_API_VERSION_1_3};
-        ZENGINE_VALIDATE_ASSERT(vmaCreateAllocator(&vma_allocator_create_info, &VmaAllocatorValue) == VK_SUCCESS, "Failed to create VMA Allocator")
+        GpuMem.Initialize(PhysicalDevice, LogicalDevice, Instance, has_budget, has_bda);
 
         /*
          * Creating Swapchain
@@ -659,15 +644,14 @@ namespace ZEngine::Hardwares
         ZReleaseScratch(scratch);
 
         AsyncResLoader->Initialize(this);
-
-        ThreadPoolHelper::Submit([this] { DirtyCollector(); });
     }
 
     void VulkanDevice::Deinitialize()
     {
         QueueWaitAll();
 
-        RunningDirtyCollector.store(false, std::memory_order_release);
+        PendingFree.Drain(&GpuMem, LogicalDevice, UINT64_MAX);
+        GpuMem.Ring.Drain(UINT64_MAX);
 
         AsyncResLoader->Shutdown();
 
@@ -703,41 +687,38 @@ namespace ZEngine::Hardwares
 
         for (auto set_layout : ShaderReservedDescriptorSetLayoutMap)
         {
-            EnqueueForDeletion(Rendering::DeviceResourceType::DESCRIPTORSETLAYOUT, set_layout.second);
+            vkDestroyDescriptorSetLayout(LogicalDevice, reinterpret_cast<VkDescriptorSetLayout>(set_layout.second), nullptr);
         }
         ShaderReservedDescriptorSetLayoutMap.clear();
 
         if (EmptyDescriptorPoolHandle)
         {
-            EnqueueForDeletion(Rendering::DeviceResourceType::DESCRIPTORPOOL, EmptyDescriptorPoolHandle);
+            vkDestroyDescriptorPool(LogicalDevice, EmptyDescriptorPoolHandle, nullptr);
             EmptyDescriptorPoolHandle = VK_NULL_HANDLE;
             EmptyDescriptorSet        = VK_NULL_HANDLE;
         }
 
         if (EmptyDescriptorSetLayout)
         {
-            EnqueueForDeletion(Rendering::DeviceResourceType::DESCRIPTORSETLAYOUT, EmptyDescriptorSetLayout);
+            vkDestroyDescriptorSetLayout(LogicalDevice, EmptyDescriptorSetLayout, nullptr);
             EmptyDescriptorSetLayout = VK_NULL_HANDLE;
         }
 
         if (GlobalDescriptorPoolHandle)
         {
-            EnqueueForDeletion(Rendering::DeviceResourceType::DESCRIPTORPOOL, GlobalDescriptorPoolHandle);
+            vkDestroyDescriptorPool(LogicalDevice, GlobalDescriptorPoolHandle, nullptr);
             GlobalDescriptorPoolHandle = VK_NULL_HANDLE;
         }
 
-        __cleanupBufferDirtyResource();
-
-        __cleanupBufferImageDirtyResource();
-
-        __cleanupDirtyResource();
-
         ZENGINE_DESTROY_VULKAN_HANDLE(Instance, vkDestroySurfaceKHR, Surface, nullptr)
+
+        // Drain deferred frees enqueued during the Dispose() calls above
+        PendingFree.Drain(&GpuMem, LogicalDevice, UINT64_MAX);
     }
 
     void VulkanDevice::Dispose()
     {
-        vmaDestroyAllocator(VmaAllocatorValue);
+        GpuMem.Shutdown();
 
         if (__destroyDebugMessengerPtr)
         {
@@ -839,32 +820,6 @@ namespace ZEngine::Hardwares
         return true;
     }
 
-    void VulkanDevice::EnqueueForDeletion(Rendering::DeviceResourceType resource_type, void* const handle)
-    {
-        if (handle)
-        {
-            DirtyResources.Add({.FrameIndex = SwapchainPtr->CurrentFrame->Index, .Handle = handle, .Type = resource_type});
-        }
-    }
-
-    void VulkanDevice::EnqueueForDeletion(Rendering::DeviceResourceType resource_type, DirtyResource resource)
-    {
-        if (resource.Handle)
-        {
-            DirtyResources.Add(resource);
-        }
-    }
-
-    void VulkanDevice::EnqueueBufferForDeletion(BufferView& buffer)
-    {
-        DirtyBuffers.Add(buffer);
-    }
-
-    void VulkanDevice::EnqueueBufferImageForDeletion(BufferImage& buffer)
-    {
-        DirtyBufferImages.Add(buffer);
-    }
-
     void VulkanDevice::QueueWait(Rendering::QueueType type)
     {
         if (!HasSeperateTransfertQueueFamily)
@@ -920,170 +875,30 @@ namespace ZEngine::Hardwares
         return VK_FALSE;
     }
 
-    void VulkanDevice::__cleanupDirtyResource()
-    {
-        size_t dirty_resource_count = DirtyResources.Head();
-        for (size_t i = 0; i < dirty_resource_count; ++i)
-        {
-            auto handle = DirtyResources.ToHandle(i);
-
-            if (!handle)
-            {
-                continue;
-            }
-
-            DirtyResource& res_handle = DirtyResources[handle];
-            switch (res_handle.Type)
-            {
-                case Rendering::DeviceResourceType::SAMPLER:
-                    // vkDestroySampler(LogicalDevice, reinterpret_cast<VkSampler>(res_handle.Handle), nullptr);
-                    break;
-                case Rendering::DeviceResourceType::FRAMEBUFFER:
-                    vkDestroyFramebuffer(LogicalDevice, reinterpret_cast<VkFramebuffer>(res_handle.Handle), nullptr);
-                    break;
-                case Rendering::DeviceResourceType::IMAGEVIEW:
-                    vkDestroyImageView(LogicalDevice, reinterpret_cast<VkImageView>(res_handle.Handle), nullptr);
-                    break;
-                case Rendering::DeviceResourceType::IMAGE:
-                    vkDestroyImage(LogicalDevice, reinterpret_cast<VkImage>(res_handle.Handle), nullptr);
-                    break;
-                case Rendering::DeviceResourceType::RENDERPASS:
-                    vkDestroyRenderPass(LogicalDevice, reinterpret_cast<VkRenderPass>(res_handle.Handle), nullptr);
-                    break;
-                case Rendering::DeviceResourceType::BUFFERMEMORY:
-                    vkFreeMemory(LogicalDevice, reinterpret_cast<VkDeviceMemory>(res_handle.Handle), nullptr);
-                    break;
-                case Rendering::DeviceResourceType::BUFFER:
-                    vkDestroyBuffer(LogicalDevice, reinterpret_cast<VkBuffer>(res_handle.Handle), nullptr);
-                    break;
-                case Rendering::DeviceResourceType::PIPELINE_LAYOUT:
-                    vkDestroyPipelineLayout(LogicalDevice, reinterpret_cast<VkPipelineLayout>(res_handle.Handle), nullptr);
-                    break;
-                case Rendering::DeviceResourceType::PIPELINE:
-                    vkDestroyPipeline(LogicalDevice, reinterpret_cast<VkPipeline>(res_handle.Handle), nullptr);
-                    break;
-                case Rendering::DeviceResourceType::DESCRIPTORSETLAYOUT:
-                    vkDestroyDescriptorSetLayout(LogicalDevice, reinterpret_cast<VkDescriptorSetLayout>(res_handle.Handle), nullptr);
-                    break;
-                case Rendering::DeviceResourceType::DESCRIPTORPOOL:
-                    vkDestroyDescriptorPool(LogicalDevice, reinterpret_cast<VkDescriptorPool>(res_handle.Handle), nullptr);
-                    break;
-                case Rendering::DeviceResourceType::SEMAPHORE:
-                    vkDestroySemaphore(LogicalDevice, reinterpret_cast<VkSemaphore>(res_handle.Handle), nullptr);
-                    break;
-                case Rendering::DeviceResourceType::FENCE:
-                    vkDestroyFence(LogicalDevice, reinterpret_cast<VkFence>(res_handle.Handle), nullptr);
-                    break;
-                case Rendering::DeviceResourceType::DESCRIPTORSET:
-                {
-                    auto ds = reinterpret_cast<VkDescriptorSet>(res_handle.Handle);
-                    vkFreeDescriptorSets(LogicalDevice, reinterpret_cast<VkDescriptorPool>(res_handle.Data1), 1, &ds);
-                    break;
-                }
-                case DeviceResourceType::RESOURCE_COUNT:
-                    break;
-            }
-
-            DirtyResources.Remove(handle);
-        }
-    }
-
-    void VulkanDevice::__cleanupBufferDirtyResource()
-    {
-        size_t dirty_buffer_count = DirtyBuffers.Head();
-        for (size_t i = 0; i < dirty_buffer_count; ++i)
-        {
-            auto handle = DirtyBuffers.ToHandle(i);
-
-            if (!handle)
-            {
-                continue;
-            }
-
-            BufferView& buffer = DirtyBuffers[handle];
-            vmaDestroyBuffer(VmaAllocatorValue, buffer.Handle, buffer.Allocation);
-            DirtyBuffers.Remove(handle);
-        }
-    }
-
-    void VulkanDevice::__cleanupBufferImageDirtyResource()
-    {
-        size_t dirty_buffer_image_count = DirtyBufferImages.Head();
-        for (size_t i = 0; i < dirty_buffer_image_count; ++i)
-        {
-            auto handle = DirtyBufferImages.ToHandle(i);
-
-            if (!handle)
-            {
-                continue;
-            }
-
-            BufferImage& buffer = DirtyBufferImages[handle];
-
-            vkDestroyImageView(LogicalDevice, buffer.ViewHandle, nullptr);
-            // vkDestroySampler(LogicalDevice, buffer.Sampler, nullptr);
-            vmaDestroyImage(VmaAllocatorValue, buffer.Handle, buffer.Allocation);
-
-            DirtyBufferImages.Remove(handle);
-        }
-    }
-
     void VulkanDevice::MapAndCopyToMemory(BufferView& buffer, size_t data_size, const void* data)
     {
-        void* mapped_memory;
         if (data)
         {
-            ZENGINE_VALIDATE_ASSERT(vmaMapMemory(VmaAllocatorValue, buffer.Allocation, &mapped_memory) == VK_SUCCESS, "Failed to map memory")
-            ZENGINE_VALIDATE_ASSERT(Helpers::secure_memcpy(mapped_memory, data_size, data, data_size) == Helpers::MEMORY_OP_SUCCESS, "Failed to perform memory copy operation")
-            vmaUnmapMemory(VmaAllocatorValue, buffer.Allocation);
+            ZENGINE_VALIDATE_ASSERT(vmaCopyMemoryToAllocation(GpuMem.Allocator, data, buffer.Allocation, 0, data_size) == VK_SUCCESS, "Failed to map and copy memory")
         }
     }
 
-    BufferView VulkanDevice::CreateBuffer(VkDeviceSize byte_size, VkBufferUsageFlags buffer_usage, VmaAllocationCreateFlags vma_create_flags)
+    BufferView VulkanDevice::CreateBuffer(VkDeviceSize byte_size, VkBufferUsageFlags buffer_usage, Core::Memory::GpuMemoryDomain domain, const char* debug_name)
     {
-        BufferView         buffer_view                 = {};
-        VkBufferCreateInfo buffer_create_info          = {};
-        buffer_create_info.sType                       = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-        buffer_create_info.size                        = byte_size;
-        buffer_create_info.usage                       = buffer_usage;
-        buffer_create_info.sharingMode                 = VK_SHARING_MODE_EXCLUSIVE;
+        BufferView buffer_view = GpuMem.AllocateBuffer(byte_size, buffer_usage, domain, debug_name);
 
-        VmaAllocationCreateInfo allocation_create_info = {};
-        allocation_create_info.usage                   = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
-        allocation_create_info.flags                   = vma_create_flags;
-
-        ZENGINE_VALIDATE_ASSERT(vmaCreateBuffer(VmaAllocatorValue, &buffer_create_info, &allocation_create_info, &(buffer_view.Handle), &(buffer_view.Allocation), nullptr) == VK_SUCCESS, "Failed to create buffer");
-
-        /*
-         * Zeroing the buffer
-         */
-        VmaAllocationInfo allocation_info = {};
-        vmaGetAllocationInfo(VmaAllocatorValue, buffer_view.Allocation, &allocation_info);
-        Helpers::secure_memset(allocation_info.pMappedData, 0, byte_size, byte_size);
-
-        // Metadata info
         buffer_view.FrameIndex = SwapchainPtr->CurrentFrame == nullptr ? 0u : SwapchainPtr->CurrentFrame->Index;
 
         if (buffer_usage & VK_BUFFER_USAGE_VERTEX_BUFFER_BIT)
-        {
-            buffer_view.Type = BufferType::VERTEX;
-        }
+            buffer_view.Type = Core::Memory::BufferType::VERTEX;
         else if (buffer_usage & VK_BUFFER_USAGE_INDEX_BUFFER_BIT)
-        {
-            buffer_view.Type = BufferType::INDEX;
-        }
+            buffer_view.Type = Core::Memory::BufferType::INDEX;
         else if (buffer_usage & VK_BUFFER_USAGE_STORAGE_BUFFER_BIT)
-        {
-            buffer_view.Type = BufferType::STORAGE;
-        }
+            buffer_view.Type = Core::Memory::BufferType::STORAGE;
         else if (buffer_usage & VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT)
-        {
-            buffer_view.Type = BufferType::INDIRECT;
-        }
+            buffer_view.Type = Core::Memory::BufferType::INDIRECT;
         else if (buffer_usage & VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT)
-        {
-            buffer_view.Type = BufferType::UNIFORM;
-        }
+            buffer_view.Type = Core::Memory::BufferType::UNIFORM;
 
         return buffer_view;
     }
@@ -1156,7 +971,6 @@ namespace ZEngine::Hardwares
 
     BufferImage VulkanDevice::CreateImage(uint32_t width, uint32_t height, VkImageType image_type, VkImageViewType image_view_type, VkFormat image_format, VkImageTiling image_tiling, VkImageLayout image_initial_layout, VkImageUsageFlags image_usage, VkSharingMode image_sharing_mode, VkSampleCountFlagBits image_sample_count, VkMemoryPropertyFlags requested_properties, VkImageAspectFlagBits image_aspect_flag, uint32_t layer_count, VkImageCreateFlags image_create_flag_bit)
     {
-        BufferImage       buffer_image                 = {};
         VkImageCreateInfo image_create_info            = {};
         image_create_info.sType                        = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
         image_create_info.flags                        = image_create_flag_bit;
@@ -1173,15 +987,11 @@ namespace ZEngine::Hardwares
         image_create_info.sharingMode                  = image_sharing_mode;
         image_create_info.samples                      = image_sample_count;
 
-        VmaAllocationCreateInfo allocation_create_info = {};
-        // allocation_create_info.requiredFlags           = requested_properties;
-        allocation_create_info.usage                   = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
-        allocation_create_info.flags                   = VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT;
+        Core::Memory::GpuMemoryDomain domain = (image_usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT || image_usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
+            ? Core::Memory::GpuMemoryDomain::RenderTarget
+            : Core::Memory::GpuMemoryDomain::DeviceTexture;
 
-        ZENGINE_VALIDATE_ASSERT(vmaCreateImage(VmaAllocatorValue, &image_create_info, &allocation_create_info, &(buffer_image.Handle), &(buffer_image.Allocation), nullptr) == VK_SUCCESS, "Failed to create buffer");
-
-        buffer_image.ViewHandle = CreateImageView(buffer_image.Handle, image_format, image_view_type, image_aspect_flag, layer_count);
-        // buffer_image.Sampler    = GlobalLinearWrapSampler;
+        BufferImage buffer_image = GpuMem.AllocateImage(image_create_info, domain, LogicalDevice, image_aspect_flag, image_view_type, layer_count);
 
         // Metadata info
         buffer_image.FrameIndex = SwapchainPtr->CurrentFrame == nullptr ? 0u : SwapchainPtr->CurrentFrame->Index;
@@ -1332,141 +1142,6 @@ namespace ZEngine::Hardwares
         }
 
         return handle;
-    }
-
-    void VulkanDevice::DirtyCollector()
-{
-        RunningDirtyCollector.store(true, std::memory_order_release);
-        
-        ZENGINE_CORE_INFO("[*] Dirty Resource Collector started...")
-        
-        while (RunningDirtyCollector.load(std::memory_order_acquire))
-        {
-            uint32_t idle_count = SwapchainPtr->IdleFrameCount.value.load(std::memory_order_acquire);
-            
-            if (idle_count < SwapchainPtr->IdleFrameThreshold)
-            {
-                std::this_thread::sleep_for(std::chrono::milliseconds(50));
-                continue;
-            }
-            
-            
-            uint32_t dirty_resource_count = DirtyResources.Size();
-            for (uint32_t i = 0; i < dirty_resource_count; ++i)
-            {
-                auto handle = DirtyResources.ToHandle(i);
-                
-                if (!handle)
-                {
-                    continue;
-                }
-                
-                DirtyResource& res_handle = DirtyResources[handle];
-                if (res_handle.FrameIndex == SwapchainPtr->CurrentFrame->Index)
-                {
-                    switch (res_handle.Type)
-                    {
-                        case Rendering::DeviceResourceType::SAMPLER:
-                            // vkDestroySampler(LogicalDevice, reinterpret_cast<VkSampler>(res_handle.Handle), nullptr);
-                            break;
-                        case Rendering::DeviceResourceType::FRAMEBUFFER:
-                            vkDestroyFramebuffer(LogicalDevice, reinterpret_cast<VkFramebuffer>(res_handle.Handle), nullptr);
-                            break;
-                        case Rendering::DeviceResourceType::IMAGEVIEW:
-                            vkDestroyImageView(LogicalDevice, reinterpret_cast<VkImageView>(res_handle.Handle), nullptr);
-                            break;
-                        case Rendering::DeviceResourceType::IMAGE:
-                            vkDestroyImage(LogicalDevice, reinterpret_cast<VkImage>(res_handle.Handle), nullptr);
-                            break;
-                        case Rendering::DeviceResourceType::RENDERPASS:
-                            vkDestroyRenderPass(LogicalDevice, reinterpret_cast<VkRenderPass>(res_handle.Handle), nullptr);
-                            break;
-                        case Rendering::DeviceResourceType::BUFFERMEMORY:
-                            vkFreeMemory(LogicalDevice, reinterpret_cast<VkDeviceMemory>(res_handle.Handle), nullptr);
-                            break;
-                        case Rendering::DeviceResourceType::BUFFER:
-                            vkDestroyBuffer(LogicalDevice, reinterpret_cast<VkBuffer>(res_handle.Handle), nullptr);
-                            break;
-                        case Rendering::DeviceResourceType::PIPELINE_LAYOUT:
-                            vkDestroyPipelineLayout(LogicalDevice, reinterpret_cast<VkPipelineLayout>(res_handle.Handle), nullptr);
-                            break;
-                        case Rendering::DeviceResourceType::PIPELINE:
-                            vkDestroyPipeline(LogicalDevice, reinterpret_cast<VkPipeline>(res_handle.Handle), nullptr);
-                            break;
-                        case Rendering::DeviceResourceType::DESCRIPTORSETLAYOUT:
-                            vkDestroyDescriptorSetLayout(LogicalDevice, reinterpret_cast<VkDescriptorSetLayout>(res_handle.Handle), nullptr);
-                            break;
-                        case Rendering::DeviceResourceType::DESCRIPTORPOOL:
-                            vkDestroyDescriptorPool(LogicalDevice, reinterpret_cast<VkDescriptorPool>(res_handle.Handle), nullptr);
-                            break;
-                        case Rendering::DeviceResourceType::SEMAPHORE:
-                            vkDestroySemaphore(LogicalDevice, reinterpret_cast<VkSemaphore>(res_handle.Handle), nullptr);
-                            break;
-                        case Rendering::DeviceResourceType::FENCE:
-                            vkDestroyFence(LogicalDevice, reinterpret_cast<VkFence>(res_handle.Handle), nullptr);
-                            break;
-                        case Rendering::DeviceResourceType::DESCRIPTORSET:
-                        {
-                            auto ds = reinterpret_cast<VkDescriptorSet>(res_handle.Handle);
-                            vkFreeDescriptorSets(LogicalDevice, reinterpret_cast<VkDescriptorPool>(res_handle.Data1), 1, &ds);
-                            break;
-                        }
-                        case DeviceResourceType::RESOURCE_COUNT:
-                            break;
-                    }
-                    
-                    DirtyResources.Remove(handle);
-                }
-            }
-            
-            uint32_t dirty_buffer_count = DirtyBuffers.Size();
-            for (uint32_t i = 0; i < dirty_buffer_count; ++i)
-            {
-                auto handle = DirtyBuffers.ToHandle(i);
-                
-                if (!handle)
-                {
-                    continue;
-                }
-                
-                BufferView& buffer = DirtyBuffers[handle];
-                if (buffer && buffer.FrameIndex == SwapchainPtr->CurrentFrame->Index)
-                {
-                    vmaDestroyBuffer(VmaAllocatorValue, buffer.Handle, buffer.Allocation);
-                    buffer.Handle     = VK_NULL_HANDLE;
-                    buffer.Allocation = VK_NULL_HANDLE;
-                    DirtyBuffers.Remove(handle);
-                }
-            }
-            
-            
-            uint32_t dirty_buffer_image_count = DirtyBufferImages.Size();
-            for (uint32_t i = 0; i < dirty_buffer_image_count; ++i)
-            {
-                auto handle = DirtyBufferImages.ToHandle(i);
-                
-                if (!handle)
-                {
-                    continue;
-                }
-                
-                BufferImage& buffer = DirtyBufferImages[handle];
-                
-                if (buffer && buffer.FrameIndex == SwapchainPtr->CurrentFrame->Index)
-                {
-                    vkDestroyImageView(LogicalDevice, buffer.ViewHandle, nullptr);
-                    // vkDestroySampler(LogicalDevice, buffer.Sampler, nullptr);
-                    vmaDestroyImage(VmaAllocatorValue, buffer.Handle, buffer.Allocation);
-                    buffer.Handle     = VK_NULL_HANDLE;
-                    buffer.Allocation = VK_NULL_HANDLE;
-                    DirtyBufferImages.Remove(handle);
-                }
-            }
-            
-            SwapchainPtr->IdleFrameCount.value.store(0, std::memory_order_release);
-        }
-        
-        ZENGINE_CORE_INFO("[*] Dirty Resource Collector stopped...")
     }
 
     Helpers::Handle<Rendering::Shaders::Shader> VulkanDevice::CompileShader(Rendering::Specifications::ShaderSpecification& spec)
@@ -2160,27 +1835,27 @@ namespace ZEngine::Hardwares
 
     BufferView VertexBuffer::CreateBuffer()
     {
-        return m_device->CreateBuffer(m_total_size, VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_ALLOW_TRANSFER_INSTEAD_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT);
+        return m_device->CreateBuffer(m_total_size, VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, Core::Memory::GpuMemoryDomain::DeviceGeometry, "VertexBuffer");
     }
 
     BufferView StorageBuffer::CreateBuffer()
     {
-        return m_device->CreateBuffer(m_total_size, VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_ALLOW_TRANSFER_INSTEAD_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT);
+        return m_device->CreateBuffer(m_total_size, VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, Core::Memory::GpuMemoryDomain::DeviceGeometry, "StorageBuffer");
     }
 
     BufferView IndexBuffer::CreateBuffer()
     {
-        return m_device->CreateBuffer(m_total_size, VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_ALLOW_TRANSFER_INSTEAD_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT);
+        return m_device->CreateBuffer(m_total_size, VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT, Core::Memory::GpuMemoryDomain::DeviceGeometry, "IndexBuffer");
     }
 
     BufferView IndirectBuffer::CreateBuffer()
     {
-        return m_device->CreateBuffer(static_cast<VkDeviceSize>(m_total_size), VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_HOST_ACCESS_ALLOW_TRANSFER_INSTEAD_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT);
+        return m_device->CreateBuffer(static_cast<VkDeviceSize>(m_total_size), VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, Core::Memory::GpuMemoryDomain::DeviceGeometry, "IndirectBuffer");
     }
 
     BufferView UniformBuffer::CreateBuffer()
     {
-        return m_device->CreateBuffer(static_cast<VkDeviceSize>(m_total_size), VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT);
+        return m_device->CreateBuffer(static_cast<VkDeviceSize>(m_total_size), VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, Core::Memory::GpuMemoryDomain::HostUniform, "UniformBuffer");
     }
 
     void IndirectBuffer::Upload(uint8_t frame_index, uint8_t thread_index, const VkDrawIndirectCommand* data, size_t byte_size)
@@ -2269,7 +1944,10 @@ namespace ZEngine::Hardwares
     {
         if (m_buffer_image)
         {
-            Device->EnqueueBufferImageForDeletion(m_buffer_image);
+            DeferredFreeEntry e  = {};
+            e.EntryKind          = DeferredFreeEntry::Kind::Image;
+            e.Data.Image         = m_buffer_image;
+            Device->DeferFree(e);
             m_buffer_image = {};
         }
     }
@@ -2300,7 +1978,7 @@ namespace ZEngine::Hardwares
             m_current_offset = 0;
             m_total_size     = size;
             Buffer           = CreateBuffer();
-            vmaSetAllocationName(m_device->VmaAllocatorValue, Buffer.Allocation, debug_name);
+            vmaSetAllocationName(m_device->GpuMem.Allocator, Buffer.Allocation, debug_name);
         }
     }
 
@@ -2366,7 +2044,10 @@ namespace ZEngine::Hardwares
     {
         if (Buffer)
         {
-            m_device->EnqueueBufferForDeletion(Buffer);
+            DeferredFreeEntry e = {};
+            e.EntryKind         = DeferredFreeEntry::Kind::Buffer;
+            e.Data.Buffer       = Buffer;
+            m_device->DeferFree(e);
             Buffer = {};
         }
     }
@@ -2495,13 +2176,27 @@ namespace ZEngine::Hardwares
             return {};
         }
 
-        auto       resource       = GlobalTextures.Access(handle);
-        auto       image_buf      = Image2DBufferManager.Access(resource->BufferHandle);
+        auto     resource    = GlobalTextures.Access(handle);
+        auto     image_buf   = Image2DBufferManager.Access(resource->BufferHandle);
 
-        BufferView staging_buffer = CreateBuffer(resource->BufferSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT);
-        MapAndCopyToMemory(staging_buffer, resource->BufferSize, data);
-        command_buf->CopyBufferToImage(staging_buffer, image_buf->GetBuffer(), resource->Width, resource->Height, resource->Specification.LayerCount, Specifications::ImageLayoutMap[VALUE_FROM_SPEC_MAP(image_buf->Layout)]);
-        return staging_buffer;
+        uint32_t ring_offset = 0;
+        void*    ring_ptr    = GpuMem.Ring.Allocate(static_cast<uint32_t>(resource->BufferSize), 4, &ring_offset);
+
+        if (ring_ptr)
+        {
+            Helpers::secure_memcpy(ring_ptr, resource->BufferSize, data, resource->BufferSize);
+            BufferView ring_view = {};
+            ring_view.Handle     = GpuMem.Ring.Buffer;
+            ring_view.Allocation = GpuMem.Ring.Allocation;
+            command_buf->CopyBufferToImage(ring_view, image_buf->GetBuffer(), resource->Width, resource->Height, resource->Specification.LayerCount, Specifications::ImageLayoutMap[VALUE_FROM_SPEC_MAP(image_buf->Layout)]);
+            // Return empty view — ring owns lifetime, caller must not free
+            return {};
+        }
+
+        BufferView staging_view = CreateBuffer(resource->BufferSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, Core::Memory::GpuMemoryDomain::HostStaging, "WriteTextureData_staging");
+        MapAndCopyToMemory(staging_view, resource->BufferSize, data);
+        command_buf->CopyBufferToImage(staging_view, image_buf->GetBuffer(), resource->Width, resource->Height, resource->Specification.LayerCount, Specifications::ImageLayoutMap[VALUE_FROM_SPEC_MAP(image_buf->Layout)]);
+        return staging_view;
     }
 
     Rendering::Renderers::RenderPasses::RenderPass* VulkanDevice::CreateRenderPass(const Rendering::Specifications::RenderPassSpecification& spec)
@@ -2509,6 +2204,21 @@ namespace ZEngine::Hardwares
         auto pass = ZPushStructCtorArgs(Arena, Rendering::Renderers::RenderPasses::RenderPass);
         pass->Initialize(this, spec);
         return pass;
+    }
+
+    void VulkanDevice::TickMemory()
+    {
+        uint64_t completed = 0;
+        vkGetSemaphoreCounterValue(LogicalDevice, SwapchainPtr->RenderTimeline->GetHandle(), &completed);
+        PendingFree.Drain(&GpuMem, LogicalDevice, completed);
+        GpuMem.Ring.Drain(completed);
+        GpuMem.SampleBudgets();
+    }
+
+    void VulkanDevice::DeferFree(DeferredFreeEntry entry)
+    {
+        entry.TimelineValue = SwapchainPtr->RenderTimelineNextValue;
+        PendingFree.Enqueue(entry);
     }
 
     void VulkanDevice::EnqueueAsyncGPUOperation(const AsyncGPUOperationHandle& operation)

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.h
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.h
@@ -4,6 +4,7 @@
 #include <ZEngine/Core/Memory/GpuAllocator.h>
 #include <ZEngine/Hardwares/DeferredFreeQueue.h>
 #include <ZEngine/Hardwares/DeviceSwapchain.h>
+#include <ZEngine/Hardwares/PerFrameUploadHeap.h>
 #include <ZEngine/Hardwares/VulkanLayer.h>
 #include <ZEngine/Helpers/HandleManager.h>
 #include <ZEngine/Helpers/MemoryOperations.h>
@@ -213,142 +214,6 @@ namespace ZEngine::Hardwares
         }
     }
 
-    struct IndirectBuffer : public IGraphicBuffer
-    {
-        explicit IndirectBuffer(Hardwares::VulkanDevice* device) : IGraphicBuffer(device) {}
-
-        uint32_t           CommandCount = 0;
-
-        virtual BufferView CreateBuffer() override;
-        virtual void       CleanUpMemory() override;
-        virtual void       Upload(uint8_t frame_index, uint8_t thread_index, const VkDrawIndirectCommand* data, size_t byte_size);
-
-        virtual void       Write(uint8_t frame_index, uint8_t thread_index, const void* data, size_t byte_size) override;
-
-        inline void        Write(uint8_t frame_index, uint8_t thread_index, Core::Containers::ArrayView<VkDrawIndirectCommand> content)
-        {
-            Write(frame_index, thread_index, content.data(), content.size_bytes());
-        }
-
-        virtual ~IndirectBuffer() {}
-    };
-
-    using IndirectBufferSet       = IBufferSet<IndirectBuffer*>;
-    using IndirectBufferSetHandle = Helpers::Handle<IndirectBufferSet>;
-
-    template <>
-    inline void IndirectBufferSet::Dispose()
-    {
-        for (auto buffer : set)
-        {
-            if (buffer)
-            {
-                buffer->Dispose();
-            }
-        }
-    }
-
-    class UniformBuffer : public IGraphicBuffer
-    {
-    public:
-        explicit UniformBuffer() : IGraphicBuffer(nullptr) {}
-        explicit UniformBuffer(Hardwares::VulkanDevice* device) : IGraphicBuffer(device) {}
-
-        explicit UniformBuffer(const UniformBuffer& rhs) = delete;
-
-        explicit UniformBuffer(UniformBuffer& rhs)
-        {
-            this->m_device     = rhs.m_device;
-            this->m_total_size = rhs.m_total_size;
-
-            std::swap(this->Buffer, rhs.Buffer);
-            std::swap(this->m_uniform_buffer_mapped, rhs.m_uniform_buffer_mapped);
-
-            rhs.m_total_size            = 0;
-            rhs.m_uniform_buffer_mapped = false;
-            rhs.Buffer                  = {};
-        }
-
-        explicit UniformBuffer(UniformBuffer&& rhs) noexcept
-        {
-            this->m_device     = rhs.m_device;
-            this->m_total_size = rhs.m_total_size;
-
-            std::swap(this->Buffer, rhs.Buffer);
-            std::swap(this->m_uniform_buffer_mapped, rhs.m_uniform_buffer_mapped);
-
-            rhs.m_total_size            = 0;
-            rhs.m_uniform_buffer_mapped = false;
-            rhs.Buffer                  = {};
-        }
-
-        UniformBuffer& operator=(const UniformBuffer& rhs) = delete;
-
-        UniformBuffer& operator=(UniformBuffer& rhs)
-        {
-            if (this == &rhs)
-            {
-                return *this;
-            }
-
-            this->m_total_size = rhs.m_total_size;
-            this->m_device     = rhs.m_device;
-
-            std::swap(this->Buffer, rhs.Buffer);
-            std::swap(this->m_uniform_buffer_mapped, rhs.m_uniform_buffer_mapped);
-
-            rhs.m_total_size            = 0;
-            rhs.m_uniform_buffer_mapped = false;
-            rhs.Buffer                  = {};
-
-            return *this;
-        }
-
-        UniformBuffer& operator=(UniformBuffer&& rhs) noexcept
-        {
-            if (this == &rhs)
-            {
-                return *this;
-            }
-
-            this->m_total_size = rhs.m_total_size;
-            this->m_device     = rhs.m_device;
-
-            std::swap(this->Buffer, rhs.Buffer);
-            std::swap(this->m_uniform_buffer_mapped, rhs.m_uniform_buffer_mapped);
-
-            rhs.m_total_size            = 0;
-            rhs.m_uniform_buffer_mapped = false;
-            rhs.Buffer                  = {};
-
-            return *this;
-        }
-
-        virtual void       Allocate(uint64_t byte_size, const char* debug_name) override;
-        virtual BufferView CreateBuffer() override;
-        virtual void       CleanUpMemory() override;
-
-        virtual ~UniformBuffer() {}
-
-    private:
-        bool m_uniform_buffer_mapped{false};
-    };
-
-    using UniformBufferSet       = IBufferSet<UniformBuffer*>;
-    using UniformBufferSetHandle = Helpers::Handle<UniformBufferSet>;
-
-    template <>
-    inline void UniformBufferSet::Dispose()
-    {
-        for (auto buffer : set)
-        {
-            if (buffer)
-            {
-                buffer->Dispose();
-            }
-        }
-    }
-
     struct Image2DBuffer
     {
         Image2DBuffer() = default;
@@ -426,11 +291,11 @@ namespace ZEngine::Hardwares
         void                              ClearDepth(float depth_color, uint32_t stencil);
         void                              BeginRenderPass(Rendering::Renderers::RenderPasses::RenderPass* const, VkFramebuffer framebuffer, bool is_content_secondary_command_buffer);
         void                              EndRenderPass();
-        void                              BindDescriptorSets(uint32_t frame_index = 0);
+        void                              BindDescriptorSets(uint32_t frame_index = 0, const uint32_t* dynamic_offsets = nullptr, uint32_t dynamic_offset_count = 0);
         void                              BindDescriptorSet(const VkDescriptorSet& descriptor);
         void                              BindPipeline(Rendering::Specifications::PipelineBindPoint bind_point, Rendering::Renderers::Pipelines::GraphicPipeline* const pipeline);
-        void                              DrawIndirect(const Hardwares::IndirectBuffer& buffer);
-        void                              DrawIndexedIndirect(const Hardwares::IndirectBuffer& buffer, uint32_t count);
+        void                              DrawIndirect(VkBuffer buffer, uint32_t offset, uint32_t draw_count);
+        void                              DrawIndexedIndirect(VkBuffer buffer, uint32_t offset, uint32_t count);
         void                              DrawIndexed(uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance);
         void                              Draw(uint32_t vertex_count, uint32_t instance_count, uint32_t first_index, uint32_t first_instance);
         void                              TransitionImageLayout(const Rendering::Primitives::ImageMemoryBarrier& image_barrier);
@@ -573,6 +438,7 @@ namespace ZEngine::Hardwares
         VkDescriptorSet                                                                                                              EmptyDescriptorSet                          = VK_NULL_HANDLE;
         Core::Memory::GpuAllocator                                                                                                   GpuMem                                      = {};
         DeferredFreeQueue                                                                                                            PendingFree                                 = {};
+        PerFrameUploadHeap                                                                                                           FrameHeaps[3]                               = {};
         VkDescriptorImageInfo                                                                                                        GlobalLinearWrapSamplerImageInfo            = {};
         VkDescriptorImageInfo                                                                                                        GlobalLinearClampToEdgeSamplerImageInfo     = {};
         CommandBufferManagerPtr                                                                                                      CommandBufferMgr                            = {};
@@ -593,9 +459,7 @@ namespace ZEngine::Hardwares
         Helpers::HandleManager<Rendering::Shaders::Shader>                                                                           ShaderManager                               = {};
         Helpers::HandleManager<VertexBufferSet>                                                                                      VertexBufferSetManager                      = {};
         Helpers::HandleManager<StorageBufferSet>                                                                                     StorageBufferSetManager                     = {};
-        Helpers::HandleManager<IndirectBufferSet>                                                                                    IndirectBufferSetManager                    = {};
         Helpers::HandleManager<IndexBufferSet>                                                                                       IndexBufferSetManager                       = {};
-        Helpers::HandleManager<UniformBufferSet>                                                                                     UniformBufferSetManager                     = {};
         std::mutex                                                                                                                   Mutex                                       = {};
         Windows::CoreWindow*                                                                                                         CurrentWindow                               = nullptr;
         ZEngine::Core::Memory::ArenaAllocator*                                                                                       Arena                                       = nullptr;
@@ -614,6 +478,8 @@ namespace ZEngine::Hardwares
         BufferView                                                                                                                   CreateBuffer(VkDeviceSize byte_size, VkBufferUsageFlags buffer_usage, Core::Memory::GpuMemoryDomain domain, const char* debug_name = nullptr);
         void                                                                                                                         TickMemory();
         void                                                                                                                         DeferFree(DeferredFreeEntry entry);
+        uint32_t                                                                                                                     MinUniformBufferOffsetAlignment() const;
+        uint32_t                                                                                                                     MinStorageBufferOffsetAlignment() const;
         VkPipelineStageFlags                                                                                                         CopyBuffer(CommandBuffer* const command_buffer, const BufferView& source, const BufferView& destination, VkDeviceSize byte_size, VkDeviceSize src_buffer_offset = 0u, VkDeviceSize dst_buffer_offset = 0u);
         BufferImage                                     CreateImage(uint32_t width, uint32_t height, VkImageType image_type, VkImageViewType image_view_type, VkFormat image_format, VkImageTiling image_tiling, VkImageLayout image_initial_layout, VkImageUsageFlags image_usage, VkSharingMode image_sharing_mode, VkSampleCountFlagBits image_sample_count, VkMemoryPropertyFlags requested_properties, VkImageAspectFlagBits image_aspect_flag, uint32_t layer_count = 1U, VkImageCreateFlags image_create_flag_bit = 0);
         VkFormat                                        FindSupportedFormat(Core::Containers::ArrayView<VkFormat> format_collection, VkImageTiling image_tiling, VkFormatFeatureFlags feature_flags);
@@ -622,9 +488,7 @@ namespace ZEngine::Hardwares
         VkFramebuffer                                   CreateFramebuffer(Core::Containers::ArrayView<VkImageView> attachments, const VkRenderPass& render_pass, uint32_t width, uint32_t height, uint32_t layer_number = 1);
         VertexBufferSetHandle                           CreateVertexBufferSet();
         StorageBufferSetHandle                          CreateStorageBufferSet();
-        IndirectBufferSetHandle                         CreateIndirectBufferSet();
         IndexBufferSetHandle                            CreateIndexBufferSet();
-        UniformBufferSetHandle                          CreateUniformBufferSet();
 
         Helpers::Handle<Rendering::Shaders::Shader>     CompileShader(Rendering::Specifications::ShaderSpecification& spec);
 
@@ -668,25 +532,7 @@ namespace ZEngine::Helpers
     }
 
     template <>
-    inline void HandleManager<Hardwares::IndirectBufferSet>::Dispose()
-    {
-        for (size_t i = 0; i < m_count; ++i)
-        {
-            m_memory[i].Dispose();
-        }
-    }
-
-    template <>
     inline void HandleManager<Hardwares::IndexBufferSet>::Dispose()
-    {
-        for (size_t i = 0; i < m_count; ++i)
-        {
-            m_memory[i].Dispose();
-        }
-    }
-
-    template <>
-    inline void HandleManager<Hardwares::UniformBufferSet>::Dispose()
     {
         for (size_t i = 0; i < m_count; ++i)
         {

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.h
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.h
@@ -1,7 +1,8 @@
 #pragma once
-#include <vk_mem_alloc.h>
 #include <vulkan/vulkan.h>
 // clang-format off
+#include <ZEngine/Core/Memory/GpuAllocator.h>
+#include <ZEngine/Hardwares/DeferredFreeQueue.h>
 #include <ZEngine/Hardwares/DeviceSwapchain.h>
 #include <ZEngine/Hardwares/VulkanLayer.h>
 #include <ZEngine/Helpers/HandleManager.h>
@@ -49,6 +50,10 @@ namespace ZEngine::Rendering::Renderers::Pipelines
 
 namespace ZEngine::Hardwares
 {
+    using Core::Memory::BufferImage;
+    using Core::Memory::BufferView;
+    using Core::Memory::GpuMemoryDomain;
+
     struct WriteDescriptorSetRequestKey;
     struct WriteDescriptorSetRequest;
     struct CommandBufferManager;
@@ -57,8 +62,6 @@ namespace ZEngine::Hardwares
     /*
      * Vertex | Index | Uniform | Storage Buffers
      */
-    struct BufferView;
-    struct BufferImage;
     struct IGraphicBuffer;
     class StorageBuffer;
     class VertexBuffer;
@@ -68,44 +71,6 @@ namespace ZEngine::Hardwares
      * GPU Device
      */
     struct VulkanDevice;
-
-    enum BufferType : uint8_t
-    {
-        UNKNOWN = 0,
-        VERTEX,
-        INDEX,
-        UNIFORM,
-        STORAGE,
-        INDIRECT
-    };
-    struct BufferView
-    {
-        uint8_t       FrameIndex = std::numeric_limits<uint8_t>::max();
-        BufferType    Type       = BufferType::UNKNOWN;
-        VkBuffer      Handle     = VK_NULL_HANDLE;
-        VmaAllocation Allocation = nullptr;
-        // clang-format off
-        operator bool() const
-        {
-            return (Handle != VK_NULL_HANDLE);
-        }
-        // clang-format on
-    };
-
-    struct BufferImage
-    {
-        uint8_t       FrameIndex{std::numeric_limits<uint8_t>::max()};
-        VkImage       Handle{VK_NULL_HANDLE};
-        VkImageView   ViewHandle{VK_NULL_HANDLE};
-        VkSampler     Sampler{VK_NULL_HANDLE};
-        VmaAllocation Allocation{nullptr};
-        // clang-format off
-        operator bool() const
-        {
-            return (Handle != VK_NULL_HANDLE);
-        }
-        // clang-format on
-    };
 
     struct IGraphicBuffer
     {
@@ -408,14 +373,6 @@ namespace ZEngine::Hardwares
         VkDescriptorImageInfo m_image_info;
     };
 
-    struct DirtyResource
-    {
-        uint32_t                      FrameIndex = UINT32_MAX;
-        void*                         Handle     = nullptr;
-        void*                         Data1      = nullptr;
-        Rendering::DeviceResourceType Type;
-    };
-
     struct QueueView
     {
         uint32_t FamilyIndex{0xFFFFFFFF};
@@ -614,7 +571,8 @@ namespace ZEngine::Hardwares
         VkDescriptorSetLayout                                                                                                        EmptyDescriptorSetLayout                    = VK_NULL_HANDLE;
         VkDescriptorPool                                                                                                             EmptyDescriptorPoolHandle                   = VK_NULL_HANDLE;
         VkDescriptorSet                                                                                                              EmptyDescriptorSet                          = VK_NULL_HANDLE;
-        VmaAllocator                                                                                                                 VmaAllocatorValue                           = nullptr;
+        Core::Memory::GpuAllocator                                                                                                   GpuMem                                      = {};
+        DeferredFreeQueue                                                                                                            PendingFree                                 = {};
         VkDescriptorImageInfo                                                                                                        GlobalLinearWrapSamplerImageInfo            = {};
         VkDescriptorImageInfo                                                                                                        GlobalLinearClampToEdgeSamplerImageInfo     = {};
         CommandBufferManagerPtr                                                                                                      CommandBufferMgr                            = {};
@@ -638,10 +596,6 @@ namespace ZEngine::Hardwares
         Helpers::HandleManager<IndirectBufferSet>                                                                                    IndirectBufferSetManager                    = {};
         Helpers::HandleManager<IndexBufferSet>                                                                                       IndexBufferSetManager                       = {};
         Helpers::HandleManager<UniformBufferSet>                                                                                     UniformBufferSetManager                     = {};
-        Helpers::HandleManager<DirtyResource>                                                                                        DirtyResources                              = {};
-        Helpers::HandleManager<BufferView>                                                                                           DirtyBuffers                                = {};
-        Helpers::HandleManager<BufferImage>                                                                                          DirtyBufferImages                           = {};
-        std::atomic_bool                                                                                                             RunningDirtyCollector                       = {};
         std::mutex                                                                                                                   Mutex                                       = {};
         Windows::CoreWindow*                                                                                                         CurrentWindow                               = nullptr;
         ZEngine::Core::Memory::ArenaAllocator*                                                                                       Arena                                       = nullptr;
@@ -653,15 +607,13 @@ namespace ZEngine::Hardwares
         void                                                                                                                         QueueSubmit(CommandBuffer* const command_buffer, Rendering::Primitives::Semaphore* const signal_semaphore, uint32_t wait_flag, uint64_t signal_value, uint64_t wait_value, Rendering::Primitives::Semaphore* const wait_timeline);
         bool                                                                                                                         QueueSubmit(const VkPipelineStageFlags wait_stage_flag, CommandBuffer* const command_buffer, Rendering::Primitives::Semaphore* const signal_semaphore = nullptr, Rendering::Primitives::Fence* const fence = nullptr);
         void                                                                                                                         EnqueueAsyncGPUOperation(const AsyncGPUOperationHandle& handle);
-        void                                                                                                                         EnqueueForDeletion(Rendering::DeviceResourceType resource_type, void* const resource_handle);
-        void                                                                                                                         EnqueueForDeletion(Rendering::DeviceResourceType resource_type, DirtyResource resource);
-        void                                                                                                                         EnqueueBufferForDeletion(BufferView& buffer);
-        void                                                                                                                         EnqueueBufferImageForDeletion(BufferImage& buffer);
         QueueView                                                                                                                    GetQueue(Rendering::QueueType type);
         void                                                                                                                         QueueWait(Rendering::QueueType type);
         void                                                                                                                         QueueWaitAll();
         void                                                                                                                         MapAndCopyToMemory(BufferView& buffer, size_t data_size, const void* data);
-        BufferView                                                                                                                   CreateBuffer(VkDeviceSize byte_size, VkBufferUsageFlags buffer_usage, VmaAllocationCreateFlags vma_create_flags = 0);
+        BufferView                                                                                                                   CreateBuffer(VkDeviceSize byte_size, VkBufferUsageFlags buffer_usage, Core::Memory::GpuMemoryDomain domain, const char* debug_name = nullptr);
+        void                                                                                                                         TickMemory();
+        void                                                                                                                         DeferFree(DeferredFreeEntry entry);
         VkPipelineStageFlags                                                                                                         CopyBuffer(CommandBuffer* const command_buffer, const BufferView& source, const BufferView& destination, VkDeviceSize byte_size, VkDeviceSize src_buffer_offset = 0u, VkDeviceSize dst_buffer_offset = 0u);
         BufferImage                                     CreateImage(uint32_t width, uint32_t height, VkImageType image_type, VkImageViewType image_view_type, VkFormat image_format, VkImageTiling image_tiling, VkImageLayout image_initial_layout, VkImageUsageFlags image_usage, VkSharingMode image_sharing_mode, VkSampleCountFlagBits image_sample_count, VkMemoryPropertyFlags requested_properties, VkImageAspectFlagBits image_aspect_flag, uint32_t layer_count = 1U, VkImageCreateFlags image_create_flag_bit = 0);
         VkFormat                                        FindSupportedFormat(Core::Containers::ArrayView<VkFormat> format_collection, VkImageTiling image_tiling, VkFormatFeatureFlags feature_flags);
@@ -673,7 +625,6 @@ namespace ZEngine::Hardwares
         IndirectBufferSetHandle                         CreateIndirectBufferSet();
         IndexBufferSetHandle                            CreateIndexBufferSet();
         UniformBufferSetHandle                          CreateUniformBufferSet();
-        void                                            DirtyCollector();
 
         Helpers::Handle<Rendering::Shaders::Shader>     CompileShader(Rendering::Specifications::ShaderSpecification& spec);
 
@@ -690,9 +641,6 @@ namespace ZEngine::Hardwares
         VkDebugUtilsMessengerEXT                                          m_debug_messenger{VK_NULL_HANDLE};
         PFN_vkCreateDebugUtilsMessengerEXT                                __createDebugMessengerPtr{VK_NULL_HANDLE};
         PFN_vkDestroyDebugUtilsMessengerEXT                               __destroyDebugMessengerPtr{VK_NULL_HANDLE};
-        void                                                              __cleanupDirtyResource();
-        void                                                              __cleanupBufferDirtyResource();
-        void                                                              __cleanupBufferImageDirtyResource();
         static VKAPI_ATTR VkBool32 VKAPI_CALL                             __debugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageType, const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData, void* pUserData);
     };
 

--- a/ZEngine/ZEngine/Rendering/Buffers/FrameBuffer.cpp
+++ b/ZEngine/ZEngine/Rendering/Buffers/FrameBuffer.cpp
@@ -75,7 +75,10 @@ namespace ZEngine::Rendering::Buffers
     {
         if (Handle)
         {
-            m_device->EnqueueForDeletion(Rendering::DeviceResourceType::FRAMEBUFFER, Handle);
+            Hardwares::DeferredFreeEntry e = {};
+            e.EntryKind                    = Hardwares::DeferredFreeEntry::Kind::VkHandle;
+            e.Data.Vk                      = {Handle, Rendering::DeviceResourceType::FRAMEBUFFER, nullptr};
+            m_device->DeferFree(e);
             Handle = VK_NULL_HANDLE;
         }
     }

--- a/ZEngine/ZEngine/Rendering/Primitives/Fence.cpp
+++ b/ZEngine/ZEngine/Rendering/Primitives/Fence.cpp
@@ -23,7 +23,10 @@ namespace ZEngine::Rendering::Primitives
             return;
         }
 
-        Device->EnqueueForDeletion(Rendering::DeviceResourceType::FENCE, m_handle);
+        Hardwares::DeferredFreeEntry e = {};
+        e.EntryKind                    = Hardwares::DeferredFreeEntry::Kind::VkHandle;
+        e.Data.Vk                      = {m_handle, Rendering::DeviceResourceType::FENCE, nullptr};
+        Device->DeferFree(e);
         m_handle      = VK_NULL_HANDLE;
         m_fence_state = FenceState::Idle;
     }

--- a/ZEngine/ZEngine/Rendering/Primitives/Semaphore.cpp
+++ b/ZEngine/ZEngine/Rendering/Primitives/Semaphore.cpp
@@ -27,8 +27,10 @@ namespace ZEngine::Rendering::Primitives
             return;
         }
 
-        /*Todo : register for deletion from device*/
-        Device->EnqueueForDeletion(Rendering::DeviceResourceType::SEMAPHORE, m_handle);
+        Hardwares::DeferredFreeEntry e = {};
+        e.EntryKind                    = Hardwares::DeferredFreeEntry::Kind::VkHandle;
+        e.Data.Vk                      = {m_handle, Rendering::DeviceResourceType::SEMAPHORE, nullptr};
+        Device->DeferFree(e);
         m_handle          = VK_NULL_HANDLE;
         m_semaphore_state = SemaphoreState::Idle;
     }

--- a/ZEngine/ZEngine/Rendering/Renderers/GraphicRenderer.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/GraphicRenderer.cpp
@@ -76,37 +76,11 @@ namespace ZEngine::Rendering::Renderers
         RenderGraph->ResourceBuilder->CreateBufferSet("g_scene_point_light_buffer");
         RenderGraph->ResourceBuilder->CreateBufferSet("g_scene_spot_light_buffer");
 
-        // Wire the env map path from the renderer config; null = no env map, pass skipped
-        skybox_pass->EnvMapPath = ActiveEnvironmentMapPath;
-
-        // Enable the Skybox Pass only when a valid env map path is configured and exists in the VFS.
-        bool skybox_enabled     = false;
-        if (ActiveEnvironmentMapPath && ActiveEnvironmentMapPath[0] != '\0')
-        {
-            auto* vfs = ZEngine::Engine::GetContext() ? ZEngine::Engine::GetContext()->VFS : nullptr;
-            if (vfs)
-            {
-                auto path_result   = ZEngine::Core::VFS::VFSPath::FromNative(ActiveEnvironmentMapPath);
-                auto exists_result = path_result.Succeeded() ? vfs->Exists(path_result.Value()) : ZEngine::Core::VFS::VFSResult<bool>::Fail(ZEngine::Core::VFS::VFSError::InvalidPath);
-                if (exists_result.Failed() || !exists_result.Value())
-                {
-                    ZENGINE_CORE_ERROR("[Renderer] Environment map not found in VFS: {}", ActiveEnvironmentMapPath)
-                }
-                else
-                {
-                    skybox_enabled = true;
-                }
-            }
-            else
-            {
-                ZENGINE_CORE_ERROR("[Renderer] VFS not available — cannot resolve environment map path: {}", ActiveEnvironmentMapPath)
-            }
-        }
-
+        // Skybox starts disabled; ApplySkyConfig enables it when a scene with an HDRI sky loads.
         RenderGraph->AddCallbackPass("Upload Pass", upload_pass);
         RenderGraph->AddCallbackPass("Base Pass", base_pass);
         RenderGraph->AddCallbackPass("Depth Pre-Pass", scene_depth_prepass);
-        RenderGraph->AddCallbackPass("Skybox Pass", skybox_pass, skybox_enabled);
+        RenderGraph->AddCallbackPass("Skybox Pass", skybox_pass, false);
         RenderGraph->AddCallbackPass("Grid Pass", grid_pass);
         //  RenderGraph->AddCallbackPass("G-Buffer Pass", gbuffer_pass);
         //      RenderGraph->AddCallbackPass("Lighting Pass", lighting_pass);
@@ -144,5 +118,46 @@ namespace ZEngine::Rendering::Renderers
     Textures::TextureHandle GraphicRenderer::GetFrameOutput()
     {
         return RenderGraph->ResourceInspector->GetRenderTarget(RendererResourceName::FrameColorRenderTargetName);
+    }
+
+    void GraphicRenderer::ApplySkyConfig(const Scenes::SkyConfig& sky)
+    {
+        auto& node = RenderGraph->NodeMap["Skybox Pass"];
+
+        if (!sky.IsHDRI())
+        {
+            node.Enabled = false;
+            return;
+        }
+
+        auto env_path = sky.EnvironmentMap.c_str();
+        if (!env_path || env_path[0] == '\0')
+        {
+            node.Enabled = false;
+            return;
+        }
+
+        auto* vfs = ZEngine::Engine::GetContext() ? ZEngine::Engine::GetContext()->VFS : nullptr;
+        if (!vfs)
+        {
+            ZENGINE_CORE_ERROR("[Renderer] VFS not available — cannot resolve environment map: {}", env_path)
+            node.Enabled = false;
+            return;
+        }
+
+        auto path_result   = ZEngine::Core::VFS::VFSPath::FromNative(env_path);
+        auto exists_result = path_result.Succeeded()
+                               ? vfs->Exists(path_result.Value())
+                               : ZEngine::Core::VFS::VFSResult<bool>::Fail(ZEngine::Core::VFS::VFSError::InvalidPath);
+        if (exists_result.Failed() || !exists_result.Value())
+        {
+            ZENGINE_CORE_ERROR("[Renderer] Environment map not found in VFS: {}", env_path)
+            node.Enabled = false;
+            return;
+        }
+
+        auto* skybox_pass   = static_cast<SkyboxPass*>(node.CallbackPass);
+        skybox_pass->EnvMapPath = env_path;
+        node.Enabled            = true;
     }
 } // namespace ZEngine::Rendering::Renderers

--- a/ZEngine/ZEngine/Rendering/Renderers/GraphicRenderer.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/GraphicRenderer.cpp
@@ -18,40 +18,31 @@ namespace ZEngine::Rendering::Renderers
 
     void GraphicRenderer::Initialize(Hardwares::VulkanDevicePtr device)
     {
-        Device                                   = device;
-        RenderGraph                              = ZPushStructCtorArgs(Device->Arena, Renderers::RenderGraph);
-        RenderSceneData                          = ZPushStructCtor(Device->Arena, Scenes::SceneData);
+        Device                                  = device;
+        RenderGraph                             = ZPushStructCtorArgs(Device->Arena, Renderers::RenderGraph);
+        RenderSceneData                         = ZPushStructCtor(Device->Arena, Scenes::SceneData);
         /*
          * Shared Buffers
          */
-        RenderSceneData->SceneCameraBufferHandle = Device->CreateUniformBufferSet();
+        RenderSceneData->VertexBufferHandle     = Device->CreateStorageBufferSet();
+        RenderSceneData->IndexBufferHandle      = Device->CreateStorageBufferSet();
+        RenderSceneData->TransformBufferHandle  = Device->CreateStorageBufferSet();
+        RenderSceneData->RenderDataBufferHandle = Device->CreateStorageBufferSet();
+        RenderSceneData->MaterialBufferHandle   = Device->CreateStorageBufferSet();
 
-        RenderSceneData->VertexBufferHandle      = Device->CreateStorageBufferSet();
-        RenderSceneData->IndexBufferHandle       = Device->CreateStorageBufferSet();
-        RenderSceneData->TransformBufferHandle   = Device->CreateStorageBufferSet();
-        RenderSceneData->RenderDataBufferHandle  = Device->CreateStorageBufferSet();
-        RenderSceneData->MaterialBufferHandle    = Device->CreateStorageBufferSet();
-        RenderSceneData->IndirectBufferHandle    = Device->CreateIndirectBufferSet();
-
-        auto scene_camera                        = Device->UniformBufferSetManager.Access(RenderSceneData->SceneCameraBufferHandle);
-
-        auto vtx_buffer_set                      = Device->StorageBufferSetManager.Access(RenderSceneData->VertexBufferHandle);
-        auto idx_buffer_set                      = Device->StorageBufferSetManager.Access(RenderSceneData->IndexBufferHandle);
-        auto tranform_buffer_set                 = Device->StorageBufferSetManager.Access(RenderSceneData->TransformBufferHandle);
-        auto rd_buffer_set                       = Device->StorageBufferSetManager.Access(RenderSceneData->RenderDataBufferHandle);
-        auto material_buffer_set                 = Device->StorageBufferSetManager.Access(RenderSceneData->MaterialBufferHandle);
-        auto indirect_buffer_set                 = Device->IndirectBufferSetManager.Access(RenderSceneData->IndirectBufferHandle);
+        auto vtx_buffer_set                     = Device->StorageBufferSetManager.Access(RenderSceneData->VertexBufferHandle);
+        auto idx_buffer_set                     = Device->StorageBufferSetManager.Access(RenderSceneData->IndexBufferHandle);
+        auto tranform_buffer_set                = Device->StorageBufferSetManager.Access(RenderSceneData->TransformBufferHandle);
+        auto rd_buffer_set                      = Device->StorageBufferSetManager.Access(RenderSceneData->RenderDataBufferHandle);
+        auto material_buffer_set                = Device->StorageBufferSetManager.Access(RenderSceneData->MaterialBufferHandle);
 
         for (int i = 0; i < Device->SwapchainPtr->BufferredFrameCount; ++i)
         {
-            scene_camera->At(i)->Allocate(sizeof(UBOCameraLayout), RendererResourceName::SceneCameraBufferName);
-
             vtx_buffer_set->At(i)->Allocate(DefaultBufferSize, VertexBufferName);
             idx_buffer_set->At(i)->Allocate(DefaultBufferSize, IndexBufferName);
             tranform_buffer_set->At(i)->Allocate(DefaultBufferSize, TransformBufferName);
             rd_buffer_set->At(i)->Allocate(DefaultBufferSize, RenderDataBufferName);
             material_buffer_set->At(i)->Allocate(DefaultBufferSize, MaterialBufferName);
-            indirect_buffer_set->At(i)->Allocate(DefaultBufferSize, "indirectbuffer");
         }
 
         /*
@@ -109,13 +100,14 @@ namespace ZEngine::Rendering::Renderers
         auto ubo_camera_data     = UBOCameraLayout{.View = camera->GetView(), .Projection = camera->GetProjection(), .Position = Vec4f(camera->GetPosition(), 1.0f)};
 
         auto material_buffer_set = Device->StorageBufferSetManager.Access(RenderSceneData->MaterialBufferHandle);
-        auto camera_buffer_set   = Device->UniformBufferSetManager.Access(RenderSceneData->SceneCameraBufferHandle);
-
-        auto camera_buf          = camera_buffer_set->At(Device->SwapchainPtr->CurrentFrame->Index);
         auto material_buffer     = material_buffer_set->At(Device->SwapchainPtr->CurrentFrame->Index);
 
         material_buffer->Write(frame_index, thread_index, ArrayView{asset_manager->GPUMeshMaterials});
-        camera_buf->Write(frame_index, thread_index, reinterpret_cast<void*>(&ubo_camera_data), sizeof(UBOCameraLayout));
+
+        // Push camera data into the per-frame heap; store offset for dynamic descriptor binding
+        auto& heap                        = Device->FrameHeaps[Device->SwapchainPtr->CurrentFrame->Index];
+        auto  camera_alloc                = heap.Push(&ubo_camera_data, sizeof(UBOCameraLayout), Device->MinUniformBufferOffsetAlignment());
+        RenderSceneData->CameraHeapOffset = camera_alloc.Offset;
 
         // todo : expand F, T to the render graph
         RenderGraph->Execute(cb);

--- a/ZEngine/ZEngine/Rendering/Renderers/GraphicRenderer.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/GraphicRenderer.cpp
@@ -146,9 +146,7 @@ namespace ZEngine::Rendering::Renderers
         }
 
         auto path_result   = ZEngine::Core::VFS::VFSPath::FromNative(env_path);
-        auto exists_result = path_result.Succeeded()
-                               ? vfs->Exists(path_result.Value())
-                               : ZEngine::Core::VFS::VFSResult<bool>::Fail(ZEngine::Core::VFS::VFSError::InvalidPath);
+        auto exists_result = path_result.Succeeded() ? vfs->Exists(path_result.Value()) : ZEngine::Core::VFS::VFSResult<bool>::Fail(ZEngine::Core::VFS::VFSError::InvalidPath);
         if (exists_result.Failed() || !exists_result.Value())
         {
             ZENGINE_CORE_ERROR("[Renderer] Environment map not found in VFS: {}", env_path)
@@ -156,7 +154,7 @@ namespace ZEngine::Rendering::Renderers
             return;
         }
 
-        auto* skybox_pass   = static_cast<SkyboxPass*>(node.CallbackPass);
+        auto* skybox_pass       = static_cast<SkyboxPass*>(node.CallbackPass);
         skybox_pass->EnvMapPath = env_path;
         node.Enabled            = true;
     }

--- a/ZEngine/ZEngine/Rendering/Renderers/GraphicRenderer.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/GraphicRenderer.cpp
@@ -1,3 +1,4 @@
+#include <ZEngine/Engine.h>
 #include <ZEngine/Managers/AssetManager.h>
 #include <ZEngine/Rendering/Renderers/Contracts/RendererDataContract.h>
 #include <ZEngine/Rendering/Renderers/GraphicRenderer.h>
@@ -75,10 +76,37 @@ namespace ZEngine::Rendering::Renderers
         RenderGraph->ResourceBuilder->CreateBufferSet("g_scene_point_light_buffer");
         RenderGraph->ResourceBuilder->CreateBufferSet("g_scene_spot_light_buffer");
 
+        // Wire the env map path from the renderer config; null = no env map, pass skipped
+        skybox_pass->EnvMapPath = ActiveEnvironmentMapPath;
+
+        // Enable the Skybox Pass only when a valid env map path is configured and exists in the VFS.
+        bool skybox_enabled     = false;
+        if (ActiveEnvironmentMapPath && ActiveEnvironmentMapPath[0] != '\0')
+        {
+            auto* vfs = ZEngine::Engine::GetContext() ? ZEngine::Engine::GetContext()->VFS : nullptr;
+            if (vfs)
+            {
+                auto path_result   = ZEngine::Core::VFS::VFSPath::FromNative(ActiveEnvironmentMapPath);
+                auto exists_result = path_result.Succeeded() ? vfs->Exists(path_result.Value()) : ZEngine::Core::VFS::VFSResult<bool>::Fail(ZEngine::Core::VFS::VFSError::InvalidPath);
+                if (exists_result.Failed() || !exists_result.Value())
+                {
+                    ZENGINE_CORE_ERROR("[Renderer] Environment map not found in VFS: {}", ActiveEnvironmentMapPath)
+                }
+                else
+                {
+                    skybox_enabled = true;
+                }
+            }
+            else
+            {
+                ZENGINE_CORE_ERROR("[Renderer] VFS not available — cannot resolve environment map path: {}", ActiveEnvironmentMapPath)
+            }
+        }
+
         RenderGraph->AddCallbackPass("Upload Pass", upload_pass);
         RenderGraph->AddCallbackPass("Base Pass", base_pass);
         RenderGraph->AddCallbackPass("Depth Pre-Pass", scene_depth_prepass);
-        RenderGraph->AddCallbackPass("Skybox Pass", skybox_pass);
+        RenderGraph->AddCallbackPass("Skybox Pass", skybox_pass, skybox_enabled);
         RenderGraph->AddCallbackPass("Grid Pass", grid_pass);
         //  RenderGraph->AddCallbackPass("G-Buffer Pass", gbuffer_pass);
         //      RenderGraph->AddCallbackPass("Lighting Pass", lighting_pass);

--- a/ZEngine/ZEngine/Rendering/Renderers/GraphicRenderer.h
+++ b/ZEngine/ZEngine/Rendering/Renderers/GraphicRenderer.h
@@ -23,6 +23,7 @@ namespace ZEngine::Rendering::Renderers
         void                    Initialize(Hardwares::VulkanDevicePtr device) override;
         void                    Deinitialize() override;
         void                    DrawScene(uint8_t frame_index, uint8_t thread_index, Hardwares::CommandBufferPtr const cb, Cameras::CameraPtr const camera);
+        void                    ApplySkyConfig(const Scenes::SkyConfig& sky);
         Textures::TextureHandle GetFrameOutput();
     };
     ZDEFINE_PTR(GraphicRenderer);

--- a/ZEngine/ZEngine/Rendering/Renderers/IRenderer.h
+++ b/ZEngine/ZEngine/Rendering/Renderers/IRenderer.h
@@ -60,6 +60,8 @@ namespace ZEngine::Rendering::Renderers
         Hardwares::VulkanDevicePtr Device                                        = nullptr;
         Renderers::RenderGraphPtr  RenderGraph                                   = nullptr;
         Scenes::SceneDataPtr       RenderSceneData                               = nullptr;
+        // Absolute path to the active .zenvmap; empty string if none configured
+        const char*                ActiveEnvironmentMapPath                      = nullptr;
 
         const size_t               DefaultBufferSize                             = ZMega(10);
 

--- a/ZEngine/ZEngine/Rendering/Renderers/IRenderer.h
+++ b/ZEngine/ZEngine/Rendering/Renderers/IRenderer.h
@@ -60,8 +60,6 @@ namespace ZEngine::Rendering::Renderers
         Hardwares::VulkanDevicePtr Device                                        = nullptr;
         Renderers::RenderGraphPtr  RenderGraph                                   = nullptr;
         Scenes::SceneDataPtr       RenderSceneData                               = nullptr;
-        // Absolute path to the active .zenvmap; empty string if none configured
-        const char*                ActiveEnvironmentMapPath                      = nullptr;
 
         const size_t               DefaultBufferSize                             = ZMega(10);
 

--- a/ZEngine/ZEngine/Rendering/Renderers/Pipelines/RendererPipeline.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/Pipelines/RendererPipeline.cpp
@@ -211,8 +211,14 @@ namespace ZEngine::Rendering::Renderers::Pipelines
     {
         Shader->Dispose();
 
-        Device->EnqueueForDeletion(Rendering::DeviceResourceType::PIPELINE_LAYOUT, Layout);
-        Device->EnqueueForDeletion(Rendering::DeviceResourceType::PIPELINE, Handle);
+        Hardwares::DeferredFreeEntry pl = {};
+        pl.EntryKind                    = Hardwares::DeferredFreeEntry::Kind::VkHandle;
+        pl.Data.Vk                      = {Layout, Rendering::DeviceResourceType::PIPELINE_LAYOUT, nullptr};
+        Device->DeferFree(pl);
+        Hardwares::DeferredFreeEntry pp = {};
+        pp.EntryKind                    = Hardwares::DeferredFreeEntry::Kind::VkHandle;
+        pp.Data.Vk                      = {Handle, Rendering::DeviceResourceType::PIPELINE, nullptr};
+        Device->DeferFree(pp);
         Layout = VK_NULL_HANDLE;
         Handle = VK_NULL_HANDLE;
     }

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.cpp
@@ -413,8 +413,6 @@ namespace ZEngine::Rendering::Renderers
             {
                 // We are safe to call Remove(...) even if Handle is invalid
                 Device->StorageBufferSetManager.Remove(value.ResourceInfo.StorageBufferSetHandle);
-                Device->UniformBufferSetManager.Remove(value.ResourceInfo.UniformBufferSetHandle);
-                Device->IndirectBufferSetManager.Remove(value.ResourceInfo.IndirectBufferSetHandle);
                 Device->VertexBufferSetManager.Remove(value.ResourceInfo.VertexBufferSetHandle);
                 Device->IndexBufferSetManager.Remove(value.ResourceInfo.IndexBufferSetHandle);
             }
@@ -426,15 +424,6 @@ namespace ZEngine::Rendering::Renderers
         Graph->ResourceMap[name].Name                                = name;
         Graph->ResourceMap[name].Type                                = RenderGraphResourceType::BUFFER_SET;
         Graph->ResourceMap[name].ResourceInfo.StorageBufferSetHandle = buffer;
-        Graph->ResourceMap[name].ResourceInfo.External               = true;
-        return Graph->ResourceMap[name];
-    }
-
-    RenderGraphResource& RenderGraphResourceBuilder::AttachBuffer(cstring name, const Hardwares::UniformBufferSetHandle& buffer)
-    {
-        Graph->ResourceMap[name].Name                                = name;
-        Graph->ResourceMap[name].Type                                = RenderGraphResourceType::BUFFER_SET;
-        Graph->ResourceMap[name].ResourceInfo.UniformBufferSetHandle = buffer;
         Graph->ResourceMap[name].ResourceInfo.External               = true;
         return Graph->ResourceMap[name];
     }
@@ -509,12 +498,6 @@ namespace ZEngine::Rendering::Renderers
         Graph->ResourceMap[name].Type = RenderGraphResourceType::BUFFER_SET;
         switch (type)
         {
-            case BufferSetCreationType::INDIRECT:
-                Graph->ResourceMap[name].ResourceInfo.IndirectBufferSetHandle = Graph->Device->CreateIndirectBufferSet();
-                break;
-            case BufferSetCreationType::UNIFORM:
-                Graph->ResourceMap[name].ResourceInfo.UniformBufferSetHandle = Graph->Device->CreateUniformBufferSet();
-                break;
             case BufferSetCreationType::STORAGE:
                 Graph->ResourceMap[name].ResourceInfo.StorageBufferSetHandle = Graph->Device->CreateStorageBufferSet();
                 break;
@@ -523,6 +506,8 @@ namespace ZEngine::Rendering::Renderers
                 break;
             case BufferSetCreationType::VERTEX:
                 Graph->ResourceMap[name].ResourceInfo.VertexBufferSetHandle = Graph->Device->CreateVertexBufferSet();
+                break;
+            default:
                 break;
         }
         Graph->ResourceMap[name].ResourceInfo.External = false;
@@ -609,24 +594,6 @@ namespace ZEngine::Rendering::Renderers
             Graph->ResourceMap[name].Name = name;
         }
         return Graph->ResourceMap[name].ResourceInfo.IndexBufferSetHandle;
-    }
-
-    Hardwares::UniformBufferSetHandle RenderGraphResourceInspector::GetBufferUniformSet(cstring name)
-    {
-        if (!Graph->ResourceMap.contains(name))
-        {
-            Graph->ResourceMap[name].Name = name;
-        }
-        return Graph->ResourceMap[name].ResourceInfo.UniformBufferSetHandle;
-    }
-
-    Hardwares::IndirectBufferSetHandle RenderGraphResourceInspector::GetIndirectBufferSet(cstring name)
-    {
-        if (!Graph->ResourceMap.contains(name))
-        {
-            Graph->ResourceMap[name].Name = name;
-        }
-        return Graph->ResourceMap[name].ResourceInfo.IndirectBufferSetHandle;
     }
 
     RenderGraphNode& RenderGraphResourceInspector::GetNode(cstring name)

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.cpp
@@ -207,7 +207,7 @@ namespace ZEngine::Rendering::Renderers
     {
         ZENGINE_VALIDATE_ASSERT(command_buffer, "Command Buffer can't be null")
 
-        command_buffer->ClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+        command_buffer->ClearColor(0.11f, 0.11f, 0.11f, 1.0f); // #1C1C1C dark carbon
         command_buffer->ClearDepth(1.0f, 0);
 
         for (auto& node_name : SortedNodesMap)

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.cpp
@@ -207,7 +207,7 @@ namespace ZEngine::Rendering::Renderers
     {
         ZENGINE_VALIDATE_ASSERT(command_buffer, "Command Buffer can't be null")
 
-        command_buffer->ClearColor(0.5f, 0.5f, 0.5f, 1.0f);
+        command_buffer->ClearColor(0.0f, 0.0f, 0.0f, 1.0f);
         command_buffer->ClearDepth(1.0f, 0);
 
         for (auto& node_name : SortedNodesMap)

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.h
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.h
@@ -48,12 +48,10 @@ namespace ZEngine::Rendering::Renderers
         Specifications::TextureSpecification TextureSpec;
         union
         {
-            Textures::TextureHandle            TextureHandle;
-            Hardwares::UniformBufferSetHandle  UniformBufferSetHandle;
-            Hardwares::StorageBufferSetHandle  StorageBufferSetHandle;
-            Hardwares::IndirectBufferSetHandle IndirectBufferSetHandle;
-            Hardwares::VertexBufferSetHandle   VertexBufferSetHandle;
-            Hardwares::IndexBufferSetHandle    IndexBufferSetHandle;
+            Textures::TextureHandle           TextureHandle;
+            Hardwares::StorageBufferSetHandle StorageBufferSetHandle;
+            Hardwares::VertexBufferSetHandle  VertexBufferSetHandle;
+            Hardwares::IndexBufferSetHandle   IndexBufferSetHandle;
         };
     };
 
@@ -125,19 +123,17 @@ namespace ZEngine::Rendering::Renderers
 
     struct RenderGraphResourceInspector
     {
-        RenderGraphPtr                     Graph = nullptr;
+        RenderGraphPtr                    Graph = nullptr;
 
-        void                               Initialize(RenderGraphPtr graph);
+        void                              Initialize(RenderGraphPtr graph);
 
-        RenderGraphResource&               GetResource(cstring name);
-        Textures::TextureHandle            GetRenderTarget(cstring name);
-        Textures::TextureHandle            GetTexture(cstring name);
-        Hardwares::StorageBufferSetHandle  GetStorageBufferSet(cstring name);
-        Hardwares::VertexBufferSetHandle   GetVertexBufferSet(cstring name);
-        Hardwares::IndexBufferSetHandle    GetIndexBufferSet(cstring name);
-        Hardwares::UniformBufferSetHandle  GetBufferUniformSet(cstring name);
-        Hardwares::IndirectBufferSetHandle GetIndirectBufferSet(cstring name);
-        RenderGraphNode&                   GetNode(cstring name);
+        RenderGraphResource&              GetResource(cstring name);
+        Textures::TextureHandle           GetRenderTarget(cstring name);
+        Textures::TextureHandle           GetTexture(cstring name);
+        Hardwares::StorageBufferSetHandle GetStorageBufferSet(cstring name);
+        Hardwares::VertexBufferSetHandle  GetVertexBufferSet(cstring name);
+        Hardwares::IndexBufferSetHandle   GetIndexBufferSet(cstring name);
+        RenderGraphNode&                  GetNode(cstring name);
     };
 
     struct RenderGraphResourceBuilder
@@ -150,7 +146,6 @@ namespace ZEngine::Rendering::Renderers
         RenderGraphResource& CreateTexture(cstring name, cstring filename);
         RenderGraphResource& CreateRenderTarget(cstring name, const Specifications::TextureSpecification& spec);
         RenderGraphResource& AttachBuffer(cstring name, const Hardwares::StorageBufferSetHandle& buffer);
-        RenderGraphResource& AttachBuffer(cstring name, const Hardwares::UniformBufferSetHandle& buffer);
         RenderGraphResource& AttachTexture(cstring name, const Textures::TextureHandle& texture);
         RenderGraphResource& AttachRenderTarget(cstring name, const Textures::TextureHandle& texture);
         void                 CreateRenderPassNode(const RenderGraphRenderPassCreation&);

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/Attachment.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/Attachment.cpp
@@ -111,7 +111,10 @@ namespace ZEngine::Rendering::Renderers::RenderPasses
     {
         if (m_handle)
         {
-            m_device->EnqueueForDeletion(DeviceResourceType::RENDERPASS, m_handle);
+            Hardwares::DeferredFreeEntry e = {};
+            e.EntryKind                    = Hardwares::DeferredFreeEntry::Kind::VkHandle;
+            e.Data.Vk                      = {m_handle, DeviceResourceType::RENDERPASS, nullptr};
+            m_device->DeferFree(e);
             m_handle = VK_NULL_HANDLE;
         }
     }

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/RenderPass.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/RenderPass.cpp
@@ -149,13 +149,11 @@ namespace ZEngine::Rendering::Renderers::RenderPasses
         return verify;
     }
 
-    void RenderPass::SetInput(std::string_view key_name, const Hardwares::UniformBufferSetHandle& handle)
+    void RenderPass::SetInputFromHeap(std::string_view key_name, VkDeviceSize range)
     {
         auto validity_output = ValidateInput(key_name);
         if (!validity_output.first)
-        {
             return;
-        }
 
         const auto& spec      = validity_output.second;
         auto        shader    = Pipeline->Shader;
@@ -164,22 +162,29 @@ namespace ZEngine::Rendering::Renderers::RenderPasses
             set_array = m_device->ShaderReservedDescriptorSetMap.find(spec.Set);
         if (!set_array)
         {
-            ZENGINE_CORE_ERROR("SetInput(UBO): descriptor set {} not found for key '{}'", spec.Set, key_name.data())
+            ZENGINE_CORE_ERROR("SetInputFromHeap: descriptor set {} not found for key '{}'", spec.Set, key_name.data())
             return;
         }
+
         auto frame_count = m_device->SwapchainPtr->BufferredFrameCount;
-        auto ubo_buf     = m_device->UniformBufferSetManager.Access(handle);
         auto write_reqs  = std::vector<VkWriteDescriptorSet>(frame_count);
+        auto buf_infos   = std::vector<VkDescriptorBufferInfo>(frame_count);
 
         for (unsigned i = 0; i < frame_count; ++i)
         {
-            auto  set      = (*set_array)[i];
-            auto& buf      = ubo_buf->At(i);
-            auto& buf_info = buf->GetDescriptorBufferInfo();
-
-            ZENGINE_VALIDATE_ASSERT((buf_info.buffer), "UniformBuffer can't be null")
-
-            write_reqs[i] = VkWriteDescriptorSet{.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, .pNext = nullptr, .dstSet = set, .dstBinding = spec.Binding, .dstArrayElement = 0, .descriptorCount = 1, .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, .pImageInfo = nullptr, .pBufferInfo = &(buf_info), .pTexelBufferView = nullptr};
+            buf_infos[i]  = {.buffer = m_device->FrameHeaps[i].Handle, .offset = 0, .range = range};
+            write_reqs[i] = VkWriteDescriptorSet{
+                .sType            = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+                .pNext            = nullptr,
+                .dstSet           = (*set_array)[i],
+                .dstBinding       = spec.Binding,
+                .dstArrayElement  = 0,
+                .descriptorCount  = 1,
+                .descriptorType   = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC,
+                .pImageInfo       = nullptr,
+                .pBufferInfo      = &buf_infos[i],
+                .pTexelBufferView = nullptr,
+            };
         }
 
         vkUpdateDescriptorSets(m_device->LogicalDevice, write_reqs.size(), write_reqs.data(), 0, nullptr);

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/RenderPass.h
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/RenderPass.h
@@ -39,8 +39,10 @@ namespace ZEngine::Rendering::Renderers::RenderPasses
         void                                    Dispose();
         void                                    Bake();
         bool                                    Verify();
-        void                                    SetInput(std::string_view key_name, const Hardwares::UniformBufferSetHandle& buffer);
         void                                    SetInput(std::string_view key_name, const Hardwares::StorageBufferSetHandle& buffer);
+        // Bind a heap-allocated resource as DYNAMIC_UNIFORM_BUFFER.
+        // The heap VkBuffer covers all frames; dynamic offsets are supplied at draw time.
+        void                                    SetInputFromHeap(std::string_view key_name, VkDeviceSize range);
         void                                    SetInput(std::string_view key_name, const Textures::TextureHandle& texture);
         void                                    SetBindlessInput(std::string_view key_name);
         // Todo : This is a temporary solution, we should have a more abstract sampler resource in the future

--- a/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.cpp
@@ -1,3 +1,4 @@
+#include <ZEngine/Engine.h>
 #include <ZEngine/Rendering/Renderers/Contracts/RendererDataContract.h>
 #include <ZEngine/Rendering/Renderers/GraphicRenderer.h>
 #include <ZEngine/Rendering/Renderers/RendererPasses.h>
@@ -205,9 +206,34 @@ namespace ZEngine::Rendering::Renderers
 
     void SkyboxPass::Setup(Hardwares::VulkanDevicePtr const device, cstring name, RenderGraphResourceBuilderPtr const res_builder, RenderGraphResourceInspectorPtr res_inspector)
     {
-        auto env_map_res                            = res_builder->CreateTexture("skybox_env_map", "Settings/EnvironmentMaps/bergen_4k.zenvmap");
+        bool env_map_available = false;
+        if (EnvMapPath && EnvMapPath[0] != '\0')
+        {
+            auto* vfs = ZEngine::Engine::GetContext() ? ZEngine::Engine::GetContext()->VFS : nullptr;
+            if (vfs)
+            {
+                auto path_result   = ZEngine::Core::VFS::VFSPath::FromNative(EnvMapPath);
+                auto exists_result = path_result.Succeeded() ? vfs->Exists(path_result.Value()) : ZEngine::Core::VFS::VFSResult<bool>::Fail(ZEngine::Core::VFS::VFSError::InvalidPath);
+                if (exists_result.Failed() || !exists_result.Value())
+                    ZENGINE_CORE_ERROR("[SkyboxPass] Environment map not found in VFS: {}", EnvMapPath)
+                else
+                    env_map_available = true;
+            }
+            else
+            {
+                ZENGINE_CORE_ERROR("[SkyboxPass] VFS not available — cannot resolve environment map path: {}", EnvMapPath)
+            }
+        }
 
-        m_env_map                                   = env_map_res.ResourceInfo.TextureHandle;
+        if (!env_map_available)
+        {
+            m_env_map = {};
+        }
+        else
+        {
+            auto env_map_res = res_builder->CreateTexture("skybox_env_map", EnvMapPath);
+            m_env_map        = env_map_res.ResourceInfo.TextureHandle;
+        }
 
         const auto&                   skybox_vb_set = res_inspector->GetResource("SkyboxVbSet");
         const auto&                   skybox_ib_set = res_inspector->GetResource("SkyboxIbSet");
@@ -257,7 +283,7 @@ namespace ZEngine::Rendering::Renderers
             (*output_pass)->Bake();
         }
 
-        if (scene)
+        if (scene && m_env_map.Valid())
         {
             (*output_pass)->SetInputFromHeap("UBCamera", sizeof(Contracts::UBOCameraLayout));
             (*output_pass)->SetInput("EnvMap", m_env_map);
@@ -269,6 +295,9 @@ namespace ZEngine::Rendering::Renderers
 
     void SkyboxPass::Execute(Hardwares::VulkanDevicePtr const device, RenderGraphResourceInspectorPtr res_inspector, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPass* const pass, Buffers::FramebufferVNext* const framebuffer, Hardwares::CommandBufferPtr const command_buffer)
     {
+        if (!m_env_map.Valid())
+            return;
+
         const auto& vb_handle     = res_inspector->GetVertexBufferSet("SkyboxVbSet");
         const auto& ib_handle     = res_inspector->GetIndexBufferSet("SkyboxIbSet");
 

--- a/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.cpp
@@ -1,3 +1,4 @@
+#include <ZEngine/Rendering/Renderers/Contracts/RendererDataContract.h>
 #include <ZEngine/Rendering/Renderers/GraphicRenderer.h>
 #include <ZEngine/Rendering/Renderers/RendererPasses.h>
 
@@ -136,7 +137,7 @@ namespace ZEngine::Rendering::Renderers
             command_buffer->SetScissor(w, h);
         }
         command_buffer->BindPipeline(Specifications::PipelineBindPoint::GRAPHIC, pass->Pipeline);
-        command_buffer->BindDescriptorSets(device->SwapchainPtr->CurrentFrame->Index);
+        command_buffer->BindDescriptorSets(device->SwapchainPtr->CurrentFrame->Index, scene ? &scene->CameraHeapOffset : nullptr, scene ? 1u : 0u);
         command_buffer->Draw(3, 1, 0, 0);
         command_buffer->EndRenderPass();
     }
@@ -166,12 +167,13 @@ namespace ZEngine::Rendering::Renderers
             // clang-format off
             *output_pass = device->CreateRenderPass(pass_spec);
             // clang-format on
+            (*output_pass)->Pipeline->Shader->MarkBindingAsDynamic(0, 0);
             (*output_pass)->Bake();
         }
 
         if (scene)
         {
-            (*output_pass)->SetInput("UBCamera", scene->SceneCameraBufferHandle);
+            (*output_pass)->SetInputFromHeap("UBCamera", sizeof(Contracts::UBOCameraLayout));
 
             (*output_pass)->SetInput("VertexSB", scene->VertexBufferHandle);
             (*output_pass)->SetInput("IndexSB", scene->IndexBufferHandle);
@@ -183,12 +185,11 @@ namespace ZEngine::Rendering::Renderers
 
     void DepthPrePass::Execute(Hardwares::VulkanDevicePtr const device, RenderGraphResourceInspectorPtr res_inspector, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPass* const pass, Buffers::FramebufferVNext* const framebuffer, Hardwares::CommandBufferPtr const command_buffer)
     {
-        if (!scene || !scene->IndirectBufferHandle)
+        if (!scene || scene->IndirectCommandCount == 0)
         {
             return;
         }
 
-        auto indirect_buffer = device->IndirectBufferSetManager.Access(scene->IndirectBufferHandle);
         command_buffer->BeginRenderPass(pass, framebuffer->Handle, false);
         {
             uint32_t w = pass->GetRenderAreaWidth();
@@ -197,8 +198,8 @@ namespace ZEngine::Rendering::Renderers
             command_buffer->SetScissor(w, h);
         }
         command_buffer->BindPipeline(Specifications::PipelineBindPoint::GRAPHIC, pass->Pipeline);
-        command_buffer->BindDescriptorSets(device->SwapchainPtr->CurrentFrame->Index);
-        command_buffer->DrawIndirect(*indirect_buffer->At(device->SwapchainPtr->CurrentFrame->Index));
+        command_buffer->BindDescriptorSets(device->SwapchainPtr->CurrentFrame->Index, scene ? &scene->CameraHeapOffset : nullptr, scene ? 1u : 0u);
+        command_buffer->DrawIndirect(device->FrameHeaps[device->SwapchainPtr->CurrentFrame->Index].Handle, scene->IndirectHeapOffset, scene->IndirectCommandCount);
         command_buffer->EndRenderPass();
     }
 
@@ -252,12 +253,13 @@ namespace ZEngine::Rendering::Renderers
             // clang-format off
             *output_pass = device->CreateRenderPass(pass_spec);
             // clang-format on
+            (*output_pass)->Pipeline->Shader->MarkBindingAsDynamic(0, 0);
             (*output_pass)->Bake();
         }
 
         if (scene)
         {
-            (*output_pass)->SetInput("UBCamera", scene->SceneCameraBufferHandle);
+            (*output_pass)->SetInputFromHeap("UBCamera", sizeof(Contracts::UBOCameraLayout));
             (*output_pass)->SetInput("EnvMap", m_env_map);
             (*output_pass)->SetInput("LinearClampToEdgeSampler", device->GlobalLinearClampToEdgeSamplerImageInfo);
         }
@@ -283,7 +285,7 @@ namespace ZEngine::Rendering::Renderers
         command_buffer->BindPipeline(Specifications::PipelineBindPoint::GRAPHIC, pass->Pipeline);
         command_buffer->BindVertexBuffer(*vertex_buffer->At(device->SwapchainPtr->CurrentFrame->Index));
         command_buffer->BindIndexBuffer(*index_buffer->At(device->SwapchainPtr->CurrentFrame->Index), VK_INDEX_TYPE_UINT16);
-        command_buffer->BindDescriptorSets(device->SwapchainPtr->CurrentFrame->Index);
+        command_buffer->BindDescriptorSets(device->SwapchainPtr->CurrentFrame->Index, scene ? &scene->CameraHeapOffset : nullptr, scene ? 1u : 0u);
         command_buffer->DrawIndexed(36, 1, 0, 0, 0);
         command_buffer->EndRenderPass();
     }
@@ -337,12 +339,13 @@ namespace ZEngine::Rendering::Renderers
             // clang-format off
             *output_pass = device->CreateRenderPass(pass_spec);
             // clang-format on
+            (*output_pass)->Pipeline->Shader->MarkBindingAsDynamic(0, 0);
             (*output_pass)->Bake();
         }
 
         if (scene)
         {
-            (*output_pass)->SetInput("UBCamera", scene->SceneCameraBufferHandle);
+            (*output_pass)->SetInputFromHeap("UBCamera", sizeof(Contracts::UBOCameraLayout));
         }
         (*output_pass)->Verify();
     }
@@ -369,7 +372,7 @@ namespace ZEngine::Rendering::Renderers
         command_buffer->BindPipeline(Specifications::PipelineBindPoint::GRAPHIC, pass->Pipeline);
         command_buffer->BindVertexBuffer(*vertex_buffer);
         command_buffer->BindIndexBuffer(*index_buffer, VK_INDEX_TYPE_UINT16);
-        command_buffer->BindDescriptorSets(device->SwapchainPtr->CurrentFrame->Index);
+        command_buffer->BindDescriptorSets(device->SwapchainPtr->CurrentFrame->Index, scene ? &scene->CameraHeapOffset : nullptr, scene ? 1u : 0u);
         command_buffer->PushConstants(VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT, 0, sizeof(GridPushConstantData), &PushData);
         command_buffer->DrawIndexed(6, 1, 0, 0, 0);
         command_buffer->EndRenderPass();
@@ -409,12 +412,13 @@ namespace ZEngine::Rendering::Renderers
         {
             auto pass_spec = pass_builder->SetPipelineName("GBuffer-Pipeline").EnablePipelineDepthTest(true).UseShader("g_buffer").Detach();
             *output_pass   = device->CreateRenderPass(pass_spec);
+            (*output_pass)->Pipeline->Shader->MarkBindingAsDynamic(0, 0);
             (*output_pass)->Bake();
         }
 
         if (scene)
         {
-            (*output_pass)->SetInput("UBCamera", scene->SceneCameraBufferHandle);
+            (*output_pass)->SetInputFromHeap("UBCamera", sizeof(Contracts::UBOCameraLayout));
 
             (*output_pass)->SetInput("VertexSB", scene->VertexBufferHandle);
             (*output_pass)->SetInput("IndexSB", scene->IndexBufferHandle);
@@ -430,9 +434,9 @@ namespace ZEngine::Rendering::Renderers
     void GbufferPass::Execute(Hardwares::VulkanDevicePtr const device, RenderGraphResourceInspectorPtr res_inspector, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPass* const pass, Buffers::FramebufferVNext* const framebuffer, Hardwares::CommandBufferPtr const command_buffer)
     {
         CHECK_AND_ESCAPE_NULL(scene)
-        CHECK_AND_ESCAPE_NULL(scene->IndirectBufferHandle)
+        if (scene->IndirectCommandCount == 0)
+            return;
 
-        auto indirect_buffer = device->IndirectBufferSetManager.Access(scene->IndirectBufferHandle);
         command_buffer->BeginRenderPass(pass, framebuffer->Handle, false);
         {
             uint32_t w = pass->GetRenderAreaWidth();
@@ -441,8 +445,8 @@ namespace ZEngine::Rendering::Renderers
             command_buffer->SetScissor(w, h);
         }
         command_buffer->BindPipeline(Specifications::PipelineBindPoint::GRAPHIC, pass->Pipeline);
-        command_buffer->BindDescriptorSets(device->SwapchainPtr->CurrentFrame->Index);
-        command_buffer->DrawIndirect(*indirect_buffer->At(device->SwapchainPtr->CurrentFrame->Index));
+        command_buffer->BindDescriptorSets(device->SwapchainPtr->CurrentFrame->Index, scene ? &scene->CameraHeapOffset : nullptr, scene ? 1u : 0u);
+        command_buffer->DrawIndirect(device->FrameHeaps[device->SwapchainPtr->CurrentFrame->Index].Handle, scene->IndirectHeapOffset, scene->IndirectCommandCount);
         command_buffer->EndRenderPass();
     }
 

--- a/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.cpp
@@ -288,9 +288,8 @@ namespace ZEngine::Rendering::Renderers
             (*output_pass)->SetInputFromHeap("UBCamera", sizeof(Contracts::UBOCameraLayout));
             (*output_pass)->SetInput("EnvMap", m_env_map);
             (*output_pass)->SetInput("LinearClampToEdgeSampler", device->GlobalLinearClampToEdgeSamplerImageInfo);
+            (*output_pass)->Verify();
         }
-
-        (*output_pass)->Verify();
     }
 
     void SkyboxPass::Execute(Hardwares::VulkanDevicePtr const device, RenderGraphResourceInspectorPtr res_inspector, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPass* const pass, Buffers::FramebufferVNext* const framebuffer, Hardwares::CommandBufferPtr const command_buffer)

--- a/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.h
+++ b/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.h
@@ -49,6 +49,9 @@ namespace ZEngine::Rendering::Renderers
 
     struct SkyboxPass : public IRenderGraphCallbackPass
     {
+        // Set before Setup() is called. Empty string = no env map, pass is disabled.
+        cstring      EnvMapPath = nullptr;
+
         virtual void Setup(Hardwares::VulkanDevicePtr const device, cstring name, RenderGraphResourceBuilderPtr const res_builder, RenderGraphResourceInspectorPtr res_inspector) override;
         virtual void Compile(Hardwares::VulkanDevicePtr const device, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPassBuilder* pass_builder, RenderGraphResourceInspectorPtr res_inspector, RenderPasses::RenderPass** const output_pass) override;
         virtual void Execute(Hardwares::VulkanDevicePtr const device, RenderGraphResourceInspectorPtr res_inspector, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPass* const pass, Buffers::FramebufferVNext* const framebuffer, Hardwares::CommandBufferPtr const command_buffer) override;

--- a/ZEngine/ZEngine/Rendering/Scenes/GraphicScene.h
+++ b/ZEngine/ZEngine/Rendering/Scenes/GraphicScene.h
@@ -14,10 +14,10 @@ namespace ZEngine::Rendering::Scenes
     // Supported modes: "atmosphere" (default), "hdri", "skySphere".
     struct SkyConfig
     {
-        ZEngine::Core::Containers::String Mode           = {};  // "atmosphere", "hdri", "skySphere"
-        ZEngine::Core::Containers::String EnvironmentMap = {};  // .zenvmap filename (hdri mode only)
+        ZEngine::Core::Containers::String Mode           = {}; // "atmosphere", "hdri", "skySphere"
+        ZEngine::Core::Containers::String EnvironmentMap = {}; // .zenvmap filename (hdri mode only)
 
-        bool IsHDRI() const
+        bool                              IsHDRI() const
         {
             return Mode.c_str() && (strcmp(Mode.c_str(), "hdri") == 0);
         }

--- a/ZEngine/ZEngine/Rendering/Scenes/GraphicScene.h
+++ b/ZEngine/ZEngine/Rendering/Scenes/GraphicScene.h
@@ -12,14 +12,18 @@ namespace ZEngine::Rendering::Scenes
 {
     struct SceneData
     {
-        Hardwares::UniformBufferSetHandle  SceneCameraBufferHandle = {};
+        // Camera UBO — migrated to PerFrameUploadHeap; offset updated each frame in DrawScene
+        uint32_t                          CameraHeapOffset       = 0;
 
-        Hardwares::StorageBufferSetHandle  TransformBufferHandle   = {};
-        Hardwares::StorageBufferSetHandle  MaterialBufferHandle    = {};
-        Hardwares::StorageBufferSetHandle  VertexBufferHandle      = {};
-        Hardwares::StorageBufferSetHandle  IndexBufferHandle       = {};
-        Hardwares::StorageBufferSetHandle  RenderDataBufferHandle  = {};
-        Hardwares::IndirectBufferSetHandle IndirectBufferHandle    = {};
+        // Indirect draw commands — migrated to PerFrameUploadHeap
+        uint32_t                          IndirectHeapOffset     = 0;
+        uint32_t                          IndirectCommandCount   = 0;
+
+        Hardwares::StorageBufferSetHandle TransformBufferHandle  = {};
+        Hardwares::StorageBufferSetHandle MaterialBufferHandle   = {};
+        Hardwares::StorageBufferSetHandle VertexBufferHandle     = {};
+        Hardwares::StorageBufferSetHandle IndexBufferHandle      = {};
+        Hardwares::StorageBufferSetHandle RenderDataBufferHandle = {};
     };
     ZDEFINE_PTR(SceneData);
 

--- a/ZEngine/ZEngine/Rendering/Scenes/GraphicScene.h
+++ b/ZEngine/ZEngine/Rendering/Scenes/GraphicScene.h
@@ -10,6 +10,27 @@
 
 namespace ZEngine::Rendering::Scenes
 {
+    // Sky rendering configuration — stored per scene, serialized in .zescene.
+    // Supported modes: "atmosphere" (default), "hdri", "skySphere".
+    struct SkyConfig
+    {
+        ZEngine::Core::Containers::String Mode           = {};  // "atmosphere", "hdri", "skySphere"
+        ZEngine::Core::Containers::String EnvironmentMap = {};  // .zenvmap filename (hdri mode only)
+
+        bool IsHDRI() const
+        {
+            return Mode.c_str() && (strcmp(Mode.c_str(), "hdri") == 0);
+        }
+        bool IsAtmosphere() const
+        {
+            return Mode.empty() || (strcmp(Mode.c_str(), "atmosphere") == 0);
+        }
+        bool IsSkySphere() const
+        {
+            return Mode.c_str() && (strcmp(Mode.c_str(), "skySphere") == 0);
+        }
+    };
+
     struct SceneData
     {
         // Camera UBO — migrated to PerFrameUploadHeap; offset updated each frame in DrawScene
@@ -31,6 +52,10 @@ namespace ZEngine::Rendering::Scenes
     {
         std::atomic_bool                                                                   MeshAllocationDirty[3]   = {false, false, false};
         std::atomic_bool                                                                   TransformBufferDirty[3]  = {false, false, false};
+        std::atomic_bool                                                                   SkyDirty[3]              = {false, false, false};
+
+        // Sky configuration — set when the scene is loaded/changed; one copy per scene object.
+        SkyConfig                                                                          Sky                      = {};
 
         uint32_t                                                                           CurrentTransformOffset   = 0;
         uint32_t                                                                           CurrentVertexOffset      = 0;

--- a/ZEngine/ZEngine/Rendering/Shaders/Shader.cpp
+++ b/ZEngine/ZEngine/Rendering/Shaders/Shader.cpp
@@ -602,6 +602,122 @@ namespace ZEngine::Rendering::Shaders
         }
     }
 
+    void Shader::MarkBindingAsDynamic(uint32_t set, uint32_t binding)
+    {
+        if (!LayoutBindingSpecificationMap.contains(set))
+            return;
+
+        auto& specs = LayoutBindingSpecificationMap[set];
+        for (uint32_t i = 0; i < specs.size(); ++i)
+        {
+            if (specs[i].Binding == binding && specs[i].DescriptorTypeValue == Specifications::DescriptorType::UNIFORM_BUFFER)
+            {
+                specs[i].DescriptorTypeValue = Specifications::DescriptorType::UNIFORM_BUFFER_DYNAMIC;
+                break;
+            }
+        }
+
+        if (!InternalDescriptorSetLayoutMap.contains(set))
+            return;
+
+        // Rebuild the set layout with the patched binding type
+        auto                                scratch                   = ZGetScratch(&LocalArena);
+        Array<VkDescriptorSetLayoutBinding> layout_binding_collection = {};
+        layout_binding_collection.init(scratch.Arena, specs.size());
+        for (uint32_t i = 0; i < specs.size(); ++i)
+        {
+            layout_binding_collection.push(VkDescriptorSetLayoutBinding{.binding = specs[i].Binding, .descriptorType = Specifications::DescriptorTypeMap[static_cast<uint32_t>(specs[i].DescriptorTypeValue)], .descriptorCount = specs[i].Count, .stageFlags = Specifications::ShaderStageFlagsMap[static_cast<uint32_t>(specs[i].Flags)], .pImmutableSamplers = nullptr});
+        }
+
+        Array<VkDescriptorBindingFlags> binding_flags_collection = {};
+        binding_flags_collection.init(scratch.Arena, layout_binding_collection.size(), layout_binding_collection.size());
+        for (uint32_t i = 0; i < layout_binding_collection.size(); ++i)
+        {
+            binding_flags_collection[i] = 0;
+        }
+
+        VkDescriptorSetLayoutBindingFlagsCreateInfo binding_flags_info = {};
+        binding_flags_info.sType                                       = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO;
+        binding_flags_info.bindingCount                                = binding_flags_collection.size();
+        binding_flags_info.pBindingFlags                               = binding_flags_collection.data();
+
+        VkDescriptorSetLayoutCreateInfo layout_info                    = {};
+        layout_info.sType                                              = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+        layout_info.pNext                                              = &binding_flags_info;
+        layout_info.bindingCount                                       = layout_binding_collection.size();
+        layout_info.pBindings                                          = layout_binding_collection.data();
+
+        VkDescriptorSetLayout new_layout                               = VK_NULL_HANDLE;
+        ZENGINE_VALIDATE_ASSERT(vkCreateDescriptorSetLayout(m_device->LogicalDevice, &layout_info, nullptr, &new_layout) == VK_SUCCESS, "Failed to recreate DescriptorSetLayout for dynamic binding")
+
+        // Destroy old layout and replace
+        vkDestroyDescriptorSetLayout(m_device->LogicalDevice, InternalDescriptorSetLayoutMap.at(set), nullptr);
+        InternalDescriptorSetLayoutMap[set] = new_layout;
+
+        // SetLayouts is a contiguous array from set 0..max_set (with gaps filled by EmptyDescriptorSetLayout).
+        // The index into SetLayouts equals the set number.
+        if (set < SetLayouts.size())
+            SetLayouts[set] = new_layout;
+
+        // Recreate the descriptor pool to include UNIFORM_BUFFER_DYNAMIC and reallocate descriptor sets.
+        // The old pool (and its sets) are destroyed; DescriptorSetMap[set] gets fresh sets.
+        if (m_descriptor_pool != VK_NULL_HANDLE)
+        {
+            vkDestroyDescriptorPool(m_device->LogicalDevice, m_descriptor_pool, nullptr);
+            m_descriptor_pool = VK_NULL_HANDLE;
+        }
+
+        // Build pool sizes from all current LayoutBindingSpecificationMaps (including the patched one)
+        Array<VkDescriptorPoolSize> pool_size_collection = {};
+        pool_size_collection.init(scratch.Arena, 10);
+        for (const auto& lbs : LayoutBindingSpecificationMap)
+        {
+            if (m_device->ShaderReservedLayoutBindingSpecificationMap.contains(lbs.first))
+                continue;
+            for (uint32_t i = 0; i < lbs.second.size(); ++i)
+            {
+                VkDescriptorType dtype = Specifications::DescriptorTypeMap[static_cast<uint32_t>(lbs.second[i].DescriptorTypeValue)];
+                auto             it    = std::find_if(pool_size_collection.begin(), pool_size_collection.end(), [dtype](const VkDescriptorPoolSize& ps) { return ps.type == dtype; });
+                if (it == pool_size_collection.end())
+                    pool_size_collection.push(VkDescriptorPoolSize{.type = dtype, .descriptorCount = lbs.second[i].Count});
+                else
+                    it->descriptorCount += lbs.second[i].Count;
+            }
+        }
+        for (auto& ps : pool_size_collection)
+            ps.descriptorCount *= m_device->SwapchainPtr->BufferredFrameCount;
+
+        if (!pool_size_collection.empty())
+        {
+            VkDescriptorPoolCreateInfo pool_info = {};
+            pool_info.sType                      = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
+            pool_info.maxSets                    = m_device->SwapchainPtr->BufferredFrameCount;
+            pool_info.poolSizeCount              = pool_size_collection.size();
+            pool_info.pPoolSizes                 = pool_size_collection.data();
+            ZENGINE_VALIDATE_ASSERT(vkCreateDescriptorPool(m_device->LogicalDevice, &pool_info, nullptr, &m_descriptor_pool) == VK_SUCCESS, "Failed to recreate descriptor pool for dynamic binding")
+
+            // Reallocate descriptor sets for this set only
+            if (!m_device->ShaderReservedDescriptorSetMap.contains(set))
+            {
+                Array<VkDescriptorSetLayout> layouts = {};
+                layouts.init(scratch.Arena, m_device->SwapchainPtr->BufferredFrameCount, m_device->SwapchainPtr->BufferredFrameCount);
+                for (uint32_t i = 0; i < m_device->SwapchainPtr->BufferredFrameCount; ++i)
+                    layouts[i] = new_layout;
+
+                VkDescriptorSetAllocateInfo alloc_info = {};
+                alloc_info.sType                       = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+                alloc_info.descriptorPool              = m_descriptor_pool;
+                alloc_info.descriptorSetCount          = m_device->SwapchainPtr->BufferredFrameCount;
+                alloc_info.pSetLayouts                 = layouts.data();
+
+                DescriptorSetMap[set].init(m_device->Arena, m_device->SwapchainPtr->BufferredFrameCount, m_device->SwapchainPtr->BufferredFrameCount);
+                ZENGINE_VALIDATE_ASSERT(vkAllocateDescriptorSets(m_device->LogicalDevice, &alloc_info, DescriptorSetMap[set].data()) == VK_SUCCESS, "Failed to reallocate descriptor sets for dynamic binding")
+            }
+        }
+
+        ZReleaseScratch(scratch);
+    }
+
     void Shader::CreatePushConstantRange()
     {
         if (!PushConstantSpecifications.empty())

--- a/ZEngine/ZEngine/Rendering/Shaders/Shader.cpp
+++ b/ZEngine/ZEngine/Rendering/Shaders/Shader.cpp
@@ -426,13 +426,19 @@ namespace ZEngine::Rendering::Shaders
 
         for (auto set_layout : InternalDescriptorSetLayoutMap)
         {
-            m_device->EnqueueForDeletion(Rendering::DeviceResourceType::DESCRIPTORSETLAYOUT, set_layout.second);
+            Hardwares::DeferredFreeEntry e = {};
+            e.EntryKind                    = Hardwares::DeferredFreeEntry::Kind::VkHandle;
+            e.Data.Vk                      = {set_layout.second, Rendering::DeviceResourceType::DESCRIPTORSETLAYOUT, nullptr};
+            m_device->DeferFree(e);
         }
         InternalDescriptorSetLayoutMap.clear();
 
         if (m_descriptor_pool)
         {
-            m_device->EnqueueForDeletion(Rendering::DeviceResourceType::DESCRIPTORPOOL, m_descriptor_pool);
+            Hardwares::DeferredFreeEntry e = {};
+            e.EntryKind                    = Hardwares::DeferredFreeEntry::Kind::VkHandle;
+            e.Data.Vk                      = {m_descriptor_pool, Rendering::DeviceResourceType::DESCRIPTORPOOL, nullptr};
+            m_device->DeferFree(e);
             m_descriptor_pool = VK_NULL_HANDLE;
         }
     }

--- a/ZEngine/ZEngine/Rendering/Shaders/Shader.h
+++ b/ZEngine/ZEngine/Rendering/Shaders/Shader.h
@@ -16,6 +16,9 @@ namespace ZEngine::Rendering::Shaders
         void                                                                                                              Initialize(Hardwares::VulkanDevice* device, const Specifications::ShaderSpecification& spec);
         void                                                                                                              Dispose();
         Specifications::LayoutBindingSpecification                                                                        GetLayoutBindingSpecification(cstring name);
+        // Patch a binding's descriptor type to DYNAMIC and rebuild its set layout + descriptor set.
+        // Call after Initialize, before the pipeline is created.
+        void                                                                                                              MarkBindingAsDynamic(uint32_t set, uint32_t binding);
 
         VkDescriptorPool                                                                                                  m_descriptor_pool              = VK_NULL_HANDLE;
         Specifications::ShaderSpecification                                                                               m_specification                = {};

--- a/ZEngine/ZEngine/ZEngineDef.h
+++ b/ZEngine/ZEngine/ZEngineDef.h
@@ -121,7 +121,7 @@
 #define ZESCENE_MAGIC                                          MAKE_MAGIC('Z', 'S', 'C', 'N')
 #define ZENVMAP_MAGIC                                          MAKE_MAGIC('Z', 'E', 'N', 'V')
 #define ASSET_FILE_VERSION                                     MAKE_VERSION(1, 0, 0)
-#define SCENE_FILE_VERSION                                     MAKE_VERSION(1, 0, 0)
+#define SCENE_FILE_VERSION                                     MAKE_VERSION(1, 1, 0)
 
 typedef const char* cstring;
 

--- a/ZEngine/docs/future-plan/gpu-allocator-rearchitecture.md
+++ b/ZEngine/docs/future-plan/gpu-allocator-rearchitecture.md
@@ -17,14 +17,14 @@ and provides the foundation for 4K resource budgets and cross-platform unified m
 | ID | Location | Problem |
 |---|---|---|
 | C1 | `VulkanDevice.cpp:1179` | `DEDICATED_MEMORY_BIT` hardcoded on every image — exhausts `VkDeviceMemory` object limit on large scenes |
-| C2 | `VulkanDevice.cpp:2501` | Texture staging uses `HOST_ACCESS_RANDOM` — wrong memory type for sequential writes |
+| C2 | `VulkanDevice.cpp:2478` | `WriteTextureData` staging uses `HOST_ACCESS_RANDOM` — wrong memory type for sequential writes |
 | C3 | `VulkanDevice.cpp:477` | `VmaAllocatorCreateInfo` has no flags — no BDA support, no driver budget signals |
 | C4 | Entire codebase | No `vmaGetHeapBudgets` call — engine is blind to VRAM pressure at 4K |
 | H1 | `VulkanDevice.cpp:1042` | All DEVICE_LOCAL allocations share one default pool — geometry holes fragment texture blocks |
-| H2 | `AsyncResourceLoader.cpp:237` | Per-upload `vmaCreateBuffer` / `vmaDestroyBuffer` — `vkAllocateMemory` storm on bulk scene loads |
+| H2 | `AsyncResourceLoader.cpp:237,273` | Per-upload `vmaCreateBuffer` / `vmaDestroyBuffer` — `vkAllocateMemory` storm on bulk scene loads |
 | H3 | `VulkanDevice.cpp:2183` | `UniformBuffer` missing `ALLOW_TRANSFER_INSTEAD` — overflows BAR window to slow system RAM |
 | H4 | `VulkanDevice.cpp:1337` | `DirtyCollector` polls idle frames — queue accumulates unboundedly during continuous rendering |
-| H5 | `AsyncResourceLoader.cpp:261` | `ClearBuffer` host-visible path skips `vmaFlushAllocation` — GPU reads stale data on non-coherent memory |
+| H5 | `AsyncResourceLoader.cpp:261` | `ClearBuffer` direct-map clear path (line 268) skips `vmaFlushAllocation` after `secure_memset` — GPU reads stale data on non-coherent memory |
 | H6 | `VulkanDevice.cpp:1384` | `DirtyResources::BUFFER`/`BUFFERMEMORY` call raw `vkDestroyBuffer`/`vkFreeMemory` — VMA allocation leaks if wrong path is taken |
 
 ---
@@ -49,7 +49,7 @@ Callers declare what they need. `GpuAllocator` selects the pool, the VMA flags, 
 ### `GpuBudget` (compile-time, 4K target — from memory-budget.md §3)
 
 ```cpp
-namespace ZEngine::Hardwares::GpuBudget {
+namespace ZEngine::Core::Memory {
     constexpr uint64_t GeometryBytes     = 512ULL << 20;  // vertex + index + storage
     constexpr uint64_t TextureBytes      = 512ULL << 20;  // BC7/BC5 atlas
     constexpr uint64_t RenderTargetBytes = 172ULL << 20;  // shadow maps + post-process + thumbnails
@@ -74,7 +74,7 @@ One 64 MB allocation, persistently mapped, reused for all uploads. Replaces per-
 
 ```cpp
 struct StagingRing {
-    static constexpr uint32_t kCapacity  = GpuBudget::StagingBytes;
+    static constexpr uint64_t kCapacity  = StagingBytes;
     static constexpr uint32_t kMaxChunks = 256;
 
     struct Chunk {
@@ -148,7 +148,7 @@ struct DeferredFreeQueue {
 ```
 
 `Drain` walks from `Head` while `Entries[Head].TimelineValue <= completed_timeline_value`,
-calls `vmaDestroyBuffer` / `vmaDestroyImage` / `vkDestroy*`, advances `Head`. O(k) where
+calls `GpuAllocator::FreeBuffer` / `FreeImage` / `vkDestroy*`, advances `Head`. O(k) where
 k is the number of resources freed this frame — bounded by `MaxFramesInFlight * MaxResourcesDestroyedPerFrame` in steady state.
 
 ### `GpuAllocator`
@@ -189,15 +189,17 @@ Internal flag mapping (inside `AllocateBuffer` — not exposed to callers):
 
 | Domain | VMA usage | VMA flags |
 |---|---|---|
-| `DeviceGeometry` | `AUTO_PREFER_DEVICE` | `SEQUENTIAL_WRITE \| ALLOW_TRANSFER_INSTEAD \| MAPPED` |
+| `DeviceGeometry` | `AUTO_PREFER_DEVICE` | none (DEVICE_LOCAL only; CPU writes via staging ring) |
 | `DeviceTexture` | `AUTO_PREFER_DEVICE` | none (driver-queried dedicated when advised) |
 | `RenderTarget` | `AUTO_PREFER_DEVICE` | driver-queried dedicated only |
 | `HostUniform` | `AUTO_PREFER_DEVICE` | `SEQUENTIAL_WRITE \| ALLOW_TRANSFER_INSTEAD \| MAPPED` |
 | `HostStaging` | `AUTO_PREFER_DEVICE` | `SEQUENTIAL_WRITE \| MAPPED` |
 
-`AllocateImage` always calls `vkGetImageMemoryRequirements2` with `VkMemoryDedicatedRequirementsKHR`
-chained. `DEDICATED_MEMORY_BIT` is set only when `prefersDedicatedAllocation ||
-requiresDedicatedAllocation`. This replaces the hardcoded flag at `VulkanDevice.cpp:1179`.
+`AllocateImage` calls `vmaCreateImage`, which internally queries `VkMemoryDedicatedRequirementsKHR`
+on the created `VkImage` handle and sets `DEDICATED_MEMORY_BIT` only when
+`prefersDedicatedAllocation || requiresDedicatedAllocation`. This requires the allocator to have
+been created with `VMA_ALLOCATOR_CREATE_KHR_DEDICATED_ALLOCATION_BIT` — already guaranteed on
+Vulkan 1.1+ by VMA 3.x. This replaces the hardcoded flag at `VulkanDevice.cpp:1156`.
 
 Pool `maxBlockCount` values derived from `GpuBudget`:
 ```
@@ -286,7 +288,7 @@ GpuMem.Ring.Drain(UINT64_MAX);
 
 `CreateImage` — routes to `GpuMem.AllocateImage`. The hardcoded `DEDICATED_MEMORY_BIT` at line 1179 is removed.
 
-`WriteTextureData` (line 2501) — fix C2:
+`WriteTextureData` (line 2478) — fix C2:
 ```cpp
 // Before: HOST_ACCESS_RANDOM (wrong)
 BufferView staging = CreateBuffer(..., VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT);
@@ -387,13 +389,13 @@ timeline (previous frame completed) and before any new command buffers are recor
 
 ### `ZEngine/Hardwares/GpuAllocator.h`
 
-Types: `GpuMemoryDomain`, `GpuBudget` constants, `StagingRing`, `GpuAllocator`.
+Types: `GpuMemoryDomain`, budget constants, `StagingRing`, `GpuAllocator`.
 
-`VMA_IMPLEMENTATION` and `VMA_VULKAN_VERSION` move here from `VulkanDevice.cpp`.
-`VulkanDevice.cpp` no longer defines them. `VulkanDevice.h` replaces
-`#include <vk_mem_alloc.h>` at the top level with `#include <ZEngine/Hardwares/GpuAllocator.h>`.
+`VulkanDevice.h` replaces `#include <vk_mem_alloc.h>` with `#include <ZEngine/Hardwares/GpuAllocator.h>`.
 
 ### `ZEngine/Hardwares/GpuAllocator.cpp`
+
+`VMA_IMPLEMENTATION` and `VMA_VULKAN_VERSION` move here from `VulkanDevice.cpp` — they must live in exactly one translation unit. `VulkanDevice.cpp` removes its definitions.
 
 All `GpuAllocator` and `StagingRing` method bodies.
 
@@ -469,7 +471,7 @@ Each step compiles and passes existing tests before the next begins.
 |---|---|---|---|
 | 1 | New `GpuAllocator.h/.cpp` | Define types, Initialize/Shutdown/Allocate/Free. Move `VMA_IMPLEMENTATION` here. | Low — additive |
 | 2 | New `DeferredFreeQueue.h` | Define `DeferredFreeEntry`, `DeferredFreeQueue`. | Low — additive |
-| 3 | `VulkanDevice.h` | Add `GpuMem`, `PendingFree`, `TickMemory`, `DeferFree`. Keep `VmaAllocatorValue` as alias temporarily. | Low |
+| 3 | `VulkanDevice.h` | Add `GpuMem`, `PendingFree`, `TickMemory`, `DeferFree`. Remove `VmaAllocatorValue`. | Low |
 | 4 | `VulkanDevice.cpp` — `Initialize` | Wire `GpuMem.Initialize`. Keep old dirty queues alive. | Low |
 | 5 | `VulkanDevice.cpp` — `CreateBuffer` / `CreateImage` | Route through `GpuMem`. Update typed buffer `CreateBuffer()` to pass `GpuMemoryDomain`. | Medium |
 | 6 | `AsyncResourceLoader.cpp` — flush fix | Add `vmaFlushAllocation` to `ClearBuffer` host-visible path. | None |

--- a/ZEngine/docs/future-plan/panzerfaust.md
+++ b/ZEngine/docs/future-plan/panzerfaust.md
@@ -120,11 +120,18 @@ the engine and set working paths.
   "projectName": "MyGame",
   "version": "1.0.0",
   "workingSpace": ".",
-  "sceneDir": "Scenes",
-  "sceneDataDir": "SceneData",
-  "defaultImportDir": {
-    "textureDir": "textures",
-    "soundDir": "sounds"
+  "sceneDir": "$(workingSpace)/Scenes",
+  "sceneDataDir": "$(workingSpace)/SceneData",
+  "assetDirs": {
+    "textureDir": "$(workingSpace)/Assets/Textures",
+    "soundDir": "$(workingSpace)/Assets/Sounds",
+    "meshDir": "$(workingSpace)/Assets/Meshes",
+    "materialDir": "$(workingSpace)/Assets/Materials",
+    "spriteDir": "$(workingSpace)/Assets/Sprites",
+    "environmentMapDir": "$(workingSpace)/Assets/EnvironmentMaps"
+  },
+  "sky": {
+    "mode": "atmosphere"
   },
   "sceneList": [
     { "name": "Default", "isDefault": true }
@@ -134,7 +141,8 @@ the engine and set working paths.
 
 Obelisk reads this file, passes `workingSpace` as `GameApplication::WorkingSpacePath`,
 and passes the config path as `GameApplication::ConfigFile`. The VFS mounts
-`workingSpace` as the root for all asset resolution.
+`workingSpace` as the root for all asset resolution. All paths using the
+`$(workingSpace)` token are expanded to absolute paths at parse time.
 
 ### 4.1 `buildCommand` and `gameDllPath` fields
 
@@ -143,11 +151,18 @@ and passes the config path as `GameApplication::ConfigFile`. The VFS mounts
   "projectName": "MyGame",
   "version": "1.0.0",
   "workingSpace": ".",
-  "sceneDir": "Scenes",
-  "sceneDataDir": "SceneData",
-  "defaultImportDir": {
-    "textureDir": "textures",
-    "soundDir": "sounds"
+  "sceneDir": "$(workingSpace)/Scenes",
+  "sceneDataDir": "$(workingSpace)/SceneData",
+  "assetDirs": {
+    "textureDir": "$(workingSpace)/Assets/Textures",
+    "soundDir": "$(workingSpace)/Assets/Sounds",
+    "meshDir": "$(workingSpace)/Assets/Meshes",
+    "materialDir": "$(workingSpace)/Assets/Materials",
+    "spriteDir": "$(workingSpace)/Assets/Sprites",
+    "environmentMapDir": "$(workingSpace)/Assets/EnvironmentMaps"
+  },
+  "sky": {
+    "mode": "atmosphere"
   },
   "sceneList": [
     { "name": "Default", "isDefault": true }

--- a/ZEngine/docs/future-plan/per-frame-upload-heap.md
+++ b/ZEngine/docs/future-plan/per-frame-upload-heap.md
@@ -87,7 +87,7 @@ struct PerFrameUploadHeap {
 
     // Flush the written range if memory is not coherent. Called once per frame after
     // all Push() calls, before command buffer recording begins.
-    void Flush(VmaAllocator allocator);
+    void Flush(GpuAllocator* alloc);
 };
 ```
 
@@ -107,9 +107,9 @@ No branches, no locks, no allocation — a pointer bump and a `memcpy`.
 `Flush` is called once per frame after all `Push` calls complete, before the command buffer
 is recorded. It issues a single `vmaFlushAllocation` covering `[0, WritePos]`:
 ```cpp
-void PerFrameUploadHeap::Flush(VmaAllocator allocator) {
+void PerFrameUploadHeap::Flush(GpuAllocator* alloc) {
     if (!Coherent && WritePos > 0)
-        vmaFlushAllocation(allocator, Allocation, 0, WritePos);
+        vmaFlushAllocation(alloc->Allocator, Allocation, 0, WritePos);
 }
 ```
 
@@ -123,8 +123,8 @@ syscalls from O(resource_count) to O(1).
 `VulkanDevice` gains:
 
 ```cpp
-// VulkanDevice.h
-PerFrameUploadHeap FrameHeaps[3] = {}; // one per BufferredFrameCount
+// VulkanDevice.h — size matches SwapchainPtr->BufferredFrameCount (3)
+PerFrameUploadHeap FrameHeaps[3] = {};
 ```
 
 Initialized in `VulkanDevice::Initialize` after `GpuMem`:
@@ -210,11 +210,15 @@ The per-frame set (set 2) is created once at `VulkanDevice::Initialize`. Its des
 writes point to `FrameHeaps[i].Handle` for frame `i`. Dynamic offsets at bind time select
 the sub-region within the heap for each data type.
 
-`minUniformBufferOffsetAlignment` (queried from `VkPhysicalDeviceLimits`) governs the
-alignment passed to `PerFrameUploadHeap::Push`. Stored as:
+`minUniformBufferOffsetAlignment` and `minStorageBufferOffsetAlignment` (queried from
+`VkPhysicalDeviceLimits`) govern the alignment passed to `PerFrameUploadHeap::Push`.
+Stored as:
 ```cpp
 uint32_t VulkanDevice::MinUniformBufferOffsetAlignment() const {
     return (uint32_t)PhysicalDeviceProperties.properties.limits.minUniformBufferOffsetAlignment;
+}
+uint32_t VulkanDevice::MinStorageBufferOffsetAlignment() const {
+    return (uint32_t)PhysicalDeviceProperties.properties.limits.minStorageBufferOffsetAlignment;
 }
 ```
 
@@ -293,7 +297,7 @@ Depends on `gpu-allocator-rearchitecture.md` steps 1–5 being complete (GpuAllo
 | 2 | `VulkanDevice.h` | Add `FrameHeaps[3]`, `MinUniformBufferOffsetAlignment()`. | Low |
 | 3 | `VulkanDevice.cpp` — `Initialize` | Allocate and init 3 heaps. | Low |
 | 4 | `VulkanDevice.cpp` — `TickMemory` | Add `FrameHeaps[fi].Reset()`. | Low |
-| 5 | Shader / descriptor set layout | Add set 2 (`DYNAMIC_UNIFORM_BUFFER` per per-frame type) to shader reflection. Update `CreateDescriptorSets` in `Shader.cpp`. | Medium |
+| 5 | Shader / descriptor set layout | Add `DYNAMIC_UNIFORM_BUFFER` binding type to the SPIRV-cross reflection path in `Shader.cpp::CreateDescriptorSetLayouts`. Create the per-frame set 2 descriptor layout and allocate one set per frame in flight. | Medium |
 | 6 | `GraphicRenderer.cpp` — camera, lights | Migrate camera and light UBOs to `heap.Push`. Update bind calls to pass dynamic offsets. | Medium |
 | 7 | `GraphicScene` — per-object transforms | Migrate per-draw transform UBOs to `heap.Push`. | Medium |
 | 8 | Skinning system (future) | Migrate bone matrix upload to `heap.Push`. | Low — new system |
@@ -305,7 +309,7 @@ Depends on `gpu-allocator-rearchitecture.md` steps 1–5 being complete (GpuAllo
 ## 10. Verification
 
 1. Frame heap `WritePos` after all pushes must be less than `kCapacity`. Assert in Debug builds. Log peak `WritePos` via `MemoryProfiler` to validate budget sizing.
-2. One `vkFlushMappedMemoryRanges` call per frame (not per buffer). Verify with `VK_LAYER_LUNARG_api_dump` — count `vkFlushMappedMemoryRanges` invocations before and after migration.
+2. One `vmaFlushAllocation` call per frame (not per buffer), which maps to one `vkFlushMappedMemoryRanges` at the Vulkan level. Verify with `VK_LAYER_LUNARG_api_dump` — count `vkFlushMappedMemoryRanges` invocations before and after migration.
 3. `vkCmdBindDescriptorSets` for per-frame set uses non-zero dynamic offsets and binds correctly. Verify with RenderDoc: capture a frame and inspect UBO bindings — data should match CPU-side values.
 4. `VkBuffer` object count for per-frame data in RenderDoc: 3 (one per frame in flight) vs. O(N) before.
 5. Scene stress test: 500 draw calls, 60 fps, 100 frames — no validation layer errors, no heap overflow asserts.

--- a/ZEngine/docs/future-plan/sky-rendering.md
+++ b/ZEngine/docs/future-plan/sky-rendering.md
@@ -1,0 +1,473 @@
+# Sky Rendering Systems
+
+**Relates to:** `render-graph-integration.md`, `render-graph-redesign.md`, `gpu-allocator-rearchitecture.md`, `per-frame-upload-heap.md`
+**Replaces:** `SkyboxPass` (currently in `RendererPasses.h`)
+**Status:** Design
+**Scope:** Four sky rendering backends and the `SkySystem` coordinator that activates exactly one backend per scene.
+
+---
+
+## 1. Motivation and Scope
+
+The current `SkyboxPass` samples a `textureCube` bound to `set 0 binding 1`. It requires that the application always load a cube-map texture and provides no path for procedural atmospheres, image-based lighting capture, or lightweight gradient skies. Replacing it with a choice of four backends covers the full range of project needs from a simple editor background to a physically-based outdoor sky with aerial perspective.
+
+| System | Mode value | Use case |
+|---|---|---|
+| `SkyAtmospherePass` | `SkyMode::Atmosphere` | Full physically-based outdoor sky |
+| `SkyLightPass` | `SkyMode::Atmosphere` (auxiliary) | IBL capture from the active sky |
+| `HDRIBackdropPass` | `SkyMode::HDRI` | Artist-supplied equirectangular HDR image |
+| `SkySpherePass` | `SkyMode::SkySphere` | Lightweight gradient or texture-based sky |
+
+`SkyLightPass` is not a standalone mode — it always runs alongside `SkyAtmospherePass` or `HDRIBackdropPass` to provide the diffuse irradiance and specular pre-filtered environment map consumed by the deferred lighting pass. The existing `SkyboxPass` struct, its vertex and fragment shaders (`skybox.vert`, `skybox.frag`), and the cube-map sampler binding at `set 0 binding 1` are removed once all four backends are validated.
+
+---
+
+## 2. SkyMode Enum and SkyConfig
+
+```cpp
+// ZEngine/Rendering/Sky/SkyConfig.h
+enum class SkyMode : uint8_t
+{
+    Atmosphere = 0,  // SkyAtmospherePass + SkyLightPass
+    HDRI       = 1,  // HDRIBackdropPass  + SkyLightPass
+    SkySphere  = 2,  // SkySpherePass only; no IBL capture
+};
+
+struct SkyConfig
+{
+    SkyMode Mode = SkyMode::Atmosphere;
+
+    // SkyAtmospherePass params
+    Core::Maths::Vec4f RayleighScattering    = { 5.802e-6f, 13.558e-6f, 33.100e-6f, 0.0f };
+    float              RayleighScaleHeight    = 8000.0f;
+    float              MieScattering          = 3.996e-6f;
+    float              MieAbsorption          = 4.400e-6f;
+    float              MieScaleHeight         = 1200.0f;
+    float              MieAnisotropy          = 0.8f;
+    float              OzoneLayerCentre       = 25000.0f;
+    float              OzoneLayerWidth        = 15000.0f;
+    Core::Maths::Vec4f OzoneAbsorption        = { 0.650e-6f, 1.881e-6f, 0.085e-6f, 0.0f };
+    float              PlanetRadiusKm         = 6360.0f;
+    float              AtmosphereRadiusKm     = 6420.0f;
+    float              SunAngularRadiusDeg    = 0.5334f;
+    float              SunIlluminanceScale    = 10.0f;
+
+    // HDRIBackdropPass params
+    cstring            EnvironmentMapPath     = nullptr;  // VFS path to .hdr / .exr asset
+    float              HDRIExposure           = 1.0f;
+    Core::Maths::Vec4f HDRITint               = { 1.0f, 1.0f, 1.0f, 1.0f };
+
+    // SkySpherePass params
+    Core::Maths::Vec4f HorizonColor           = { 0.53f, 0.81f, 0.98f, 1.0f };
+    Core::Maths::Vec4f ZenithColor            = { 0.10f, 0.31f, 0.72f, 1.0f };
+    Core::Maths::Vec4f GroundColor            = { 0.30f, 0.27f, 0.24f, 1.0f };
+    float              SunDiscSize            = 0.005f;
+    float              SunDiscIntensity       = 5.0f;
+    float              HorizonSharpness       = 8.0f;
+    bool               ShowSunDisc            = true;
+};
+```
+
+project.json extension:
+
+```json
+{
+    "sky": {
+        "mode": "atmosphere",
+        "environmentMap": "$(workingSpace)/Assets/HDRI/outdoor_noon.hdr"
+    }
+}
+```
+
+When `mode` is `"atmosphere"` or `"skySphere"`, the `environmentMap` field is not required. When `mode` is `"hdri"`, a missing `environmentMap` causes `HDRIBackdropPass` to render solid black until an asset is assigned at runtime.
+
+---
+
+## 3. SkyAtmospherePass
+
+### 3.1 Theory
+
+Based on Bruneton 2017 and Hillaire 2020. Uses four pre-computed lookup tables rebuilt only when atmosphere parameters change. Per-frame cost is two full-screen triangle dispatches: one for the sky-view LUT and one to composite aerial perspective over scene geometry.
+
+Scattering model: Rayleigh from air molecules (wavelength-dependent, isotropic phase function), Mie from aerosols (Henyey-Greenstein, asymmetry `g`), ozone absorption (Gaussian layer at 25 km). Sun direction derived from the scene's first active directional light.
+
+### 3.2 LUT inventory
+
+| LUT | Dimensions | Format | Rebuilt when | GpuMemoryDomain |
+|---|---|---|---|---|
+| Transmittance LUT | 256x64 | `R11G11B10_UFLOAT` | Atmosphere params change | `DeviceTexture` |
+| Multiscattering LUT | 32x32 | `RGBA16F` | Atmosphere params change | `DeviceTexture` |
+| Sky-view LUT | 192x108 | `RGBA16F` | Every frame | `RenderTarget` |
+| Aerial perspective LUT | 32x32x32 | `RGBA16F` | Every frame | `RenderTarget` |
+
+Transmittance and multiscattering LUTs are persistent — allocated once via `GpuAllocator::AllocateImage(DeviceTexture)`, uploaded via the staging ring when parameters change. Sky-view and aerial perspective are transient render targets declared as RenderGraph resources.
+
+### 3.3 Atmosphere UBO
+
+```cpp
+// sizeof(SkyAtmosphereUBO) == 160 bytes, std140-compatible
+// Pushed into PerFrameUploadHeap each frame via:
+//   heap.Push(&atmo_ubo, sizeof(SkyAtmosphereUBO), device->MinUniformBufferOffsetAlignment())
+struct SkyAtmosphereUBO
+{
+    Core::Maths::Vec4f RayleighScattering;     //   0
+    Core::Maths::Vec4f MieScattering;          //  16
+    Core::Maths::Vec4f MieAbsorption;          //  32
+    Core::Maths::Vec4f OzoneAbsorption;        //  48
+    float              PlanetRadius;           //  64
+    float              AtmosphereRadius;       //  68
+    float              RayleighScaleHeight;    //  72
+    float              MieScaleHeight;         //  76
+    float              MieAnisotropy;          //  80
+    float              OzoneLayerCentre;       //  84
+    float              OzoneLayerWidth;        //  88
+    float              SunIlluminanceScale;    //  92
+    Core::Maths::Vec4f SunDirection;           //  96
+    float              SunAngularRadius;       // 112
+    float              _pad[3];                // 116
+    Core::Maths::Vec4f CameraPositionKm;       // 128
+    float              _pad2[4];               // 144
+};
+// static_assert(sizeof(SkyAtmosphereUBO) == 160);
+```
+
+### 3.4 GLSL binding layout
+
+```glsl
+// set 0 binding 0 — camera UBO (dynamic offset, shared with all passes)
+// set 0 binding 1 — SkyAtmosphereUBO (dynamic offset, PerFrameUploadHeap)
+
+// LUT samplers (sky-view and combine passes)
+layout(set = 1, binding = 0) uniform sampler2D  u_transmittance_lut;
+layout(set = 1, binding = 1) uniform sampler2D  u_multiscatter_lut;
+layout(set = 1, binding = 2) uniform sampler2D  u_skyview_lut;
+layout(set = 1, binding = 3) uniform sampler3D  u_aerial_perspective_lut;
+
+// LUT generation outputs (compute passes — storage images)
+layout(set = 1, binding = 0, r11f_g11f_b10f) uniform writeonly image2D  o_transmittance;
+layout(set = 1, binding = 0, rgba16f)          uniform writeonly image2D  o_multiscatter;
+layout(set = 1, binding = 0, rgba16f)          uniform writeonly image2D  o_skyview;
+layout(set = 1, binding = 0, rgba16f)          uniform writeonly image3D  o_aerial_persp;
+```
+
+Shader files:
+- `sky_transmittance.comp` — local_size 8x8x1, 256x64 output, optical depth integration
+- `sky_multiscatter.comp` — local_size 1x1x64, 32x32 output, first N scattering orders
+- `sky_skyview.comp` — local_size 8x8x1, 192x108, non-linear lat-lon parameterisation (Hillaire 2020)
+- `sky_aerial_perspective.comp` — local_size 8x8x1, 32x32x32, froxel in-scatter integration
+- `sky_combine.frag` — composite sky over geometry; aerial perspective for scene pixels, sky-view for background pixels
+
+### 3.5 Render graph integration
+
+```
+Setup():
+    declare transient RenderTargets: "sky_view_lut" (192x108 RGBA16F),
+                                     "aerial_persp" (32x32x32 RGBA16F)
+    inputs:  hdr_depth (for aerial perspective compositing)
+    outputs: hdr_lit (sky written on top), sky_view_lut, aerial_persp
+
+Execute():
+    1. if LUTsDirty:
+           dispatch transmittance compute (32x8 groups)
+           barrier: compute SHADER_WRITE -> SHADER_READ
+           dispatch multiscatter compute
+           barrier: compute SHADER_WRITE -> SHADER_READ
+           LUTsDirty = false
+    2. dispatch sky-view LUT compute (24x14 groups)
+    3. dispatch aerial perspective LUT compute (4x4x8 groups)
+    4. sky combine fullscreen draw(3,1,0,0) onto hdr_lit
+```
+
+### 3.6 Memory budget
+
+| Resource | Format | Size | Domain |
+|---|---|---|---|
+| Transmittance LUT | R11G11B10_UFLOAT | 256x64 = 64 KB | `DeviceTexture` |
+| Multiscattering LUT | RGBA16F | 32x32 = 8 KB | `DeviceTexture` |
+| Sky-view LUT | RGBA16F | 192x108 = 162 KB | `RenderTarget` |
+| Aerial perspective LUT | RGBA16F | 32x32x32 = 256 KB | `RenderTarget` |
+| SkyAtmosphereUBO in heap | — | 160 B per frame-in-flight | `HostUniform` |
+| **Total** | | **~490 KB** | |
+
+---
+
+## 4. SkyLightPass
+
+### 4.1 Purpose
+
+Captures sky radiance into three IBL resources for the deferred lighting pass:
+- Diffuse irradiance cubemap — 32x32 per face, `RGBA16F`, 6 faces
+- Specular pre-filtered env map — 128x128 base, 5 mip levels, `RGBA16F`, 6 faces
+- BRDF integration LUT — 512x512, `RG16F` (split-sum `A` and `B` terms)
+
+The BRDF LUT depends only on roughness and view angle. It is computed once at startup and never rebuilt. The diffuse and specular cubemaps are rebuilt on scene open, `SkyMode` change, and when `SkyAtmospherePass::MarkLUTsDirty()` is called.
+
+### 4.2 Capture trigger
+
+`SkySystem::m_ibl_dirty` is set in:
+- `SkySystem::Initialize()` — always capture on first frame
+- `SkySystem::SetConfig(cfg)` when mode changes
+- `SkyAtmospherePass::MarkLUTsDirty()` — atmosphere params changed
+- `HDRIBackdropPass::OnHDRIReady()` — new HDRI loaded
+
+`SkyLightPass::Execute()` exits early if `!SkySystem::IsIBLDirty()`.
+
+### 4.3 GLSL shader layout
+
+```glsl
+// Source sky input (cubemap from atmosphere or HDRI conversion)
+layout(set = 0, binding = 0) uniform samplerCube u_sky_cubemap;
+
+// IBL output storage images
+layout(set = 0, binding = 1, rgba16f) uniform writeonly imageCube o_irradiance;
+layout(set = 0, binding = 2, rgba16f) uniform writeonly imageCube o_prefiltered_mip;
+
+// Push constants
+layout(push_constant) uniform IBLPush {
+    uint  FaceIndex;
+    uint  MipLevel;
+    float Roughness;
+    uint  SampleCount;  // 1024 for prefiltered mip0, 64 for irradiance
+} pc;
+```
+
+Shader files:
+- `sky_brdf_lut.comp` — split-sum GGX A/B, 512x512 RG16F, local_size 8x8x1, run once at startup
+- `sky_irradiance.comp` — cosine-weighted hemisphere integral, 64 samples, local_size 8x8x6, 32x32 cubemap output
+- `sky_prefilter.comp` — GGX NDF importance sampling, 1024 samples at mip0, local_size 8x8x1
+
+### 4.4 Integration with LightingPass
+
+`SkyLightPass` exposes three getters. `LightingPass::Compile` calls them and binds to set 4:
+
+```glsl
+layout(set = 4, binding = 0) uniform samplerCube u_diffuse_irradiance;
+layout(set = 4, binding = 1) uniform samplerCube u_specular_env_map;
+layout(set = 4, binding = 2) uniform sampler2D   u_brdf_lut;
+```
+
+### 4.5 Memory budget
+
+| Resource | Format | Size | Domain |
+|---|---|---|---|
+| Diffuse irradiance cubemap | RGBA16F | 32x32x6 = 48 KB | `DeviceTexture` |
+| Specular env map cubemap | RGBA16F | 128x128x6 + 4 mips ≈ 1 MB | `DeviceTexture` |
+| BRDF integration LUT | RG16F | 512x512 = 512 KB | `DeviceTexture` |
+| **Total** | | **~1.5 MB** | |
+
+---
+
+## 5. HDRIBackdropPass
+
+### 5.1 Pipeline
+
+1. User places an `.hdr` or `.exr` in their project assets
+2. Editor import pipeline (via `IAssetImporter`) converts to internal format and stores in `{project}/Assets/HDRI/`
+3. `project.json` references the asset: `"sky": { "mode": "hdri", "environmentMap": "$(workingSpace)/Assets/HDRI/noon.hdr" }`
+4. At scene load, `SkySystem::SetConfig` requests async load via the asset pipeline
+5. On completion, `HDRIBackdropPass::OnHDRIReady(equirect_handle)` fires from the render thread
+6. Next `Execute()` dispatches the equirect-to-cubemap compute
+7. Every subsequent frame: fullscreen triangle backdrop draw only
+
+When `EnvironmentMapPath` is null or asset fails to load: renders solid black background. No crash, no error log spam — only a single `ZENGINE_CORE_WARN` on first miss.
+
+### 5.2 GLSL shader layout
+
+**Equirect-to-cubemap compute** (`hdri_equirect_to_cube.comp`, local_size 8x8x6, dispatch 64x64x1 groups for 512x512 faces):
+
+```glsl
+layout(set = 0, binding = 0) uniform sampler2D   u_equirect;
+layout(set = 0, binding = 1, rgba16f) uniform writeonly imageCube o_cubemap;
+layout(push_constant) uniform EquirectPush { uint FaceSize; } pc;
+// Converts cube face texel to direction, then maps to equirectangular UV via atan2/asin.
+```
+
+**Backdrop fullscreen** (`hdri_backdrop.frag`):
+
+```glsl
+layout(set = 0, binding = 0) uniform samplerCube u_hdri_cubemap;
+// Camera UBO at set 0 binding 1 (dynamic offset)
+layout(push_constant) uniform BackdropPush { float exposure; float tint[3]; } pc;
+// Reconstructs world-space ray via inverse(mat4(mat3(View))) * inv_proj * clip.
+// Samples cubemap along ray. Applies exposure and tint.
+```
+
+### 5.3 Memory budget
+
+| Resource | Format | Size | Domain |
+|---|---|---|---|
+| Equirect source 4K | RGBA32F | 4096x2048 = 128 MB | `DeviceTexture` |
+| Equirect source 2K | RGBA32F | 2048x1024 = 32 MB | `DeviceTexture` |
+| Converted cubemap | RGBA16F | 512x512x6 = 6 MB | `DeviceTexture` |
+
+Recommendation: import pipeline should offer optional downscale to 2K on import to reduce VRAM cost from 128 MB to 32 MB. If `GpuAllocator::HeapPressure` exceeds `WarnPressure (0.90)`, the import pipeline should trigger downscale automatically.
+
+---
+
+## 6. SkySpherePass
+
+A lightweight fallback — fullscreen triangle with analytical gradient sky, optional sun disc, no LUTs, no cubemap. All parameters pass via push constants (80 bytes).
+
+```cpp
+struct SkySpherePush  // 80 bytes, within 128-byte guaranteed minimum
+{
+    float HorizonColor[4];
+    float ZenithColor[4];
+    float GroundColor[4];
+    float SunDirection[4];  // w unused
+    float SunDiscSize;
+    float SunDiscIntensity;
+    float HorizonSharpness;
+    float ShowSunDisc;      // float bool
+    float _pad;
+};
+```
+
+**sky_sphere.frag** — trilinear gradient above/below horizon, Henyey-Greenstein-like sun disc via `acos(dot(dir, sun_dir)) < SunDiscSize`. Zero auxiliary GPU resources.
+
+---
+
+## 7. SkySystem
+
+Coordinator. Owns all four pass instances. Activates exactly one backend per frame. Drives `SkyLightPass` when mode is `Atmosphere` or `HDRI`.
+
+```cpp
+struct SkySystem
+{
+    void Initialize(VulkanDevice*, RenderGraph*, ArenaAllocator*);
+    void Update(const SkyConfig& cfg);      // call each frame from render thread
+    void RegisterPasses(RenderGraph*);
+    void Dispose();
+
+    bool IsIBLDirty()   const;
+    void ConsumeIBLDirty();
+    void MarkIBLDirty();
+
+    SkyLightPass* GetSkyLightPass();
+    SkyMode       GetActiveMode() const;
+
+private:
+    SkyConfig         m_config;
+    SkyMode           m_active_mode = SkyMode::Atmosphere;
+    bool              m_ibl_dirty   = true;
+    bool              m_mode_changed = false;
+
+    SkyAtmospherePass m_atmosphere_pass;
+    SkyLightPass      m_sky_light_pass;
+    HDRIBackdropPass  m_hdri_pass;
+    SkySpherePass     m_skysphere_pass;
+};
+```
+
+`RegisterPasses` is called from `GraphicRenderer::RegisterPasses` in place of the old `SkyboxPass` registration:
+
+```cpp
+// Mode = Atmosphere or HDRI: register SkyLightPass first (IBL needed before LightingPass)
+graph->AddCallbackPass("SkyLightPass", &m_sky_light_pass, mode != SkySphere);
+
+switch (mode) {
+    case Atmosphere: graph->AddCallbackPass("SkyAtmospherePass", &m_atmosphere_pass, true); break;
+    case HDRI:       graph->AddCallbackPass("HDRIBackdropPass",  &m_hdri_pass,        true); break;
+    case SkySphere:  graph->AddCallbackPass("SkySpherePass",     &m_skysphere_pass,   true); break;
+}
+graph->NodeMap["SkyboxPass"].Enabled = false;  // disable legacy pass
+```
+
+Mode changes at runtime require `RenderGraph::Compile()` — `SkySystem::Update` sets `m_mode_changed`; `GraphicRenderer::DrawScene` detects it and calls `m_render_graph->Compile()` before the next `Execute()`.
+
+Sun direction is derived from the scene's first active directional light each frame in `SkySystem::Update`. Falls back to `normalize(1,1,0)` if no directional light exists.
+
+---
+
+## 8. Render Graph Pass Order
+
+```
+[DepthPrePass]         -> hdr_depth
+[GeometryPass]         -> hdr_gbuffer
+[SkyLightPass]         (conditional; rebuilds IBL cubemaps if dirty)
+[LightingPass]         -> hdr_lit   (reads gbuffer + IBL from SkyLightPass)
+[SkyAtmospherePass]    (or HDRIBackdropPass, or SkySpherePass)
+    reads hdr_depth    (sky/geometry compositing)
+    writes hdr_lit     (additive sky luminance)
+[BloomThresholdPass]   -> bloom_threshold
+[ToneMappingPass]      -> ldr_color
+```
+
+`SkyLightPass` declares no RenderGraph attachments (its IBL cubemaps are persistent externals). Its graph registration ensures `Setup` and `Execute` are called in the correct frame slot before `LightingPass` consumes the IBL handles.
+
+---
+
+## 9. Descriptor Set Assignment
+
+| Set | Binding | Purpose |
+|---|---|---|
+| 0 | 0 | Camera UBO (UNIFORM_BUFFER_DYNAMIC, PerFrameUploadHeap) |
+| 0 | 1..N | Pass-specific LUT samplers / cubemaps |
+| 1 | 0 | `SkyAtmosphereUBO` (UNIFORM_BUFFER_DYNAMIC, PerFrameUploadHeap) |
+| 2 | 0-3 | IBL outputs for LightingPass (diffuse irradiance, specular env map, BRDF LUT) |
+
+Sky passes do not use the global bindless texture array. LUTs and cubemaps are explicit combined image samplers.
+
+---
+
+## 10. File Layout
+
+```
+ZEngine/Rendering/Sky/
+├── SkyConfig.h
+├── SkySystem.h / .cpp
+├── SkyAtmospherePass.h / .cpp
+├── SkyAtmosphereUBO.h
+├── SkyLightPass.h / .cpp
+├── HDRIBackdropPass.h / .cpp
+└── SkySpherePass.h / .cpp
+
+Resources/Shaders/Sky/
+├── sky_transmittance.comp
+├── sky_multiscatter.comp
+├── sky_skyview.comp
+├── sky_aerial_perspective.comp
+├── sky_combine.vert / .frag
+├── sky_irradiance.comp
+├── sky_prefilter.comp
+├── sky_brdf_lut.comp
+├── hdri_equirect_to_cube.comp
+├── hdri_backdrop.vert / .frag
+├── sky_sphere.vert / .frag
+```
+
+---
+
+## 11. Implementation Order
+
+| Step | Deliverable | Depends on | Risk |
+|---|---|---|---|
+| 1 | `SkyConfig.h`, `SkyMode` enum | Nothing | None |
+| 2 | `SkySpherePass` + `sky_sphere.frag` | Step 1 | Low — no LUTs, push constants only |
+| 3 | `SkySystem` skeleton (mode switch, pass registration) | Steps 1-2 | Low |
+| 4 | `SkyAtmospherePass` — transmittance + multiscatter LUT compute | Step 3, compute pipeline | Medium |
+| 5 | `SkyAtmospherePass` — sky-view + aerial perspective per-frame LUTs | Step 4; requires `TextureSpecification.Depth` for 3D textures | Medium |
+| 6 | `SkyAtmospherePass` — sky combine fullscreen graphics pass | Step 5 | Low |
+| 7 | `SkyLightPass` — BRDF LUT (once at startup) | Step 4 | Low |
+| 8 | `SkyLightPass` — irradiance + specular prefilter | Steps 6-7 | Medium |
+| 9 | `SkyLightPass` integration with `LightingPass` set 4 | Step 8 | Medium |
+| 10 | `HDRIBackdropPass` — equirect-to-cube compute | Steps 3, 8; `.hdr` importer | High |
+| 11 | `HDRIBackdropPass` — backdrop fullscreen pass | Step 10 | Low |
+| 12 | `HDRIBackdropPass` IBL source for `SkyLightPass` | Steps 9, 11 | Low |
+| 13 | `SkySystem::Update` with mode change + dirty tracking | Steps 3-12 | Medium |
+| 14 | Remove `SkyboxPass`, `skybox.vert/frag`, cube-map binding | All steps | Low |
+
+Note: Step 5 requires `TextureSpecification` to support a `Depth` field and a `Type3D` image view type for the 32x32x32 aerial perspective LUT. This must be added before Step 5 can proceed.
+
+---
+
+## 12. Memory Budget Impact
+
+| Mode | Resources | Total bytes | Domain |
+|---|---|---|---|
+| `Atmosphere` | 4 LUTs + 3 IBL textures | ~1.8 MB | DeviceTexture + RenderTarget |
+| `HDRI` (2K source) | Equirect + cubemap + 3 IBL | ~39 MB | DeviceTexture |
+| `HDRI` (4K source) | Equirect + cubemap + 3 IBL | ~135 MB | DeviceTexture |
+| `SkySphere` | None | 0 | — |
+
+For `Atmosphere` mode the budget impact is negligible. For `HDRI` mode with a 4K source, 135 MB is significant against the 512 MB `DeviceTexture` pool — the import pipeline should offer or auto-apply a 2K downscale option when heap pressure exceeds `WarnPressure (0.90)`.

--- a/ZEngine/tests/CMakeLists.txt
+++ b/ZEngine/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ file(GLOB TEST_SOURCES
 
 # macOS and Windows are multi-config
 if (((APPLE) OR (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")))
-    if ((${CMAKE_CONFIGURATION_TYPES} STREQUAL "Release"))
+    if ("Release" IN_LIST CMAKE_CONFIGURATION_TYPES)
         list(APPEND TEST_SOURCES CrashHandlers/CrashHandler_test.cpp)
         add_executable(ZEngineCrashDialogDemo CrashHandlers/CrashDialogDemo.cpp)
         target_link_libraries(ZEngineCrashDialogDemo PRIVATE zEngineLib)


### PR DESCRIPTION
Add GpuAllocator as the single owner of VmaAllocator with per-domain VmaPool handles and budget sampling. Move VMA_IMPLEMENTATION out of VulkanDevice.cpp into GpuAllocator.cpp so the translation unit boundary is owned by the allocator layer.

GpuAllocator.h declares:
- GpuMemoryDomain enum (DeviceGeometry, DeviceTexture, RenderTarget, HostUniform, HostStaging) with compile-time byte budgets matching the memory-budget spec (512/512/172/64/64 MB)
- AllocateBuffer / AllocateImage / FreeBuffer / FreeImage stubs
- SampleBudgets / HeapPressure for VK_EXT_memory_budget integration

GpuAllocator.cpp implements Initialize (VmaAllocator creation with VMA_ALLOCATOR_CREATE_EXT_MEMORY_BUDGET_BIT and
VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT flags) and Shutdown. Pool creation, allocation paths, and StagingRing are follow-on work.

Allocator.cpp: add defensive assertions to CreateSubArena for null out_arena, zero size, and overflow of parent arena bounds.