### PR TITLE
fix(imgui): font atlas upload via owned-copy deferral through RRM

### DIFF
--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
@@ -788,6 +788,36 @@ namespace ZEngine::Rendering
         return handle;
     }
 
+    Rendering::Textures::TextureHandle RenderResourceManager::UploadFontAtlas(unsigned char* pixels, uint32_t width, uint32_t height)
+    {
+        using namespace Rendering::Specifications;
+
+        if (!pixels || width == 0 || height == 0)
+            return {};
+
+        TextureSpecification spec = {};
+        spec.Width                = width;
+        spec.Height               = height;
+        spec.Format               = ImageFormat::R8G8B8A8_UNORM;
+        spec.PerformTransition    = false;
+
+        auto            handle    = m_device->CreateTexture(spec);
+
+        // Copy pixel data into an owned buffer so the caller (ImGui) can release
+        // its atlas memory at any time after this call returns.
+        const size_t    byte_size = static_cast<size_t>(width) * height * 4u;
+        TextureDeferral deferral  = {};
+        deferral.FrameIdx         = 0;
+        deferral.ThreadIdx        = 0;
+        deferral.TexHandle        = handle;
+        deferral.IsLarge          = true;
+        deferral.Buffer           = std::vector<uint8_t>(pixels, pixels + byte_size);
+
+        EnqueueTextureDeferral(std::move(deferral));
+
+        return handle;
+    }
+
     void RenderResourceManager::EnqueueTextureDeferral(TextureDeferral&& deferral)
     {
         m_tex_deferral_queue.Emplace(std::forward<TextureDeferral>(deferral));

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.h
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.h
@@ -57,10 +57,16 @@ namespace ZEngine::Rendering
         BufferHandle                       UploadMesh(Managers::AssetHandle asset_handle);
         ImageHandle                        UploadTexture(Managers::AssetHandle asset_handle);
 
-        // Direct texture upload from raw pixel data (e.g. ImGui font, procedural textures).
-        // Returns a TextureHandle; submits via timeline job queue (same path as file-based uploads).
-        // Thread-safe — may be called from any thread; submission drains in SubmitTextureJobs().
+        // Direct texture upload from raw pixel data (e.g. procedural textures).
+        // Submits via timeline job queue; submission drains in SubmitTextureJobs().
         Rendering::Textures::TextureHandle UploadTextureBuffer(uint8_t frame_index, uint8_t thread_index, const Rendering::Textures::TextureHandle& handle, unsigned char* data);
+
+        // Create the font atlas texture and enqueue an owned-copy deferral.
+        // The pixel data is copied immediately so the caller may free its buffer after
+        // this call returns. The GPU upload is dispatched by CompleteDeferrals on the
+        // next BeginFrame. Caller must enqueue the returned handle to
+        // TextureHandleToUpdates for bindless descriptor registration.
+        Rendering::Textures::TextureHandle UploadFontAtlas(unsigned char* pixels, uint32_t width, uint32_t height);
 
         // Load a texture file from disk, decode it on the thread pool, and upload to GPU.
         Rendering::Textures::TextureHandle SubmitTextureFile(uint8_t frame_index, uint8_t thread_index, const char* filename);

--- a/ZEngine/ZEngine/Rendering/Renderers/ImGUIRenderer.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/ImGUIRenderer.cpp
@@ -67,34 +67,21 @@ namespace ZEngine::Rendering::Renderers
         }
 
         /*
-         * Font uploading
+         * Font uploading — RRM creates the texture and copies pixel data into an
+         * owned buffer. The GPU upload is deferred to the first BeginFrame call.
          */
         unsigned char* pixels;
         int            width, height;
         io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
 
-        Specifications::TextureSpecification font_tex_spec = {};
-        font_tex_spec.Width                                = width;
-        font_tex_spec.Height                               = height;
-        font_tex_spec.Format                               = Specifications::ImageFormat::R8G8B8A8_UNORM;
-
-        auto font_tex_handle                               = Device->CreateTexture(font_tex_spec);
-
+        TextureHandle font_tex_handle = {};
         if (Device->RRM)
         {
-            auto*                                  rrm = static_cast<RenderResourceManager*>(Device->RRM);
-            RenderResourceManager::TextureDeferral deferral;
-            deferral.FrameIdx  = 0;
-            deferral.ThreadIdx = 0;
-            deferral.TexHandle = font_tex_handle;
-            deferral.Buffer    = pixels;
-            deferral.IsLarge   = false;
-            rrm->EnqueueTextureDeferral(std::move(deferral));
+            auto* rrm       = static_cast<RenderResourceManager*>(Device->RRM);
+            font_tex_handle = rrm->UploadFontAtlas(pixels, static_cast<uint32_t>(width), static_cast<uint32_t>(height));
         }
 
-        // We enqueue the tex handle so, we write the DescriptorSet at Present(...)
         Device->TextureHandleToUpdates.Enqueue(font_tex_handle);
-
         io.Fonts->TexID   = (ImTextureID) font_tex_handle.Index;
 
         auto pass_builder = RenderGraph->RenderPassBuilder;


### PR DESCRIPTION
## Problem

The old font upload path in `ImGUIRenderer::Initialize` had two issues:

1. **Raw pointer aliasing** — `TextureDeferral` stored ImGui's `pixels` pointer as a raw `unsigned char*`. `CompleteDeferrals` dereferenced it one frame later. If ImGui called `ClearTexData()` between initialization and the first `BeginFrame`, the pointer would be dangling.

2. **ImGUIRenderer calling `Device->CreateTexture` directly** — the renderer should not own font texture allocation. That belongs in RRM.

## Fix

`RRM::UploadFontAtlas(pixels, width, height)`:
- Creates the `VkImage` internally via `Device->CreateTexture`
- Copies `pixels` into an owned `std::vector<uint8_t>` immediately — caller can release its atlas memory any time after the call returns
- Enqueues the deferral with `IsLarge = true` so `CompleteDeferrals` on the next `BeginFrame` dispatches the GPU upload via `UploadTextureBuffer` → timeline semaphore job

The GPU upload path is unchanged — same `IsLarge` deferral → `CompleteDeferrals` → `UploadTextureBuffer` → timeline semaphore, consistent with all other texture uploads.

## Test plan

- [x] Editor starts and ImGui renders with correct fonts
- [x] No Vulkan validation layer errors on startup
- [x] Font renders correctly on the first frame (deferral processed by first `BeginFrame`)