### PR TITLE
fix(rendering): initialise render targets to swapchain size

### DIFF
--- a/ZEngine/ZEngine/Rendering/Renderers/GraphicRenderer.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/GraphicRenderer.cpp
@@ -49,18 +49,19 @@ namespace ZEngine::Rendering::Renderers
         /*
          * Renderer Passes
          */
-        auto base_pass           = ZPushStructCtor(Device->Arena, BasePass);
-        auto upload_pass         = ZPushStructCtor(Device->Arena, UploadPass);
-        auto scene_depth_prepass = ZPushStructCtor(Device->Arena, DepthPrePass);
-        auto skybox_pass         = ZPushStructCtor(Device->Arena, SkyboxPass);
-        auto grid_pass           = ZPushStructCtor(Device->Arena, GridPass);
-        auto gbuffer_pass        = ZPushStructCtor(Device->Arena, GbufferPass);
-        auto lighting_pass       = ZPushStructCtor(Device->Arena, LightingPass);
+        auto     base_pass           = ZPushStructCtor(Device->Arena, BasePass);
+        auto     upload_pass         = ZPushStructCtor(Device->Arena, UploadPass);
+        auto     scene_depth_prepass = ZPushStructCtor(Device->Arena, DepthPrePass);
+        auto     skybox_pass         = ZPushStructCtor(Device->Arena, SkyboxPass);
+        auto     grid_pass           = ZPushStructCtor(Device->Arena, GridPass);
+        auto     gbuffer_pass        = ZPushStructCtor(Device->Arena, GbufferPass);
+        auto     lighting_pass       = ZPushStructCtor(Device->Arena, LightingPass);
         // auto composite_pass      = ZPushStructCtor(Device->Arena, CompositePass);
 
-        // FrameSharedRenderTarget  = Device->CreateTexture({.PerformTransition = false, .Width = 1280, .Height = 780, .Format = ImageFormat::R8G8B8A8_UNORM});
-        FrameColorRenderTarget   = Device->CreateTexture({.PerformTransition = false, .Width = 1280, .Height = 780, .Format = ImageFormat::R8G8B8A8_UNORM});
-        FrameDepthRenderTarget   = Device->CreateTexture({.PerformTransition = false, .Width = 1280, .Height = 780, .Format = ImageFormat::DEPTH_STENCIL_FROM_DEVICE});
+        uint32_t rt_w                = Device->SwapchainPtr->SwapchainImageWidth;
+        uint32_t rt_h                = Device->SwapchainPtr->SwapchainImageHeight;
+        FrameColorRenderTarget       = Device->CreateTexture({.PerformTransition = false, .Width = rt_w, .Height = rt_h, .Format = ImageFormat::R8G8B8A8_UNORM});
+        FrameDepthRenderTarget       = Device->CreateTexture({.PerformTransition = false, .Width = rt_w, .Height = rt_h, .Format = ImageFormat::DEPTH_STENCIL_FROM_DEVICE});
 
         Device->TextureHandleToUpdates.Enqueue(FrameColorRenderTarget);
         /*

--- a/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.cpp
@@ -408,10 +408,12 @@ namespace ZEngine::Rendering::Renderers
 
     void GbufferPass::Setup(Hardwares::VulkanDevicePtr const device, cstring name, RenderGraphResourceBuilderPtr const res_builder, RenderGraphResourceInspectorPtr res_inspector)
     {
-        Specifications::TextureSpecification normal_output_spec   = {.IsUsageStorage = true, .Width = 1280, .Height = 780, .Format = ImageFormat::R16G16B16A16_SFLOAT};
-        Specifications::TextureSpecification position_output_spec = {.IsUsageStorage = true, .Width = 1280, .Height = 780, .Format = ImageFormat::R16G16B16A16_SFLOAT};
-        Specifications::TextureSpecification specular_output_spec = {.IsUsageStorage = true, .Width = 1280, .Height = 780, .Format = ImageFormat::R8G8B8A8_UNORM};
-        Specifications::TextureSpecification colour_output_spec   = {.IsUsageStorage = true, .Width = 1280, .Height = 780, .Format = ImageFormat::R8G8B8A8_UNORM};
+        uint32_t                             rt_w                 = device->SwapchainPtr->SwapchainImageWidth;
+        uint32_t                             rt_h                 = device->SwapchainPtr->SwapchainImageHeight;
+        Specifications::TextureSpecification normal_output_spec   = {.IsUsageStorage = true, .Width = rt_w, .Height = rt_h, .Format = ImageFormat::R16G16B16A16_SFLOAT};
+        Specifications::TextureSpecification position_output_spec = {.IsUsageStorage = true, .Width = rt_w, .Height = rt_h, .Format = ImageFormat::R16G16B16A16_SFLOAT};
+        Specifications::TextureSpecification specular_output_spec = {.IsUsageStorage = true, .Width = rt_w, .Height = rt_h, .Format = ImageFormat::R8G8B8A8_UNORM};
+        Specifications::TextureSpecification colour_output_spec   = {.IsUsageStorage = true, .Width = rt_w, .Height = rt_h, .Format = ImageFormat::R8G8B8A8_UNORM};
 
         auto&                                gbuffer_albedo       = res_builder->CreateRenderTarget("gbuffer_albedo_render_target", colour_output_spec);
         auto&                                gbuffer_specular     = res_builder->CreateRenderTarget("gbuffer_specular_render_target", specular_output_spec);

--- a/ZEngine/docs/future-plan/input-system.md
+++ b/ZEngine/docs/future-plan/input-system.md
@@ -134,6 +134,11 @@ struct InputManager {
         int      gamepad_index = 0
     );
 
+    // Bind the mouse scroll wheel Y axis to an Axis1D action slot.
+    // `scale` = 1.f means scroll up is positive. Use -1.f to invert.
+    // Scroll accumulates between Poll calls and is reset to 0 at the start of each Poll.
+    void BindScrollAxis(uint32_t slot, float scale = 1.f);
+
     // THREAD SAFETY: InputManager is NOT thread-safe.
     // Poll() and all Get* accessors must be called from the main thread only.
     // Do not call GetButton()/GetAxis()/GetCurrentFrame() from physics, audio,
@@ -170,9 +175,13 @@ private:
     InputFrame                    m_prev_frame    = {};
 
     // Mouse state carried between Poll calls
-    Vec2f                         m_last_mouse_pos = {};
-    Vec2f                         m_mouse_delta    = {};
-    Vec2f                         m_mouse_pos      = {};
+    Vec2f                         m_last_mouse_pos    = {};
+    Vec2f                         m_mouse_delta       = {};
+    Vec2f                         m_mouse_pos         = {};
+
+    // Scroll accumulator — written by glfwSetScrollCallback, drained by Poll.
+    float                         m_scroll_accumulator = 0.0f;
+    float                         m_current_scroll     = 0.0f;
 };
 
 } // namespace ZEngine::Input
@@ -337,23 +346,32 @@ void InputSystem::Tick(Scene& scene, const WorldTick& tick)
 
 ---
 
-## 9. Mouse Delta and Screen-Space Coordinates
+## 9. Mouse Delta, Screen-Space Coordinates, and Scroll
 
-Mouse delta and screen-space position are available as direct accessors on `InputManager`, independent of the action map. They are always valid after the first `Poll` call.
+Mouse delta, screen-space position, and scroll delta are available as direct accessors on `InputManager`, independent of the action map. They are always valid after the first `Poll` call.
 
 ```cpp
-// Free-look camera rotation — call from CameraSystem::Tick
+// Free-look camera rotation — call from FlyCameraController::Update
 Vec2f InputManager::GetMouseDelta() const;
 
-// UI hit testing — call from UIContext::ProcessInput
+// UI hit testing, scroll-toward-cursor ray origin
 Vec2f InputManager::GetMousePosition() const;
+
+// Raw scroll wheel Y accumulated this frame — positive = scroll up.
+// Reset to 0.f at the start of each Poll. Also available as a registered
+// Axis1D action via BindScrollAxis for rebindable scroll.
+float InputManager::GetScrollDelta() const;
 ```
 
-`GetMouseDelta` returns the pixel-space delta from the previous frame to the current frame. The delta is computed inside `Poll` by comparing `glfwGetCursorPos` results between successive calls.
+`GetMouseDelta` returns the pixel-space delta in logical pixels (GLFW convention) from the previous frame to the current frame. The delta is computed inside `Poll` by comparing `glfwGetCursorPos` results between successive calls.
 
-`GetMousePosition` returns the current cursor position in screen pixels, origin at top-left, consistent with GLFW's coordinate convention.
+`GetMousePosition` returns the current cursor position in logical screen pixels, origin at top-left, consistent with GLFW's coordinate convention.
 
-Both accessors may return zero before the first `Poll` call. Camera systems that consume mouse delta should clamp or filter the first frame to avoid a large initial jump if the cursor is not centered.
+`GetScrollDelta` returns the raw scroll wheel Y accumulated since the last `Poll`. It is stored in `m_scroll_delta` and set via `glfwSetScrollCallback`. The callback accumulates values between `Poll` calls; `Poll` reads and resets the accumulator. Scroll registered as an Axis1D action via `BindScrollAxis` uses the same accumulator — binding and raw accessor return the same value.
+
+Camera integration: `FlyCameraController` reads scroll via the registered `"CameraScroll"` Axis1D slot (bound with `BindScrollAxis`) and reads mouse delta via `GetMouseDelta()`. The camera never calls `glfwGetCursorPos` or `glfwSetScrollCallback` directly.
+
+Both `GetMouseDelta` and `GetScrollDelta` may return zero before the first `Poll` call. Camera systems should clamp or filter the first frame to avoid a large initial jump.
 
 Mouse capture (hiding the cursor and enabling unlimited movement) is managed by `GameWindow::SetCursorMode(CursorMode::Captured)`. `InputManager` does not manage cursor mode; it only reads position.
 
@@ -401,7 +419,8 @@ Game code accesses it via the engine context or a helper:
 - [ ] `InputManager.cpp` — `Poll`: keyboard, mouse button, gamepad button, gamepad axis
 - [ ] `InputManager.cpp` — `JustDown`/`JustUp` derivation via prev/current frame comparison
 - [ ] `InputManager.cpp` — `ApplyDeadzone` and `ApplyDeadzone2D`
-- [ ] `InputManager.cpp` — `GetMouseDelta`, `GetMousePosition`
+- [ ] `InputManager.cpp` — `GetMouseDelta`, `GetMousePosition`, `GetScrollDelta`
+- [ ] `InputManager.cpp` — `BindScrollAxis`: registers a `glfwSetScrollCallback` (once, on first call), stores scale; `Poll` reads `m_scroll_accumulator`, multiplies by scale, stores in the bound action slot and in `m_current_scroll`, then resets accumulator to 0
 - [ ] `InputManager.cpp` — `SaveBindings`/`LoadBindings` using `GameSaveData` API
 - [ ] `InputSystem.h/.cpp` — ECS system with correct `SystemDeps` masks
 - [ ] `Engine.h` — add `InputManager` to `EngineContext`


### PR DESCRIPTION
## Summary

Fixes #264 — scene geometry was clipped when the viewport panel was larger than 1280×780.

`GraphicRenderer::Initialize` and `GbufferPass::Setup` hardcoded render target dimensions to `1280×780`. When the editor viewport panel expanded beyond that size, `ImGui::Image` stretched the texture to fill the panel but geometry rendered outside the original RT boundary was absent — it was never rendered in the first place.

Render targets now initialise to `SwapchainImageWidth × SwapchainImageHeight` at startup. The existing `RenderTargetResizeRequests` path handles all subsequent viewport resizes.

## Files changed

| File | Change |
|---|---|
| `GraphicRenderer.cpp` | `FrameColorRenderTarget` and `FrameDepthRenderTarget` initialised to swapchain dimensions |
| `RendererPasses.cpp` | `GbufferPass` g-buffer attachments initialised to swapchain dimensions |
| `input-system.md` | `BindScrollAxis` and scroll delta accessor added (doc update from InputManager session) |

## Test plan

- [ ] Launch editor — viewport renders full scene with no clipping at any panel size
- [ ] Resize viewport panel — no clipping at any intermediate size
- [ ] No validation layer errors on startup