### PR TITLE
feat(rrm): UploadBuffer, GetBuffer, typed EnqueueDeletion — complete RRM API

### DIFF
--- a/ZEngine/ZEngine/Hardwares/DeferredFreeQueue.h
+++ b/ZEngine/ZEngine/Hardwares/DeferredFreeQueue.h
@@ -81,6 +81,9 @@ namespace ZEngine::Hardwares
                             case Rendering::DeviceResourceType::PIPELINE:
                                 vkDestroyPipeline(device, reinterpret_cast<VkPipeline>(e.Data.Vk.Handle), nullptr);
                                 break;
+                            case Rendering::DeviceResourceType::SHADERMODULE:
+                                vkDestroyShaderModule(device, reinterpret_cast<VkShaderModule>(e.Data.Vk.Handle), nullptr);
+                                break;
                             case Rendering::DeviceResourceType::DESCRIPTORSETLAYOUT:
                                 vkDestroyDescriptorSetLayout(device, reinterpret_cast<VkDescriptorSetLayout>(e.Data.Vk.Handle), nullptr);
                                 break;

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
@@ -175,6 +175,12 @@ namespace ZEngine::Rendering
                 m_device->GpuMem.FreeImage(m_image_slots[i].Data, m_device->LogicalDevice);
         }
 
+        for (uint32_t i = 0; i < m_gbuf_slot_count; ++i)
+        {
+            if (m_gbuf_slots[i].Generation != 0 && m_gbuf_slots[i].Data)
+                m_device->GpuMem.FreeBuffer(m_gbuf_slots[i].Data);
+        }
+
         m_device   = nullptr;
         m_registry = nullptr;
     }
@@ -508,11 +514,32 @@ namespace ZEngine::Rendering
 
     void RenderResourceManager::Release(BufferHandle handle)
     {
-        // Per-mesh release in the packed buffer model just invalidates the slot.
-        // The global buffer is append-only; physical reclamation requires compaction (future).
-        if (!handle.IsValid() || handle.Index >= m_mesh_slot_count)
+        if (!handle.IsValid())
             return;
-        m_mesh_slots[handle.Index].Generation = 0;
+
+        if (handle.Generation & GBUF_GEN_TAG)
+        {
+            // Generic device-local buffer — deferred-free the VmaAllocation.
+            if (handle.Index >= m_gbuf_slot_count)
+                return;
+            auto& slot = m_gbuf_slots[handle.Index];
+            if (slot.Generation != handle.Generation)
+                return;
+            DeferredFreeEntry e;
+            e.EntryKind     = DeferredFreeEntry::Kind::Buffer;
+            e.TimelineValue = m_device->SwapchainPtr->RenderTimelineNextValue;
+            e.Data.Buffer   = slot.Data;
+            m_device->DeferFree(e);
+            slot.Data       = {};
+            slot.Generation = 0;
+        }
+        else
+        {
+            // Mesh slot — packed global buffer is append-only; just invalidate the slot.
+            if (handle.Index >= m_mesh_slot_count)
+                return;
+            m_mesh_slots[handle.Index].Generation = 0;
+        }
     }
 
     void RenderResourceManager::Release(ImageHandle handle)
@@ -552,6 +579,57 @@ namespace ZEngine::Rendering
         m_device->DeferFree(entry);
     }
 
+    void RenderResourceManager::EnqueueDeletion(VkShaderModule module)
+    {
+        if (module == VK_NULL_HANDLE)
+            return;
+        DeferredFreeEntry e;
+        e.EntryKind      = DeferredFreeEntry::Kind::VkHandle;
+        e.TimelineValue  = m_device->SwapchainPtr->RenderTimelineNextValue;
+        e.Data.Vk.Handle = reinterpret_cast<void*>(module);
+        e.Data.Vk.Type   = Rendering::DeviceResourceType::SHADERMODULE;
+        e.Data.Vk.Extra  = nullptr;
+        m_device->DeferFree(e);
+    }
+
+    void RenderResourceManager::EnqueueDeletion(VkPipeline pipeline)
+    {
+        if (pipeline == VK_NULL_HANDLE)
+            return;
+        DeferredFreeEntry e;
+        e.EntryKind      = DeferredFreeEntry::Kind::VkHandle;
+        e.TimelineValue  = m_device->SwapchainPtr->RenderTimelineNextValue;
+        e.Data.Vk.Handle = reinterpret_cast<void*>(pipeline);
+        e.Data.Vk.Type   = Rendering::DeviceResourceType::PIPELINE;
+        e.Data.Vk.Extra  = nullptr;
+        m_device->DeferFree(e);
+    }
+
+    void RenderResourceManager::EnqueueDeletion(VkBuffer buffer, VmaAllocation allocation)
+    {
+        if (buffer == VK_NULL_HANDLE)
+            return;
+        DeferredFreeEntry e;
+        e.EntryKind              = DeferredFreeEntry::Kind::Buffer;
+        e.TimelineValue          = m_device->SwapchainPtr->RenderTimelineNextValue;
+        e.Data.Buffer.Handle     = buffer;
+        e.Data.Buffer.Allocation = allocation;
+        m_device->DeferFree(e);
+    }
+
+    void RenderResourceManager::EnqueueDeletion(VkImage image, VkImageView view, VmaAllocation allocation)
+    {
+        if (image == VK_NULL_HANDLE)
+            return;
+        DeferredFreeEntry e;
+        e.EntryKind             = DeferredFreeEntry::Kind::Image;
+        e.TimelineValue         = m_device->SwapchainPtr->RenderTimelineNextValue;
+        e.Data.Image.Handle     = image;
+        e.Data.Image.ViewHandle = view;
+        e.Data.Image.Allocation = allocation;
+        m_device->DeferFree(e);
+    }
+
     uint32_t RenderResourceManager::AllocMeshSlot()
     {
         for (uint32_t i = 0; i < m_mesh_slot_count; ++i)
@@ -582,6 +660,49 @@ namespace ZEngine::Rendering
         uint32_t idx                  = m_image_slot_count++;
         m_image_slots[idx].Generation = idx + 1;
         return idx;
+    }
+
+    uint32_t RenderResourceManager::AllocGBufSlot()
+    {
+        for (uint32_t i = 0; i < m_gbuf_slot_count; ++i)
+        {
+            if (m_gbuf_slots[i].Generation == 0)
+            {
+                m_gbuf_slots[i].Generation = (i + 1) | GBUF_GEN_TAG;
+                return i;
+            }
+        }
+        ZENGINE_VALIDATE_ASSERT(m_gbuf_slot_count < MAX_GENERIC_BUFS, "RRM: MAX_GENERIC_BUFS exceeded")
+        uint32_t idx                 = m_gbuf_slot_count++;
+        m_gbuf_slots[idx].Generation = (idx + 1) | GBUF_GEN_TAG;
+        return idx;
+    }
+
+    BufferHandle RenderResourceManager::UploadBuffer(const void* data, size_t byte_size, VkBufferUsageFlags usage, const char* debug_name)
+    {
+        if (!data || byte_size == 0)
+            return {};
+
+        Core::Memory::BufferView buf = m_device->GpuMem.AllocateBuffer(static_cast<VkDeviceSize>(byte_size), usage | VK_BUFFER_USAGE_TRANSFER_DST_BIT, Core::Memory::GpuMemoryDomain::DeviceGeometry, debug_name ? debug_name : "RRM::UploadBuffer");
+
+        if (!buf)
+            return {};
+
+        AppendToGlobalBuffer(buf, data, byte_size, 0, 0);
+
+        uint32_t slot_idx           = AllocGBufSlot();
+        m_gbuf_slots[slot_idx].Data = buf;
+        return {slot_idx, m_gbuf_slots[slot_idx].Generation};
+    }
+
+    const Core::Memory::BufferView* RenderResourceManager::GetBuffer(BufferHandle handle) const
+    {
+        if (!handle.IsValid() || !(handle.Generation & GBUF_GEN_TAG))
+            return nullptr;
+        if (handle.Index >= m_gbuf_slot_count)
+            return nullptr;
+        const auto& slot = m_gbuf_slots[handle.Index];
+        return slot.Generation == handle.Generation ? &slot.Data : nullptr;
     }
 
     void RenderResourceManager::InitTextureTimelines()

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.h
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.h
@@ -40,38 +40,80 @@ namespace ZEngine::Rendering
     public:
         static constexpr uint32_t          FRAMES_IN_FLIGHT = 3;
 
+        /// @brief Initialize the RRM and bind it to a VulkanDevice and AssetRegistry.
+        /// @details Registers OnAssetReady and OnAssetStale callbacks on the registry,
+        ///          allocates the dedicated upload command pool and fence, and creates
+        ///          the packed global vertex and index buffers.
+        /// @param device   The active Vulkan device; must outlive this RRM instance.
+        /// @param registry The asset registry to subscribe to; must outlive this RRM instance.
         void                               Initialize(Hardwares::VulkanDevice* device, Core::VFS::AssetRegistry* registry);
+
+        /// @brief Drain in-flight GPU work and release all GPU resources.
+        /// @details Calls vkQueueWaitAll, shuts down texture timelines, frees the global
+        ///          geometry buffers, all image slots, and all generic buffer slots.
+        ///          Must be called from the main thread before VulkanDevice teardown.
         void                               Shutdown();
 
-        // Called once per frame from the render thread (AppRenderPipeline::BeginFrame).
-        // Flushes pending uploads queued from the asset thread.
+        /// @brief Per-frame render-thread entry point.
+        /// @details Flushes pending mesh and texture uploads that were queued from the
+        ///          asset thread since the previous BeginFrame. Called by AppRenderPipeline.
+        /// @param frame_index Current swapchain frame index (0 .. FRAMES_IN_FLIGHT-1).
         void                               BeginFrame(uint32_t frame_index);
 
-        // Called once per frame from the render thread (AppRenderPipeline::EndFrame).
-        // Drains swap entries that have aged past FRAMES_IN_FLIGHT.
+        /// @brief Per-frame render-thread exit point.
+        /// @details Drains hot-reload swap entries that have aged past FRAMES_IN_FLIGHT
+        ///          frames. Called by AppRenderPipeline after command buffer submission.
+        /// @param frame_index Current swapchain frame index (0 .. FRAMES_IN_FLIGHT-1).
         void                               EndFrame(uint32_t frame_index);
 
-        // Upload mesh/texture from an AssetHandle to a device-local GPU resource.
-        // Returns an invalid handle on failure (out of memory, null asset, etc.).
-        // Safe to call from any thread — work is queued and flushed in BeginFrame.
+        /// @brief Upload a mesh asset to the packed global vertex and index buffers.
+        /// @details Thread-safe: enqueues a pending upload consumed by BeginFrame.
+        ///          Vertices and indices are appended at the current watermark cursor.
+        /// @param asset_handle Handle to a fully imported MeshAsset in the AssetManager.
+        /// @return A valid BufferHandle on success; invalid if the asset is null or upload fails.
         BufferHandle                       UploadMesh(Managers::AssetHandle asset_handle);
+
+        /// @brief Upload a texture asset to a new device-local VkImage.
+        /// @details Thread-safe: enqueues a pending upload consumed by BeginFrame.
+        ///          The image is transitioned to SHADER_READ_ONLY_OPTIMAL via timeline semaphore.
+        /// @param asset_handle Handle to a fully imported TextureAsset in the AssetManager.
+        /// @return A valid ImageHandle on success; invalid if the asset is null or upload fails.
         ImageHandle                        UploadTexture(Managers::AssetHandle asset_handle);
 
-        // Direct texture upload from raw pixel data (e.g. procedural textures).
-        // Submits via timeline job queue; submission drains in SubmitTextureJobs().
+        /// @brief Upload raw RGBA pixel data to an existing TextureHandle via the timeline path.
+        /// @details Records a staging copy into an instant command buffer and enqueues the
+        ///          submission to the timeline job queue. Actual GPU submission drains in
+        ///          SubmitTextureJobs(). For font atlas upload prefer UploadFontAtlas.
+        /// @param frame_index  Render frame index used to select the per-frame command pool.
+        /// @param thread_index Thread index within the pool.
+        /// @param handle       Pre-allocated TextureHandle whose VkImage will receive the data.
+        /// @param data         RGBA pixel data; must remain valid until SubmitTextureJobs runs.
+        /// @return The same handle on success; invalid handle if no free upload slot.
         Rendering::Textures::TextureHandle UploadTextureBuffer(uint8_t frame_index, uint8_t thread_index, const Rendering::Textures::TextureHandle& handle, unsigned char* data);
 
-        // Create the font atlas texture and enqueue an owned-copy deferral.
-        // The pixel data is copied immediately so the caller may free its buffer after
-        // this call returns. The GPU upload is dispatched by CompleteDeferrals on the
-        // next BeginFrame. Caller must enqueue the returned handle to
-        // TextureHandleToUpdates for bindless descriptor registration.
+        /// @brief Create the ImGui font atlas texture and enqueue an owned-copy deferral.
+        /// @details The pixel data is copied immediately into an owned std::vector so the
+        ///          caller (ImGui) can release its atlas memory after this call returns.
+        ///          The GPU upload runs on the first BeginFrame via CompleteDeferrals.
+        ///          Caller must enqueue the returned handle to TextureHandleToUpdates for
+        ///          bindless descriptor registration.
+        /// @param pixels  Pointer to RGBA atlas data (from io.Fonts->GetTexDataAsRGBA32).
+        /// @param width   Atlas width in pixels.
+        /// @param height  Atlas height in pixels.
+        /// @return A valid TextureHandle for the font atlas.
         Rendering::Textures::TextureHandle UploadFontAtlas(unsigned char* pixels, uint32_t width, uint32_t height);
 
-        // Load a texture file from disk, decode it on the thread pool, and upload to GPU.
+        /// @brief Load a texture file from disk, decode it on the thread pool, and upload.
+        /// @details Asynchronously reads and decodes the image; uploads via the timeline path.
+        /// @param frame_index  Render frame index.
+        /// @param thread_index Thread index within the per-frame pool.
+        /// @param filename     Absolute path to the image file on disk.
+        /// @return A valid TextureHandle that will become readable once the upload drains.
         Rendering::Textures::TextureHandle SubmitTextureFile(uint8_t frame_index, uint8_t thread_index, const char* filename);
 
-        // Queue a deferred texture upload (for large textures or cross-frame deferral).
+        /// @brief Payload for a deferred texture upload.
+        /// @details IsLarge = true stores an owned copy of the pixel data (std::vector<uint8_t>).
+        ///          IsLarge = false stores a raw pointer valid until CompleteDeferrals runs.
         struct TextureDeferral
         {
             uint8_t                                            FrameIdx  = 0;
@@ -80,67 +122,169 @@ namespace ZEngine::Rendering
             Rendering::Textures::TextureHandle                 TexHandle = {};
             bool                                               IsLarge   = false;
         };
+
+        /// @brief Enqueue a texture upload deferral for processing in the next BeginFrame.
+        /// @param deferral Deferral to enqueue; ownership of the Buffer variant is transferred.
         void                             EnqueueTextureDeferral(TextureDeferral&& deferral);
 
-        // Drain deferred texture uploads queued via EnqueueTextureDeferral.
-        // Called from AppRenderPipeline::BeginFrame.
+        /// @brief Drain all pending texture deferrals by dispatching UploadTextureBuffer.
+        /// @details Called from AppRenderPipeline::BeginFrame. Processes every entry in
+        ///          m_tex_deferral_queue and submits the underlying staging copies.
         void                             CompleteDeferrals();
 
-        // Submit all pending timeline semaphore jobs to the GPU queue.
-        // Called from AppRenderPipeline::EndFrame.
+        /// @brief Submit all pending timeline semaphore jobs to the GPU graphics queue.
+        /// @details Called from AppRenderPipeline::EndFrame. Processes m_tex_job_queue.
         void                             SubmitTextureJobs();
 
-        // Retire completed command buffers for a given frame/thread pool.
-        // Called from AppRenderPipeline::BeginFrame on each pool.
+        /// @brief Retire command buffers whose timeline fence has been signalled.
+        /// @details Frees staging buffers associated with completed texture uploads for the
+        ///          given frame/thread pool. Called from AppRenderPipeline::BeginFrame.
+        /// @param frame_index  Render frame index.
+        /// @param thread_index Thread index within the per-frame pool.
         void                             RetireTextureSlots(uint8_t frame_index, uint8_t thread_index);
 
-        // Cancel all queued timeline jobs (called on swapchain resize/recreate).
+        /// @brief Cancel all queued timeline jobs without submitting them.
+        /// @details Called on swapchain resize or recreate to discard stale uploads.
         void                             ClearTextureJobs();
 
-        // Reset timeline semaphore counters for all pools after a swapchain recreate.
+        /// @brief Reset all texture timeline semaphore counters after a swapchain recreate.
+        /// @details Re-initialises per-pool signal values and retire arrays to zero.
         void                             ResetTextureTimelines();
 
-        // Hot-reload: upload new version, swap after FRAMES_IN_FLIGHT frames drain.
+        /// @brief Schedule a hot-reload swap for a mesh buffer.
+        /// @details Uploads the new version of new_asset and swaps it into old_handle after
+        ///          FRAMES_IN_FLIGHT frames have drained, then queues the old buffer for deletion.
+        /// @param old_handle The live BufferHandle to replace.
+        /// @param new_asset  AssetHandle for the new version of the mesh.
         void                             ScheduleSwap(BufferHandle old_handle, Managers::AssetHandle new_asset);
+
+        /// @brief Schedule a hot-reload swap for a texture image.
+        /// @details Uploads the new version of new_asset and swaps it into old_handle after
+        ///          FRAMES_IN_FLIGHT frames, then queues the old image for deletion.
+        /// @param old_handle The live ImageHandle to replace.
+        /// @param new_asset  AssetHandle for the new version of the texture.
         void                             ScheduleSwap(ImageHandle old_handle, Managers::AssetHandle new_asset);
 
-        // Deferred release — actual GPU memory freed after FRAMES_IN_FLIGHT frames.
+        /// @brief Deferred release of a GPU buffer.
+        /// @details For generic device-local buffers (handles returned by UploadBuffer) the
+        ///          underlying VmaAllocation is freed after FRAMES_IN_FLIGHT frames via the
+        ///          deferred-free queue. For mesh handles the slot is invalidated only — the
+        ///          packed global buffer is append-only and reclaimed on shutdown.
+        /// @param handle Handle returned by UploadMesh or UploadBuffer.
         void                             Release(BufferHandle handle);
+
+        /// @brief Deferred release of a GPU image.
+        /// @details The VmaAllocation and VkImageView are freed after FRAMES_IN_FLIGHT frames.
+        /// @param handle Handle returned by UploadTexture.
         void                             Release(ImageHandle handle);
 
-        // Read-only accessors — valid only for the current frame on the render thread.
+        /// @brief Look up a generic device-local buffer by handle.
+        /// @details Valid only for handles returned by UploadBuffer. Mesh handles must use
+        ///          GetMeshOffsets instead. The returned pointer is valid for the current frame
+        ///          only — do not store it across BeginFrame calls.
+        /// @param handle Handle returned by UploadBuffer.
+        /// @return Pointer to the BufferView, or nullptr if the handle is invalid or stale.
+        const Core::Memory::BufferView*  GetBuffer(BufferHandle handle) const;
+
+        /// @brief Look up a GPU image by handle.
+        /// @details The returned pointer is valid for the current frame only.
+        /// @param handle Handle returned by UploadTexture.
+        /// @return Pointer to the BufferImage, or nullptr if the handle is invalid or stale.
         const Core::Memory::BufferImage* GetImage(ImageHandle handle) const;
 
-        // Global geometry buffers — one VkBuffer for all vertex data, one for all index data.
-        // All mesh uploads are appended at the current watermark cursor.
-        // VertexSB/IndexSB descriptors bind these once; DrawData offsets select the right region.
+        /// @brief Return the shared device-local VkBuffer that holds all uploaded vertex data.
+        /// @details All mesh uploads are appended sequentially at the watermark cursor.
+        ///          Bound once to the VertexSB descriptor; per-draw vertex offset is in DrawData.
+        /// @return Pointer to the global vertex BufferView; always valid after Initialize.
         const Core::Memory::BufferView*  GetGlobalVertexBuffer() const
         {
             return &m_global_vertex_buf;
         }
+
+        /// @brief Return the shared device-local VkBuffer that holds all uploaded index data.
+        /// @details Analogous to GetGlobalVertexBuffer for index (uint32) data.
+        /// @return Pointer to the global index BufferView; always valid after Initialize.
         const Core::Memory::BufferView* GetGlobalIndexBuffer() const
         {
             return &m_global_index_buf;
         }
+
+        /// @brief Return true once at least one mesh has been appended to the global buffers.
+        /// @details Used by GraphicRenderer to defer global-buffer descriptor binding until
+        ///          data is present.
         bool GlobalBuffersReady() const
         {
             return m_vtx_cursor > 0;
         }
 
-        // Look up the element-count offsets for a mesh already uploaded to the global buffers.
-        // vtx_offset = first DrawVertex element index; idx_offset = first uint32 index element.
+        /// @brief Query the element-count offsets for a mesh in the global geometry buffers.
+        /// @param handle     BufferHandle returned by UploadMesh.
+        /// @param vtx_offset Out: index of the first DrawVertex element in the global VB.
+        /// @param idx_offset Out: index of the first uint32 element in the global IB.
+        /// @return true if the handle is valid and the offsets were written; false otherwise.
         bool         GetMeshOffsets(BufferHandle handle, uint32_t& vtx_offset, uint32_t& idx_offset) const;
 
-        // Look up the vertex buffer handle registered for a mesh asset UUID.
-        // Returns an invalid handle if the mesh has not been uploaded yet.
+        /// @brief Find the BufferHandle registered for a mesh asset by UUID.
+        /// @details Returns an invalid handle if the mesh has not been uploaded yet or
+        ///          the UUID is not in the uuid-to-buffer map.
+        /// @param uuid Asset UUID from the meta file.
+        /// @return Valid BufferHandle if found; invalid otherwise.
         BufferHandle FindMeshBuffer(const uuids::uuid& uuid) const;
 
-        // Upload / update buffer contents from CPU data.
-        // Uses RRM's dedicated command pool + Ring staging. Render-thread only.
+        /// @brief Write CPU data into an existing HOST_VISIBLE BufferView.
+        /// @details Uses the ring allocator for staging; falls back to a one-shot staging
+        ///          buffer and RecordAndSubmit. Render-thread only.
+        /// @param dst        Destination HOST_VISIBLE buffer (e.g. TransformSB, DrawDataSB).
+        /// @param data       Source CPU data.
+        /// @param byte_size  Number of bytes to write.
+        /// @param dst_offset Byte offset within dst at which to begin writing.
         void         UpdateBuffer(Hardwares::BufferView& dst, const void* data, size_t byte_size, uint32_t dst_offset = 0);
 
-        // Enqueue a raw Vulkan object for timeline-gated deferred destruction.
-        // Used by shader hot-reload and pipeline rebuild paths.
+        /// @brief Upload arbitrary CPU data to a new device-local VkBuffer.
+        /// @details Allocates a VkBuffer with the requested usage flags plus
+        ///          VK_BUFFER_USAGE_TRANSFER_DST_BIT, stages data through the ring allocator
+        ///          (or a fallback staging buffer), and submits via RecordAndSubmit.
+        ///          Intended for per-entity or per-system GPU data that changes infrequently:
+        ///          bone matrices, morph-target deltas, particle emitter configs, etc.
+        ///          The handle must be passed to Release() when the buffer is no longer needed.
+        /// @param data        CPU-side source data; must remain valid until the call returns.
+        /// @param byte_size   Size in bytes of the data to upload.
+        /// @param usage       VkBufferUsageFlags for the destination buffer (e.g. VK_BUFFER_USAGE_STORAGE_BUFFER_BIT).
+        /// @param debug_name  Optional label attached to the VmaAllocation for GPU debuggers.
+        /// @return A valid BufferHandle on success; an invalid handle if allocation fails.
+        BufferHandle UploadBuffer(const void* data, size_t byte_size, VkBufferUsageFlags usage, const char* debug_name = nullptr);
+
+        /// @brief Enqueue a VkShaderModule for timeline-gated deferred destruction.
+        /// @details Used by shader hot-reload: call after all in-flight frames that reference
+        ///          the old module have retired. The module is destroyed once the render
+        ///          timeline semaphore advances past the current value.
+        /// @param module The VkShaderModule to destroy; no-op if VK_NULL_HANDLE.
+        void         EnqueueDeletion(VkShaderModule module);
+
+        /// @brief Enqueue a VkPipeline for timeline-gated deferred destruction.
+        /// @details Used by pipeline hot-reload and render graph rebuilds.
+        ///          Safe to call immediately after switching to the new pipeline.
+        /// @param pipeline The VkPipeline to destroy; no-op if VK_NULL_HANDLE.
+        void         EnqueueDeletion(VkPipeline pipeline);
+
+        /// @brief Enqueue a raw VkBuffer + VmaAllocation for deferred destruction.
+        /// @details For buffers managed outside the RRM slot pools (e.g. scratch allocations).
+        ///          Freed after FRAMES_IN_FLIGHT frames via the deferred-free queue.
+        /// @param buffer     The VkBuffer to destroy; no-op if VK_NULL_HANDLE.
+        /// @param allocation The associated VmaAllocation to free.
+        void         EnqueueDeletion(VkBuffer buffer, VmaAllocation allocation);
+
+        /// @brief Enqueue a VkImage + VkImageView + VmaAllocation for deferred destruction.
+        /// @details For images managed outside the RRM slot pools.
+        ///          Freed after FRAMES_IN_FLIGHT frames via the deferred-free queue.
+        /// @param image      The VkImage to destroy; no-op if VK_NULL_HANDLE.
+        /// @param view       The associated VkImageView to destroy.
+        /// @param allocation The associated VmaAllocation to free.
+        void         EnqueueDeletion(VkImage image, VkImageView view, VmaAllocation allocation);
+
+        /// @brief Enqueue a pre-built DeferredFreeEntry for timeline-gated deferred destruction.
+        /// @details Low-level overload for callers that construct the entry themselves.
+        ///          Prefer the typed overloads above when possible.
         void         EnqueueDeletion(Hardwares::DeferredFreeEntry entry);
 
     private:
@@ -188,8 +332,12 @@ namespace ZEngine::Rendering
             uint32_t Generation = 0; // 0 = free
         };
 
-        static constexpr uint32_t MAX_BUFFERS = 4096;
-        static constexpr uint32_t MAX_IMAGES  = 4096;
+        static constexpr uint32_t MAX_BUFFERS      = 4096;
+        static constexpr uint32_t MAX_IMAGES       = 4096;
+        static constexpr uint32_t MAX_GENERIC_BUFS = 4096;
+        // Generation tag: bit 31 = 1 marks a generic-buffer handle so Release() and
+        // GetBuffer() can distinguish them from mesh handles (bit 31 = 0).
+        static constexpr uint32_t GBUF_GEN_TAG     = 0x8000'0000u;
 
         // Per-mesh record in the slot pool — element-count offsets into the global buffers.
         struct MeshSlot
@@ -213,25 +361,31 @@ namespace ZEngine::Rendering
         void                            InitGlobalBuffers();
         uint32_t                        AllocMeshSlot();
         uint32_t                        AllocImageSlot();
+        uint32_t                        AllocGBufSlot();
 
-        Hardwares::VulkanDevice*        m_device                  = nullptr;
-        Core::VFS::AssetRegistry*       m_registry                = nullptr;
+        Hardwares::VulkanDevice*        m_device                       = nullptr;
+        Core::VFS::AssetRegistry*       m_registry                     = nullptr;
 
         // Global geometry buffers — all mesh vertices/indices packed together.
-        static constexpr VkDeviceSize   GLOBAL_VTX_CAPACITY       = 256 * 1024 * 1024; // 256 MB → ~8M DrawVertex
-        static constexpr VkDeviceSize   GLOBAL_IDX_CAPACITY       = 256 * 1024 * 1024; // 256 MB → ~64M uint32
-        Core::Memory::BufferView        m_global_vertex_buf       = {};
-        Core::Memory::BufferView        m_global_index_buf        = {};
-        VkDeviceSize                    m_vtx_cursor              = 0; // byte offset of next write
-        VkDeviceSize                    m_idx_cursor              = 0;
+        static constexpr VkDeviceSize   GLOBAL_VTX_CAPACITY            = 256 * 1024 * 1024; // 256 MB → ~8M DrawVertex
+        static constexpr VkDeviceSize   GLOBAL_IDX_CAPACITY            = 256 * 1024 * 1024; // 256 MB → ~64M uint32
+        Core::Memory::BufferView        m_global_vertex_buf            = {};
+        Core::Memory::BufferView        m_global_index_buf             = {};
+        VkDeviceSize                    m_vtx_cursor                   = 0; // byte offset of next write
+        VkDeviceSize                    m_idx_cursor                   = 0;
 
         // Mesh slot pool — stores per-mesh offsets into the global buffers.
-        Slot<MeshSlot>                  m_mesh_slots[MAX_BUFFERS] = {};
-        uint32_t                        m_mesh_slot_count         = 0;
+        Slot<MeshSlot>                  m_mesh_slots[MAX_BUFFERS]      = {};
+        uint32_t                        m_mesh_slot_count              = 0;
 
         // Image pool
-        Slot<Core::Memory::BufferImage> m_image_slots[MAX_IMAGES] = {};
-        uint32_t                        m_image_slot_count        = 0;
+        Slot<Core::Memory::BufferImage> m_image_slots[MAX_IMAGES]      = {};
+        uint32_t                        m_image_slot_count             = 0;
+
+        // Generic device-local buffer pool — for bone matrices, particle VBs, etc.
+        // Handles carry GBUF_GEN_TAG in bit 31 to distinguish from mesh handles.
+        Slot<Core::Memory::BufferView>  m_gbuf_slots[MAX_GENERIC_BUFS] = {};
+        uint32_t                        m_gbuf_slot_count              = 0;
 
         // UUID → handle maps (for hot-reload swap lookup)
         // Written on first upload; read on OnAssetStale. Protected by m_uuid_map_mutex.

--- a/ZEngine/ZEngine/Rendering/ResourceTypes.h
+++ b/ZEngine/ZEngine/Rendering/ResourceTypes.h
@@ -19,6 +19,7 @@ namespace ZEngine::Rendering
         BUFFERMEMORY,
         PIPELINE_LAYOUT,
         PIPELINE,
+        SHADERMODULE,
         SEMAPHORE,
         FENCE,
         DESCRIPTORSETLAYOUT,


### PR DESCRIPTION
## Summary

Closes three gaps between the RRM design spec and what was implemented.

### `UploadBuffer(data, size, usage, name) → BufferHandle`
Allocates a device-local `VkBuffer`, stages data through the ring allocator (or fallback staging buffer + `RecordAndSubmit`), and stores the `BufferView` in a new **generic buffer slot pool** (`m_gbuf_slots[MAX_GENERIC_BUFS]`). Intended for per-entity GPU data that changes infrequently: bone matrices, morph-target deltas, particle emitter configs.

Handles carry `GBUF_GEN_TAG` (bit 31 of `Generation`) to distinguish them from mesh handles at runtime in `GetBuffer` and `Release`.

### `GetBuffer(handle) → const BufferView*`
Read accessor for handles returned by `UploadBuffer`. Validates the tag bit — mesh handles (no tag) must use `GetMeshOffsets` instead. Pointer is valid for the current frame only.

### `Release(BufferHandle)` — updated
Dispatches on `GBUF_GEN_TAG`:
- **Generic buffer** → `DeferredFreeEntry::Kind::Buffer` (VmaAllocation freed after `FRAMES_IN_FLIGHT` frames)
- **Mesh slot** → slot invalidation only (packed global buffer is append-only)

### `EnqueueDeletion` typed overloads (4)
| Overload | Use case |
|---|---|
| `EnqueueDeletion(VkShaderModule)` | Shader hot-reload |
| `EnqueueDeletion(VkPipeline)` | Pipeline rebuild |
| `EnqueueDeletion(VkBuffer, VmaAllocation)` | External buffer cleanup |
| `EnqueueDeletion(VkImage, VkImageView, VmaAllocation)` | External image cleanup |

`VkShaderModule` required adding `DeviceResourceType::SHADERMODULE` to `ResourceTypes.h` and the corresponding `vkDestroyShaderModule` drain case in `DeferredFreeQueue.h`.

### Documentation
All public RRM methods now carry Doxygen `///` doc blocks.

## Test plan

- [x] Build succeeds; no regressions in Obelisk startup
- [x] `UploadBuffer` + `GetBuffer` round-trip: handle is valid after upload, `BufferView` is non-null
- [x] `Release(BufferHandle)` on a generic buffer: slot Generation reset to 0, `GetBuffer` returns nullptr
- [x] `Release(BufferHandle)` on a mesh handle: slot invalidated, global buffers untouched
- [x] `EnqueueDeletion(VkPipeline)` / `EnqueueDeletion(VkShaderModule)`: drain on next frame tick