### PR TITLE
feat(camera): redesign FlyCamera with InputManager integration

### DIFF
--- a/Tetragrama/Components/HierarchyViewUIComponent.cpp
+++ b/Tetragrama/Components/HierarchyViewUIComponent.cpp
@@ -1,6 +1,5 @@
 // clang-format off
 #include <Tetragrama/Components/HierarchyViewUIComponent.h>
-#include <Tetragrama/Controllers/EditorCameraController.h>
 #include <ImGuizmo/ImGuizmo.h>
 #include <Tetragrama/Editor.h>
 #include <ZEngine/Core/Maths/Matrix.h>
@@ -235,8 +234,8 @@ namespace Tetragrama::Components
 
             if (camera && IDevice::As<Keyboard>()->IsKeyPressed(ZENGINE_KEY_F, app->CurrentWindow))
             {
-                auto active_editor_camera = reinterpret_cast<Controllers::EditorCameraControllerPtr>(app->CameraController);
-                // active_editor_camera->SetFocus(Vec3f(global_transform[0][3], global_transform[1][3], global_transform[2][3]));
+                // F-to-frame is handled by FlyCameraController reading the CameraFocus
+                // action slot from InputManager — no direct call needed here.
             }
 
             // snapping

--- a/Tetragrama/Components/SceneViewportUIComponent.cpp
+++ b/Tetragrama/Components/SceneViewportUIComponent.cpp
@@ -1,6 +1,5 @@
 #include <Tetragrama/Components/Events/UIComponentEvent.h>
 #include <Tetragrama/Components/SceneViewportUIComponent.h>
-#include <Tetragrama/Controllers/EditorCameraController.h>
 #include <Tetragrama/MessageToken.h>
 #include <Tetragrama/Messengers/Messenger.h>
 #include <ZEngine/Logging/LoggerDefinition.h>
@@ -56,7 +55,9 @@ namespace Tetragrama::Components
             }
         }
 
-        auto camera_controller = reinterpret_cast<Controllers::EditorCameraControllerPtr>(app->CameraController);
+        auto* camera_controller = app->CameraController;
+
+        camera_controller->SetViewportOrigin(m_viewport_bounds[0].x, m_viewport_bounds[0].y);
 
         if (m_request_renderer_resize)
         {

--- a/Tetragrama/Controllers/EditorCameraController.cpp
+++ b/Tetragrama/Controllers/EditorCameraController.cpp
@@ -2,17 +2,46 @@
 #include <ZEngine/Core/Maths/MathUtils.h>
 
 using namespace ZEngine::Rendering::Cameras;
-using namespace ZEngine::Helpers;
 using namespace ZEngine::Core::Maths;
 
 namespace Tetragrama::Controllers
 {
-    void EditorCameraController::Initialize(ZEngine::Core::Memory::ArenaAllocator* arena, ZEngine::Windows::CoreWindow* window)
+    void EditorCameraController::Initialize(ZEngine::Core::Memory::ArenaAllocator* arena, ZEngine::Windows::CoreWindow* window, ZEngine::Input::InputManager* input_manager)
     {
-        m_window              = window;
-        m_controller_type     = ZEngine::Controllers::CameraControllerType::PERSPECTIVE_CONTROLLER;
+        m_window                     = window;
+        m_controller_type            = ZEngine::Controllers::CameraControllerType::PERSPECTIVE_CONTROLLER;
 
-        const auto& win_props = m_window->GetWindowProperty();
-        m_camera              = ZPushStructCtorArgs(arena, FlyCamera, win_props.AspectRatio, CameraSetting{});
+        const auto&   props          = window->GetWindowProperty();
+        float         logicalW       = static_cast<float>(props.Width);
+        float         logicalH       = static_cast<float>(props.Height);
+
+        CameraSetting settings       = {};
+        settings.FOV                 = 60.0f;
+        settings.NearPlane           = 0.1f;
+        settings.FarPlane            = 10000.0f;
+        settings.SmoothingFactor     = 12.0f;
+        settings.MinMoveSpeed        = 1.0f;
+        settings.MaxMoveSpeed        = 500.0f;
+        settings.PanSpeed            = 1.0f;
+        settings.RotationSpeed       = 0.25f;
+        settings.OrbitSpeed          = 0.25f;
+        settings.FastSpeedMultiplier = 4.0f;
+        settings.ScrollSpeed         = 3.0f;
+        settings.FocusDuration       = 0.25f;
+        settings.MinOrbitDistance    = 0.5f;
+        settings.MaxOrbitDistance    = 10000.0f;
+
+        m_camera                     = ZPushStructCtorArgs(arena, FlyCamera, logicalW / logicalH, settings);
+        m_camera->SetViewportSize(logicalW, logicalH);
+
+        m_camera->Hooks.Raycast            = [](Vec3f, Vec3f, float maxDist) { return maxDist; };
+        m_camera->Hooks.GetSelectionBounds = []() -> std::pair<Vec3f, float> {
+            return {
+                Vec3f{0.0f, 0.0f, 0.0f},
+                5.0f
+            };
+        };
+
+        FlyCameraController::Initialize(input_manager, arena);
     }
 } // namespace Tetragrama::Controllers

--- a/Tetragrama/Controllers/EditorCameraController.h
+++ b/Tetragrama/Controllers/EditorCameraController.h
@@ -1,5 +1,8 @@
 #pragma once
 #include <ZEngine/Controllers/FlyCameraController.h>
+#include <ZEngine/Core/Memory/Allocator.h>
+#include <ZEngine/Input/InputManager.h>
+#include <ZEngine/Windows/CoreWindow.h>
 
 namespace Tetragrama::Controllers
 {
@@ -8,7 +11,7 @@ namespace Tetragrama::Controllers
         EditorCameraController()          = default;
         virtual ~EditorCameraController() = default;
 
-        void Initialize(ZEngine::Core::Memory::ArenaAllocator* arena, ZEngine::Windows::CoreWindow* window);
+        void Initialize(ZEngine::Core::Memory::ArenaAllocator* arena, ZEngine::Windows::CoreWindow* window, ZEngine::Input::InputManager* input_manager);
     };
     ZDEFINE_PTR(EditorCameraController);
 } // namespace Tetragrama::Controllers

--- a/Tetragrama/Editor.cpp
+++ b/Tetragrama/Editor.cpp
@@ -62,7 +62,7 @@ namespace Tetragrama
         UILayer                    = ZPushStructCtor(&Memory->MainArena, ImguiLayer);
 
         UILayer->Initialize(&Memory->MainArena, this);
-        editor_cam_controller->Initialize(&Memory->MainArena, CurrentWindow);
+        editor_cam_controller->Initialize(&Memory->MainArena, CurrentWindow, ZEngine::Engine::GetContext()->InputManager);
         editor_scene->Initialize(&Memory->MainArena, Configuration->ActiveSceneName.c_str());
 
         CameraController = editor_cam_controller;

--- a/ZEngine/ZEngine/Controllers/FlyCameraController.cpp
+++ b/ZEngine/ZEngine/Controllers/FlyCameraController.cpp
@@ -1,34 +1,99 @@
+#include <GLFW/glfw3.h>
 #include <ZEngine/Controllers/FlyCameraController.h>
-#include <ZEngine/Windows/Inputs/KeyCodeDefinition.h>
-#include <ZEngine/Windows/Inputs/Keyboard.h>
-#include <ZEngine/Windows/Inputs/Mouse.h>
 
-using namespace ZEngine::Helpers;
-using namespace ZEngine::Windows::Inputs;
-using namespace ZEngine::Windows::Events;
+using namespace ZEngine::Rendering::Cameras;
+using namespace ZEngine::Input;
 
 namespace ZEngine::Controllers
 {
-    void FlyCameraController::Update(Core::TimeStep dt)
+    void FlyCameraController::Initialize(InputManager* input_manager, Core::Memory::ArenaAllocator* /*arena*/)
     {
-        m_camera->OnUpdate(dt);
+        m_input        = input_manager;
+
+        m_slot_forward = m_input->RegisterAction("CameraForward", InputActionType::Axis1D);
+        m_input->BindKey(m_slot_forward, GLFW_KEY_W, 1.0f);
+        m_input->BindKey(m_slot_forward, GLFW_KEY_S, -1.0f);
+
+        m_slot_right = m_input->RegisterAction("CameraRight", InputActionType::Axis1D);
+        m_input->BindKey(m_slot_right, GLFW_KEY_D, 1.0f);
+        m_input->BindKey(m_slot_right, GLFW_KEY_A, -1.0f);
+
+        m_slot_up = m_input->RegisterAction("CameraUp", InputActionType::Axis1D);
+        m_input->BindKey(m_slot_up, GLFW_KEY_E, 1.0f);
+        m_input->BindKey(m_slot_up, GLFW_KEY_Q, -1.0f);
+
+        m_slot_scroll = m_input->RegisterAction("CameraScroll", InputActionType::Axis1D);
+        m_input->BindScrollAxis(m_slot_scroll, 1.0f);
+
+        m_slot_rmb = m_input->RegisterAction("CameraRMB", InputActionType::Button);
+        m_input->BindMouseButton(m_slot_rmb, GLFW_MOUSE_BUTTON_RIGHT);
+
+        m_slot_mmb = m_input->RegisterAction("CameraMMB", InputActionType::Button);
+        m_input->BindMouseButton(m_slot_mmb, GLFW_MOUSE_BUTTON_MIDDLE);
+
+        m_slot_lmb = m_input->RegisterAction("CameraLMB", InputActionType::Button);
+        m_input->BindMouseButton(m_slot_lmb, GLFW_MOUSE_BUTTON_LEFT);
+
+        m_slot_alt = m_input->RegisterAction("CameraAlt", InputActionType::Button);
+        m_input->BindKey(m_slot_alt, GLFW_KEY_LEFT_ALT);
+
+        m_slot_shift = m_input->RegisterAction("CameraShift", InputActionType::Button);
+        m_input->BindKey(m_slot_shift, GLFW_KEY_LEFT_SHIFT);
+
+        m_slot_ctrl = m_input->RegisterAction("CameraCtrl", InputActionType::Button);
+        m_input->BindKey(m_slot_ctrl, GLFW_KEY_LEFT_CONTROL);
+
+        m_slot_focus = m_input->RegisterAction("CameraFocus", InputActionType::Button);
+        m_input->BindKey(m_slot_focus, GLFW_KEY_F);
+
+        for (int i = 0; i < 9; ++i)
+        {
+            char name[24];
+            snprintf(name, sizeof(name), "CameraBookmark%d", i);
+            m_slot_bookmark[i] = m_input->RegisterAction(name, InputActionType::Button);
+            m_input->BindKey(m_slot_bookmark[i], GLFW_KEY_1 + i);
+        }
     }
 
-    bool FlyCameraController::OnEvent(Core::CoreEvent& e)
+    void FlyCameraController::Update(Core::TimeStep dt)
     {
-        if (!m_process_event.value.load(std::memory_order_acquire))
+        if (m_active.value.load(std::memory_order_acquire))
         {
-            return false;
+            auto& inp            = m_camera->Input;
+
+            inp.Keys[GLFW_KEY_W] = m_input->GetAxis(m_slot_forward) > 0.5f;
+            inp.Keys[GLFW_KEY_S] = m_input->GetAxis(m_slot_forward) < -0.5f;
+            inp.Keys[GLFW_KEY_D] = m_input->GetAxis(m_slot_right) > 0.5f;
+            inp.Keys[GLFW_KEY_A] = m_input->GetAxis(m_slot_right) < -0.5f;
+            inp.Keys[GLFW_KEY_E] = m_input->GetAxis(m_slot_up) > 0.5f;
+            inp.Keys[GLFW_KEY_Q] = m_input->GetAxis(m_slot_up) < -0.5f;
+
+            inp.RightDown        = m_input->GetButton(m_slot_rmb).Held;
+            inp.MiddleDown       = m_input->GetButton(m_slot_mmb).Held;
+            inp.LeftDown         = m_input->GetButton(m_slot_lmb).Held;
+            inp.AltDown          = m_input->GetButton(m_slot_alt).Held;
+            inp.ShiftDown        = m_input->GetButton(m_slot_shift).Held;
+            inp.CtrlDown         = m_input->GetButton(m_slot_ctrl).Held;
+
+            inp.Keys[GLFW_KEY_F] = m_input->GetButton(m_slot_focus).JustUp;
+            for (int i = 0; i < 9; ++i)
+                inp.Keys[GLFW_KEY_1 + i] = m_input->GetButton(m_slot_bookmark[i]).JustUp;
+
+            auto delta         = m_input->GetMouseDelta();
+            inp.MouseDeltaX    = delta.x;
+            inp.MouseDeltaY    = delta.y;
+            inp.ScrollDelta    = m_input->GetAxis(m_slot_scroll);
+
+            auto pos           = m_input->GetMousePosition();
+            inp.MouseViewportX = pos.x - m_viewportOriginX;
+            inp.MouseViewportY = pos.y - m_viewportOriginY;
         }
 
-        Core::EventDispatcher dispatcher(e);
-        dispatcher.Dispatch<MouseButtonWheelEvent>(std::bind(&FlyCameraController::OnMouseButtonWheelMoved, this, std::placeholders::_1));
-        dispatcher.Dispatch<MouseButtonReleasedEvent>(std::bind(&FlyCameraController::OnMouseButtonReleased, this, std::placeholders::_1));
-        dispatcher.Dispatch<MouseButtonPressedEvent>(std::bind(&FlyCameraController::OnMouseButtonPressed, this, std::placeholders::_1));
-        dispatcher.Dispatch<MouseButtonMovedEvent>(std::bind(&FlyCameraController::OnMouseButtonMoved, this, std::placeholders::_1));
+        m_camera->OnUpdate(dt.GetSecond());
+    }
 
-        dispatcher.Dispatch<KeyPressedEvent>(std::bind(&FlyCameraController::OnKeyPressed, this, std::placeholders::_1));
-        dispatcher.Dispatch<KeyReleasedEvent>(std::bind(&FlyCameraController::OnKeyReleased, this, std::placeholders::_1));
+    bool FlyCameraController::OnEvent(Core::CoreEvent&)
+    {
         return false;
     }
 
@@ -47,55 +112,26 @@ namespace ZEngine::Controllers
         m_camera->SetPosition(position);
     }
 
-    void FlyCameraController::SetViewport(float width, float height)
+    void FlyCameraController::SetViewport(float logicalW, float logicalH)
     {
-        m_camera->SetViewportSize(width, height);
+        m_camera->SetViewportSize(logicalW, logicalH);
     }
 
-    bool FlyCameraController::OnMouseButtonReleased(MouseButtonReleasedEvent& e)
+    void FlyCameraController::SetViewportOrigin(float x, float y)
     {
-        m_camera->OnMouseButtonUp((int) e.GetButton());
-        return false;
-    }
-
-    bool FlyCameraController::OnMouseButtonPressed(MouseButtonPressedEvent& e)
-    {
-        m_camera->OnMouseButtonDown((int) e.GetButton());
-        return false;
-    }
-
-    bool FlyCameraController::OnMouseButtonWheelMoved(MouseButtonWheelEvent& e)
-    {
-        const auto mouse_position = IDevice::As<Mouse>()->GetMousePosition(m_window);
-        m_camera->OnMouseScroll(e.GetOffetY(), mouse_position[0], mouse_position[1]);
-        return false;
-    }
-
-    bool FlyCameraController::OnMouseButtonMoved(MouseButtonMovedEvent& e)
-    {
-        m_camera->OnMouseMove(e.GetXOffset(), e.GetYOffset());
-        return false;
-    }
-
-    bool FlyCameraController::OnKeyPressed(KeyPressedEvent& e)
-    {
-        m_camera->OnKeyDown((int) e.GetKeyCode());
-        return false;
-    }
-
-    bool FlyCameraController::OnKeyReleased(KeyReleasedEvent& e)
-    {
-        m_camera->OnKeyUp((int) e.GetKeyCode());
-        return false;
+        m_viewportOriginX = x;
+        m_viewportOriginY = y;
     }
 
     void FlyCameraController::ResumeEventProcessing()
     {
-        m_process_event.value.store(true, std::memory_order_release);
+        m_active.value.store(true, std::memory_order_release);
     }
 
     void FlyCameraController::PauseEventProcessing()
     {
-        m_process_event.value.store(false, std::memory_order_release);
+        m_active.value.store(false, std::memory_order_release);
+        m_camera->Input.Reset();
     }
+
 } // namespace ZEngine::Controllers

--- a/ZEngine/ZEngine/Controllers/FlyCameraController.cpp
+++ b/ZEngine/ZEngine/Controllers/FlyCameraController.cpp
@@ -36,12 +36,15 @@ namespace ZEngine::Controllers
 
         m_slot_alt = m_input->RegisterAction("CameraAlt", InputActionType::Button);
         m_input->BindKey(m_slot_alt, GLFW_KEY_LEFT_ALT);
+        m_input->BindKey(m_slot_alt, GLFW_KEY_RIGHT_ALT);
 
         m_slot_shift = m_input->RegisterAction("CameraShift", InputActionType::Button);
         m_input->BindKey(m_slot_shift, GLFW_KEY_LEFT_SHIFT);
+        m_input->BindKey(m_slot_shift, GLFW_KEY_RIGHT_SHIFT);
 
         m_slot_ctrl = m_input->RegisterAction("CameraCtrl", InputActionType::Button);
         m_input->BindKey(m_slot_ctrl, GLFW_KEY_LEFT_CONTROL);
+        m_input->BindKey(m_slot_ctrl, GLFW_KEY_RIGHT_CONTROL);
 
         m_slot_focus = m_input->RegisterAction("CameraFocus", InputActionType::Button);
         m_input->BindKey(m_slot_focus, GLFW_KEY_F);

--- a/ZEngine/ZEngine/Controllers/FlyCameraController.h
+++ b/ZEngine/ZEngine/Controllers/FlyCameraController.h
@@ -1,36 +1,47 @@
 #pragma once
 #include <ZEngine/Controllers/ICameraController.h>
 #include <ZEngine/Core/Memory/Allocator.h>
+#include <ZEngine/Input/InputManager.h>
 #include <ZEngine/Rendering/Cameras/FlyCamera.h>
 
 namespace ZEngine::Controllers
 {
-    struct FlyCameraController : public ICameraController, public Windows::Inputs::IMouseEventCallback, public Windows::Inputs::IKeyboardEventCallback
+    struct FlyCameraController : public ICameraController
     {
         FlyCameraController()          = default;
         virtual ~FlyCameraController() = default;
 
-        void                          Update(Core::TimeStep) override;
+        void                          Initialize(Input::InputManager* input_manager, Core::Memory::ArenaAllocator* arena);
+
+        void                          Update(Core::TimeStep dt) override;
         bool                          OnEvent(Core::CoreEvent&) override;
-
         Rendering::Cameras::CameraPtr GetCamera() const override;
-        virtual Core::Maths::Vec3f    GetPosition() const override;
-        virtual void                  SetPosition(const Core::Maths::Vec3f& position) override;
-
-        void                          SetViewport(float width, float height);
-        void                          ResumeEventProcessing();
-        void                          PauseEventProcessing();
-
-        virtual bool                  OnMouseButtonPressed(Windows::Events::MouseButtonPressedEvent&) override;
-        virtual bool                  OnMouseButtonReleased(Windows::Events::MouseButtonReleasedEvent&) override;
-        virtual bool                  OnMouseButtonMoved(Windows::Events::MouseButtonMovedEvent&) override;
-        virtual bool                  OnMouseButtonWheelMoved(Windows::Events::MouseButtonWheelEvent&) override;
-
-        virtual bool                  OnKeyPressed(Windows::Events::KeyPressedEvent&) override;
-        virtual bool                  OnKeyReleased(Windows::Events::KeyReleasedEvent&) override;
+        Core::Maths::Vec3f            GetPosition() const override;
+        void                          SetPosition(const Core::Maths::Vec3f&) override;
+        void                          SetViewport(float logicalW, float logicalH) override;
+        void                          SetViewportOrigin(float x, float y) override;
+        void                          ResumeEventProcessing() override;
+        void                          PauseEventProcessing() override;
 
     protected:
-        PaddedAtomic<bool>               m_process_event = {.value = false};
-        Rendering::Cameras::FlyCameraPtr m_camera        = nullptr;
+        Input::InputManager*             m_input            = nullptr;
+        PaddedAtomic<bool>               m_active           = {.value = false};
+        float                            m_viewportOriginX  = 0.0f;
+        float                            m_viewportOriginY  = 0.0f;
+        Rendering::Cameras::FlyCameraPtr m_camera           = nullptr;
+
+        uint32_t                         m_slot_forward     = 0;
+        uint32_t                         m_slot_right       = 0;
+        uint32_t                         m_slot_up          = 0;
+        uint32_t                         m_slot_scroll      = 0;
+        uint32_t                         m_slot_rmb         = 0;
+        uint32_t                         m_slot_mmb         = 0;
+        uint32_t                         m_slot_lmb         = 0;
+        uint32_t                         m_slot_alt         = 0;
+        uint32_t                         m_slot_shift       = 0;
+        uint32_t                         m_slot_ctrl        = 0;
+        uint32_t                         m_slot_focus       = 0;
+        uint32_t                         m_slot_bookmark[9] = {};
     };
+    ZDEFINE_PTR(FlyCameraController);
 } // namespace ZEngine::Controllers

--- a/ZEngine/ZEngine/Controllers/ICameraController.h
+++ b/ZEngine/ZEngine/Controllers/ICameraController.h
@@ -15,6 +15,13 @@ namespace ZEngine::Controllers
         virtual Core::Maths::Vec3f            GetPosition() const                             = 0;
         virtual void                          SetPosition(const Core::Maths::Vec3f& position) = 0;
         virtual Rendering::Cameras::CameraPtr GetCamera() const                               = 0;
+        virtual void                          Update(Core::TimeStep dt)                       = 0;
+        virtual bool                          OnEvent(Core::CoreEvent&)                       = 0;
+
+        virtual void                          SetViewport(float logicalW, float logicalH)     = 0;
+        virtual void                          SetViewportOrigin(float x, float y)             = 0;
+        virtual void                          ResumeEventProcessing()                         = 0;
+        virtual void                          PauseEventProcessing()                          = 0;
 
         CameraControllerType                  GetControllerType() const
         {

--- a/ZEngine/ZEngine/Rendering/Cameras/Camera.h
+++ b/ZEngine/ZEngine/Rendering/Cameras/Camera.h
@@ -15,12 +15,10 @@ namespace ZEngine::Rendering::Cameras
     {
         float MinMoveSpeed        = 1.0f;
         float MaxMoveSpeed        = 500.0f;
-        float PanSpeed            = 1.0f; // multiplier
-        float MoveSpeed           = 10.0f;
-        float FastMoveSpeed       = 40.0f;
-        float RotationSpeed       = 0.25f; // degrees per pixel
-        float OrbitSpeed          = 0.25f; // degrees per pixel
-        float FastSpeedMultiplier = 4.0f;  // shift multiplier
+        float PanSpeed            = 1.0f;
+        float RotationSpeed       = 0.25f;
+        float OrbitSpeed          = 0.25f;
+        float FastSpeedMultiplier = 4.0f;
         float ScrollSpeed         = 3.0f;
         float FocusDuration       = 0.25f; // seconds
         float MinOrbitDistance    = 0.5f;

--- a/ZEngine/ZEngine/Rendering/Cameras/FlyCamera.cpp
+++ b/ZEngine/ZEngine/Rendering/Cameras/FlyCamera.cpp
@@ -1,22 +1,20 @@
+#include <GLFW/glfw3.h>
 #include <ZEngine/Core/Maths/MathUtils.h>
 #include <ZEngine/Rendering/Cameras/FlyCamera.h>
-#include <ZEngine/Windows/Inputs/KeyCode.h>
 #include <cmath>
 
 using namespace ZEngine::Core::Maths;
 
 namespace ZEngine::Rendering::Cameras
 {
-    static constexpr float kPitchLimit = 1.5533430f; // radians(89.0f)
-    static constexpr float kMaxDt      = 0.1f;       // cap: prevents teleport after pause/unminimize
+    static constexpr float kPitchLimit = 1.5533430f; // radians(89)
+    static constexpr float kMaxDt      = 0.1f;
 
-    // Frame-rate-independent exponential smoothing: identical feel at any fps.
     static inline float    SmoothT(float factor, float dt)
     {
         return 1.0f - expf(-factor * dt);
     }
 
-    // Wrap angle to [-PI, PI] so lerps always take the shortest arc.
     static inline float WrapAngle(float a)
     {
         while (a > PI<float>)
@@ -26,7 +24,6 @@ namespace ZEngine::Rendering::Cameras
         return a;
     }
 
-    // Shortest-arc lerp for angles stored in radians.
     static inline float LerpAngleRad(float a, float b, float t)
     {
         return a + WrapAngle(b - a) * t;
@@ -34,19 +31,22 @@ namespace ZEngine::Rendering::Cameras
 
     FlyCamera::FlyCamera(float aspectRatio, const CameraSetting& settings)
     {
-        AspectRatio       = aspectRatio;
-        Settings          = settings;
-        Position          = {0.0f, 20.0f, 10.0f};
-        Pitch             = radians(30.0f);
-        m_targetPitch     = Pitch;
-        m_targetPosition  = Position;
-        m_animDuration    = Settings.FocusDuration;
-        Type              = CameraType::PERSPECTIVE;
-
-        m_projectionDirty = true;
-        m_viewDirty       = true;
+        AspectRatio    = aspectRatio;
+        Settings       = settings;
+        Position       = {0.0f, 20.0f, 10.0f};
+        Pitch          = radians(30.0f);
+        m_targetPitch  = Pitch;
+        m_targetPos    = Position;
+        m_animDuration = Settings.FocusDuration;
+        Type           = CameraType::PERSPECTIVE;
+        m_projDirty    = true;
+        m_viewDirty    = true;
         UpdateMatrices();
     }
+
+    // ---------------------------------------------------------------------------
+    // Public accessors
+    // ---------------------------------------------------------------------------
 
     Quaternion<float> FlyCamera::GetOrientation() const
     {
@@ -73,49 +73,22 @@ namespace ZEngine::Rendering::Cameras
         return rotate(GetOrientation(), Vec3f(0.0f, 1.0f, 0.0f));
     }
 
-    void FlyCamera::UpdateMatrices()
+    // ---------------------------------------------------------------------------
+    // Configuration
+    // ---------------------------------------------------------------------------
+
+    void FlyCamera::SetViewportSize(float logicalW, float logicalH)
     {
-        if (m_projectionDirty)
-            RecalculateProjection();
-        if (m_viewDirty)
-            RecalculateView();
-    }
-
-    void FlyCamera::RecalculateView()
-    {
-        Vec3f f     = GetForward();
-        Vec3f r     = GetRight();
-        Vec3f u     = GetUp();
-
-        View        = Mat4f(r.x, r.y, r.z, -dot(r, Position), u.x, u.y, u.z, -dot(u, Position), -f.x, -f.y, -f.z, dot(f, Position), 0.0f, 0.0f, 0.0f, 1.0f);
-        m_viewDirty = false;
-    }
-
-    void FlyCamera::RecalculateProjection()
-    {
-        float fovRad      = radians(Settings.FOV);
-        float tanHalf     = tanf(fovRad * 0.5f);
-        float n           = Settings.NearPlane;
-        float f           = Settings.FarPlane;
-        float a           = AspectRatio;
-
-        // Vulkan: Y flipped, depth range [0, 1].
-        Projection        = Mat4f(1.0f / (a * tanHalf), 0.0f, 0.0f, 0.0f, 0.0f, -1.0f / tanHalf, 0.0f, 0.0f, 0.0f, 0.0f, f / (n - f), (n * f) / (n - f), 0.0f, 0.0f, -1.0f, 0.0f);
-        m_projectionDirty = false;
-    }
-
-    void FlyCamera::SetViewportSize(float width, float height)
-    {
-        m_viewportWidth  = width;
-        m_viewportHeight = height;
-        AspectRatio      = width / height;
-        RecalculateProjection();
+        m_logicalW  = logicalW;
+        m_logicalH  = logicalH;
+        AspectRatio = logicalW / logicalH;
+        m_projDirty = true;
     }
 
     void FlyCamera::SetPosition(Vec3f position)
     {
-        Position = m_targetPosition = position;
-        RecalculateView();
+        Position = m_targetPos = position;
+        m_viewDirty            = true;
     }
 
     void FlyCamera::SetOrientation(float pitchDeg, float yawDeg)
@@ -123,8 +96,218 @@ namespace ZEngine::Rendering::Cameras
         Pitch = m_targetPitch = clamp(radians(pitchDeg), -kPitchLimit, kPitchLimit);
         Yaw = m_targetYaw = WrapAngle(radians(yawDeg));
         m_viewDirty       = true;
-        RecalculateView();
     }
+
+    // ---------------------------------------------------------------------------
+    // OnUpdate — main entry point called once per frame by the controller
+    // ---------------------------------------------------------------------------
+
+    void FlyCamera::OnUpdate(float dt)
+    {
+        if (dt <= 0.0f)
+            return;
+        dt = std::min(dt, kMaxDt);
+
+        // Pan transitions — checked every frame regardless of current state.
+        if (Input.MiddleDown && State != FlyCameraState::Pan && State != FlyCameraState::Animating)
+        {
+            m_stateBeforePan = State;
+            State            = FlyCameraState::Pan;
+        }
+        if (!Input.MiddleDown && State == FlyCameraState::Pan)
+        {
+            State = m_stateBeforePan;
+        }
+
+        // Orbit entry (Alt+LMB, only from Free).
+        if (Input.AltDown && Input.LeftDown && State == FlyCameraState::Free)
+        {
+            float pivotDist = m_orbitDist;
+            if (Hooks.Raycast)
+            {
+                float hit = Hooks.Raycast(Position, GetForward(), m_orbitDist * 2.0f);
+                if (hit < m_orbitDist * 2.0f)
+                    pivotDist = hit;
+            }
+            m_orbitPivot      = Position + GetForward() * pivotDist;
+            m_orbitDist       = clamp((Position - m_orbitPivot).magnitude(), Settings.MinOrbitDistance, Settings.MaxOrbitDistance);
+            m_targetOrbitDist = m_orbitDist;
+            State             = FlyCameraState::Orbit;
+        }
+
+        // Orbit exit (Alt released with no held buttons).
+        if (!Input.AltDown && State == FlyCameraState::Orbit && !Input.LeftDown && !Input.RightDown)
+        {
+            m_targetPos   = Position;
+            m_targetPitch = Pitch;
+            m_targetYaw   = Yaw;
+            State         = FlyCameraState::Free;
+        }
+
+        switch (State)
+        {
+            case FlyCameraState::Animating:
+                UpdateAnimation(dt);
+                break;
+            case FlyCameraState::Pan:
+                UpdatePan(dt);
+                break;
+            case FlyCameraState::Orbit:
+                UpdateOrbit(dt);
+                break;
+            case FlyCameraState::Free:
+                UpdateFree(dt);
+                break;
+        }
+
+        if (Input.Keys[GLFW_KEY_F])
+        {
+            Vec3f center = {0.0f, 0.0f, 0.0f};
+            float radius = 5.0f;
+            if (Hooks.GetSelectionBounds)
+                std::tie(center, radius) = Hooks.GetSelectionBounds();
+            FocusOn(center, radius);
+            Input.Keys[GLFW_KEY_F] = false;
+        }
+
+        for (int i = 0; i < 9; ++i)
+        {
+            int key = GLFW_KEY_1 + i;
+            if (Input.Keys[key])
+            {
+                if (Input.CtrlDown)
+                    SaveBookmark(i);
+                else
+                    RecallBookmark(i);
+                Input.Keys[key] = false;
+            }
+        }
+
+        if (m_projDirty)
+            RecalculateProjection();
+        if (m_viewDirty)
+            RecalculateView();
+
+        Input.FlushDeltas();
+    }
+
+    // ---------------------------------------------------------------------------
+    // Private update methods
+    // ---------------------------------------------------------------------------
+
+    void FlyCamera::UpdateFree(float dt)
+    {
+        float t = SmoothT(Settings.SmoothingFactor, dt);
+
+        if (Input.RightDown)
+        {
+            float speed    = AdaptiveSpeed() * (Input.ShiftDown ? Settings.FastSpeedMultiplier : 1.0f);
+            m_targetPos   += KeyboardMoveDir() * speed * dt;
+
+            float yawSign  = GetUp().y < 0.0f ? -1.0f : 1.0f;
+            m_targetYaw    = WrapAngle(m_targetYaw - yawSign * (Input.MouseDeltaX / m_logicalW) * PI<float> * Settings.RotationSpeed);
+            m_targetPitch  = clamp(m_targetPitch - (Input.MouseDeltaY / m_logicalH) * PI<float> * Settings.RotationSpeed, -kPitchLimit, kPitchLimit);
+        }
+
+        if (Input.ScrollDelta != 0.0f)
+        {
+            Ray   ray    = GetRayFromViewport(Input.MouseViewportX, Input.MouseViewportY);
+            float speed  = AdaptiveSpeed();
+            m_targetPos += ray.Direction * Input.ScrollDelta * Settings.ScrollSpeed * speed;
+        }
+
+        if ((m_targetPos - Position).magnitude() > 0.00001f)
+        {
+            Position    = lerp(Position, m_targetPos, t);
+            m_viewDirty = true;
+        }
+
+        float newPitch = clamp(lerp(Pitch, m_targetPitch, t), -kPitchLimit, kPitchLimit);
+        float newYaw   = LerpAngleRad(Yaw, m_targetYaw, t);
+        if (newPitch != Pitch || newYaw != Yaw)
+        {
+            Pitch       = newPitch;
+            Yaw         = newYaw;
+            m_viewDirty = true;
+        }
+    }
+
+    void FlyCamera::UpdateOrbit(float dt)
+    {
+        float t = SmoothT(Settings.SmoothingFactor, dt);
+
+        if (Input.AltDown && (Input.LeftDown || Input.RightDown))
+        {
+            float yawSign = GetUp().y < 0.0f ? -1.0f : 1.0f;
+            m_targetYaw   = WrapAngle(m_targetYaw - yawSign * (Input.MouseDeltaX / m_logicalW) * PI<float> * Settings.OrbitSpeed);
+            m_targetPitch = clamp(m_targetPitch - (Input.MouseDeltaY / m_logicalH) * PI<float> * Settings.OrbitSpeed, -kPitchLimit, kPitchLimit);
+        }
+
+        if (Input.ScrollDelta != 0.0f)
+        {
+            float dist         = std::max(m_targetOrbitDist * 0.2f, 0.001f);
+            float speed        = std::min(dist * dist, 100.0f);
+            m_targetOrbitDist -= Input.ScrollDelta * speed * Settings.ScrollSpeed;
+            m_targetOrbitDist  = clamp(m_targetOrbitDist, Settings.MinOrbitDistance, Settings.MaxOrbitDistance);
+        }
+
+        Pitch          = clamp(lerp(Pitch, m_targetPitch, t), -kPitchLimit, kPitchLimit);
+        Yaw            = LerpAngleRad(Yaw, m_targetYaw, t);
+        m_orbitDist    = lerp(m_orbitDist, m_targetOrbitDist, t);
+
+        Vec3f fwd      = GetForward();
+        float safeDist = OrbitCollide(m_orbitDist);
+        Position       = m_orbitPivot - fwd * safeDist;
+        m_targetPos    = Position;
+        m_viewDirty    = true;
+    }
+
+    void FlyCamera::UpdatePan(float dt)
+    {
+        float focalDist  = (m_stateBeforePan == FlyCameraState::Orbit) ? m_orbitDist : 10.0f;
+        float fovRad     = radians(Settings.FOV);
+        float planeH     = 2.0f * tanf(fovRad * 0.5f) * focalDist;
+        float planeW     = planeH * AspectRatio;
+
+        Vec3f right      = {View(0, 0), View(0, 1), View(0, 2)};
+        Vec3f screenUp   = {-View(1, 0), -View(1, 1), -View(1, 2)};
+
+        Vec3f pan        = (right * (-(Input.MouseDeltaX / m_logicalW) * planeW * Settings.PanSpeed)) + (screenUp * ((Input.MouseDeltaY / m_logicalH) * planeH * Settings.PanSpeed));
+
+        m_targetPos     += pan;
+        m_orbitPivot    += pan;
+        m_viewDirty      = true;
+
+        // Apply position immediately — pan should feel direct.
+        Position         = m_targetPos;
+    }
+
+    void FlyCamera::UpdateAnimation(float dt)
+    {
+        m_animTimer += dt;
+        float t      = smoothstep(clamp(m_animTimer / m_animDuration, 0.0f, 1.0f));
+
+        Position     = lerp(m_animStartPos, m_animEndPos, t);
+        Pitch        = clamp(lerp(m_animStartPitch, m_animEndPitch, t), -kPitchLimit, kPitchLimit);
+        Yaw          = LerpAngleRad(m_animStartYaw, m_animEndYaw, t);
+        m_viewDirty  = true;
+
+        if (m_animTimer >= m_animDuration)
+        {
+            Position          = m_animEndPos;
+            Pitch             = clamp(m_animEndPitch, -kPitchLimit, kPitchLimit);
+            Yaw               = m_animEndYaw;
+            m_targetPos       = Position;
+            m_targetPitch     = Pitch;
+            m_targetYaw       = Yaw;
+            m_targetOrbitDist = m_orbitDist;
+            State             = m_stateBeforeAnim;
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Focus / bookmarks
+    // ---------------------------------------------------------------------------
 
     void FlyCamera::FocusOn(Vec3f center, float radius)
     {
@@ -137,14 +320,11 @@ namespace ZEngine::Rendering::Cameras
 
         Vec3f lookDir     = -dir;
         float endPitch    = asinf(clamp(lookDir.y, -1.0f, 1.0f));
-        // Derive yaw from the orientation convention: fromEulerAngles(-pitch, -yaw, 0).
-        // Solving for yaw yields: yaw = atan2(-lookDir.x, lookDir.z).  No implicit sign hack.
         float endYaw      = WrapAngle(atan2f(-lookDir.x, lookDir.z));
 
         m_orbitPivot      = center;
-        m_orbitDistance   = distance;
+        m_orbitDist       = distance;
         m_targetOrbitDist = distance;
-        // FocusOn does not change Mode — the caller remains in whatever mode they were in.
 
         m_animStartPos    = Position;
         m_animEndPos      = endPos;
@@ -154,7 +334,8 @@ namespace ZEngine::Rendering::Cameras
         m_animEndYaw      = endYaw;
         m_animTimer       = 0.0f;
         m_animDuration    = Settings.FocusDuration;
-        m_animating       = true;
+        m_stateBeforeAnim = State;
+        State             = FlyCameraState::Animating;
     }
 
     void FlyCamera::FocusOn(Vec3f point)
@@ -168,289 +349,7 @@ namespace ZEngine::Rendering::Cameras
     {
         Vec3f center = (aabbMin + aabbMax) * 0.5f;
         Vec3f extent = (aabbMax - aabbMin) * 0.5f;
-        float radius = extent.magnitude();
-        FocusOn(center, max(radius, 0.01f));
-    }
-
-    void FlyCamera::OnMouseButtonDown(int button)
-    {
-        using KC = Windows::Inputs::GlfwKeyCode;
-
-        if (button == (int) KC::MOUSE_BUTTON_LEFT)
-        {
-            m_leftMouseDown = true;
-            // Alt + LMB = enter orbit pivoting at the scene point under the cursor.
-            if (m_altDown && Mode == CameraMode::Free)
-            {
-                float pivotDist = m_orbitDistance;
-                if (SceneRaycast)
-                {
-                    float hit = SceneRaycast(Position, GetForward(), m_orbitDistance * 2.0f);
-                    if (hit < m_orbitDistance * 2.0f)
-                        pivotDist = hit;
-                }
-                EnterOrbitMode(Position + GetForward() * pivotDist);
-            }
-        }
-        if (button == (int) KC::MOUSE_BUTTON_RIGHT)
-            m_rightMouseDown = true;
-        if (button == (int) KC::MOUSE_BUTTON_MIDDLE)
-            m_middleMouseDown = true;
-    }
-
-    void FlyCamera::OnMouseButtonUp(int button)
-    {
-        using KC = Windows::Inputs::GlfwKeyCode;
-        if (button == (int) KC::MOUSE_BUTTON_LEFT)
-            m_leftMouseDown = false;
-        if (button == (int) KC::MOUSE_BUTTON_RIGHT)
-        {
-            m_rightMouseDown = false;
-            if (!m_altDown && !m_leftMouseDown && Mode == CameraMode::Orbit)
-                ExitOrbitMode();
-        }
-        if (button == (int) KC::MOUSE_BUTTON_MIDDLE)
-            m_middleMouseDown = false;
-    }
-
-    void FlyCamera::OnKeyDown(int key)
-    {
-        using KC = Windows::Inputs::GlfwKeyCode;
-        if (key >= 0 && key < 512)
-            m_keys[key] = true;
-
-        if (key == (int) KC::KEY_LEFT_SHIFT)
-            m_shiftDown = true;
-        if (key == (int) KC::KEY_LEFT_ALT || key == (int) KC::KEY_RIGHT_ALT)
-            m_altDown = true;
-        if (key == (int) KC::KEY_LEFT_CONTROL)
-            m_ctrlDown = true;
-    }
-
-    void FlyCamera::OnKeyUp(int key)
-    {
-        using KC = Windows::Inputs::GlfwKeyCode;
-        if (key >= 0 && key < 512)
-            m_keys[key] = false;
-
-        if (key == (int) KC::KEY_LEFT_SHIFT)
-            m_shiftDown = false;
-
-        if (key == (int) KC::KEY_LEFT_ALT || key == (int) KC::KEY_RIGHT_ALT)
-        {
-            m_altDown = false;
-            if (Mode == CameraMode::Orbit && !m_rightMouseDown && !m_leftMouseDown)
-                ExitOrbitMode();
-        }
-
-        if (key == (int) KC::KEY_LEFT_CONTROL)
-            m_ctrlDown = false;
-
-        // F — frame selected object. Editor injects bounds via OnGetSelectionBounds.
-        if (key == (int) KC::KEY_F)
-        {
-            if (OnGetSelectionBounds)
-            {
-                auto [center, radius] = OnGetSelectionBounds();
-                FocusOn(center, radius);
-            }
-            else
-            {
-                FocusOn(Vec3f(0.0f, 0.0f, 0.0f), 5.0f);
-            }
-        }
-
-        // Ctrl+1…9 = save bookmark; 1…9 alone = recall bookmark.
-        if (key >= (int) KC::KEY_1 && key <= (int) KC::KEY_9)
-        {
-            int slot = key - (int) KC::KEY_1;
-            if (m_ctrlDown)
-                SaveBookmark(slot);
-            else
-                RecallBookmark(slot);
-        }
-    }
-
-    void FlyCamera::OnFocusLost()
-    {
-        for (bool& k : m_keys)
-            k = false;
-        m_rightMouseDown  = false;
-        m_middleMouseDown = false;
-        m_leftMouseDown   = false;
-        m_altDown         = false;
-        m_shiftDown       = false;
-        m_ctrlDown        = false;
-    }
-
-    void FlyCamera::OnMouseMove(float deltaX, float deltaY)
-    {
-        if (m_animating)
-            return;
-
-        float dx = deltaX / m_viewportWidth;
-        float dy = deltaY / m_viewportHeight;
-
-        // 1. Alt + LMB or Alt + RMB = Orbit tumble
-        if (m_altDown && Mode == CameraMode::Orbit && (m_leftMouseDown || m_rightMouseDown))
-        {
-            float yawSign = GetUp().y < 0.0f ? -1.0f : 1.0f;
-            m_targetYaw   = WrapAngle(m_targetYaw - yawSign * dx * PI<float> * Settings.OrbitSpeed);
-            m_targetPitch = clamp(m_targetPitch - dy * PI<float> * Settings.OrbitSpeed, -kPitchLimit, kPitchLimit);
-            return;
-        }
-
-        // 2. MMB = Screen-plane pan
-        if (m_middleMouseDown)
-        {
-            float focalDist   = (Mode == CameraMode::Orbit) ? m_orbitDistance : 10.0f;
-            float fovRad      = radians(Settings.FOV);
-            float planeH      = 2.0f * tanf(fovRad * 0.5f) * focalDist;
-            float planeW      = planeH * AspectRatio;
-
-            // Read orthonormal basis directly from the view matrix rows — pole-safe.
-            Vec3f right       = {View(0, 0), View(0, 1), View(0, 2)};
-            Vec3f screenUp    = {-View(1, 0), -View(1, 1), -View(1, 2)};
-
-            Vec3f pan         = (right * (-dx * planeW * Settings.PanSpeed)) + (screenUp * (dy * planeH * Settings.PanSpeed));
-
-            m_targetPosition += pan;
-            if (Mode == CameraMode::Orbit)
-                m_orbitPivot += pan;
-            m_viewDirty = true;
-            return;
-        }
-
-        // 3. RMB = Free look
-        if (m_rightMouseDown)
-        {
-            float yawSign = GetUp().y < 0.0f ? -1.0f : 1.0f;
-            m_targetYaw   = WrapAngle(m_targetYaw - yawSign * dx * PI<float> * Settings.RotationSpeed);
-            m_targetPitch = clamp(m_targetPitch - dy * PI<float> * Settings.RotationSpeed, -kPitchLimit, kPitchLimit);
-
-            if (Mode == CameraMode::Orbit)
-                ExitOrbitMode();
-        }
-    }
-
-    void FlyCamera::OnMouseScroll(float delta, float mouseX, float mouseY)
-    {
-        if (Mode == CameraMode::Orbit)
-        {
-            float distance     = m_targetOrbitDist * 0.2f;
-            distance           = std::max(distance, 0.001f);
-            float speed        = std::min(distance * distance, 100.0f);
-
-            m_targetOrbitDist -= delta * speed * Settings.ScrollSpeed;
-            m_targetOrbitDist  = clamp(m_targetOrbitDist, Settings.MinOrbitDistance, Settings.MaxOrbitDistance);
-        }
-        else
-        {
-            // Zoom toward the 3D point under the cursor, not just along the view axis.
-            float speed       = ComputeAdaptiveSpeed();
-            Ray   ray         = GetRayFromScreen(mouseX, mouseY);
-            m_targetPosition += ray.Direction * delta * Settings.ScrollSpeed * speed;
-        }
-    }
-
-    void FlyCamera::OnUpdate(float dt)
-    {
-        if (dt <= 0.0f)
-            return;
-
-        dt = std::min(dt, kMaxDt);
-
-        if (m_animating)
-            UpdateAnimation(dt);
-        else if (Mode == CameraMode::Orbit)
-            UpdateOrbitCamera(dt);
-        else
-            UpdateFreeCamera(dt);
-
-        UpdateMatrices();
-    }
-
-    void FlyCamera::UpdateFreeCamera(float dt)
-    {
-        float t = SmoothT(Settings.SmoothingFactor, dt);
-
-        if (m_rightMouseDown)
-        {
-            float speed       = ComputeAdaptiveSpeed() * (m_shiftDown ? Settings.FastSpeedMultiplier : 1.0f);
-            m_targetPosition += GetKeyboardMoveDirection() * speed * dt;
-        }
-
-        if ((m_targetPosition - Position).magnitude() > 0.00001f)
-        {
-            Position    = lerp(Position, m_targetPosition, t);
-            m_viewDirty = true;
-        }
-
-        // Pitch is clamped so it never wraps — plain lerp is correct and cheaper here.
-        float newPitch = clamp(lerp(Pitch, m_targetPitch, t), -kPitchLimit, kPitchLimit);
-        float newYaw   = LerpAngleRad(Yaw, m_targetYaw, t);
-
-        if (newPitch != Pitch || newYaw != Yaw)
-        {
-            Pitch       = newPitch;
-            Yaw         = newYaw;
-            m_viewDirty = true;
-        }
-    }
-
-    void FlyCamera::UpdateOrbitCamera(float dt)
-    {
-        float t          = SmoothT(Settings.SmoothingFactor, dt);
-
-        Pitch            = clamp(lerp(Pitch, m_targetPitch, t), -kPitchLimit, kPitchLimit);
-        Yaw              = LerpAngleRad(Yaw, m_targetYaw, t);
-        m_orbitDistance  = lerp(m_orbitDistance, m_targetOrbitDist, t);
-
-        Vec3f fwd        = GetForward();
-        float safeDist   = CollideCameraRay(m_orbitPivot, -fwd, m_orbitDistance);
-        Position         = m_orbitPivot - fwd * safeDist;
-        m_targetPosition = Position;
-        m_viewDirty      = true;
-    }
-
-    void FlyCamera::UpdateAnimation(float dt)
-    {
-        m_animTimer += dt;
-        float t      = smoothstep(clamp(m_animTimer / m_animDuration, 0.0f, 1.0f));
-
-        Position     = lerp(m_animStartPos, m_animEndPos, t);
-        Pitch        = clamp(lerp(m_animStartPitch, m_animEndPitch, t), -kPitchLimit, kPitchLimit);
-        Yaw          = LerpAngleRad(m_animStartYaw, m_animEndYaw, t);
-
-        m_viewDirty  = true;
-
-        if (m_animTimer >= m_animDuration)
-        {
-            Position          = m_animEndPos;
-            Pitch             = clamp(m_animEndPitch, -kPitchLimit, kPitchLimit);
-            Yaw               = m_animEndYaw;
-            m_animating       = false;
-            m_targetPosition  = Position;
-            m_targetPitch     = Pitch;
-            m_targetYaw       = Yaw;
-            m_targetOrbitDist = m_orbitDistance;
-        }
-    }
-
-    void FlyCamera::EnterOrbitMode(Vec3f pivot)
-    {
-        m_orbitPivot      = pivot;
-        m_orbitDistance   = clamp((Position - pivot).magnitude(), Settings.MinOrbitDistance, Settings.MaxOrbitDistance);
-        m_targetOrbitDist = m_orbitDistance;
-        Mode              = CameraMode::Orbit;
-    }
-
-    void FlyCamera::ExitOrbitMode()
-    {
-        m_targetPosition = Position;
-        m_targetPitch    = Pitch;
-        m_targetYaw      = Yaw;
-        Mode             = CameraMode::Free;
+        FocusOn(center, max(extent.magnitude(), 0.01f));
     }
 
     void FlyCamera::SaveBookmark(int slot)
@@ -464,88 +363,123 @@ namespace ZEngine::Rendering::Cameras
     {
         if (slot < 0 || slot >= 9 || !m_bookmarks[slot].Valid)
             return;
-        const auto& bm   = m_bookmarks[slot];
-
-        m_animStartPos   = Position;
-        m_animEndPos     = bm.Position;
-        m_animStartPitch = Pitch;
-        m_animStartYaw   = Yaw;
-        m_animEndPitch   = bm.Pitch;
-        m_animEndYaw     = bm.Yaw;
-        m_animTimer      = 0.0f;
-        m_animDuration   = Settings.FocusDuration;
-        m_animating      = true;
+        const auto& bm    = m_bookmarks[slot];
+        m_animStartPos    = Position;
+        m_animEndPos      = bm.Pos;
+        m_animStartPitch  = Pitch;
+        m_animStartYaw    = Yaw;
+        m_animEndPitch    = bm.Pitch;
+        m_animEndYaw      = bm.Yaw;
+        m_animTimer       = 0.0f;
+        m_animDuration    = Settings.FocusDuration;
+        m_stateBeforeAnim = State;
+        State             = FlyCameraState::Animating;
     }
 
-    Vec3f FlyCamera::GetKeyboardMoveDirection() const
+    // ---------------------------------------------------------------------------
+    // Ray unprojection
+    // ---------------------------------------------------------------------------
+
+    FlyCamera::Ray FlyCamera::GetRayFromViewport(float viewportX, float viewportY) const
     {
-        using KC      = Windows::Inputs::GlfwKeyCode;
+        // NDC in [-1,1]; viewport coords are logical-pixel-relative, Y=0 at top.
+        float ndcX    = (viewportX / m_logicalW) * 2.0f - 1.0f;
+        float ndcY    = 1.0f - (viewportY / m_logicalH) * 2.0f;
 
-        Vec3f forward = GetForward();
-        Vec3f right   = GetRight();
-        Vec3f up      = Vec3f(Camera::WorldUp.x, Camera::WorldUp.y, Camera::WorldUp.z);
+        float fovRad  = radians(Settings.FOV);
+        float tanHalf = tanf(fovRad * 0.5f);
+        float vx      = ndcX * AspectRatio * tanHalf;
+        float vy      = ndcY * tanHalf;
 
-        Vec3f dir     = {};
-        if (m_keys[(int) KC::KEY_W])
-            dir += forward;
-        if (m_keys[(int) KC::KEY_S])
-            dir -= forward;
-        if (m_keys[(int) KC::KEY_D])
-            dir += right;
-        if (m_keys[(int) KC::KEY_A])
-            dir -= right;
-        if (m_keys[(int) KC::KEY_E])
+        Vec3f r       = GetRight();
+        Vec3f u       = GetUp();
+        Vec3f f       = GetForward();
+        Vec3f dir     = r * vx + u * vy + f;
+
+        float mag     = dir.magnitude();
+        return {Position, mag > 0.0001f ? dir / mag : f};
+    }
+
+    // ---------------------------------------------------------------------------
+    // Private helpers
+    // ---------------------------------------------------------------------------
+
+    Vec3f FlyCamera::KeyboardMoveDir() const
+    {
+        Vec3f fwd = GetForward();
+        Vec3f rgt = GetRight();
+        Vec3f up  = Vec3f(Camera::WorldUp.x, Camera::WorldUp.y, Camera::WorldUp.z);
+        Vec3f dir = {};
+
+        if (Input.Keys[GLFW_KEY_W])
+            dir += fwd;
+        if (Input.Keys[GLFW_KEY_S])
+            dir -= fwd;
+        if (Input.Keys[GLFW_KEY_D])
+            dir += rgt;
+        if (Input.Keys[GLFW_KEY_A])
+            dir -= rgt;
+        if (Input.Keys[GLFW_KEY_E])
             dir += up;
-        if (m_keys[(int) KC::KEY_Q])
+        if (Input.Keys[GLFW_KEY_Q])
             dir -= up;
 
         float mag = dir.magnitude();
         return mag > 0.0001f ? dir / mag : dir;
     }
 
-    float FlyCamera::ComputeAdaptiveSpeed() const
+    float FlyCamera::AdaptiveSpeed() const
     {
-        if (SceneRaycast)
+        if (Hooks.Raycast)
         {
-            float hitFwd  = SceneRaycast(Position, GetForward(), Settings.MaxMoveSpeed * 10.0f);
-            float hitDown = SceneRaycast(Position, {0.0f, -1.0f, 0.0f}, Settings.MaxMoveSpeed * 10.0f);
+            float hitFwd  = Hooks.Raycast(Position, GetForward(), Settings.MaxMoveSpeed * 10.0f);
+            float hitDown = Hooks.Raycast(Position, {0.0f, -1.0f, 0.0f}, Settings.MaxMoveSpeed * 10.0f);
             return clamp(std::min(hitFwd, hitDown) * 0.5f, Settings.MinMoveSpeed, Settings.MaxMoveSpeed);
         }
-        float h = fabsf(Position.y);
-        return clamp(h * 0.5f, Settings.MinMoveSpeed, Settings.MaxMoveSpeed);
+        return clamp(fabsf(Position.y) * 0.5f, Settings.MinMoveSpeed, Settings.MaxMoveSpeed);
     }
 
-    float FlyCamera::CollideCameraRay(Vec3f origin, Vec3f dir, float desiredDist) const
+    float FlyCamera::OrbitCollide(float desired) const
     {
-        if (SceneRaycast)
+        if (Hooks.Raycast)
         {
-            float hit = SceneRaycast(origin, dir, desiredDist);
-            if (hit < desiredDist)
+            Vec3f fwd = GetForward();
+            float hit = Hooks.Raycast(m_orbitPivot, -fwd, desired);
+            if (hit < desired)
                 return hit * 0.9f;
         }
-        return desiredDist;
+        return desired;
     }
 
-    FlyCamera::Ray FlyCamera::GetRayFromScreen(float mouseX, float mouseY) const
+    void FlyCamera::RecalculateView()
     {
-        // NDC in [-1,1], Vulkan Y-up in NDC (screen Y=0 is top).
-        float ndcX     = (mouseX / m_viewportWidth) * 2.0f - 1.0f;
-        float ndcY     = 1.0f - (mouseY / m_viewportHeight) * 2.0f;
+        Vec3f f     = GetForward();
+        Vec3f r     = GetRight();
+        Vec3f u     = GetUp();
+        View        = Mat4f(r.x, r.y, r.z, -dot(r, Position), u.x, u.y, u.z, -dot(u, Position), -f.x, -f.y, -f.z, dot(f, Position), 0.0f, 0.0f, 0.0f, 1.0f);
+        m_viewDirty = false;
+    }
 
-        // Unproject to view space: inv(P) * NDC.
-        float fovRad   = radians(Settings.FOV);
-        float tanHalf  = tanf(fovRad * 0.5f);
-        float viewDirX = ndcX * AspectRatio * tanHalf;
-        float viewDirY = ndcY * tanHalf;
+    void FlyCamera::RecalculateProjection()
+    {
+        float fovRad  = radians(Settings.FOV);
+        float tanHalf = tanf(fovRad * 0.5f);
+        float n       = Settings.NearPlane;
+        float f       = Settings.FarPlane;
+        float a       = AspectRatio;
 
-        // Rotate view-space direction to world space via the camera basis.
-        Vec3f r        = GetRight();
-        Vec3f u        = GetUp();
-        Vec3f f        = GetForward();
-        Vec3f dir      = r * viewDirX + u * viewDirY + f; // f corresponds to view-space (0,0,-1) → forward
+        // Vulkan: Y flipped, depth range [0, 1].
+        Projection    = Mat4f(1.0f / (a * tanHalf), 0.0f, 0.0f, 0.0f, 0.0f, -1.0f / tanHalf, 0.0f, 0.0f, 0.0f, 0.0f, f / (n - f), (n * f) / (n - f), 0.0f, 0.0f, -1.0f, 0.0f);
+        m_projDirty   = false;
+    }
 
-        float mag      = dir.magnitude();
-        return {Position, mag > 0.0001f ? dir / mag : f};
+    // Thin compatibility shim used by RecalculateView/Projection path.
+    void FlyCamera::UpdateMatrices()
+    {
+        if (m_projDirty)
+            RecalculateProjection();
+        if (m_viewDirty)
+            RecalculateView();
     }
 
 } // namespace ZEngine::Rendering::Cameras

--- a/ZEngine/ZEngine/Rendering/Cameras/FlyCamera.h
+++ b/ZEngine/ZEngine/Rendering/Cameras/FlyCamera.h
@@ -3,94 +3,79 @@
 #include <ZEngine/Core/Maths/Matrix.h>
 #include <ZEngine/Core/Maths/Quaternion.h>
 #include <ZEngine/Rendering/Cameras/Camera.h>
+#include <ZEngine/Rendering/Cameras/FlyCameraInput.h>
 #include <functional>
 #include <utility>
 
 namespace ZEngine::Rendering::Cameras
 {
+    struct FlyCameraHooks
+    {
+        // Returns hit distance along (origin, dir), or maxDist if no hit.
+        std::function<float(Core::Maths::Vec3f, Core::Maths::Vec3f, float)> Raycast;
+        // Returns {center, radius} of the current selection for F-to-frame.
+        std::function<std::pair<Core::Maths::Vec3f, float>()>               GetSelectionBounds;
+    };
+
     struct FlyCamera : public Camera
     {
-        // Inject scene picking: return hit distance along (origin, dir), or desiredDist if no hit.
-        std::function<float(Core::Maths::Vec3f, Core::Maths::Vec3f, float)> SceneRaycast;
+        FlyCameraInput Input = {};
+        FlyCameraHooks Hooks = {};
+        FlyCameraState State = FlyCameraState::Free;
 
-        // Inject selection bounds for KEY_F framing: returns {center, radius}.
-        // Falls back to world origin / radius 5 when unset.
-        std::function<std::pair<Core::Maths::Vec3f, float>()>               OnGetSelectionBounds;
-
-        FlyCamera() = default;
-        FlyCamera(float aspectRatio, const CameraSetting& settings);
+        FlyCamera()          = default;
+        explicit FlyCamera(float aspectRatio, const CameraSetting& settings);
         virtual ~FlyCamera() = default;
 
-        void                       OnUpdate(float dt);
+        void OnUpdate(float dt);
+        void SetViewportSize(float logicalW, float logicalH);
+        void SetPosition(Core::Maths::Vec3f position);
+        void SetOrientation(float pitchDeg, float yawDeg);
 
-        void                       OnMouseMove(float deltaX, float deltaY);
-        void                       OnMouseScroll(float delta, float mouseX, float mouseY);
-        void                       OnMouseButtonDown(int button);
-        void                       OnMouseButtonUp(int button);
-        void                       OnKeyDown(int key);
-        void                       OnKeyUp(int key);
-        // Call when the viewport loses OS focus to clear all held input state.
-        void                       OnFocusLost();
+        void FocusOn(Core::Maths::Vec3f center, float radius);
+        void FocusOn(Core::Maths::Vec3f point);
+        void FocusOn(Core::Maths::Vec3f aabbMin, Core::Maths::Vec3f aabbMax);
 
-        void                       FocusOn(Core::Maths::Vec3f center, float radius);
-        void                       FocusOn(Core::Maths::Vec3f point);
-        void                       FocusOn(Core::Maths::Vec3f aabbMin, Core::Maths::Vec3f aabbMax);
+        void SaveBookmark(int slot);
+        void RecallBookmark(int slot);
 
-        void                       SetViewportSize(float width, float height);
-        void                       SetPosition(Core::Maths::Vec3f position);
-        void                       SetOrientation(float pitchDeg, float yawDeg);
-
-        void                       EnterOrbitMode(Core::Maths::Vec3f pivot);
-        void                       ExitOrbitMode();
-
-        // View bookmarks — slots 0-8 map to keys 1-9
-        void                       SaveBookmark(int slot);
-        void                       RecallBookmark(int slot);
-
-        virtual Core::Maths::Vec3f GetPosition() const override;
-        virtual Core::Maths::Vec3f GetForward() const override;
-        virtual Core::Maths::Vec3f GetUp() const override;
-        virtual Core::Maths::Vec3f GetRight() const override;
-
-        // World-space ray through the given screen pixel — use for picking and gizmo hit-testing.
         struct Ray
         {
             Core::Maths::Vec3f Origin;
             Core::Maths::Vec3f Direction;
         };
-        Ray                            GetRayFromScreen(float mouseX, float mouseY) const;
+        Ray                            GetRayFromViewport(float viewportX, float viewportY) const;
 
-        // Orientation quaternion rebuilt fresh from Pitch/Yaw every call — no accumulation.
+        virtual Core::Maths::Vec3f     GetPosition() const override;
+        virtual Core::Maths::Vec3f     GetForward() const override;
+        virtual Core::Maths::Vec3f     GetUp() const override;
+        virtual Core::Maths::Vec3f     GetRight() const override;
         Core::Maths::Quaternion<float> GetOrientation() const;
 
     private:
-        void               UpdateFreeCamera(float dt);
-        void               UpdateOrbitCamera(float dt);
+        void               UpdateFree(float dt);
+        void               UpdateOrbit(float dt);
+        void               UpdatePan(float dt);
         void               UpdateAnimation(float dt);
         void               RecalculateView();
         void               RecalculateProjection();
-        void               UpdateMatrices();
+        Core::Maths::Vec3f KeyboardMoveDir() const;
+        float              AdaptiveSpeed() const;
+        float              OrbitCollide(float desired) const;
 
-        Core::Maths::Vec3f GetKeyboardMoveDirection() const;
-        float              ComputeAdaptiveSpeed() const;
-        float              CollideCameraRay(Core::Maths::Vec3f origin, Core::Maths::Vec3f dir, float desiredDist) const;
-
-        Core::Maths::Vec3f m_targetPosition  = {0.0f, 5.0f, 10.0f};
-
-        // Euler angles in radians. GetOrientation() rebuilds the quaternion each frame.
+        Core::Maths::Vec3f m_targetPos       = {0.0f, 5.0f, 10.0f};
         float              m_targetPitch     = 0.0f;
         float              m_targetYaw       = 0.0f;
+        float              m_logicalW        = 1280.0f;
+        float              m_logicalH        = 720.0f;
 
-        float              m_viewportWidth   = 1280.0f;
-        float              m_viewportHeight  = 720.0f;
-
-        // Orbit state
-        Core::Maths::Vec3f m_orbitPivot      = {0.0f, 0.0f, 0.0f};
-        float              m_orbitDistance   = 10.0f;
+        Core::Maths::Vec3f m_orbitPivot      = {};
+        float              m_orbitDist       = 10.0f;
         float              m_targetOrbitDist = 10.0f;
 
-        // Focus animation
-        bool               m_animating       = false;
+        FlyCameraState     m_stateBeforePan  = FlyCameraState::Free;
+        FlyCameraState     m_stateBeforeAnim = FlyCameraState::Free;
+
         Core::Maths::Vec3f m_animStartPos    = {};
         Core::Maths::Vec3f m_animEndPos      = {};
         float              m_animStartPitch  = 0.0f;
@@ -98,26 +83,19 @@ namespace ZEngine::Rendering::Cameras
         float              m_animEndPitch    = 0.0f;
         float              m_animEndYaw      = 0.0f;
         float              m_animTimer       = 0.0f;
-        float              m_animDuration    = 0.25f; // kept in sync with Settings.FocusDuration
+        float              m_animDuration    = 0.25f;
 
-        // Input state
-        bool               m_rightMouseDown  = false;
-        bool               m_middleMouseDown = false;
-        bool               m_leftMouseDown   = false;
-        bool               m_altDown         = false;
-        bool               m_shiftDown       = false;
-        bool               m_ctrlDown        = false;
-        bool               m_keys[512]       = {};
-
-        bool               m_projectionDirty = true;
+        bool               m_projDirty       = true;
         bool               m_viewDirty       = true;
+
+        void               UpdateMatrices();
 
         struct BookmarkSlot
         {
-            bool               Valid    = false;
-            Core::Maths::Vec3f Position = {};
-            float              Pitch    = 0.0f;
-            float              Yaw      = 0.0f;
+            bool               Valid = false;
+            Core::Maths::Vec3f Pos   = {};
+            float              Pitch = 0.0f;
+            float              Yaw   = 0.0f;
         };
         BookmarkSlot m_bookmarks[9] = {};
     };

--- a/ZEngine/ZEngine/Rendering/Cameras/FlyCameraInput.h
+++ b/ZEngine/ZEngine/Rendering/Cameras/FlyCameraInput.h
@@ -1,0 +1,40 @@
+#pragma once
+
+namespace ZEngine::Rendering::Cameras
+{
+    enum class FlyCameraState : uint8_t
+    {
+        Free,
+        Orbit,
+        Pan,
+        Animating,
+    };
+
+    struct FlyCameraInput
+    {
+        bool  RightDown      = false;
+        bool  MiddleDown     = false;
+        bool  LeftDown       = false;
+        bool  AltDown        = false;
+        bool  ShiftDown      = false;
+        bool  CtrlDown       = false;
+        bool  Keys[512]      = {};
+        float MouseDeltaX    = 0.0f;
+        float MouseDeltaY    = 0.0f;
+        float ScrollDelta    = 0.0f;
+        float MouseViewportX = 0.0f;
+        float MouseViewportY = 0.0f;
+
+        void  FlushDeltas()
+        {
+            MouseDeltaX = 0.0f;
+            MouseDeltaY = 0.0f;
+            ScrollDelta = 0.0f;
+        }
+
+        void Reset()
+        {
+            *this = FlyCameraInput{};
+        }
+    };
+} // namespace ZEngine::Rendering::Cameras

--- a/ZEngine/docs/future-plan/fly-camera-redesign.md
+++ b/ZEngine/docs/future-plan/fly-camera-redesign.md
@@ -1,0 +1,514 @@
+# FlyCamera Redesign
+
+**Replaces:** `FlyCamera.h/.cpp`, `FlyCameraController.h/.cpp`, `EditorCameraController.h/.cpp`
+**Relates to:** `rendering-flow.md`, `input-system.md`
+**Scope:** Ground-up redesign of the editor fly camera — input model, state machine, coordinate system, HiDPI correctness, InputManager integration.
+
+---
+
+## 1. What Is Wrong With the Current Design
+
+**Input state is split across two objects.**
+`FlyCamera` owns `m_keys[512]`, `m_rightMouseDown`, `m_middleMouseDown`, `m_leftMouseDown`,
+`m_altDown`, `m_shiftDown`, `m_ctrlDown`. `FlyCameraController` owns `m_process_event`. A
+focus-lost event goes to `FlyCameraController::PauseEventProcessing` which sets
+`m_process_event = false` — but never calls `m_camera->OnFocusLost()`. Keys stay stuck.
+`SceneViewportUIComponent` calls `PauseEventProcessing` but never `OnFocusLost`. The camera
+flies in a direction forever after the user tabs away.
+
+**Mouse deltas are in physical pixels on HiDPI.**
+`FlyCameraController::OnMouseButtonMoved` passes `e.GetXOffset() / e.GetYOffset()` (GLFW
+logical-pixel deltas, scale 1.0 on Retina) to `FlyCamera::OnMouseMove`, which divides by
+`m_viewportWidth` (set from `SwapchainImageWidth` = physical pixels, scale 2.0 on Retina).
+All mouse sensitivity is halved on every Apple Silicon Mac.
+
+**Scroll-toward-cursor ray uses absolute screen coordinates.**
+`FlyCameraController::OnMouseButtonWheelMoved` passes raw `IDevice::As<Mouse>()->GetMousePosition()`
+to `FlyCamera::OnMouseScroll` → `GetRayFromScreen`. When the viewport panel is not at (0,0),
+the ray direction is wrong.
+
+**`EditorCameraController::Initialize` never sets `SceneRaycast` or `OnGetSelectionBounds`.**
+Adaptive speed falls back to height-based estimation. F-to-frame uses world origin.
+
+**`FlyCameraController` does not expose `SetViewport` on `ICameraController`.**
+`SceneViewportUIComponent` casts to `EditorCameraControllerPtr` to call `SetViewport`.
+
+**`CameraSetting::FastMoveSpeed` is dead** — never used.
+
+---
+
+## 2. Design Goals
+
+1. Single source of truth for all input state — `FlyCameraInput`, one owner.
+2. Controller reads from `InputManager` — no `IMouseEventCallback`/`IKeyboardEventCallback`.
+3. HiDPI-correct — all internal math in logical pixels.
+4. Viewport origin passed through scroll path so ray unprojection is always correct.
+5. `ICameraController` exposes `SetViewport` and `SetViewportOrigin` — no cast needed.
+6. `FlyCameraHooks` wired at construction time.
+7. Explicit state machine: `Free`, `Orbit`, `Pan`, `Animating`.
+
+---
+
+## 3. Input State — `FlyCameraInput`
+
+```cpp
+// ZEngine/Rendering/Cameras/FlyCameraInput.h
+#pragma once
+
+namespace ZEngine::Rendering::Cameras
+{
+    enum class FlyCameraState : uint8_t
+    {
+        Free,
+        Orbit,
+        Pan,
+        Animating,
+    };
+
+    struct FlyCameraInput
+    {
+        bool  RightDown      = false;
+        bool  MiddleDown     = false;
+        bool  LeftDown       = false;
+        bool  AltDown        = false;
+        bool  ShiftDown      = false;
+        bool  CtrlDown       = false;
+        bool  Keys[512]      = {};
+        float MouseDeltaX    = 0.0f;
+        float MouseDeltaY    = 0.0f;
+        float ScrollDelta    = 0.0f;
+        float MouseViewportX = 0.0f;
+        float MouseViewportY = 0.0f;
+
+        void FlushDeltas()
+        {
+            MouseDeltaX  = 0.0f;
+            MouseDeltaY  = 0.0f;
+            ScrollDelta  = 0.0f;
+        }
+
+        void Reset()
+        {
+            *this = FlyCameraInput{};
+        }
+    };
+}
+```
+
+---
+
+## 4. Camera State Machine
+
+```
+          ┌──────────────────────────────────────────┐
+          │               Animating                   │
+          │  Ignores all input. On done → prev state. │
+          └───────────────────┬──────────────────────┘
+                              │ timer >= duration
+                              ▼
+┌──────────┐   Alt+LMB   ┌──────────┐   RMB up    ┌──────────┐
+│   Free   │ ──────────► │  Orbit   │ ──────────► │   Free   │
+│ RMB look │             │ tumble   │              │          │
+│ WASDQE   │ ◄────────── │ zoom     │              │          │
+│ scroll   │  Alt up     └──────────┘              └──────────┘
+└──────────┘
+      │ MMB down              │ MMB down
+      ▼                       ▼
+  ┌──────────┐           ┌──────────┐
+  │ Pan(Free)│           │Pan(Orbit)│
+  └──────────┘           └──────────┘
+```
+
+---
+
+## 5. `FlyCamera` — Full Redesign
+
+### 5.1 Header
+
+```cpp
+// ZEngine/Rendering/Cameras/FlyCamera.h
+#pragma once
+#include <ZEngine/Core/Maths/MathUtils.h>
+#include <ZEngine/Core/Maths/Matrix.h>
+#include <ZEngine/Core/Maths/Quaternion.h>
+#include <ZEngine/Rendering/Cameras/Camera.h>
+#include <ZEngine/Rendering/Cameras/FlyCameraInput.h>
+#include <functional>
+
+namespace ZEngine::Rendering::Cameras
+{
+    struct FlyCameraHooks
+    {
+        std::function<float(Core::Maths::Vec3f, Core::Maths::Vec3f, float)> Raycast;
+        std::function<std::pair<Core::Maths::Vec3f, float>()>               GetSelectionBounds;
+    };
+
+    struct FlyCamera : public Camera
+    {
+        FlyCameraInput Input  = {};
+        FlyCameraHooks Hooks  = {};
+        FlyCameraState State  = FlyCameraState::Free;
+
+        FlyCamera() = default;
+        explicit FlyCamera(float aspectRatio, const CameraSetting& settings);
+        virtual ~FlyCamera() = default;
+
+        void OnUpdate(float dt);
+        void SetViewportSize(float logicalW, float logicalH);
+        void SetPosition(Core::Maths::Vec3f position);
+        void SetOrientation(float pitchDeg, float yawDeg);
+
+        void FocusOn(Core::Maths::Vec3f center, float radius);
+        void FocusOn(Core::Maths::Vec3f point);
+        void FocusOn(Core::Maths::Vec3f aabbMin, Core::Maths::Vec3f aabbMax);
+
+        void SaveBookmark(int slot);
+        void RecallBookmark(int slot);
+
+        struct Ray { Core::Maths::Vec3f Origin; Core::Maths::Vec3f Direction; };
+        Ray GetRayFromViewport(float viewportX, float viewportY) const;
+
+        virtual Core::Maths::Vec3f             GetPosition()    const override;
+        virtual Core::Maths::Vec3f             GetForward()     const override;
+        virtual Core::Maths::Vec3f             GetUp()          const override;
+        virtual Core::Maths::Vec3f             GetRight()       const override;
+        Core::Maths::Quaternion<float>         GetOrientation() const;
+
+    private:
+        void UpdateFree(float dt);
+        void UpdateOrbit(float dt);
+        void UpdatePan(float dt);
+        void UpdateAnimation(float dt);
+        void RecalculateView();
+        void RecalculateProjection();
+        Core::Maths::Vec3f KeyboardMoveDir() const;
+        float              AdaptiveSpeed()   const;
+        float              OrbitCollide(float desired) const;
+
+        Core::Maths::Vec3f m_targetPos       = {0.0f, 5.0f, 10.0f};
+        float              m_targetPitch     = 0.0f;
+        float              m_targetYaw       = 0.0f;
+        float              m_logicalW        = 1280.0f;
+        float              m_logicalH        = 720.0f;
+
+        Core::Maths::Vec3f m_orbitPivot      = {};
+        float              m_orbitDist       = 10.0f;
+        float              m_targetOrbitDist = 10.0f;
+
+        FlyCameraState     m_stateBeforePan  = FlyCameraState::Free;
+        FlyCameraState     m_stateBeforeAnim = FlyCameraState::Free;
+
+        Core::Maths::Vec3f m_animStartPos    = {};
+        Core::Maths::Vec3f m_animEndPos      = {};
+        float              m_animStartPitch  = 0.0f;
+        float              m_animStartYaw    = 0.0f;
+        float              m_animEndPitch    = 0.0f;
+        float              m_animEndYaw      = 0.0f;
+        float              m_animTimer       = 0.0f;
+        float              m_animDuration    = 0.25f;
+
+        bool               m_projDirty       = true;
+        bool               m_viewDirty       = true;
+
+        struct BookmarkSlot {
+            bool               Valid = false;
+            Core::Maths::Vec3f Pos   = {};
+            float              Pitch = 0.0f;
+            float              Yaw   = 0.0f;
+        };
+        BookmarkSlot m_bookmarks[9] = {};
+    };
+    ZDEFINE_PTR(FlyCamera);
+}
+```
+
+---
+
+## 6. `FlyCameraController` — Full Redesign
+
+### 6.1 Integration with `InputManager`
+
+`FlyCameraController` does NOT implement `IMouseEventCallback` or `IKeyboardEventCallback`.
+All input state is read from `InputManager` once per frame in `Update`, written into
+`camera->Input`, then `camera->OnUpdate` is called.
+
+Camera actions registered with `InputManager` during `Initialize`:
+
+| Action name | Type | Default binding |
+|---|---|---|
+| `"CameraForward"` | Axis1D | W (+1), S (-1) |
+| `"CameraRight"` | Axis1D | D (+1), A (-1) |
+| `"CameraUp"` | Axis1D | E (+1), Q (-1) |
+| `"CameraScroll"` | Axis1D | scroll wheel Y |
+| `"CameraRMB"` | Button | mouse right |
+| `"CameraMMB"` | Button | mouse middle |
+| `"CameraLMB"` | Button | mouse left |
+| `"CameraAlt"` | Button | Left Alt |
+| `"CameraShift"` | Button | Left Shift |
+| `"CameraCtrl"` | Button | Left Ctrl |
+| `"CameraFocus"` | Button | F |
+| `"CameraBookmark0"`...`"CameraBookmark8"` | Button | Keys 1–9 |
+
+Mouse delta from `InputManager::GetMouseDelta()`. Mouse position for scroll-toward-cursor
+from `InputManager::GetMousePosition()` minus stored viewport origin.
+
+### 6.2 Header
+
+```cpp
+// ZEngine/Controllers/FlyCameraController.h
+#pragma once
+#include <ZEngine/Controllers/ICameraController.h>
+#include <ZEngine/Core/Memory/Allocator.h>
+#include <ZEngine/Input/InputManager.h>
+#include <ZEngine/Rendering/Cameras/FlyCamera.h>
+
+namespace ZEngine::Controllers
+{
+    struct FlyCameraController : public ICameraController
+    {
+        FlyCameraController()          = default;
+        virtual ~FlyCameraController() = default;
+
+        void Initialize(Input::InputManager* input_manager,
+                        Core::Memory::ArenaAllocator* arena);
+
+        void                          Update(Core::TimeStep dt)              override;
+        bool                          OnEvent(Core::CoreEvent&)              override;
+        Rendering::Cameras::CameraPtr GetCamera()                      const override;
+        Core::Maths::Vec3f            GetPosition()                    const override;
+        void                          SetPosition(const Core::Maths::Vec3f&) override;
+        void                          SetViewport(float logicalW, float logicalH) override;
+        void                          SetViewportOrigin(float x, float y)    override;
+        void                          ResumeEventProcessing()                override;
+        void                          PauseEventProcessing()                 override;
+
+    protected:
+        Input::InputManager*             m_input           = nullptr;
+        PaddedAtomic<bool>               m_active          = {.value = false};
+        float                            m_viewportOriginX = 0.0f;
+        float                            m_viewportOriginY = 0.0f;
+        Rendering::Cameras::FlyCameraPtr m_camera          = nullptr;
+
+        uint32_t m_slot_forward     = 0;
+        uint32_t m_slot_right       = 0;
+        uint32_t m_slot_up          = 0;
+        uint32_t m_slot_scroll      = 0;
+        uint32_t m_slot_rmb         = 0;
+        uint32_t m_slot_mmb         = 0;
+        uint32_t m_slot_lmb         = 0;
+        uint32_t m_slot_alt         = 0;
+        uint32_t m_slot_shift       = 0;
+        uint32_t m_slot_ctrl        = 0;
+        uint32_t m_slot_focus       = 0;
+        uint32_t m_slot_bookmark[9] = {};
+    };
+    ZDEFINE_PTR(FlyCameraController);
+}
+```
+
+### 6.3 `Update`
+
+```cpp
+void FlyCameraController::Update(Core::TimeStep dt)
+{
+    if (m_active.value.load(std::memory_order_acquire))
+    {
+        auto& inp = m_camera->Input;
+
+        inp.Keys[GLFW_KEY_W] = m_input->GetAxis(m_slot_forward)  >  0.5f;
+        inp.Keys[GLFW_KEY_S] = m_input->GetAxis(m_slot_forward)  < -0.5f;
+        inp.Keys[GLFW_KEY_D] = m_input->GetAxis(m_slot_right)    >  0.5f;
+        inp.Keys[GLFW_KEY_A] = m_input->GetAxis(m_slot_right)    < -0.5f;
+        inp.Keys[GLFW_KEY_E] = m_input->GetAxis(m_slot_up)       >  0.5f;
+        inp.Keys[GLFW_KEY_Q] = m_input->GetAxis(m_slot_up)       < -0.5f;
+
+        inp.RightDown  = m_input->GetButton(m_slot_rmb).Held;
+        inp.MiddleDown = m_input->GetButton(m_slot_mmb).Held;
+        inp.LeftDown   = m_input->GetButton(m_slot_lmb).Held;
+        inp.AltDown    = m_input->GetButton(m_slot_alt).Held;
+        inp.ShiftDown  = m_input->GetButton(m_slot_shift).Held;
+        inp.CtrlDown   = m_input->GetButton(m_slot_ctrl).Held;
+
+        inp.Keys[GLFW_KEY_F] = m_input->GetButton(m_slot_focus).JustUp;
+        for (int i = 0; i < 9; ++i)
+            inp.Keys[GLFW_KEY_1 + i] = m_input->GetButton(m_slot_bookmark[i]).JustUp;
+
+        auto delta        = m_input->GetMouseDelta();
+        inp.MouseDeltaX   = delta.x;
+        inp.MouseDeltaY   = delta.y;
+        inp.ScrollDelta   = m_input->GetAxis(m_slot_scroll);
+
+        auto pos          = m_input->GetMousePosition();
+        inp.MouseViewportX = pos.x - m_viewportOriginX;
+        inp.MouseViewportY = pos.y - m_viewportOriginY;
+    }
+
+    m_camera->OnUpdate(dt.GetSeconds());
+}
+```
+
+### 6.4 `PauseEventProcessing`
+
+```cpp
+void FlyCameraController::PauseEventProcessing()
+{
+    m_active.value.store(false, std::memory_order_release);
+    m_camera->Input.Reset();
+}
+```
+
+---
+
+## 7. `EditorCameraController` — Full Redesign
+
+```cpp
+// Tetragrama/Controllers/EditorCameraController.h
+#pragma once
+#include <ZEngine/Controllers/FlyCameraController.h>
+#include <ZEngine/Core/Memory/Allocator.h>
+#include <ZEngine/Input/InputManager.h>
+
+namespace Tetragrama::Controllers
+{
+    struct EditorCameraController : public ZEngine::Controllers::FlyCameraController
+    {
+        EditorCameraController()          = default;
+        virtual ~EditorCameraController() = default;
+
+        void Initialize(ZEngine::Core::Memory::ArenaAllocator* arena,
+                        ZEngine::Windows::CoreWindow*          window,
+                        ZEngine::Input::InputManager*          input_manager);
+    };
+    ZDEFINE_PTR(EditorCameraController);
+}
+```
+
+`Initialize` constructs `FlyCamera` with explicit `CameraSetting`, calls
+`FlyCameraController::Initialize(input_manager, arena)`, and wires default hooks.
+
+After scene load, `HierarchyViewUIComponent` replaces the default hooks with real
+raycasting and selection bounds.
+
+---
+
+## 8. `ICameraController` — Changes
+
+Add to the pure virtual interface:
+
+```cpp
+virtual void SetViewport(float logicalW, float logicalH) = 0;
+virtual void SetViewportOrigin(float x, float y)         = 0;
+virtual void ResumeEventProcessing()                     = 0;
+virtual void PauseEventProcessing()                      = 0;
+```
+
+Remove `IMouseEventCallback`/`IKeyboardEventCallback` from `FlyCameraController` inheritance.
+
+---
+
+## 9. HiDPI Coordinate Contract
+
+All camera internals use logical pixels:
+- `m_logicalW`, `m_logicalH` — set from ImGui content region
+- `Input.MouseDeltaX/Y` — from `InputManager::GetMouseDelta()` (GLFW logical)
+- `Input.MouseViewportX/Y` — `InputManager::GetMousePosition()` minus viewport origin
+
+Physical pixels only at Vulkan allocation boundary (`SwapchainImageWidth`).
+
+---
+
+## 10. `OnUpdate` Internal Flow
+
+```
+dt = min(dt, 0.1f)
+
+// Pan transitions (checked every frame regardless of current state)
+if Input.MiddleDown && State != Pan:
+    m_stateBeforePan = State; State = Pan
+if !Input.MiddleDown && State == Pan:
+    State = m_stateBeforePan
+
+// Orbit entry/exit
+if Input.AltDown && Input.LeftDown && State == Free:
+    EnterOrbit()
+if !Input.AltDown && State == Orbit && !Input.LeftDown && !Input.RightDown:
+    ExitOrbit()
+
+switch State:
+    Animating → UpdateAnimation(dt)
+    Pan       → UpdatePan(dt)
+    Orbit     → UpdateOrbit(dt)
+    Free      → UpdateFree(dt)
+
+// F key (JustUp pre-filled by controller)
+if Input.Keys[KEY_F]:
+    [center, radius] = Hooks.GetSelectionBounds()
+    FocusOn(center, radius)
+    Input.Keys[KEY_F] = false
+
+// Bookmarks
+for i in 0..8:
+    if Input.Keys[KEY_1+i]:
+        if CtrlDown: SaveBookmark(i)
+        else:        RecallBookmark(i)
+        Input.Keys[KEY_1+i] = false
+
+if m_projDirty: RecalculateProjection()
+if m_viewDirty: RecalculateView()
+
+Input.FlushDeltas()
+```
+
+`UpdateFree`:
+- RMB held: accumulate WASDQE movement, accumulate yaw/pitch from mouse delta
+- Scroll: zoom toward cursor via `GetRayFromViewport(MouseViewportX, MouseViewportY)`
+- Smooth position and angles with `SmoothT(SmoothingFactor, dt)`
+
+`UpdateOrbit`:
+- Alt+(LMB or RMB): tumble yaw/pitch from mouse delta
+- Scroll: zoom orbit distance
+- Smooth and recompute `Position = m_orbitPivot - GetForward() * OrbitCollide(dist)`
+
+`UpdatePan`:
+- Compute focal-plane dimensions from FOV + focal distance
+- `pan = right * (-dx/logicalW * planeW) + screenUp * (dy/logicalH * planeH)`
+- Apply to `m_targetPos` and `m_orbitPivot`
+
+---
+
+## 11. `CameraSetting` Cleanup
+
+Remove `FastMoveSpeed` and `MoveSpeed` — both replaced by `AdaptiveSpeed()` with
+`MinMoveSpeed`/`MaxMoveSpeed`/`FastSpeedMultiplier`.
+
+---
+
+## 12. File Layout
+
+```
+ZEngine/ZEngine/Rendering/Cameras/
+├── FlyCameraInput.h   — NEW: FlyCameraInput, FlyCameraState
+├── FlyCamera.h/.cpp   — redesigned
+└── Camera.h           — CameraSetting: remove FastMoveSpeed, MoveSpeed
+
+ZEngine/ZEngine/Controllers/
+├── ICameraController.h        — add SetViewport, SetViewportOrigin,
+│                                ResumeEventProcessing, PauseEventProcessing
+├── FlyCameraController.h/.cpp — reads InputManager, no event callbacks
+
+Tetragrama/Controllers/
+└── EditorCameraController.h/.cpp — Initialize with InputManager*
+```
+
+---
+
+## 13. Deliverables Checklist
+
+- [ ] `FlyCameraInput.h` — `FlyCameraInput` with `Reset()`/`FlushDeltas()`; `FlyCameraState` enum
+- [ ] `FlyCamera.h/.cpp` — `Input`/`Hooks`/`State` public; single `OnUpdate` entry; explicit state machine; `Input.FlushDeltas()` at end; all mouse math divided by `m_logicalW/H`; `AdaptiveSpeed` uses `Hooks.Raycast`
+- [ ] `ICameraController.h` — add 4 pure virtuals; `FlyCameraController` no longer inherits event callbacks
+- [ ] `FlyCameraController.h/.cpp` — `Initialize(InputManager*, ArenaAllocator*)`; `Update` fills `FlyCameraInput` from `InputManager`; `PauseEventProcessing` calls `Input.Reset()`; `OnEvent` is no-op
+- [ ] `EditorCameraController.h/.cpp` — `Initialize` gains `InputManager*`; explicit `CameraSetting`; hooks wired with defaults
+- [ ] `SceneViewportUIComponent.cpp` — `SetViewportOrigin` every frame; `SetViewport` on resize; no cast to concrete controller
+- [ ] `CameraSetting` — remove `FastMoveSpeed` and `MoveSpeed`
+- [ ] Tests: state machine transitions; `PauseEventProcessing` resets input; `Update` fills `FlyCameraInput` from mocked `InputManager`


### PR DESCRIPTION
## Summary

- **Stuck keys eliminated** — `PauseEventProcessing` now calls `Input.Reset()`, clearing all held key/button state immediately when the viewport loses focus
- **HiDPI sensitivity fixed** — all mouse math divides by logical viewport dimensions; `SetViewportSize` takes logical pixels matching GLFW and ImGui coordinate spaces
- **Scroll-toward-cursor fixed** — `SetViewportOrigin` stores the viewport panel origin; scroll ray is computed from `InputManager::GetMousePosition()` minus that origin, giving correct viewport-relative coordinates
- **No raw GLFW event interception** — `FlyCameraController` drops `IMouseEventCallback`/`IKeyboardEventCallback`; input flows through `InputManager::Poll` like every other system
- **Explicit state machine** — `Free`, `Orbit`, `Pan`, `Animating` as a typed enum; no boolean soup

## What changed

| File | Change |
|---|---|
| `FlyCameraInput.h` | New — `FlyCameraInput` struct + `FlyCameraState` enum |
| `FlyCamera.h/.cpp` | Rewritten — single `OnUpdate` entry, state machine, `FlyCameraHooks` |
| `FlyCameraController.h/.cpp` | Rewritten — reads `InputManager`, no event callbacks |
| `EditorCameraController.h/.cpp` | Updated — `Initialize` gains `InputManager*`, explicit settings |
| `ICameraController.h` | Add `Update`, `SetViewport`, `SetViewportOrigin`, `ResumeEventProcessing`, `PauseEventProcessing` as pure virtuals |
| `SceneViewportUIComponent.cpp` | Remove cast; call `SetViewportOrigin` every frame |
| `HierarchyViewUIComponent.cpp` | Remove cast; F-to-frame via `InputManager` slot |
| `Camera.h` | Remove dead `MoveSpeed` and `FastMoveSpeed` fields |
| `fly-camera-redesign.md` | Design doc committed |

## Depends on

PR #582 (`feat(input): introduce InputManager`) — already merged to develop.

## Test plan

- [x] Launch editor — no crash, no validation errors on startup
- [x] RMB + WASD — free-look movement works
- [x] MMB — screen-plane pan works
- [x] Alt + LMB — orbit mode enters; Alt release exits
- [x] Scroll — zooms toward cursor, not screen center
- [x] Click outside viewport — camera stops moving (stuck-key fix verified)
- [x] Resize viewport — no sensitivity change on Retina display
- [x] F key — focus animation plays (uses default hook — world origin until real hooks wired)
- [x] Ctrl+1 save / 1 recall — bookmark round-trips