### PR TITLE
feat(vfs/editor): VFS backend hierarchy, engine assets via VFS, UE-style content browser

### DIFF
--- a/Resources/CMakeLists.txt
+++ b/Resources/CMakeLists.txt
@@ -11,16 +11,27 @@ endif()
 file (MAKE_DIRECTORY "${ShaderOutputPath}")
 
 # Mirror locations that the engine binary reads at runtime.
-set(ShaderBinOutputPath "${CMAKE_INSTALL_PREFIX}/bin/Shaders/Cache")
+set(ShaderBinOutputPath "${CMAKE_INSTALL_PREFIX}/bin/ZodiacEngine/Shaders/Cache")
 if (UNIX AND NOT APPLE)
-  set(ShaderObeliskOutputPath "${CMAKE_INSTALL_PREFIX}/Obelisk/Shaders/Cache")
+  set(ShaderObeliskOutputPath "${CMAKE_INSTALL_PREFIX}/Obelisk/ZodiacEngine/Shaders/Cache")
 else()
-  set(ShaderObeliskOutputPath "${CMAKE_INSTALL_PREFIX}/Obelisk/${CMAKE_BUILD_TYPE}/Shaders/Cache")
+  set(ShaderObeliskOutputPath "${CMAKE_INSTALL_PREFIX}/Obelisk/${CMAKE_BUILD_TYPE}/ZodiacEngine/Shaders/Cache")
+endif()
+
+set(SettingsSourcePath "${CMAKE_CURRENT_SOURCE_DIR}/Editor/Settings")
+set(SettingsBinOutputPath "${CMAKE_INSTALL_PREFIX}/bin/ZodiacEngine/Settings")
+if (UNIX AND NOT APPLE)
+  set(SettingsObeliskOutputPath "${CMAKE_INSTALL_PREFIX}/Obelisk/ZodiacEngine/Settings")
+else()
+  set(SettingsObeliskOutputPath "${CMAKE_INSTALL_PREFIX}/Obelisk/${CMAKE_BUILD_TYPE}/ZodiacEngine/Settings")
 endif()
 
 file (MAKE_DIRECTORY "${ShaderBinOutputPath}")
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   file (MAKE_DIRECTORY "${ShaderObeliskOutputPath}")
+  add_custom_target(CopyEngineSettings ALL
+      COMMAND ${CMAKE_COMMAND} -E copy_directory "${SettingsSourcePath}" "${SettingsObeliskOutputPath}"
+      COMMENT "Copying engine Settings to ZodiacEngine/")
 endif()
 
 file (GLOB VertexShaders CONFIGURE_DEPENDS "${ShaderPath}/*.vert")
@@ -64,15 +75,15 @@ foreach(FragmentShader ${FragmentShaders})
 
 endforeach()
 
-install(DIRECTORY Editor/Settings DESTINATION bin)
-install(DIRECTORY Shaders/Cache DESTINATION bin/Shaders)
+install(DIRECTORY Editor/Settings DESTINATION bin/ZodiacEngine)
+install(DIRECTORY Shaders/Cache DESTINATION bin/ZodiacEngine/Shaders)
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
   if (UNIX AND NOT APPLE)
-    install(DIRECTORY Editor/Settings DESTINATION Obelisk)
-    install(DIRECTORY Shaders/Cache DESTINATION Obelisk/Shaders)
+    install(DIRECTORY Editor/Settings DESTINATION Obelisk/ZodiacEngine)
+    install(DIRECTORY Shaders/Cache DESTINATION Obelisk/ZodiacEngine/Shaders)
   else()
-    install(DIRECTORY Editor/Settings DESTINATION Obelisk/${CMAKE_BUILD_TYPE})
-    install(DIRECTORY Shaders/Cache DESTINATION Obelisk/${CMAKE_BUILD_TYPE}/Shaders)
+    install(DIRECTORY Editor/Settings DESTINATION Obelisk/${CMAKE_BUILD_TYPE}/ZodiacEngine)
+    install(DIRECTORY Shaders/Cache DESTINATION Obelisk/${CMAKE_BUILD_TYPE}/ZodiacEngine/Shaders)
   endif()
 endif()

--- a/Resources/Shaders/imgui.frag
+++ b/Resources/Shaders/imgui.frag
@@ -3,7 +3,7 @@
 
 layout(location = 0) out vec4 fColor;
 layout(set = 1, binding = 0) uniform texture2D TextureArray[];
-layout(set = 1, binding = 1) uniform sampler LinearWrapSampler;
+layout(set = 1, binding = 2) uniform sampler LinearClampSampler;
 
 layout(location = 0) in struct
 {
@@ -15,6 +15,6 @@ void main()
 {
     // texId derives from pc.index (push constant) - dynamically uniform; nonuniformEXT not needed.
     uint texId  = uint(floor(In.TexData.z + 0.5));
-    vec4 texVal = texture(sampler2D(TextureArray[texId], LinearWrapSampler), In.TexData.xy);
+    vec4 texVal = texture(sampler2D(TextureArray[texId], LinearClampSampler), In.TexData.xy);
     fColor      = In.Color * texVal;
 }

--- a/Tetragrama/Components/ContentBrowserIcons.h
+++ b/Tetragrama/Components/ContentBrowserIcons.h
@@ -1,0 +1,273 @@
+#pragma once
+#include <ZEngine/Core/VFS/VFSPath.h>
+#include <imgui.h>
+
+namespace Tetragrama::Components
+{
+    enum class ContentIconType
+    {
+        Folder,
+        Texture,   // .png .jpg .jpeg .tga .bmp .dds .hdr .exr
+        Mesh,      // .obj .fbx .gltf .glb .ply .stl .zemesh
+        Shader,    // .glsl .vert .frag .geom .comp .hlsl .tesc .tese .rgen .rchit .rmiss
+        Material,  // .mat .zemat
+        Audio,     // .wav .mp3 .ogg .flac .aiff
+        Scene,     // .scene .zescene .level
+        Config,    // .json .yaml .yml .xml .toml .ini .cfg
+        CppSource, // .cpp .cc .cxx .c .h .hpp .hxx .inl
+        Meta,      // .meta
+        Generic,
+    };
+
+    inline ContentIconType GetContentIconType(bool is_dir, const ZEngine::Core::VFS::VFSPathComponent& ext)
+    {
+        if (is_dir)
+            return ContentIconType::Folder;
+        if (ext.Empty())
+            return ContentIconType::Generic;
+
+        if (ext.Equals(".png") || ext.Equals(".jpg") || ext.Equals(".jpeg") || ext.Equals(".tga") || ext.Equals(".bmp") || ext.Equals(".dds") || ext.Equals(".hdr") || ext.Equals(".exr"))
+            return ContentIconType::Texture;
+
+        if (ext.Equals(".obj") || ext.Equals(".fbx") || ext.Equals(".gltf") || ext.Equals(".glb") || ext.Equals(".ply") || ext.Equals(".stl") || ext.Equals(".zemesh"))
+            return ContentIconType::Mesh;
+
+        if (ext.Equals(".glsl") || ext.Equals(".vert") || ext.Equals(".frag") || ext.Equals(".geom") || ext.Equals(".comp") || ext.Equals(".hlsl") || ext.Equals(".tesc") || ext.Equals(".tese") || ext.Equals(".rgen") || ext.Equals(".rchit") || ext.Equals(".rmiss"))
+            return ContentIconType::Shader;
+
+        if (ext.Equals(".mat") || ext.Equals(".zemat"))
+            return ContentIconType::Material;
+
+        if (ext.Equals(".wav") || ext.Equals(".mp3") || ext.Equals(".ogg") || ext.Equals(".flac") || ext.Equals(".aiff"))
+            return ContentIconType::Audio;
+
+        if (ext.Equals(".scene") || ext.Equals(".zescene") || ext.Equals(".level"))
+            return ContentIconType::Scene;
+
+        if (ext.Equals(".json") || ext.Equals(".yaml") || ext.Equals(".yml") || ext.Equals(".xml") || ext.Equals(".toml") || ext.Equals(".ini") || ext.Equals(".cfg"))
+            return ContentIconType::Config;
+
+        if (ext.Equals(".cpp") || ext.Equals(".cc") || ext.Equals(".cxx") || ext.Equals(".c") || ext.Equals(".h") || ext.Equals(".hpp") || ext.Equals(".hxx") || ext.Equals(".inl"))
+            return ContentIconType::CppSource;
+
+        if (ext.Equals(".meta"))
+            return ContentIconType::Meta;
+
+        return ContentIconType::Generic;
+    }
+
+    // Draws a flat/minimal content-browser icon into dl.
+    // ixo        : top-left of the icon area (same as the caller's ixo)
+    // ic         : icon size (sz * 0.85f)
+    // dark_theme : true for dark editor backgrounds
+    //
+    // When a per-asset thumbnail is available, call dl->AddImage() instead and
+    // skip this function. This icon acts as the no-thumbnail fallback.
+    inline void DrawContentIcon(ImDrawList* dl, ImVec2 ixo, float ic, ContentIconType type, bool dark_theme)
+    {
+        if (type == ContentIconType::Folder)
+        {
+            const ImU32 body = dark_theme ? IM_COL32(200, 175, 100, 255) : IM_COL32(185, 155, 75, 255);
+            const ImU32 tab  = dark_theme ? IM_COL32(220, 195, 120, 255) : IM_COL32(205, 175, 95, 255);
+            const float tw   = ic * 0.42f;
+            const float th   = ic * 0.14f;
+            const float by   = ixo.y + th;
+            dl->AddRectFilled({ixo.x, ixo.y}, {ixo.x + tw, by + 1.0f}, tab, 2.0f);
+            dl->AddRectFilled({ixo.x, by}, {ixo.x + ic, ixo.y + ic * 0.92f}, body, 2.0f);
+            return;
+        }
+
+        ImU32 body_col, fold_col, sym_col;
+        switch (type)
+        {
+            case ContentIconType::Texture:
+                body_col = dark_theme ? IM_COL32(230, 130, 50, 255) : IM_COL32(210, 110, 35, 255);
+                fold_col = dark_theme ? IM_COL32(180, 100, 30, 255) : IM_COL32(165, 85, 20, 255);
+                sym_col  = dark_theme ? IM_COL32(255, 230, 190, 255) : IM_COL32(100, 55, 10, 255);
+                break;
+            case ContentIconType::Mesh:
+                body_col = dark_theme ? IM_COL32(80, 150, 230, 255) : IM_COL32(55, 125, 210, 255);
+                fold_col = dark_theme ? IM_COL32(50, 110, 190, 255) : IM_COL32(35, 95, 170, 255);
+                sym_col  = dark_theme ? IM_COL32(205, 225, 255, 255) : IM_COL32(20, 60, 130, 255);
+                break;
+            case ContentIconType::Shader:
+                body_col = dark_theme ? IM_COL32(155, 85, 220, 255) : IM_COL32(135, 65, 200, 255);
+                fold_col = dark_theme ? IM_COL32(115, 55, 180, 255) : IM_COL32(100, 40, 165, 255);
+                sym_col  = dark_theme ? IM_COL32(230, 205, 255, 255) : IM_COL32(75, 25, 140, 255);
+                break;
+            case ContentIconType::Material:
+                body_col = dark_theme ? IM_COL32(50, 195, 175, 255) : IM_COL32(35, 170, 155, 255);
+                fold_col = dark_theme ? IM_COL32(30, 150, 135, 255) : IM_COL32(20, 130, 118, 255);
+                sym_col  = dark_theme ? IM_COL32(190, 255, 245, 255) : IM_COL32(10, 85, 75, 255);
+                break;
+            case ContentIconType::Audio:
+                body_col = dark_theme ? IM_COL32(75, 200, 105, 255) : IM_COL32(50, 175, 80, 255);
+                fold_col = dark_theme ? IM_COL32(45, 160, 75, 255) : IM_COL32(30, 140, 55, 255);
+                sym_col  = dark_theme ? IM_COL32(200, 255, 215, 255) : IM_COL32(15, 90, 35, 255);
+                break;
+            case ContentIconType::Scene:
+                body_col = dark_theme ? IM_COL32(230, 200, 50, 255) : IM_COL32(205, 175, 30, 255);
+                fold_col = dark_theme ? IM_COL32(185, 160, 30, 255) : IM_COL32(165, 140, 15, 255);
+                sym_col  = dark_theme ? IM_COL32(255, 245, 185, 255) : IM_COL32(105, 85, 5, 255);
+                break;
+            case ContentIconType::Config:
+                body_col = dark_theme ? IM_COL32(125, 160, 205, 255) : IM_COL32(95, 130, 180, 255);
+                fold_col = dark_theme ? IM_COL32(90, 120, 170, 255) : IM_COL32(65, 98, 150, 255);
+                sym_col  = dark_theme ? IM_COL32(220, 230, 248, 255) : IM_COL32(40, 65, 115, 255);
+                break;
+            case ContentIconType::CppSource:
+                body_col = dark_theme ? IM_COL32(220, 80, 80, 255) : IM_COL32(195, 55, 55, 255);
+                fold_col = dark_theme ? IM_COL32(175, 50, 50, 255) : IM_COL32(155, 30, 30, 255);
+                sym_col  = dark_theme ? IM_COL32(255, 210, 210, 255) : IM_COL32(105, 15, 15, 255);
+                break;
+            case ContentIconType::Meta:
+                body_col = dark_theme ? IM_COL32(130, 120, 200, 255) : IM_COL32(105, 95, 175, 255);
+                fold_col = dark_theme ? IM_COL32(95, 85, 160, 255) : IM_COL32(75, 65, 140, 255);
+                sym_col  = dark_theme ? IM_COL32(220, 215, 255, 255) : IM_COL32(50, 40, 120, 255);
+                break;
+            default: // Generic
+                body_col = dark_theme ? IM_COL32(160, 160, 165, 255) : IM_COL32(130, 130, 135, 255);
+                fold_col = dark_theme ? IM_COL32(120, 120, 125, 255) : IM_COL32(95, 95, 100, 255);
+                sym_col  = dark_theme ? IM_COL32(220, 220, 225, 255) : IM_COL32(55, 55, 60, 255);
+                break;
+        }
+
+        // Document base with dog-ear fold
+        const float  f  = ic * 0.22f;
+        const ImVec2 tl = {ixo.x + ic * 0.08f, ixo.y + ic * 0.04f};
+        const ImVec2 br = {ixo.x + ic * 0.92f, ixo.y + ic * 0.96f};
+        dl->AddRectFilled({tl.x, tl.y + f}, br, body_col, 2.0f);
+        dl->AddRectFilled(tl, {br.x - f, tl.y + f}, body_col);
+        dl->AddTriangleFilled({br.x - f, tl.y}, {br.x, tl.y + f}, {br.x - f, tl.y + f}, fold_col);
+
+        // Symbol drawn in the body area below the fold line
+        const float cx     = (tl.x + br.x) * 0.5f;
+        const float area_t = tl.y + f;
+        const float area_b = br.y;
+        const float cy     = (area_t + area_b) * 0.5f;
+        const float area_h = area_b - area_t;
+        const float area_w = br.x - tl.x;
+
+        switch (type)
+        {
+            case ContentIconType::Texture:
+            {
+                // Sun circle + mountain triangle
+                const float sr  = area_h * 0.16f;
+                const float scx = cx - area_w * 0.12f;
+                const float scy = area_t + area_h * 0.28f;
+                dl->AddCircleFilled({scx, scy}, sr, sym_col, 10);
+                const float my = area_t + area_h * 0.82f;
+                dl->AddTriangleFilled({tl.x + area_w * 0.10f, my}, {tl.x + area_w * 0.90f, my}, {cx, area_t + area_h * 0.42f}, sym_col);
+                break;
+            }
+            case ContentIconType::Mesh:
+            {
+                // Isometric cube: flat-top hexagon + 3 inner Y-lines
+                const float  r      = area_h * 0.30f;
+                const float  rx     = r * 0.866f; // cos(30)
+                const float  ry     = r * 0.5f;   // sin(30)
+                const ImVec2 vtop   = {cx, cy - r};
+                const ImVec2 vtr    = {cx + rx, cy - ry};
+                const ImVec2 vbr    = {cx + rx, cy + ry};
+                const ImVec2 vbot   = {cx, cy + r};
+                const ImVec2 vbl    = {cx - rx, cy + ry};
+                const ImVec2 vtl    = {cx - rx, cy - ry};
+                const ImVec2 vctr   = {cx, cy};
+                const float  lw     = 1.5f;
+                ImVec2       hex[6] = {vtop, vtr, vbr, vbot, vbl, vtl};
+                dl->AddPolyline(hex, 6, sym_col, ImDrawFlags_Closed, lw);
+                dl->AddLine(vtop, vctr, sym_col, lw);
+                dl->AddLine(vbl, vctr, sym_col, lw);
+                dl->AddLine(vbr, vctr, sym_col, lw);
+                break;
+            }
+            case ContentIconType::Shader:
+            {
+                // GPU render triangle
+                const float th = area_h * 0.55f;
+                const float tw = area_w * 0.58f;
+                dl->AddTriangleFilled({cx, cy - th * 0.5f}, {cx + tw * 0.5f, cy + th * 0.5f}, {cx - tw * 0.5f, cy + th * 0.5f}, sym_col);
+                break;
+            }
+            case ContentIconType::Material:
+            {
+                // Sphere with specular highlight
+                const float r  = area_h * 0.32f;
+                const ImU32 hi = IM_COL32(255, 255, 255, dark_theme ? 55 : 80);
+                dl->AddCircleFilled({cx, cy}, r, sym_col, 20);
+                dl->AddCircleFilled({cx - r * 0.28f, cy - r * 0.28f}, r * 0.35f, hi, 12);
+                break;
+            }
+            case ContentIconType::Audio:
+            {
+                // Quarter note: filled head + vertical stem
+                const float nr = area_h * 0.18f;
+                const float nx = cx - nr * 0.3f;
+                const float ny = area_t + area_h * 0.72f;
+                dl->AddCircleFilled({nx, ny}, nr, sym_col, 10);
+                dl->AddLine({nx + nr * 0.9f, ny - nr * 0.2f}, {nx + nr * 0.9f, area_t + area_h * 0.18f}, sym_col, 1.5f);
+                break;
+            }
+            case ContentIconType::Scene:
+            {
+                // Ground line + building rectangle + sun circle
+                const float gy = area_t + area_h * 0.78f;
+                dl->AddLine({tl.x + area_w * 0.06f, gy}, {br.x - area_w * 0.06f, gy}, sym_col, 1.5f);
+                const float bw = area_w * 0.32f;
+                const float bh = area_h * 0.40f;
+                dl->AddRectFilled({cx - bw * 0.5f, gy - bh}, {cx + bw * 0.5f, gy}, sym_col, 1.5f);
+                const float sr  = area_h * 0.10f;
+                const float scx = tl.x + area_w * 0.76f;
+                const float scy = area_t + area_h * 0.22f;
+                dl->AddCircleFilled({scx, scy}, sr, sym_col, 8);
+                break;
+            }
+            case ContentIconType::Config:
+            {
+                // Three horizontal data lines (full / short / full)
+                const float lh  = 1.5f;
+                const float gap = area_h * 0.20f;
+                const float lx0 = tl.x + area_w * 0.10f;
+                const float lx1 = br.x - area_w * 0.10f;
+                float       ly  = area_t + area_h * 0.22f;
+                for (int i = 0; i < 3; ++i)
+                {
+                    const float rx1 = (i == 1) ? lx0 + (lx1 - lx0) * 0.62f : lx1;
+                    dl->AddRectFilled({lx0, ly}, {rx1, ly + lh + 0.5f}, sym_col);
+                    ly += gap;
+                }
+                break;
+            }
+            case ContentIconType::Meta:
+            {
+                // Info "i": dot above a vertical bar
+                const float bar_w  = area_w * 0.12f;
+                const float bar_h  = area_h * 0.38f;
+                const float dot_r  = bar_w * 1.1f;
+                const float bar_x0 = cx - bar_w * 0.5f;
+                const float bar_y0 = cy - bar_h * 0.1f;
+                dl->AddCircleFilled({cx, cy - bar_h * 0.52f - dot_r}, dot_r, sym_col, 10);
+                dl->AddRectFilled({bar_x0, bar_y0}, {bar_x0 + bar_w, bar_y0 + bar_h}, sym_col, 1.0f);
+                break;
+            }
+            case ContentIconType::CppSource:
+            {
+                // < > angle brackets
+                const float aw = area_w * 0.22f;
+                const float ah = area_h * 0.38f;
+                const float lw = 2.0f;
+                const float lx = cx - area_w * 0.32f;
+                const float rx = cx + area_w * 0.32f;
+                dl->AddLine({lx + aw, cy - ah * 0.5f}, {lx, cy}, sym_col, lw);
+                dl->AddLine({lx, cy}, {lx + aw, cy + ah * 0.5f}, sym_col, lw);
+                dl->AddLine({rx - aw, cy - ah * 0.5f}, {rx, cy}, sym_col, lw);
+                dl->AddLine({rx, cy}, {rx - aw, cy + ah * 0.5f}, sym_col, lw);
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+} // namespace Tetragrama::Components

--- a/Tetragrama/Components/ProjectViewUIComponent.cpp
+++ b/Tetragrama/Components/ProjectViewUIComponent.cpp
@@ -1,12 +1,13 @@
+#include <Tetragrama/Components/ContentBrowserIcons.h>
 #include <Tetragrama/Components/ProjectViewUIComponent.h>
 #include <Tetragrama/Editor.h>
 #include <Tetragrama/Helpers/SearchPatternAlgorithm.h>
+#include <ZEngine/Core/VFS/VFSPath.h>
 #include <ZEngine/Engine.h>
 #include <ZEngine/Helpers/MemoryOperations.h>
 #include <imgui.h>
 #include <cstdio>
-#include <filesystem>
-#include <fstream>
+#include <cstring>
 
 using namespace ZEngine::Helpers;
 using namespace ZEngine::Core::VFS;
@@ -30,23 +31,18 @@ namespace Tetragrama::Components
         m_current_vfs_dir = m_assets_vfs_root;
 
         {
-            std::filesystem::path ws(ParentLayer->CurrentApp->WorkingSpacePath);
-            std::string           label = ws.filename().string();
-            if (label.empty())
-            {
-                label = ws.string();
-            }
-            secure_strcpy(m_root_label, sizeof(m_root_label), label.c_str());
+            cstring ws = ParentLayer->CurrentApp->WorkingSpacePath;
+            secure_strcpy(m_workspace_root, sizeof(m_workspace_root), ws ? ws : "");
+            const char* slash = strrchr(ws, '/');
+            const char* label = (slash && slash[1] != '\0') ? slash + 1 : ws;
+            secure_strcpy(m_root_label, sizeof(m_root_label), label);
         }
 
-        auto       asset_mgr           = ZEngine::Managers::AssetManager::Instance();
-
-        const auto current_directoy    = std::filesystem::current_path();
-        const auto directory_icon_path = fmt::format("{0}{1}{2}", current_directoy.string(), PLATFORM_OS_BACKSLASH, "Settings/Icons/DirectoryIcon.png");
-        const auto file_icon_path      = fmt::format("{0}{1}{2}", current_directoy.string(), PLATFORM_OS_BACKSLASH, "Settings/Icons/FileIcon.png");
-
-        m_directory_icon               = asset_mgr->LoadTextureFileAsAsset(directory_icon_path.c_str(), true);
-        m_file_icon                    = asset_mgr->LoadTextureFileAsAsset(file_icon_path.c_str(), true);
+        // Reset popup input buffers to their defaults.
+        secure_strcpy(m_popup_new_file_name, sizeof(m_popup_new_file_name), "NewFile.txt");
+        secure_strcpy(m_popup_new_folder_name, sizeof(m_popup_new_folder_name), "New Folder");
+        m_popup_rename_name[0]     = '\0';
+        m_popup_rename_initialized = false;
 
         TriggerScan();
     }
@@ -76,18 +72,23 @@ namespace Tetragrama::Components
 
             /*Right Pane*/
             ImGui::TableSetColumnIndex(1);
-            if (ImGui::IsWindowHovered() && ImGui::IsMouseClicked(ImGuiMouseButton_Right))
+            {
+                ImVec2 col_min       = ImGui::GetCursorScreenPos();
+                ImVec2 avail         = ImGui::GetContentRegionAvail();
+                ImVec2 col_max       = {col_min.x + avail.x, col_min.y + avail.y};
+                m_right_pane_hovered = ImGui::IsMouseHoveringRect(col_min, col_max, false);
+            }
+            if (m_right_pane_hovered && ImGui::IsMouseClicked(ImGuiMouseButton_Right))
             {
                 ImGui::OpenPopup("ContextMenu");
             }
             if (ImGui::BeginPopup("ContextMenu"))
             {
                 char native[MAX_FILE_PATH_COUNT];
-                m_current_vfs_dir.ResolveNative(ParentLayer->CurrentApp->WorkingSpacePath, native, sizeof(native));
+                m_current_vfs_dir.ResolveNative(m_workspace_root, native, sizeof(native));
                 RenderContextMenu(ContextMenuType::RightPane, native);
                 ImGui::EndPopup();
             }
-            RenderPopUpMenu();
 
             RenderBackButton();
 
@@ -112,6 +113,11 @@ namespace Tetragrama::Components
 
             ImGui::EndTable();
         }
+
+        // Modals must be opened in the root window context, not inside a table cell,
+        // so that the backdrop covers the full window and clipping is correct.
+        RenderPopUpMenu();
+
         ImGui::PopStyleVar();
 
         ImGui::End();
@@ -128,19 +134,52 @@ namespace Tetragrama::Components
         {
             if (auto len = secure_strlen(m_search_buffer))
             {
-                char search_term_lower[256] = {0};
-                for (unsigned i = 0; i < len; ++i)
+                // Rebuild cached results only when the query changes.
+                if (strcmp(m_search_buffer, m_last_search) != 0)
                 {
-                    search_term_lower[i] = ::tolower(m_search_buffer[i]);
+                    secure_strcpy(m_last_search, sizeof(m_last_search), m_search_buffer);
+                    m_search_results.clear();
+
+                    char search_term_lower[MAX_FILE_PATH_COUNT] = {};
+                    for (size_t i = 0; i < len && i < sizeof(search_term_lower) - 1; ++i)
+                        search_term_lower[i] = static_cast<char>(::tolower(static_cast<unsigned char>(m_search_buffer[i])));
+
+                    auto scratch = ZGetScratch(&m_local_arena);
+                    m_directory_cache->ForEachDir([&](const VFSPath& /*dir*/, ZEngine::Core::Containers::ArrayView<const VFSDirEntry> entries) {
+                        for (size_t i = 0; i < entries.size(); ++i)
+                        {
+                            char name_lower[MAX_FILE_PATH_COUNT] = {};
+                            char raw[MAX_FILE_PATH_COUNT];
+                            entries[i].Path.CopyFilename(raw, sizeof(raw));
+                            size_t rlen = secure_strlen(raw);
+                            for (size_t j = 0; j < rlen && j < sizeof(name_lower) - 1; ++j)
+                                name_lower[j] = static_cast<char>(::tolower(static_cast<unsigned char>(raw[j])));
+
+                            if (!entries[i].Path.Extension().Equals(".meta") && Helpers::KMPSearch(scratch.Arena, name_lower, search_term_lower))
+                                m_search_results.push_back(entries[i]);
+                        }
+                    });
+                    ZReleaseScratch(scratch);
                 }
 
-                RenderFilteredContent(renderer, search_term_lower);
+                for (const auto& entry : m_search_results)
+                {
+                    ImGui::TableNextColumn();
+                    RenderContentTile(renderer, entry);
+                }
             }
             else
             {
+                if (m_last_search[0] != '\0')
+                {
+                    m_last_search[0] = '\0';
+                    m_search_results.clear();
+                }
                 auto listing = m_directory_cache->GetListing(m_current_vfs_dir);
                 for (size_t i = 0; i < listing.size(); ++i)
                 {
+                    if (listing[i].Path.Extension().Equals(".meta"))
+                        continue;
                     ImGui::TableNextColumn();
                     RenderContentTile(renderer, listing[i]);
                 }
@@ -154,62 +193,82 @@ namespace Tetragrama::Components
         char name[MAX_FILE_PATH_COUNT];
         entry.Path.CopyFilename(name, sizeof(name));
 
+        // --- UE thumbnail-first card layout ---
+        // Icon fills the top portion, name overlaid on a semi-transparent footer strip.
+        const float sz       = m_thumbnail_size;
+        const float pad      = 6.0f;
+        const float line_h   = ImGui::GetTextLineHeightWithSpacing();
+        const float footer_h = line_h * 2.0f + pad * 2.0f; // fixed 2-line footer
+        const float card_w   = sz + pad * 2.0f;
+        const float card_h   = sz + footer_h;
+        const float rounding = 4.0f;
+
         ImGui::PushID(entry.Path.CStr());
 
-        ImTextureID icon      = entry.IsDirectory ? (ImTextureID) m_directory_icon->Handle.Index : (ImTextureID) m_file_icon->Handle.Index;
+        ImVec2     origin   = ImGui::GetCursorScreenPos();
+        ImVec2     card_end = {origin.x + card_w, origin.y + card_h};
+        const bool hov      = ImGui::IsMouseHoveringRect(origin, card_end);
 
-        const float margin    = 5.0f;
-        ImVec2      cursorPos = ImGui::GetCursorPos();
-        ImGui::SetCursorPos(ImVec2(cursorPos.x + margin, cursorPos.y + margin));
+        // Invisible button for interaction (hover, click, drag-drop)
+        ImGui::InvisibleButton("##card", {card_w, card_h});
 
-        ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0, 0, 0, 0));
-        ImGui::ImageButton("#image", icon, {m_thumbnail_size, m_thumbnail_size}, {0, 1}, {1, 0});
-        ImGui::PopStyleColor();
-        ImGui::SetCursorPos(ImVec2(cursorPos.x, cursorPos.y + m_thumbnail_size + margin));
-
-        /*
-         * Drag and Drop scene file
-         * We don't support drag-and-drop for folder for now
-         */
-        if (!entry.IsDirectory)
+        // Drag-and-drop (files only)
+        if (!entry.IsDirectory && ImGui::BeginDragDropSource(ImGuiDragDropFlags_SourceAllowNullID))
         {
-            if (ImGui::BeginDragDropSource(ImGuiDragDropFlags_SourceAllowNullID))
-            {
-                char native[MAX_FILE_PATH_COUNT];
-                entry.Path.ResolveNative(ParentLayer->CurrentApp->WorkingSpacePath, native, sizeof(native));
-                ImGui::SetDragDropPayload("CONTENT_BROWSER_FILE_DRAG_OP", native, (secure_strlen(native) + 1) * sizeof(char));
-                ImGui::EndDragDropSource();
-            }
+            char native[MAX_FILE_PATH_COUNT];
+            entry.Path.ResolveNative(m_workspace_root, native, sizeof(native));
+            ImGui::SetDragDropPayload("CONTENT_BROWSER_FILE_DRAG_OP", native, secure_strlen(native) + 1);
+            ImGui::EndDragDropSource();
         }
 
-        if (ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left))
+        // Navigate into directory on double-click
+        if (hov && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left) && entry.IsDirectory)
         {
-            if (entry.IsDirectory)
-            {
-                m_current_vfs_dir = entry.Path;
-                secure_memset(m_search_buffer, 0, sizeof(m_search_buffer), sizeof(m_search_buffer));
-            }
+            m_current_vfs_dir = entry.Path;
+            secure_memset(m_search_buffer, 0, sizeof(m_search_buffer), sizeof(m_search_buffer));
         }
 
-        if (ImGui::IsItemHovered() && ImGui::IsMouseClicked(ImGuiMouseButton_Right))
-        {
+        // Context menu
+        if (hov && ImGui::IsMouseClicked(ImGuiMouseButton_Right))
             ImGui::OpenPopup("ItemContextMenu");
-        }
         if (ImGui::BeginPopup("ItemContextMenu"))
         {
             char native[MAX_FILE_PATH_COUNT];
-            entry.Path.ResolveNative(ParentLayer->CurrentApp->WorkingSpacePath, native, sizeof(native));
+            entry.Path.ResolveNative(m_workspace_root, native, sizeof(native));
             entry.IsDirectory ? RenderContextMenu(ContextMenuType::Folder, native) : RenderContextMenu(ContextMenuType::File, native);
             ImGui::EndPopup();
         }
 
-        // centered label
-        float textWidth  = ImGui::CalcTextSize(name).x;
-        float cursorPosX = ImGui::GetCursorPosX();
-        float centerPosX = cursorPosX + (m_thumbnail_size - textWidth) * 0.5f;
+        // ---- DrawList rendering ----
+        ImDrawList* dl       = ImGui::GetWindowDrawList();
+        ImVec2      icon_end = {origin.x + card_w, origin.y + sz};
 
-        ImGui::SetCursorPosX(centerPosX);
-        ImGui::TextWrapped("%s", name);
+        // Card body background
+        dl->AddRectFilled(origin, card_end, hov ? IM_COL32(70, 70, 70, 200) : IM_COL32(42, 42, 42, 140), rounding);
+
+        // --- Icon (vector, centered in the thumbnail area) ---
+        // When a per-asset thumbnail is ready, call
+        //   dl->AddImage((ImTextureID)(intptr_t)thumb.Index, ixo, {ixo.x + ic, ixo.y + ic * 0.92f})
+        // instead of DrawContentIcon().
+        const float ic  = sz * 0.85f;
+        const float ofx = (sz - ic) * 0.5f + pad;
+        const float ofy = (sz - ic * 0.92f) * 0.5f;
+        ImVec2      ixo = {origin.x + ofx, origin.y + ofy};
+
+        DrawContentIcon(dl, ixo, ic, GetContentIconType(entry.IsDirectory, entry.Path.Extension()), true);
+
+        // Semi-transparent footer strip
+        ImVec2 footer_min = {origin.x, origin.y + sz};
+        dl->AddRectFilled(footer_min, card_end, IM_COL32(0, 0, 0, 140), rounding, ImDrawFlags_RoundCornersBottom);
+
+        // Name text inside footer (single line, truncated)
+        {
+            const float  text_x = footer_min.x + pad;
+            const float  text_y = footer_min.y + pad;
+            const float  max_w  = card_w - pad * 2.0f;
+            const ImVec4 clip   = {text_x, text_y, text_x + max_w, text_y + line_h * 2.0f};
+            dl->AddText(nullptr, 0.0f, {text_x, text_y}, IM_COL32(230, 230, 230, 255), name, nullptr, max_w, &clip);
+        }
 
         ImGui::PopID();
     }
@@ -235,7 +294,7 @@ namespace Tetragrama::Components
                 }
                 name_lower[copy] = '\0';
 
-                if (Helpers::KMPSearch(scratch.Arena, name_lower, searchTerm))
+                if (!entry.Path.Extension().Equals(".meta") && Helpers::KMPSearch(scratch.Arena, name_lower, searchTerm))
                 {
                     ImGui::TableNextColumn();
                     RenderContentTile(renderer, entry);
@@ -246,25 +305,53 @@ namespace Tetragrama::Components
         ZReleaseScratch(scratch);
     }
 
+    // Draws a small folder icon at `pos` with text-line height, using the
+    // same golden palette as the content browser tiles.
+    static void DrawTreeFolderIcon(ImDrawList* dl, ImVec2 pos, float line_h)
+    {
+        const float sz       = line_h * 0.80f;
+        const float off_y    = (line_h - sz) * 0.50f;
+        const float tab_w    = sz * 0.42f;
+        const float tab_h    = sz * 0.18f;
+        const float body_top = pos.y + off_y + tab_h;
+        const ImU32 tab_col  = IM_COL32(220, 195, 120, 255);
+        const ImU32 body_col = IM_COL32(200, 175, 100, 255);
+        dl->AddRectFilled({pos.x, pos.y + off_y}, {pos.x + tab_w, body_top + 1.0f}, tab_col, 1.0f);
+        dl->AddRectFilled({pos.x, body_top}, {pos.x + sz, pos.y + off_y + sz * 0.88f}, body_col, 1.0f);
+    }
+
     void ProjectViewUIComponent::RenderTreeBrowser()
     {
-        bool nodeOpen = ImGui::TreeNodeEx(m_root_label, ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_DefaultOpen);
+        ImGui::PushID("##root");
+        bool nodeOpen     = ImGui::TreeNodeEx("##", ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_DefaultOpen);
+        bool clicked      = ImGui::IsItemClicked();
+        bool rightClicked = ImGui::IsItemClicked(ImGuiMouseButton_Right);
 
-        if (ImGui::IsItemClicked())
+        // Folder icon + root label inline
+        ImGui::SameLine();
+        {
+            float  lh  = ImGui::GetTextLineHeight();
+            ImVec2 pos = ImGui::GetCursorScreenPos();
+            DrawTreeFolderIcon(ImGui::GetWindowDrawList(), pos, lh);
+            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + lh * 0.80f + 3.0f);
+        }
+        ImGui::TextUnformatted(m_root_label);
+        clicked      |= ImGui::IsItemClicked();
+        rightClicked |= ImGui::IsItemClicked(ImGuiMouseButton_Right);
+        ImGui::PopID();
+
+        if (clicked)
         {
             m_current_vfs_dir = m_assets_vfs_root;
             secure_memset(m_search_buffer, 0, sizeof(m_search_buffer), sizeof(m_search_buffer));
         }
-
-        if (ImGui::IsItemClicked(ImGuiMouseButton_Right))
-        {
+        if (rightClicked)
             ImGui::OpenPopup("RootContextMenu");
-        }
 
         if (ImGui::BeginPopup("RootContextMenu"))
         {
             char native[MAX_FILE_PATH_COUNT];
-            m_assets_vfs_root.ResolveNative(ParentLayer->CurrentApp->WorkingSpacePath, native, sizeof(native));
+            m_assets_vfs_root.ResolveNative(m_workspace_root, native, sizeof(native));
             RenderContextMenu(ContextMenuType::LeftPane, native);
             ImGui::EndPopup();
         }
@@ -283,39 +370,48 @@ namespace Tetragrama::Components
         {
             const VFSDirEntry& entry = listing[i];
             if (!entry.IsDirectory)
-            {
                 continue;
-            }
 
             ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow;
             if (entry.Path == m_current_vfs_dir)
-            {
                 flags |= ImGuiTreeNodeFlags_Selected;
-            }
 
             char label[MAX_FILE_PATH_COUNT];
             entry.Path.CopyFilename(label, sizeof(label));
 
-            char popup_id[MAX_FILE_PATH_COUNT + 8];
+            char popup_id[MAX_FILE_PATH_COUNT + 4 + 1];
             std::snprintf(popup_id, sizeof(popup_id), "Dir_%s", entry.Path.CStr());
 
-            bool nodeOpen = ImGui::TreeNodeEx(label, flags);
+            ImGui::PushID(entry.Path.CStr());
+            bool nodeOpen     = ImGui::TreeNodeEx("##", flags);
+            bool clicked      = ImGui::IsItemClicked();
+            bool rightClicked = ImGui::IsItemClicked(ImGuiMouseButton_Right);
 
-            if (ImGui::IsItemClicked())
+            // Folder icon + label inline
+            ImGui::SameLine();
+            {
+                float  lh  = ImGui::GetTextLineHeight();
+                ImVec2 pos = ImGui::GetCursorScreenPos();
+                DrawTreeFolderIcon(ImGui::GetWindowDrawList(), pos, lh);
+                ImGui::SetCursorPosX(ImGui::GetCursorPosX() + lh * 0.80f + 3.0f);
+            }
+            ImGui::TextUnformatted(label);
+            clicked      |= ImGui::IsItemClicked();
+            rightClicked |= ImGui::IsItemClicked(ImGuiMouseButton_Right);
+            ImGui::PopID();
+
+            if (clicked)
             {
                 m_current_vfs_dir = entry.Path;
                 secure_memset(m_search_buffer, 0, sizeof(m_search_buffer), sizeof(m_search_buffer));
             }
-
-            if (ImGui::IsItemClicked(ImGuiMouseButton_Right))
-            {
+            if (rightClicked)
                 ImGui::OpenPopup(popup_id);
-            }
 
             if (ImGui::BeginPopup(popup_id))
             {
                 char native[MAX_FILE_PATH_COUNT];
-                entry.Path.ResolveNative(ParentLayer->CurrentApp->WorkingSpacePath, native, sizeof(native));
+                entry.Path.ResolveNative(m_workspace_root, native, sizeof(native));
                 RenderContextMenu(ContextMenuType::LeftPane, native);
                 ImGui::EndPopup();
             }
@@ -328,42 +424,49 @@ namespace Tetragrama::Components
         }
     }
 
-    void ProjectViewUIComponent::HandleCreateFilePopup(const std::filesystem::path& path)
+    void ProjectViewUIComponent::HandleCreateFilePopup(const char* path)
     {
-        ImGui::OpenPopup("Create New File");
         ImVec2 center = ImGui::GetMainViewport()->GetCenter();
         ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
 
         if (ImGui::BeginPopupModal("Create New File", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
         {
-            static char new_file_name[MAX_FILE_PATH_COUNT] = "NewFile.txt";
             ImGui::Text("Enter file name (with extension):");
-            ImGui::InputText("##create", new_file_name, sizeof(new_file_name));
+            ImGui::InputText("##create", m_popup_new_file_name, sizeof(m_popup_new_file_name));
 
             if (ImGui::Button("Create", ImVec2(120, 0)))
             {
-                if (secure_strlen(new_file_name) > 0)
+                if (secure_strlen(m_popup_new_file_name) > 0)
                 {
-                    std::filesystem::path newPath = path / new_file_name;
-                    if (!std::filesystem::exists(newPath))
-                    {
+                    char new_native[MAX_FILE_PATH_COUNT];
+                    snprintf(new_native, sizeof(new_native), "%s/%s", path, m_popup_new_file_name);
 
-                        std::ofstream file(newPath.string());
-                        if (file.is_open())
+                    size_t      ws_len  = secure_strlen(m_workspace_root);
+                    const char* rel     = (ws_len > 0 && std::strncmp(new_native, m_workspace_root, ws_len) == 0) ? new_native + ws_len : new_native;
+                    auto        vfs_res = VFSPath::Parse(rel);
+
+                    if (vfs_res.Succeeded())
+                    {
+                        auto exists = m_vfs_context->Exists(vfs_res.Value());
+                        if (!exists.Succeeded() || !exists.Value())
                         {
-                            file.close();
-                            m_active_popup = PopupType::None;
-                            TriggerScan();
-                            ImGui::CloseCurrentPopup();
+                            auto file_res = m_vfs_context->Open(vfs_res.Value(), VFSOpenFlags::Write);
+                            if (file_res.Succeeded())
+                            {
+                                m_vfs_context->Close(file_res.Value());
+                                m_active_popup = PopupType::None;
+                                TriggerScan();
+                                ImGui::CloseCurrentPopup();
+                            }
+                            else
+                            {
+                                ZENGINE_CORE_ERROR("Failed to create file: {}", m_popup_new_file_name);
+                            }
                         }
                         else
                         {
-                            ZENGINE_CORE_ERROR("Failed to create file: {}", new_file_name);
+                            ZENGINE_CORE_ERROR("A file with the name {} already exists!", m_popup_new_file_name);
                         }
-                    }
-                    else
-                    {
-                        ZENGINE_CORE_ERROR("A file with the name {} already exists!", new_file_name);
                     }
                 }
                 else
@@ -384,33 +487,41 @@ namespace Tetragrama::Components
         }
     }
 
-    void ProjectViewUIComponent::HandleCreateFolderPopup(const std::filesystem::path& path)
+    void ProjectViewUIComponent::HandleCreateFolderPopup(const char* path)
     {
-        ImGui::OpenPopup("Create New Folder");
         ImVec2 center = ImGui::GetMainViewport()->GetCenter();
         ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
 
         if (ImGui::BeginPopupModal("Create New Folder", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
         {
-            static char new_folder_name[MAX_FILE_PATH_COUNT] = "New Folder";
             ImGui::Text("Enter folder name:");
-            ImGui::InputText("##create", new_folder_name, sizeof(new_folder_name));
+            ImGui::InputText("##create", m_popup_new_folder_name, sizeof(m_popup_new_folder_name));
 
             if (ImGui::Button("Create", ImVec2(120, 0)))
             {
-                if (secure_strlen(new_folder_name) > 0)
+                if (secure_strlen(m_popup_new_folder_name) > 0)
                 {
-                    std::filesystem::path newPath = path / new_folder_name;
-                    if (!std::filesystem::exists(newPath))
+                    char new_native[MAX_FILE_PATH_COUNT];
+                    snprintf(new_native, sizeof(new_native), "%s/%s", path, m_popup_new_folder_name);
+
+                    size_t      ws_len  = secure_strlen(m_workspace_root);
+                    const char* rel     = (ws_len > 0 && std::strncmp(new_native, m_workspace_root, ws_len) == 0) ? new_native + ws_len : new_native;
+                    auto        vfs_res = VFSPath::Parse(rel);
+
+                    if (vfs_res.Succeeded())
                     {
-                        std::filesystem::create_directory(newPath);
-                        m_active_popup = PopupType::None;
-                        TriggerScan();
-                        ImGui::CloseCurrentPopup();
-                    }
-                    else
-                    {
-                        ZENGINE_CORE_ERROR("A folder with the name {} already exists!", new_folder_name);
+                        auto exists = m_vfs_context->Exists(vfs_res.Value());
+                        if (!exists.Succeeded() || !exists.Value())
+                        {
+                            m_vfs_context->CreateDir(vfs_res.Value());
+                            m_active_popup = PopupType::None;
+                            TriggerScan();
+                            ImGui::CloseCurrentPopup();
+                        }
+                        else
+                        {
+                            ZENGINE_CORE_ERROR("A folder with the name {} already exists!", m_popup_new_folder_name);
+                        }
                     }
                 }
                 else
@@ -428,53 +539,68 @@ namespace Tetragrama::Components
         }
     }
 
-    void ProjectViewUIComponent::HandleRenameFolderPopup(const std::filesystem::path& path)
+    void ProjectViewUIComponent::HandleRenameFolderPopup(const char* path)
     {
         char root_native[MAX_FILE_PATH_COUNT];
-        m_assets_vfs_root.ResolveNative(ParentLayer->CurrentApp->WorkingSpacePath, root_native, sizeof(root_native));
-        if (m_popup_target_path == std::filesystem::path(root_native))
+        m_assets_vfs_root.ResolveNative(m_workspace_root, root_native, sizeof(root_native));
+        if (strcmp(m_popup_target_path, root_native) == 0)
         {
             ZENGINE_CORE_ERROR("Cannot rename root folder");
             m_active_popup = PopupType::None;
             return;
         }
-        ImGui::OpenPopup("Rename Folder");
+
         ImVec2 center = ImGui::GetMainViewport()->GetCenter();
         ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
 
         if (ImGui::BeginPopupModal("Rename Folder", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
         {
-            static char new_name[MAX_FILE_PATH_COUNT];
-            static bool initialized = false;
-
-            if (!initialized)
+            if (!m_popup_rename_initialized)
             {
-                secure_strcpy(new_name, sizeof(new_name), path.filename().string().c_str());
-                initialized = true;
+                const char* slash = strrchr(path, '/');
+                secure_strcpy(m_popup_rename_name, sizeof(m_popup_rename_name), slash ? slash + 1 : path);
+                m_popup_rename_initialized = true;
             }
 
             ImGui::Text("Enter new folder name:");
-            ImGui::InputText("##rename", new_name, sizeof(new_name));
+            ImGui::InputText("##rename", m_popup_rename_name, sizeof(m_popup_rename_name));
 
             if (ImGui::Button("Rename", ImVec2(120, 0)))
             {
-                if (secure_strlen(new_name) > 0)
+                if (secure_strlen(m_popup_rename_name) > 0)
                 {
-                    std::filesystem::path newPath = path.parent_path() / new_name;
+                    const char* last_slash                  = strrchr(path, '/');
+                    char        parent[MAX_FILE_PATH_COUNT] = {};
+                    if (last_slash && last_slash > path)
+                        secure_strncpy(parent, sizeof(parent), path, (size_t) (last_slash - path));
 
-                    if (!std::filesystem::exists(newPath))
-                    {
-                        std::filesystem::rename(path, newPath);
-                        m_current_vfs_dir = m_assets_vfs_root;
+                    char new_native[MAX_FILE_PATH_COUNT];
+                    snprintf(new_native, sizeof(new_native), "%s/%s", parent, m_popup_rename_name);
 
-                        m_active_popup    = PopupType::None;
-                        initialized       = false;
-                        TriggerScan();
-                        ImGui::CloseCurrentPopup();
-                    }
-                    else
+                    size_t ws_len = secure_strlen(m_workspace_root);
+                    auto   to_vfs = [&](const char* n) {
+                        const char* rel = (ws_len > 0 && std::strncmp(n, m_workspace_root, ws_len) == 0) ? n + ws_len : n;
+                        return VFSPath::Parse(rel);
+                    };
+                    auto src_res = to_vfs(path);
+                    auto dst_res = to_vfs(new_native);
+
+                    if (src_res.Succeeded() && dst_res.Succeeded())
                     {
-                        ZENGINE_CORE_ERROR("A folder with the name {} already exists!", new_name);
+                        auto exists = m_vfs_context->Exists(dst_res.Value());
+                        if (!exists.Succeeded() || !exists.Value())
+                        {
+                            m_vfs_context->Rename(src_res.Value(), dst_res.Value());
+                            m_current_vfs_dir          = m_assets_vfs_root;
+                            m_active_popup             = PopupType::None;
+                            m_popup_rename_initialized = false;
+                            TriggerScan();
+                            ImGui::CloseCurrentPopup();
+                        }
+                        else
+                        {
+                            ZENGINE_CORE_ERROR("A folder with the name {} already exists!", m_popup_rename_name);
+                        }
                     }
                 }
                 else
@@ -487,8 +613,8 @@ namespace Tetragrama::Components
 
             if (ImGui::Button("Cancel", ImVec2(120, 0)))
             {
-                m_active_popup = PopupType::None;
-                initialized    = false;
+                m_active_popup             = PopupType::None;
+                m_popup_rename_initialized = false;
                 ImGui::CloseCurrentPopup();
             }
 
@@ -496,16 +622,18 @@ namespace Tetragrama::Components
         }
     }
 
-    void ProjectViewUIComponent::HandleDeleteFilePopup(const std::filesystem::path& path)
+    void ProjectViewUIComponent::HandleDeleteFilePopup(const char* path)
     {
-        ImGui::OpenPopup("Delete File");
         ImVec2 center = ImGui::GetMainViewport()->GetCenter();
         ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
 
         if (ImGui::BeginPopupModal("Delete File", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
         {
+            const char* filename = strrchr(path, '/');
+            filename             = filename ? filename + 1 : path;
+
             ImGui::Text("Are you sure you want to delete this file?");
-            ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), "%s", path.filename().string().c_str());
+            ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), "%s", filename);
 
             ImGui::Spacing();
             ImGui::Separator();
@@ -513,9 +641,15 @@ namespace Tetragrama::Components
 
             if (ImGui::Button("Delete", ImVec2(120, 0)))
             {
-                if (std::filesystem::exists(path))
+                size_t      ws_len  = secure_strlen(m_workspace_root);
+                const char* rel     = (ws_len > 0 && std::strncmp(path, m_workspace_root, ws_len) == 0) ? path + ws_len : path;
+                auto        vfs_res = VFSPath::Parse(rel);
+
+                if (vfs_res.Succeeded())
                 {
-                    std::filesystem::remove(path);
+                    auto exists = m_vfs_context->Exists(vfs_res.Value());
+                    if (exists.Succeeded() && exists.Value())
+                        m_vfs_context->Remove(vfs_res.Value());
                 }
 
                 m_active_popup = PopupType::None;
@@ -535,30 +669,45 @@ namespace Tetragrama::Components
         }
     }
 
-    void ProjectViewUIComponent::HandleDeleteFolderPopup(const std::filesystem::path& path)
+    void ProjectViewUIComponent::HandleDeleteFolderPopup(const char* path)
     {
         char root_native[MAX_FILE_PATH_COUNT];
-        m_assets_vfs_root.ResolveNative(ParentLayer->CurrentApp->WorkingSpacePath, root_native, sizeof(root_native));
-        if (m_popup_target_path == std::filesystem::path(root_native))
+        m_assets_vfs_root.ResolveNative(m_workspace_root, root_native, sizeof(root_native));
+        if (strcmp(m_popup_target_path, root_native) == 0)
         {
-            ZENGINE_CORE_ERROR("Cannot rename root folder");
+            ZENGINE_CORE_ERROR("Cannot delete root folder");
             m_active_popup = PopupType::None;
             return;
         }
-        ImGui::OpenPopup("Delete Folder");
+
         ImVec2 center = ImGui::GetMainViewport()->GetCenter();
         ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
 
         if (ImGui::BeginPopupModal("Delete Folder", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
         {
-            ImGui::Text("Are you sure you want to delete this folder?");
-            ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), "%s", path.filename().string().c_str());
+            const char* dirname = strrchr(path, '/');
+            dirname             = dirname ? dirname + 1 : path;
 
-            if (!std::filesystem::is_empty(path))
+            ImGui::Text("Are you sure you want to delete this folder?");
+            ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f), "%s", dirname);
+
             {
-                ImGui::Spacing();
-                ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "Warning: This folder is not empty!");
-                ImGui::Text("All contents will be permanently deleted.");
+                size_t      ws_len = secure_strlen(m_workspace_root);
+                const char* rel    = (ws_len > 0 && std::strncmp(path, m_workspace_root, ws_len) == 0) ? path + ws_len : path;
+                auto        vp     = VFSPath::Parse(rel);
+                if (vp.Succeeded())
+                {
+                    // Use a scratch arena so this per-frame listing doesn't leak into m_local_arena.
+                    auto scratch = ZGetScratch(&m_local_arena);
+                    auto listing = m_vfs_context->List(vp.Value(), scratch.Arena);
+                    if (listing.Succeeded() && !listing.Value().empty())
+                    {
+                        ImGui::Spacing();
+                        ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.4f, 1.0f), "Warning: This folder is not empty!");
+                        ImGui::Text("All contents will be permanently deleted.");
+                    }
+                    ZReleaseScratch(scratch);
+                }
             }
 
             ImGui::Spacing();
@@ -567,7 +716,11 @@ namespace Tetragrama::Components
 
             if (ImGui::Button("Delete", ImVec2(120, 0)))
             {
-                std::filesystem::remove_all(path);
+                size_t      ws_len = secure_strlen(m_workspace_root);
+                const char* rel    = (ws_len > 0 && std::strncmp(path, m_workspace_root, ws_len) == 0) ? path + ws_len : path;
+                auto        vp     = VFSPath::Parse(rel);
+                if (vp.Succeeded())
+                    m_vfs_context->RemoveAll(vp.Value());
                 m_current_vfs_dir = m_assets_vfs_root;
                 m_active_popup    = PopupType::None;
                 TriggerScan();
@@ -586,43 +739,58 @@ namespace Tetragrama::Components
         }
     }
 
-    void ProjectViewUIComponent::HandleRenameFilePopup(const std::filesystem::path& path)
+    void ProjectViewUIComponent::HandleRenameFilePopup(const char* path)
     {
-        ImGui::OpenPopup("Rename File");
         ImVec2 center = ImGui::GetMainViewport()->GetCenter();
         ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
 
         if (ImGui::BeginPopupModal("Rename File", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
         {
-            static char new_name[MAX_FILE_PATH_COUNT];
-            static bool initialized = false;
-
-            if (!initialized)
+            if (!m_popup_rename_initialized)
             {
-                secure_strcpy(new_name, sizeof(new_name), path.filename().string().c_str());
-                initialized = true;
+                const char* slash = strrchr(path, '/');
+                secure_strcpy(m_popup_rename_name, sizeof(m_popup_rename_name), slash ? slash + 1 : path);
+                m_popup_rename_initialized = true;
             }
 
             ImGui::Text("Enter new file name (with extension):");
-            ImGui::InputText("##rename", new_name, sizeof(new_name));
+            ImGui::InputText("##rename", m_popup_rename_name, sizeof(m_popup_rename_name));
 
             if (ImGui::Button("Rename", ImVec2(120, 0)))
             {
-                if (secure_strlen(new_name) > 0)
+                if (secure_strlen(m_popup_rename_name) > 0)
                 {
-                    std::filesystem::path newPath = path.parent_path() / new_name;
+                    const char* last_slash                  = strrchr(path, '/');
+                    char        parent[MAX_FILE_PATH_COUNT] = {};
+                    if (last_slash && last_slash > path)
+                        secure_strncpy(parent, sizeof(parent), path, (size_t) (last_slash - path));
 
-                    if (!std::filesystem::exists(newPath))
+                    char new_native[MAX_FILE_PATH_COUNT];
+                    snprintf(new_native, sizeof(new_native), "%s/%s", parent, m_popup_rename_name);
+
+                    size_t ws_len = secure_strlen(m_workspace_root);
+                    auto   to_vfs = [&](const char* n) {
+                        const char* rel = (ws_len > 0 && std::strncmp(n, m_workspace_root, ws_len) == 0) ? n + ws_len : n;
+                        return VFSPath::Parse(rel);
+                    };
+                    auto src_res = to_vfs(path);
+                    auto dst_res = to_vfs(new_native);
+
+                    if (src_res.Succeeded() && dst_res.Succeeded())
                     {
-                        std::filesystem::rename(path, newPath);
-                        m_active_popup = PopupType::None;
-                        initialized    = false;
-                        TriggerScan();
-                        ImGui::CloseCurrentPopup();
-                    }
-                    else
-                    {
-                        ZENGINE_CORE_ERROR("A file with the name {} already exists!", new_name);
+                        auto exists = m_vfs_context->Exists(dst_res.Value());
+                        if (!exists.Succeeded() || !exists.Value())
+                        {
+                            m_vfs_context->Rename(src_res.Value(), dst_res.Value());
+                            m_active_popup             = PopupType::None;
+                            m_popup_rename_initialized = false;
+                            TriggerScan();
+                            ImGui::CloseCurrentPopup();
+                        }
+                        else
+                        {
+                            ZENGINE_CORE_ERROR("A file with the name {} already exists!", m_popup_rename_name);
+                        }
                     }
                 }
                 else
@@ -635,8 +803,8 @@ namespace Tetragrama::Components
 
             if (ImGui::Button("Cancel", ImVec2(120, 0)))
             {
-                m_active_popup = PopupType::None;
-                initialized    = false;
+                m_active_popup             = PopupType::None;
+                m_popup_rename_initialized = false;
                 ImGui::CloseCurrentPopup();
             }
 
@@ -647,81 +815,63 @@ namespace Tetragrama::Components
     void ProjectViewUIComponent::RenderBackButton()
     {
         bool canGoBack = !(m_current_vfs_dir == m_assets_vfs_root);
-        if (canGoBack)
-        {
-            if (ImGui::ArrowButton("##left", ImGuiDir_Left))
-            {
-                m_current_vfs_dir = m_current_vfs_dir.Parent();
-            }
-        }
-        else
-        {
-            ImVec4 color = {0.2f, 0.2f, 0.2f, .2f};
-            ImGui::PushStyleColor(ImGuiCol_Button, color); // Grayed out color
-            ImGui::PushStyleColor(ImGuiCol_ButtonHovered, color);
-            ImGui::PushStyleColor(ImGuiCol_ButtonActive, color);
-
-            ImGui::ArrowButton("##left", ImGuiDir_Left);
-
-            ImGui::PopStyleColor(3);
-        }
+        ImGui::BeginDisabled(!canGoBack);
+        if (ImGui::ArrowButton("##left", ImGuiDir_Left) && canGoBack)
+            m_current_vfs_dir = m_current_vfs_dir.Parent();
+        ImGui::EndDisabled();
     }
 
-    void ProjectViewUIComponent::RenderContextMenu(ContextMenuType type, const std::filesystem::path& targetPath)
+    void ProjectViewUIComponent::RenderContextMenu(ContextMenuType type, const char* targetPath)
     {
-        m_popup_target_path = targetPath;
+        // Helper: set the target path, open the named popup, and reset the relevant
+        // input buffer so each opening starts fresh.
+        auto open_popup = [&](PopupType popup, const char* popup_name) {
+            secure_strcpy(m_popup_target_path, sizeof(m_popup_target_path), targetPath ? targetPath : "");
+            m_active_popup = popup;
+            if (popup == PopupType::NewFile)
+                secure_strcpy(m_popup_new_file_name, sizeof(m_popup_new_file_name), "NewFile.txt");
+            else if (popup == PopupType::CreateFolder)
+                secure_strcpy(m_popup_new_folder_name, sizeof(m_popup_new_folder_name), "New Folder");
+            else if (popup == PopupType::RenameFolder || popup == PopupType::RenameFile)
+            {
+                m_popup_rename_name[0]     = '\0';
+                m_popup_rename_initialized = false;
+            }
+            ImGui::OpenPopup(popup_name);
+        };
+
         switch (type)
         {
             case ContextMenuType::RightPane:
                 if (ImGui::MenuItem("Create New File"))
-                {
-                    m_active_popup = PopupType::NewFile;
-                }
+                    open_popup(PopupType::NewFile, "Create New File");
                 if (ImGui::MenuItem("Create New Folder"))
-                {
-                    m_active_popup = PopupType::CreateFolder;
-                }
+                    open_popup(PopupType::CreateFolder, "Create New Folder");
                 break;
 
             case ContextMenuType::LeftPane:
                 if (ImGui::MenuItem("Create New Folder"))
-                {
-                    m_active_popup = PopupType::CreateFolder;
-                }
+                    open_popup(PopupType::CreateFolder, "Create New Folder");
                 if (ImGui::MenuItem("Create New File"))
-                {
-                    m_active_popup = PopupType::NewFile;
-                }
+                    open_popup(PopupType::NewFile, "Create New File");
                 if (ImGui::MenuItem("Delete Folder"))
-                {
-                    m_active_popup = PopupType::DeleteFolder;
-                }
+                    open_popup(PopupType::DeleteFolder, "Delete Folder");
                 if (ImGui::MenuItem("Rename Folder"))
-                {
-                    m_active_popup = PopupType::RenameFolder;
-                }
+                    open_popup(PopupType::RenameFolder, "Rename Folder");
                 break;
 
             case ContextMenuType::File:
                 if (ImGui::MenuItem("Rename File"))
-                {
-                    m_active_popup = PopupType::RenameFile;
-                }
+                    open_popup(PopupType::RenameFile, "Rename File");
                 if (ImGui::MenuItem("Delete File"))
-                {
-                    m_active_popup = PopupType::RemoveFile;
-                }
+                    open_popup(PopupType::RemoveFile, "Delete File");
                 break;
 
             case ContextMenuType::Folder:
                 if (ImGui::MenuItem("Rename Folder"))
-                {
-                    m_active_popup = PopupType::RenameFolder;
-                }
+                    open_popup(PopupType::RenameFolder, "Rename Folder");
                 if (ImGui::MenuItem("Delete Folder"))
-                {
-                    m_active_popup = PopupType::DeleteFolder;
-                }
+                    open_popup(PopupType::DeleteFolder, "Delete Folder");
                 break;
         }
     }
@@ -751,51 +901,6 @@ namespace Tetragrama::Components
             case PopupType::None:
             default:
                 break;
-        }
-    }
-
-    void ProjectViewUIComponent::MakeRelative(const std::filesystem::path& path, const std::filesystem::path& base, char* output)
-    {
-        auto path_itr = path.begin();
-        auto base_itr = base.begin();
-
-        while (path_itr != path.end() && base_itr != base.end() && *path_itr == *base_itr)
-        {
-            ++path_itr;
-            ++base_itr;
-        }
-
-        std::filesystem::path result;
-        while (base_itr != base.end())
-        {
-            result /= "..";
-            ++base_itr;
-        }
-
-        while (path_itr != path.end())
-        {
-            result /= *path_itr;
-            ++path_itr;
-        }
-
-        // Formatted
-        auto path_str   = result.string();
-        auto c_path_str = path_str.c_str();
-
-        while (*c_path_str)
-        {
-            if (*c_path_str == PLATFORM_OS_BACKSLASH)
-            {
-                *output++ = ' ';
-                *output++ = '>';
-                *output++ = ' ';
-            }
-            else
-            {
-                *output++ = *c_path_str;
-            }
-
-            c_path_str++;
         }
     }
 

--- a/Tetragrama/Components/ProjectViewUIComponent.h
+++ b/Tetragrama/Components/ProjectViewUIComponent.h
@@ -1,11 +1,8 @@
 #pragma once
-#include <Tetragrama/Components/ProjectViewUIComponent.h>
 #include <Tetragrama/Components/UIComponent.h>
 #include <ZEngine/Core/Memory/Allocator.h>
 #include <ZEngine/Core/VFS/VFSScanner.h>
-#include <ZEngine/Importers/AssetTypes.h>
-#include <filesystem>
-
+#include <vector>
 namespace Tetragrama::Components
 {
     enum class ContextMenuType
@@ -47,38 +44,45 @@ namespace Tetragrama::Components
         void         RenderBackButton();
         void         RenderTreeBrowser();
 
-        // Popup helpers
-        void         RenderContextMenu(ContextMenuType type, const std::filesystem::path& targetPath);
+        // Popup helpers — all paths are native absolute C strings
+        void         RenderContextMenu(ContextMenuType type, const char* targetPath);
         void         RenderPopUpMenu();
-        void         HandleCreateFolderPopup(const std::filesystem::path& path);
-        void         HandleCreateFilePopup(const std::filesystem::path& path);
-
-        void         HandleRenameFolderPopup(const std::filesystem::path& path);
-        void         HandleDeleteFolderPopup(const std::filesystem::path& path);
-        void         HandleRenameFilePopup(const std::filesystem::path& path);
-        void         HandleDeleteFilePopup(const std::filesystem::path& path);
-
-        void         MakeRelative(const std::filesystem::path& path, const std::filesystem::path& base, char* output);
+        void         HandleCreateFolderPopup(const char* path);
+        void         HandleCreateFilePopup(const char* path);
+        void         HandleRenameFolderPopup(const char* path);
+        void         HandleDeleteFolderPopup(const char* path);
+        void         HandleRenameFilePopup(const char* path);
+        void         HandleDeleteFilePopup(const char* path);
 
         void         TriggerScan();
 
     private:
-        ZEngine::Core::Memory::ArenaAllocator  m_local_arena                     = {};
+        ZEngine::Core::Memory::ArenaAllocator        m_local_arena                                = {};
 
-        ZEngine::Core::VFS::IVFSContext*       m_vfs_context                     = nullptr;
-        ZEngine::Core::VFS::VFSDirectoryCache* m_directory_cache                 = nullptr;
-        ZEngine::Core::VFS::VFSScanner*        m_scanner                         = nullptr;
+        ZEngine::Core::VFS::IVFSContext*             m_vfs_context                                = nullptr;
+        ZEngine::Core::VFS::VFSDirectoryCache*       m_directory_cache                            = nullptr;
+        ZEngine::Core::VFS::VFSScanner*              m_scanner                                    = nullptr;
 
-        ZEngine::Core::VFS::VFSPath            m_assets_vfs_root                 = {};
-        ZEngine::Core::VFS::VFSPath            m_current_vfs_dir                 = {};
-        char                                   m_root_label[MAX_FILE_PATH_COUNT] = "";
+        ZEngine::Core::VFS::VFSPath                  m_assets_vfs_root                            = {};
+        ZEngine::Core::VFS::VFSPath                  m_current_vfs_dir                            = {};
+        char                                         m_root_label[MAX_FILE_PATH_COUNT]            = "";
+        char                                         m_workspace_root[MAX_FILE_PATH_COUNT]        = "";
 
-        PopupType                              m_active_popup                    = PopupType::None;
-        std::filesystem::path                  m_popup_target_path;
+        PopupType                                    m_active_popup                               = PopupType::None;
+        char                                         m_popup_target_path[MAX_FILE_PATH_COUNT]     = {};
+        // Input buffers for popup modals — promoted from static locals so each
+        // instance has its own state and opening a new item resets the buffer.
+        char                                         m_popup_new_file_name[MAX_FILE_PATH_COUNT]   = "NewFile.txt";
+        char                                         m_popup_new_folder_name[MAX_FILE_PATH_COUNT] = "New Folder";
+        char                                         m_popup_rename_name[MAX_FILE_PATH_COUNT]     = {};
+        bool                                         m_popup_rename_initialized                   = false;
 
-        ZEngine::Importers::AssetTexture*      m_directory_icon;
-        ZEngine::Importers::AssetTexture*      m_file_icon;
-        static constexpr float                 m_thumbnail_size                     = 64.0f;
-        char                                   m_search_buffer[MAX_FILE_PATH_COUNT] = "";
+        // Search result cache — rebuilt only when m_search_buffer changes.
+        char                                         m_last_search[MAX_FILE_PATH_COUNT]           = {};
+        std::vector<ZEngine::Core::VFS::VFSDirEntry> m_search_results;
+
+        bool                                         m_right_pane_hovered                 = false;
+        static constexpr float                       m_thumbnail_size                     = 80.0f;
+        char                                         m_search_buffer[MAX_FILE_PATH_COUNT] = "";
     };
 } // namespace Tetragrama::Components

--- a/Tetragrama/Editor.cpp
+++ b/Tetragrama/Editor.cpp
@@ -37,6 +37,7 @@ namespace Tetragrama
         if (WorkingSpacePath && WorkingSpacePath[0] != '\0')
         {
             WorkingSpaceBackend.Initialize(WorkingSpacePath, ZEngine::Core::VFS::VFSBackendCaps::Read | ZEngine::Core::VFS::VFSBackendCaps::Write | ZEngine::Core::VFS::VFSBackendCaps::List, &Memory->MainArena);
+            VFSBackend = &WorkingSpaceBackend;
         }
     }
 
@@ -51,14 +52,6 @@ namespace Tetragrama
 
     void Editor::OnInitialized()
     {
-        if (WorkingSpacePath && WorkingSpacePath[0] != '\0')
-        {
-            if (ZEngine::Engine::GetContext()->VFS->Mount(&WorkingSpaceBackend, ZEngine::Core::VFS::VFSPath::Root(), 0).Failed())
-            {
-                ZENGINE_CORE_ERROR("Failed to mount working space '{}' into the VFS", WorkingSpacePath)
-            }
-        }
-
         auto editor_scene          = ZPushStructCtor(&Memory->MainArena, EditorScene);
         auto editor_cam_controller = ZPushStructCtor(&Memory->MainArena, Controllers::EditorCameraController);
         UILayer                    = ZPushStructCtor(&Memory->MainArena, ImguiLayer);

--- a/ZEngine/ZEngine/Applications/GameApplication.cpp
+++ b/ZEngine/ZEngine/Applications/GameApplication.cpp
@@ -1,7 +1,9 @@
 #include <GLFW/glfw3.h>
 #include <ZEngine/Applications/AppRenderPipeline.h>
 #include <ZEngine/Applications/GameApplication.h>
+#include <ZEngine/Core/VFS/VFSPath.h>
 #include <ZEngine/Engine.h>
+#include <ZEngine/Logging/LoggerDefinition.h>
 
 namespace ZEngine::Applications
 {
@@ -16,8 +18,14 @@ namespace ZEngine::Applications
 
         Engine::Initialize(Memory, &WindowCfg, this);
 
-        // Step 22 — AppRenderPipeline: must follow Engine::Initialize (device live) and
-        // precede OnInitialized so the game DLL sees a fully constructed pipeline
+        if (VFSBackend)
+        {
+            if (Engine::GetContext()->VFS->Mount(VFSBackend, Core::VFS::VFSPath::Root(), 0).Failed())
+            {
+                ZENGINE_CORE_ERROR("GameApplication: failed to mount VFSBackend")
+            }
+        }
+
         RenderPipeline = ZPushStructCtor(&Memory->MainArena, AppRenderPipeline);
         RenderPipeline->Initialize(Engine::GetContext()->Device);
 

--- a/ZEngine/ZEngine/Applications/GameApplication.h
+++ b/ZEngine/ZEngine/Applications/GameApplication.h
@@ -4,6 +4,7 @@
 #include <ZEngine/Core/Memory/Allocator.h>
 #include <ZEngine/Core/Memory/MemoryManager.h>
 #include <ZEngine/Core/TimeStep.h>
+#include <ZEngine/Core/VFS/IVFSBackend.h>
 #include <ZEngine/Rendering/Scenes/RenderScene.h>
 #include <ZEngine/Windows/CoreWindow.h>
 #include <ZEngine/Windows/WindowConfiguration.h>
@@ -30,6 +31,7 @@ namespace ZEngine::Applications
         bool                              EnableRenderOverlay = false;
         cstring                           ConfigFile          = nullptr;
         cstring                           WorkingSpacePath    = nullptr;
+        Core::VFS::IVFSBackend*           VFSBackend          = nullptr;
         Windows::WindowConfiguration      WindowCfg           = {};
 
         Core::Memory::MemoryManager*      Memory              = nullptr;

--- a/ZEngine/ZEngine/Core/VFS/IVFSBackend.h
+++ b/ZEngine/ZEngine/Core/VFS/IVFSBackend.h
@@ -57,6 +57,10 @@ namespace ZEngine::Core::VFS
         {
             return VFSResult<void>::Fail(VFSError::Unsupported);
         }
+        [[nodiscard]] virtual VFSResult<void> RemoveAll(const VFSPath& path)
+        {
+            return VFSResult<void>::Fail(VFSError::Unsupported);
+        }
 
         virtual cstring        BackendType() const  = 0;
         virtual VFSBackendCaps Capabilities() const = 0;

--- a/ZEngine/ZEngine/Core/VFS/IVFSContext.h
+++ b/ZEngine/ZEngine/Core/VFS/IVFSContext.h
@@ -27,6 +27,9 @@ namespace ZEngine::Core::VFS
 
         [[nodiscard]] virtual VFSResult<void>                           Remove(const VFSPath& absolute_path)                                   = 0;
 
+        // Recursively remove a directory and all its contents.
+        [[nodiscard]] virtual VFSResult<void>                           RemoveAll(const VFSPath& absolute_path)                                = 0;
+
         [[nodiscard]] virtual VFSResult<void>                           Rename(const VFSPath& src, const VFSPath& dst)                         = 0;
 
         virtual void                                                    Close(IVFSFile* const file)                                            = 0;

--- a/ZEngine/ZEngine/Core/VFS/VFSContext.cpp
+++ b/ZEngine/ZEngine/Core/VFS/VFSContext.cpp
@@ -373,6 +373,15 @@ namespace ZEngine::Core::VFS
         return hit.Backend->Remove(hit.RelativePath);
     }
 
+    VFSResult<void> VFSContext::RemoveAll(const VFSPath& absolute_path)
+    {
+        VFSResult<ResolveResult> writable = ResolveWritable(absolute_path);
+        if (writable.Failed())
+            return VFSResult<void>::Fail(writable.Error());
+        const ResolveResult& hit = writable.Value();
+        return hit.Backend->RemoveAll(hit.RelativePath);
+    }
+
     VFSResult<void> VFSContext::Rename(const VFSPath& src, const VFSPath& dst)
     {
         VFSResult<ResolveResult> src_hit = ResolveWritable(src);

--- a/ZEngine/ZEngine/Core/VFS/VFSContext.h
+++ b/ZEngine/ZEngine/Core/VFS/VFSContext.h
@@ -52,6 +52,7 @@ namespace ZEngine::Core::VFS
         [[nodiscard]] VFSResult<void>                           Unmount(const VFSPath& logical_root) override;
         [[nodiscard]] VFSResult<void>                           CreateDir(const VFSPath& absolute_path) override;
         [[nodiscard]] VFSResult<void>                           Remove(const VFSPath& absolute_path) override;
+        [[nodiscard]] VFSResult<void>                           RemoveAll(const VFSPath& absolute_path) override;
         [[nodiscard]] VFSResult<void>                           Rename(const VFSPath& src, const VFSPath& dst) override;
         void                                                    Shutdown() override;
 

--- a/ZEngine/ZEngine/Core/VFS/VFSDiskBackend.cpp
+++ b/ZEngine/ZEngine/Core/VFS/VFSDiskBackend.cpp
@@ -481,6 +481,22 @@ namespace ZEngine::Core::VFS
         return VFSResult<void>::Ok();
     }
 
+    VFSResult<void> VFSDiskBackend::RemoveAll(const VFSPath& relative_path)
+    {
+        if (!HasCap(m_caps, VFSBackendCaps::Write))
+        {
+            return VFSResult<void>::Fail(VFSError::Unsupported);
+        }
+        char native[MAX_FILE_PATH_COUNT] = {};
+        if (!ResolveNativePath(relative_path, native))
+        {
+            return VFSResult<void>::Fail(VFSError::PermissionDenied);
+        }
+        std::error_code ec;
+        std::filesystem::remove_all(native, ec);
+        return ec ? VFSResult<void>::Fail(VFSError::IOError) : VFSResult<void>::Ok();
+    }
+
     VFSResult<void> VFSDiskBackend::Rename(const VFSPath& rel_src, const VFSPath& rel_dst)
     {
         if (!HasCap(m_caps, VFSBackendCaps::Write))

--- a/ZEngine/ZEngine/Core/VFS/VFSDiskBackend.h
+++ b/ZEngine/ZEngine/Core/VFS/VFSDiskBackend.h
@@ -61,9 +61,14 @@ namespace ZEngine::Core::VFS
         [[nodiscard]] VFSResult<Core::Containers::Array<VFSDirEntry>> List(Core::Memory::ArenaAllocator* arena, const VFSPath& dir) const override;
         [[nodiscard]] VFSResult<void>                                 CreateDir(const VFSPath& relative_path) override;
         [[nodiscard]] VFSResult<void>                                 Remove(const VFSPath& relative_path) override;
+        [[nodiscard]] VFSResult<void>                                 RemoveAll(const VFSPath& relative_path) override;
         [[nodiscard]] VFSResult<void>                                 Rename(const VFSPath& rel_src, const VFSPath& rel_dst) override;
         cstring                                                       BackendType() const override;
         VFSBackendCaps                                                Capabilities() const override;
+        cstring                                                       NativeRoot() const
+        {
+            return m_native_root;
+        }
 
     private:
         bool                    ResolveNativePath(const VFSPath& relative, char* out_buf) const;

--- a/ZEngine/ZEngine/Core/VFS/VFSMountTable.cpp
+++ b/ZEngine/ZEngine/Core/VFS/VFSMountTable.cpp
@@ -94,19 +94,31 @@ namespace ZEngine::Core::VFS
     {
         std::shared_lock<std::shared_mutex> lock(m_mutex);
 
+        // Select the mount with the longest matching prefix (most specific).
+        // Among equal-length prefixes, the higher-priority mount wins (mounts are
+        // stored highest-priority-first so the first same-length match is best).
+        size_t                              best_idx    = SIZE_MAX;
+        size_t                              best_prefix = 0;
+
         for (size_t i = 0; i < m_mounts.size(); ++i)
         {
-            if (IsPrefixOf(m_mounts[i].LogicalRoot, path))
+            if (!IsPrefixOf(m_mounts[i].LogicalRoot, path))
+                continue;
+            const size_t prefix_len = m_mounts[i].LogicalRoot.Length();
+            if (prefix_len > best_prefix)
             {
-                VFSResult<VFSPath> rel = StripPrefix(m_mounts[i].LogicalRoot, path);
-                if (rel.Failed())
-                {
-                    return VFSResult<ResolveResult>::Fail(rel.Error());
-                }
-                return VFSResult<ResolveResult>::Ok(ResolveResult{m_mounts[i].Backend, rel.Value()});
+                best_prefix = prefix_len;
+                best_idx    = i;
             }
         }
-        return VFSResult<ResolveResult>::Fail(VFSError::NotFound);
+
+        if (best_idx == SIZE_MAX)
+            return VFSResult<ResolveResult>::Fail(VFSError::NotFound);
+
+        VFSResult<VFSPath> rel = StripPrefix(m_mounts[best_idx].LogicalRoot, path);
+        if (rel.Failed())
+            return VFSResult<ResolveResult>::Fail(rel.Error());
+        return VFSResult<ResolveResult>::Ok(ResolveResult{m_mounts[best_idx].Backend, rel.Value()});
     }
 
     VFSResult<void> VFSMountTable::ResolveAll(const VFSPath& dir_path, Containers::Array<ResolveResult>& out_results) const

--- a/ZEngine/ZEngine/Engine.cpp
+++ b/ZEngine/ZEngine/Engine.cpp
@@ -1,6 +1,8 @@
 #include <GLFW/glfw3.h>
 #include <ZEngine/Applications/GameApplication.h>
 #include <ZEngine/Core/VFS/VFSContext.h>
+#include <ZEngine/Core/VFS/VFSDiskBackend.h>
+#include <ZEngine/Core/VFS/VFSPath.h>
 #include <ZEngine/Engine.h>
 #include <ZEngine/Engine/FixedTimestepAccumulator.h>
 #include <ZEngine/Engine/FrameRateCap.h>
@@ -16,6 +18,7 @@
 #include <ZEngine/Managers/AssetManager.h>
 #include <ZEngine/Windows/GameWindow.h>
 #include <chrono>
+#include <filesystem>
 
 #ifdef __APPLE__
 #include <mach/mach.h>
@@ -40,7 +43,7 @@ namespace ZEngine
 
         auto& arena  = memory->MainArena;
 
-        g_engine_ctx = ZPushStruct(&arena, EngineContext);
+        g_engine_ctx = ZPushStructCtor(&arena, EngineContext);
 
         auto window  = ZPushStructCtor(&arena, Windows::GameWindow);
         window->SetCallbackFunction(std::bind(&Applications::GameApplication::ProcessEvent, app, std::placeholders::_1));
@@ -55,6 +58,14 @@ namespace ZEngine
         auto vfs_ctx = ZPushStructCtor(&g_engine_ctx->VFSArena, Core::VFS::VFSContext);
         vfs_ctx->Initialize(&g_engine_ctx->VFSArena);
         g_engine_ctx->VFS = vfs_ctx;
+
+        {
+            const std::string engine_dir = std::filesystem::current_path().string() + "/ZodiacEngine";
+            g_engine_ctx->EngineAssetsBackend.Initialize(engine_dir.c_str(), Core::VFS::VFSBackendCaps::Read | Core::VFS::VFSBackendCaps::Write | Core::VFS::VFSBackendCaps::List, &g_engine_ctx->VFSArena);
+            auto mount_path = Core::VFS::VFSPath::Parse("/ZodiacEngine");
+            if (mount_path.Succeeded())
+                vfs_ctx->Mount(&g_engine_ctx->EngineAssetsBackend, mount_path.Value(), -1);
+        }
 
         memory->CreateBudgetedArena(memory->Budget.AssetManager, &g_engine_ctx->AssetArena);
         Managers::AssetManager::Initialize(&g_engine_ctx->AssetArena, g_engine_ctx->Device, app->WorkingSpacePath);

--- a/ZEngine/ZEngine/Engine.h
+++ b/ZEngine/ZEngine/Engine.h
@@ -2,6 +2,7 @@
 #include <ZEngine/Applications/GameApplication.h>
 #include <ZEngine/Core/Memory/MemoryManager.h>
 #include <ZEngine/Core/VFS/IVFSContext.h>
+#include <ZEngine/Core/VFS/VFSDiskBackend.h>
 #include <ZEngine/ECS/ActorManager.h>
 #include <ZEngine/ECS/Scene.h>
 #include <ZEngine/ECS/WorldCommands.h>
@@ -18,6 +19,11 @@ namespace ZEngine
 {
     struct EngineContext
     {
+        // VFS backend for engine-owned assets (Shaders/, Settings/).
+        // Mounted at VFSPath::Root() with priority -1 so the workspace backend
+        // (priority 0) takes precedence for any overlapping paths.
+        Core::VFS::VFSDiskBackend         EngineAssetsBackend   = {};
+
         // Sub-arenas (large structs — grouped together to avoid pointer/arena interleaving)
         Core::Memory::ArenaAllocator      VFSArena              = {};
         Core::Memory::ArenaAllocator      AssetArena            = {};

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
@@ -1,3 +1,5 @@
+#include <ZEngine/Core/VFS/VFSPath.h>
+#include <ZEngine/Engine.h>
 #include <ZEngine/Hardwares/VulkanDevice.h>
 #include <ZEngine/Helpers/MemoryOperations.h>
 #include <ZEngine/Helpers/ThreadPool.h>
@@ -552,13 +554,14 @@ namespace ZEngine::Hardwares
         ShaderReservedLayoutBindingSpecificationMap[1].init(Arena, 2);
         ShaderReservedLayoutBindingSpecificationMap[1].push(LayoutBindingSpecification{.Set = 1, .Binding = 0, .Count = MaxGlobalTexture, .Name = "TextureArray", .DescriptorTypeValue = DescriptorType::SAMPLED_IMAGE, .Flags = ShaderStageFlags::FRAGMENT});
         ShaderReservedLayoutBindingSpecificationMap[1].push(LayoutBindingSpecification{.Set = 1, .Binding = 1, .Count = 1, .Name = "LinearWrapSampler", .DescriptorTypeValue = DescriptorType::SAMPLER, .Flags = ShaderStageFlags::FRAGMENT});
+        ShaderReservedLayoutBindingSpecificationMap[1].push(LayoutBindingSpecification{.Set = 1, .Binding = 2, .Count = 1, .Name = "LinearClampSampler", .DescriptorTypeValue = DescriptorType::SAMPLER, .Flags = ShaderStageFlags::FRAGMENT});
 
         ShaderReservedDescriptorSetMap.init(Arena, ShaderReservedLayoutBindingSpecificationMap.size());
         ShaderReservedDescriptorSetLayoutMap.init(Arena, ShaderReservedLayoutBindingSpecificationMap.size());
 
         VkDescriptorPoolSize pool_sizes[] = {
             {.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, .descriptorCount = (MaxGlobalTexture * SwapchainPtr->BufferredFrameCount)},
-            {      .type = VK_DESCRIPTOR_TYPE_SAMPLER,                .descriptorCount = (1 * SwapchainPtr->BufferredFrameCount)}
+            {      .type = VK_DESCRIPTOR_TYPE_SAMPLER,                .descriptorCount = (2 * SwapchainPtr->BufferredFrameCount)}
         };
 
         for (const auto& layout_binding_set : ShaderReservedLayoutBindingSpecificationMap)
@@ -1082,10 +1085,6 @@ namespace ZEngine::Hardwares
 
     Helpers::Handle<Rendering::Shaders::Shader> VulkanDevice::CompileShader(Rendering::Specifications::ShaderSpecification& spec)
     {
-        const char* base_dir           = "Shaders/Cache/";
-        const char* vertex_name_part   = "_vertex.spv";
-        const char* fragment_name_part = "_fragment.spv";
-
         if (ShaderCaches.contains(spec.Name))
         {
             return ShaderCaches.at(spec.Name);
@@ -1096,24 +1095,22 @@ namespace ZEngine::Hardwares
 
         if (shader)
         {
-            auto vertex_file   = fmt::format("{}{}{}", base_dir, spec.Name, vertex_name_part);
-            auto fragment_file = fmt::format("{}{}{}", base_dir, spec.Name, fragment_name_part);
+            auto* vfs      = Engine::GetContext()->VFS;
+            auto  try_set  = [&](const std::string& path, cstring& out) {
+                auto vfs_path = Core::VFS::VFSPath::Parse(path.c_str());
+                if (!vfs_path.Succeeded())
+                    return;
+                auto exists = vfs->Exists(vfs_path.Value());
+                if (!exists.Succeeded() || !exists.Value())
+                    return;
+                auto n = path.size() + 1u;
+                auto s = ZPushString(Arena, n);
+                Helpers::secure_strcpy(s, n, path.c_str());
+                out = s;
+            };
 
-            if (std::filesystem::exists(vertex_file))
-            {
-                                auto name_c_size = (vertex_file.size() + 1u);
-                auto name_c_str  = ZPushString(Arena, name_c_size);
-                Helpers::secure_strcpy(name_c_str, name_c_size, vertex_file.c_str());
-                spec.VertexFilename = name_c_str;
-            }
-
-            if (std::filesystem::exists(fragment_file))
-            {
-                                                auto name_c_size = (fragment_file.size() + 1u);
-                auto name_c_str  = ZPushString(Arena, name_c_size);
-                Helpers::secure_strcpy(name_c_str, name_c_size, fragment_file.c_str());
-                spec.FragmentFilename = name_c_str;
-            }
+            try_set(fmt::format("/ZodiacEngine/Shaders/Cache/{}_vertex.spv", spec.Name), spec.VertexFilename);
+            try_set(fmt::format("/ZodiacEngine/Shaders/Cache/{}_fragment.spv", spec.Name), spec.FragmentFilename);
 
             shader->Initialize(this, spec);
         }

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
@@ -912,29 +912,73 @@ namespace ZEngine::Rendering
     Rendering::Textures::TextureHandle RenderResourceManager::UploadFontAtlas(unsigned char* pixels, uint32_t width, uint32_t height)
     {
         using namespace Rendering::Specifications;
+        using namespace Rendering::Primitives;
 
         if (!pixels || width == 0 || height == 0)
             return {};
 
-        TextureSpecification spec = {};
-        spec.Width                = width;
-        spec.Height               = height;
-        spec.Format               = ImageFormat::R8G8B8A8_UNORM;
-        spec.PerformTransition    = false;
+        TextureSpecification spec                     = {};
+        spec.Width                                    = width;
+        spec.Height                                   = height;
+        spec.Format                                   = ImageFormat::R8G8B8A8_UNORM;
+        spec.PerformTransition                        = false;
 
-        auto            handle    = m_device->CreateTexture(spec);
+        auto                            handle        = m_device->CreateTexture(spec);
+        auto                            texture       = m_device->GlobalTextures.Access(handle);
+        auto                            img_buf       = m_device->Image2DBufferManager.Access(texture->BufferHandle);
+        auto                            buffer_handle = img_buf->GetHandle();
 
-        // Copy pixel data into an owned buffer so the caller (ImGui) can release
-        // its atlas memory at any time after this call returns.
-        const size_t    byte_size = static_cast<size_t>(width) * height * 4u;
-        TextureDeferral deferral  = {};
-        deferral.FrameIdx         = 0;
-        deferral.ThreadIdx        = 0;
-        deferral.TexHandle        = handle;
-        deferral.IsLarge          = true;
-        deferral.Buffer           = std::vector<uint8_t>(pixels, pixels + byte_size);
+        ImageMemoryBarrierSpecification to_transfer   = {};
+        to_transfer.ImageHandle                       = buffer_handle;
+        to_transfer.OldLayout                         = img_buf->Layout;
+        to_transfer.NewLayout                         = ImageLayout::TRANSFER_DST_OPTIMAL;
+        to_transfer.ImageAspectMask                   = VK_IMAGE_ASPECT_COLOR_BIT;
+        to_transfer.SourceAccessMask                  = VK_ACCESS_NONE;
+        to_transfer.DestinationAccessMask             = VK_ACCESS_TRANSFER_WRITE_BIT;
+        to_transfer.SourceStageMask                   = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+        to_transfer.DestinationStageMask              = VK_PIPELINE_STAGE_TRANSFER_BIT;
+        to_transfer.LayerCount                        = 1;
+        to_transfer.SourceQueueFamily                 = m_device->GraphicFamilyIndex;
+        to_transfer.DestinationQueueFamily            = m_device->GraphicFamilyIndex;
 
-        EnqueueTextureDeferral(std::move(deferral));
+        ImageMemoryBarrierSpecification to_final      = {};
+        to_final.ImageHandle                          = buffer_handle;
+        to_final.OldLayout                            = ImageLayout::TRANSFER_DST_OPTIMAL;
+        to_final.NewLayout                            = ImageLayout::SHADER_READ_ONLY_OPTIMAL;
+        to_final.ImageAspectMask                      = VK_IMAGE_ASPECT_COLOR_BIT;
+        to_final.SourceAccessMask                     = VK_ACCESS_TRANSFER_WRITE_BIT;
+        to_final.DestinationAccessMask                = VK_ACCESS_SHADER_READ_BIT;
+        to_final.SourceStageMask                      = VK_PIPELINE_STAGE_TRANSFER_BIT;
+        to_final.DestinationStageMask                 = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+        to_final.LayerCount                           = 1;
+        to_final.SourceQueueFamily                    = m_device->GraphicFamilyIndex;
+        to_final.DestinationQueueFamily               = m_device->GraphicFamilyIndex;
+
+        auto* cmd                                     = m_upload_cmd;
+        cmd->ResetState();
+        vkResetCommandBuffer(cmd->GetHandle(), 0);
+        cmd->Begin();
+        cmd->TransitionImageLayout(ImageMemoryBarrier{to_transfer});
+        img_buf->Layout    = to_transfer.NewLayout;
+        BufferView staging = m_device->WriteTextureData(cmd, handle, pixels);
+        cmd->TransitionImageLayout(ImageMemoryBarrier{to_final});
+        img_buf->Layout = to_final.NewLayout;
+        cmd->End();
+
+        VkQueue         gfx_queue = m_device->GetQueue(QueueType::GRAPHIC_QUEUE).Handle;
+        VkCommandBuffer raw       = cmd->GetHandle();
+        VkSubmitInfo    submit{VK_STRUCTURE_TYPE_SUBMIT_INFO};
+        submit.commandBufferCount = 1;
+        submit.pCommandBuffers    = &raw;
+
+        vkWaitForFences(m_device->LogicalDevice, 1, &m_upload_fence, VK_TRUE, UINT64_MAX);
+        vkResetFences(m_device->LogicalDevice, 1, &m_upload_fence);
+        vkQueueSubmit(gfx_queue, 1, &submit, m_upload_fence);
+        vkWaitForFences(m_device->LogicalDevice, 1, &m_upload_fence, VK_TRUE, UINT64_MAX);
+        cmd->ResetState();
+
+        if (staging)
+            m_device->GpuMem.FreeBuffer(staging);
 
         return handle;
     }

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.h
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.h
@@ -91,16 +91,10 @@ namespace ZEngine::Rendering
         /// @return The same handle on success; invalid handle if no free upload slot.
         Rendering::Textures::TextureHandle UploadTextureBuffer(uint8_t frame_index, uint8_t thread_index, const Rendering::Textures::TextureHandle& handle, unsigned char* data);
 
-        /// @brief Create the ImGui font atlas texture and enqueue an owned-copy deferral.
-        /// @details The pixel data is copied immediately into an owned std::vector so the
-        ///          caller (ImGui) can release its atlas memory after this call returns.
-        ///          The GPU upload runs on the first BeginFrame via CompleteDeferrals.
-        ///          Caller must enqueue the returned handle to TextureHandleToUpdates for
-        ///          bindless descriptor registration.
-        /// @param pixels  Pointer to RGBA atlas data (from io.Fonts->GetTexDataAsRGBA32).
-        /// @param width   Atlas width in pixels.
-        /// @param height  Atlas height in pixels.
-        /// @return A valid TextureHandle for the font atlas.
+        // Upload the ImGui font atlas synchronously using m_upload_cmd/m_upload_fence.
+        // Blocks until the GPU copy is complete so the texture is ready before the first
+        // frame renders. Caller must enqueue the returned handle to
+        // TextureHandleToUpdates for bindless descriptor registration.
         Rendering::Textures::TextureHandle UploadFontAtlas(unsigned char* pixels, uint32_t width, uint32_t height);
 
         /// @brief Load a texture file from disk, decode it on the thread pool, and upload.

--- a/ZEngine/ZEngine/Rendering/Renderers/GraphicRenderer.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/GraphicRenderer.cpp
@@ -36,7 +36,6 @@ namespace ZEngine::Rendering::Renderers
          * Renderer Passes
          */
         auto     base_pass                = ZPushStructCtor(Device->Arena, BasePass);
-        auto     upload_pass              = ZPushStructCtor(Device->Arena, UploadPass);
         auto     scene_depth_prepass      = ZPushStructCtor(Device->Arena, DepthPrePass);
         auto     skybox_pass              = ZPushStructCtor(Device->Arena, SkyboxPass);
         auto     grid_pass                = ZPushStructCtor(Device->Arena, GridPass);
@@ -56,7 +55,6 @@ namespace ZEngine::Rendering::Renderers
         RenderGraph->ResourceBuilder->AttachRenderTarget(RendererResourceName::FrameColorRenderTargetName, FrameColorRenderTarget);
 
         // Skybox starts disabled; ApplySkyConfig enables it when a scene with an HDRI sky loads.
-        RenderGraph->AddCallbackPass("Upload Pass", upload_pass);
         RenderGraph->AddCallbackPass("Base Pass", base_pass);
         RenderGraph->AddCallbackPass("Depth Pre-Pass", scene_depth_prepass);
         RenderGraph->AddCallbackPass("Skybox Pass", skybox_pass, false);
@@ -69,8 +67,10 @@ namespace ZEngine::Rendering::Renderers
     void GraphicRenderer::Deinitialize()
     {
         RenderGraph->Dispose();
-        Device->GlobalTextures.Remove(FrameColorRenderTarget);
-        Device->GlobalTextures.Remove(FrameDepthRenderTarget);
+        // Queue render targets for proper GPU memory release — TextureHandleToDispose
+        // is drained in VulkanDevice::Deinitialize which runs after this call.
+        Device->TextureHandleToDispose.Enqueue(FrameColorRenderTarget);
+        Device->TextureHandleToDispose.Enqueue(FrameDepthRenderTarget);
         if (RenderSceneData)
         {
             Device->GpuMem.FreeBuffer(RenderSceneData->TransformBuffer);

--- a/ZEngine/ZEngine/Rendering/Renderers/ImGUIRenderer.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/ImGUIRenderer.cpp
@@ -1,3 +1,7 @@
+#include <ZEngine/Core/Containers/Array.h>
+#include <ZEngine/Core/VFS/IVFSFile.h>
+#include <ZEngine/Core/VFS/VFSPath.h>
+#include <ZEngine/Engine.h>
 #include <ZEngine/Hardwares/VulkanDevice.h>
 #include <ZEngine/Rendering/RenderResourceManager.h>
 #include <ZEngine/Rendering/Renderers/ImGUIRenderer.h>
@@ -6,7 +10,6 @@
 #include <backends/imgui_impl_glfw.h>
 #include <backends/imgui_impl_vulkan.h>
 #include <ImGuizmo/ImGuizmo.h>
-#include <filesystem>
 // clang-format on
 
 using namespace ZEngine::Hardwares;
@@ -28,20 +31,27 @@ namespace ZEngine::Rendering::Renderers
         ImGui::CreateContext();
         StyleDarkTheme();
 
-        ImGuiIO& io                          = ImGui::GetIO();
-        io.ConfigViewportsNoTaskBarIcon      = true;
-        io.ConfigViewportsNoDecoration       = true;
-        io.BackendFlags                     |= ImGuiBackendFlags_RendererHasViewports;
-        io.BackendFlags                     |= ImGuiBackendFlags_RendererHasVtxOffset;
-        io.BackendFlags                     |= ImGuiBackendFlags_HasMouseHoveredViewport;
-        io.BackendRendererName               = "ZEngine-Imgui";
+        ImGuiIO& io                      = ImGui::GetIO();
+        io.ConfigViewportsNoTaskBarIcon  = true;
+        io.ConfigViewportsNoDecoration   = true;
+        io.BackendFlags                 |= ImGuiBackendFlags_RendererHasViewports;
+        io.BackendFlags                 |= ImGuiBackendFlags_RendererHasVtxOffset;
+        io.BackendFlags                 |= ImGuiBackendFlags_HasMouseHoveredViewport;
+        io.BackendRendererName           = "ZEngine-Imgui";
 
-        std::string_view default_layout_ini  = "Settings/DefaultLayout.ini";
-        const auto       current_directoy    = std::filesystem::current_path();
-        auto             layout_file_path    = fmt::format("{0}/{1}", current_directoy.string(), default_layout_ini);
-        if (std::filesystem::exists(std::filesystem::path(layout_file_path)))
         {
-            io.IniFilename = default_layout_ini.data();
+            auto* ctx          = Engine::GetContext();
+            auto  ini_vfs_path = Core::VFS::VFSPath::Parse("/ZodiacEngine/Settings/DefaultLayout.ini");
+            if (ini_vfs_path.Succeeded())
+            {
+                auto exists = ctx->VFS->Exists(ini_vfs_path.Value());
+                if (exists.Succeeded() && exists.Value())
+                {
+                    static char s_ini_path[MAX_FILE_PATH_COUNT];
+                    fmt::format_to_n(s_ini_path, sizeof(s_ini_path) - 1, "{}/Settings/DefaultLayout.ini", ctx->EngineAssetsBackend.NativeRoot());
+                    io.IniFilename = s_ini_path;
+                }
+            }
         }
 
         io.ConfigFlags         |= ImGuiConfigFlags_NavEnableKeyboard;
@@ -53,9 +63,30 @@ namespace ZEngine::Rendering::Renderers
         style.ChildBorderSize   = 0.f;
         style.FrameRounding     = 7.0f;
 
-        io.FontDefault          = io.Fonts->AddFontFromFileTTF("Settings/Fonts/OpenSans/OpenSans-Regular.ttf", 17.f);
+        {
+            auto* vfs      = Engine::GetContext()->VFS;
+            auto  font_res = Core::VFS::VFSPath::Parse("/ZodiacEngine/Settings/Fonts/OpenSans/OpenSans-Regular.ttf");
+            if (font_res.Succeeded())
+            {
+                auto file_res = vfs->Open(font_res.Value(), Core::VFS::VFSOpenFlags::Read);
+                if (file_res.Succeeded())
+                {
+                    auto* f        = file_res.Value();
+                    auto  size_res = f->Size();
+                    if (size_res.Succeeded())
+                    {
+                        const uint64_t                       sz   = size_res.Value();
+                        void*                                data = IM_ALLOC(static_cast<size_t>(sz));
+                        Core::Containers::ArrayView<uint8_t> view{static_cast<uint8_t*>(data), sz};
+                        f->ReadAll(view);
+                        io.FontDefault = io.Fonts->AddFontFromMemoryTTF(data, static_cast<int>(sz), 17.f);
+                    }
+                    vfs->Close(f);
+                }
+            }
+        }
 
-        auto current_window     = Device->CurrentWindow->GetNativeWindow();
+        auto current_window = Device->CurrentWindow->GetNativeWindow();
 
         ImGui_ImplGlfw_InitForVulkan(reinterpret_cast<GLFWwindow*>(current_window), false);
 
@@ -74,15 +105,14 @@ namespace ZEngine::Rendering::Renderers
         int            width, height;
         io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);
 
-        TextureHandle font_tex_handle = {};
         if (Device->RRM)
         {
-            auto* rrm       = static_cast<RenderResourceManager*>(Device->RRM);
-            font_tex_handle = rrm->UploadFontAtlas(pixels, static_cast<uint32_t>(width), static_cast<uint32_t>(height));
+            auto* rrm   = static_cast<RenderResourceManager*>(Device->RRM);
+            FontTexture = rrm->UploadFontAtlas(pixels, static_cast<uint32_t>(width), static_cast<uint32_t>(height));
         }
 
-        Device->TextureHandleToUpdates.Enqueue(font_tex_handle);
-        io.Fonts->TexID   = (ImTextureID) font_tex_handle.Index;
+        Device->TextureHandleToUpdates.Enqueue(FontTexture);
+        io.Fonts->TexID   = (ImTextureID) FontTexture.Index;
 
         auto pass_builder = RenderGraph->RenderPassBuilder;
         pass_builder->SetName("Imgui Pass")
@@ -114,6 +144,7 @@ namespace ZEngine::Rendering::Renderers
         UIPass = Device->CreateRenderPass(pass_builder->Detach());
         UIPass->SetBindlessInput("TextureArray");
         UIPass->SetInput("LinearWrapSampler", Device->GlobalLinearWrapSamplerImageInfo);
+        UIPass->SetInput("LinearClampSampler", Device->GlobalLinearClampToEdgeSamplerImageInfo);
         UIPass->Verify();
         UIPass->Bake();
     }
@@ -121,6 +152,9 @@ namespace ZEngine::Rendering::Renderers
     void ImGUIRenderer::Deinitialize()
     {
         UIPass->Dispose();
+
+        if (FontTexture.Valid())
+            Device->TextureHandleToDispose.Enqueue(FontTexture);
 
         for (uint32_t i = 0; i < FRAMES_IN_FLIGHT; ++i)
         {

--- a/ZEngine/ZEngine/Rendering/Renderers/ImGUIRenderer.h
+++ b/ZEngine/ZEngine/Rendering/Renderers/ImGUIRenderer.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <ZEngine/Rendering/Renderers/IRenderer.h>
 #include <ZEngine/Rendering/Renderers/RenderPasses/RenderPass.h>
+#include <ZEngine/Rendering/Textures/Texture.h>
 #include <ZEngine/ZEngineDef.h>
 
 namespace ZEngine::Rendering::Renderers
@@ -16,19 +17,20 @@ namespace ZEngine::Rendering::Renderers
     struct ImGUIRenderer : public IRenderer
     {
 
-        static constexpr uint32_t FRAMES_IN_FLIGHT              = 3;
-        RenderPasses::RenderPass* UIPass                        = nullptr;
-        Core::Memory::BufferView  VBHandles[FRAMES_IN_FLIGHT]   = {};
-        Core::Memory::BufferView  IdxBHandles[FRAMES_IN_FLIGHT] = {};
+        static constexpr uint32_t          FRAMES_IN_FLIGHT              = 3;
+        RenderPasses::RenderPass*          UIPass                        = nullptr;
+        Core::Memory::BufferView           VBHandles[FRAMES_IN_FLIGHT]   = {};
+        Core::Memory::BufferView           IdxBHandles[FRAMES_IN_FLIGHT] = {};
+        Rendering::Textures::TextureHandle FontTexture                   = {};
 
-        void                      Initialize(Hardwares::VulkanDevicePtr device) override;
-        void                      Deinitialize() override;
+        void                               Initialize(Hardwares::VulkanDevicePtr device) override;
+        void                               Deinitialize() override;
 
-        void                      StyleDarkTheme();
+        void                               StyleDarkTheme();
 
-        void                      NewFrame();
-        void                      EndFrame();
-        void                      PreparePayload(RenderOverlayPayload& payload);
+        void                               NewFrame();
+        void                               EndFrame();
+        void                               PreparePayload(RenderOverlayPayload& payload);
     };
 
     ZDEFINE_PTR(ImGUIRenderer);

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.cpp
@@ -391,6 +391,7 @@ namespace ZEngine::Rendering::Renderers
         for (auto& node_name : SortedNodesMap)
         {
             auto& node = NodeMap[node_name];
+            node.CallbackPass->Deinitialize(Device);
             node.Handle->Dispose();
             if (node.Handle->Specification.Type == Specifications::RenderPassType::GRAPHIC)
             {
@@ -408,7 +409,8 @@ namespace ZEngine::Rendering::Renderers
 
             if (value.Type == RenderGraphResourceType::ATTACHMENT || value.Type == RenderGraphResourceType::TEXTURE)
             {
-                Device->GlobalTextures.Remove(value.ResourceInfo.TextureHandle);
+                if (value.ResourceInfo.TextureHandle.Valid())
+                    Device->TextureHandleToDispose.Enqueue(value.ResourceInfo.TextureHandle);
             }
         }
     }

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.h
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.h
@@ -69,6 +69,7 @@ namespace ZEngine::Rendering::Renderers
         virtual void Setup(Hardwares::VulkanDevicePtr const device, cstring name, RenderGraphResourceBuilderPtr const res_builder, RenderGraphResourceInspectorPtr res_inspector)                                                                                                                       = 0;
         virtual void Compile(Hardwares::VulkanDevicePtr const device, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPassBuilder* pass_builder, RenderGraphResourceInspectorPtr res_inspector, RenderPasses::RenderPass** const output_pass)                                          = 0;
         virtual void Execute(Hardwares::VulkanDevicePtr const device, RenderGraphResourceInspectorPtr res_inspector, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPass* const pass, Buffers::FramebufferVNext* const framebuffer, Hardwares::CommandBufferPtr const command_buffer) = 0;
+        virtual void Deinitialize(Hardwares::VulkanDevicePtr const device) {}
     };
 
     struct RenderGraphNode

--- a/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.cpp
@@ -9,61 +9,6 @@ using namespace ZEngine::Core::Containers;
 
 namespace ZEngine::Rendering::Renderers
 {
-    // File-scoped pointers so SkyboxPass/GridPass can access UploadPass's BufferViews
-    // without going through the RenderGraph resource inspector (which only handles BufferSets).
-    static UploadPass* s_upload_pass_instance = nullptr;
-
-    void               UploadPass::Setup(Hardwares::VulkanDevicePtr const device, cstring name, RenderGraphResourceBuilderPtr const res_builder, RenderGraphResourceInspectorPtr res_inspector)
-    {
-        WriteOnceControl.init(device->Arena, device->SwapchainPtr->BufferredFrameCount, device->SwapchainPtr->BufferredFrameCount);
-
-        SkyboxVertexData.init(device->Arena, 24, make_initializer_list(device->Arena, -1.0f, -1.0f, 1.0f, 1.0f, -1.0f, 1.0f, 1.0f, 1.0f, 1.0f, -1.0f, 1.0f, 1.0f, -1.0f, -1.0f, -1.0f, 1.0f, -1.0f, -1.0f, 1.0f, 1.0f, -1.0f, -1.0f, 1.0f, -1.0f));
-        SkyboxIndexData.init(device->Arena, 36, make_initializer_list<uint16_t>(device->Arena, 0, 1, 2, 2, 3, 0, 1, 5, 6, 6, 2, 1, 5, 4, 7, 7, 6, 5, 4, 0, 3, 3, 7, 4, 3, 2, 6, 6, 7, 3, 4, 5, 1, 1, 0, 4));
-        GridVertexData.init(device->Arena, 12, make_initializer_list<float>(device->Arena, -1000.0f, 0.01f, -1000.0f, 1000.0f, 0.01f, -1000.0f, 1000.0f, 0.01f, 1000.0f, -1000.0f, 0.01f, 1000.0f));
-        GridIndexData.init(device->Arena, 6, make_initializer_list<uint16_t>(device->Arena, 0, 1, 2, 2, 3, 0));
-
-        // Allocate HOST_VISIBLE vertex/index buffers directly — no per-frame copies.
-        SkyboxVBHandle                          = device->GpuMem.AllocateBuffer(ArrayView{SkyboxVertexData}.size_bytes(), VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, Core::Memory::GpuMemoryDomain::HostUniform, "SkyboxVb");
-        SkyboxIBHandle                          = device->GpuMem.AllocateBuffer(ArrayView{SkyboxIndexData}.size_bytes(), VK_BUFFER_USAGE_INDEX_BUFFER_BIT, Core::Memory::GpuMemoryDomain::HostUniform, "SkyboxIb");
-        GridVBHandle                            = device->GpuMem.AllocateBuffer(ArrayView{GridVertexData}.size_bytes(), VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, Core::Memory::GpuMemoryDomain::HostUniform, "GridVb");
-        GridIBHandle                            = device->GpuMem.AllocateBuffer(ArrayView{GridIndexData}.size_bytes(), VK_BUFFER_USAGE_INDEX_BUFFER_BIT, Core::Memory::GpuMemoryDomain::HostUniform, "GridIb");
-
-        s_upload_pass_instance                  = this;
-
-        RenderGraphRenderPassCreation pass_node = {.Name = name};
-        pass_node.Inputs.init(device->Arena, 1);
-        pass_node.Outputs.init(device->Arena, 0);
-        res_builder->CreateRenderPassNode(pass_node);
-    }
-
-    void UploadPass::Compile(Hardwares::VulkanDevicePtr const device, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPassBuilder* pass_builder, RenderGraphResourceInspectorPtr res_inspector, RenderPasses::RenderPass** const output_pass)
-    {
-        CHECK_AND_ESCAPE_NULL(output_pass)
-
-        if (output_pass && !(*output_pass))
-        {
-            auto pass_spec = pass_builder->Detach();
-            pass_spec.Type = Specifications::RenderPassType::TRANSFER;
-            *output_pass   = device->CreateRenderPass(pass_spec);
-            (*output_pass)->Bake();
-        }
-    }
-
-    void UploadPass::Execute(Hardwares::VulkanDevicePtr const device, RenderGraphResourceInspectorPtr res_inspector, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPass* const pass, Buffers::FramebufferVNext* const framebuffer, Hardwares::CommandBufferPtr const command_buffer)
-    {
-        auto index = device->SwapchainPtr->CurrentFrame->Index;
-        if (WriteOnceControl[index] != 0)
-            return;
-
-        // Write geometry once via direct vmaCopyMemoryToAllocation (HOST_VISIBLE).
-        auto copy = [&](Core::Memory::BufferView& buf, const void* data, size_t size) { vmaCopyMemoryToAllocation(device->GpuMem.Allocator, data, buf.Allocation, 0, size); };
-        copy(SkyboxVBHandle, SkyboxVertexData.data(), ArrayView{SkyboxVertexData}.size_bytes());
-        copy(SkyboxIBHandle, SkyboxIndexData.data(), ArrayView{SkyboxIndexData}.size_bytes());
-        copy(GridVBHandle, GridVertexData.data(), ArrayView{GridVertexData}.size_bytes());
-        copy(GridIBHandle, GridIndexData.data(), ArrayView{GridIndexData}.size_bytes());
-
-        WriteOnceControl[index] = 1;
-    }
 
     void BasePass::Setup(Hardwares::VulkanDevicePtr const device, cstring name, RenderGraphResourceBuilderPtr const res_builder, RenderGraphResourceInspectorPtr res_inspector)
     {
@@ -171,6 +116,16 @@ namespace ZEngine::Rendering::Renderers
 
     void SkyboxPass::Setup(Hardwares::VulkanDevicePtr const device, cstring name, RenderGraphResourceBuilderPtr const res_builder, RenderGraphResourceInspectorPtr res_inspector)
     {
+        static constexpr float verts[] = {
+            -1.0f, -1.0f, 1.0f, 1.0f, -1.0f, 1.0f, 1.0f, 1.0f, 1.0f, -1.0f, 1.0f, 1.0f, -1.0f, -1.0f, -1.0f, 1.0f, -1.0f, -1.0f, 1.0f, 1.0f, -1.0f, -1.0f, 1.0f, -1.0f,
+        };
+        static constexpr uint16_t idxs[] = {0, 1, 2, 2, 3, 0, 1, 5, 6, 6, 2, 1, 5, 4, 7, 7, 6, 5, 4, 0, 3, 3, 7, 4, 3, 2, 6, 6, 7, 3, 4, 5, 1, 1, 0, 4};
+
+        VBHandle                         = device->GpuMem.AllocateBuffer(sizeof(verts), VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, Core::Memory::GpuMemoryDomain::HostUniform, "SkyboxVb");
+        IBHandle                         = device->GpuMem.AllocateBuffer(sizeof(idxs), VK_BUFFER_USAGE_INDEX_BUFFER_BIT, Core::Memory::GpuMemoryDomain::HostUniform, "SkyboxIb");
+        vmaCopyMemoryToAllocation(device->GpuMem.Allocator, verts, VBHandle.Allocation, 0, sizeof(verts));
+        vmaCopyMemoryToAllocation(device->GpuMem.Allocator, idxs, IBHandle.Allocation, 0, sizeof(idxs));
+
         bool env_map_available = false;
         if (EnvMapPath && EnvMapPath[0] != '\0')
         {
@@ -190,29 +145,17 @@ namespace ZEngine::Rendering::Renderers
             }
         }
 
-        if (!env_map_available)
-        {
-            m_env_map = {};
-        }
-        else
+        if (env_map_available)
         {
             auto env_map_res = res_builder->CreateTexture("skybox_env_map", EnvMapPath);
             m_env_map        = env_map_res.ResourceInfo.TextureHandle;
         }
 
-        const auto&                   skybox_vb_set = res_inspector->GetResource("SkyboxVbSet");
-        const auto&                   skybox_ib_set = res_inspector->GetResource("SkyboxIbSet");
-
-        RenderGraphRenderPassCreation pass_node     = {.Name = name};
-
-        pass_node.Inputs.init(device->Arena, 4);
+        RenderGraphRenderPassCreation pass_node = {.Name = name};
+        pass_node.Inputs.init(device->Arena, 2);
         pass_node.Outputs.init(device->Arena, 1);
-
-        pass_node.Inputs.push(RenderGraphRenderPassInputOutputInfo{.Name = skybox_vb_set.Name, .Type = skybox_vb_set.Type});
-        pass_node.Inputs.push(RenderGraphRenderPassInputOutputInfo{.Name = skybox_ib_set.Name, .Type = skybox_ib_set.Type});
         pass_node.Inputs.push(RenderGraphRenderPassInputOutputInfo{.Name = RendererResourceName::FrameDepthRenderTargetName});
         pass_node.Inputs.push(RenderGraphRenderPassInputOutputInfo{.Name = RendererResourceName::FrameColorRenderTargetName});
-
         res_builder->CreateRenderPassNode(pass_node);
     }
 
@@ -258,7 +201,7 @@ namespace ZEngine::Rendering::Renderers
 
     void SkyboxPass::Execute(Hardwares::VulkanDevicePtr const device, RenderGraphResourceInspectorPtr res_inspector, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPass* const pass, Buffers::FramebufferVNext* const framebuffer, Hardwares::CommandBufferPtr const command_buffer)
     {
-        if (!m_env_map.Valid() || !s_upload_pass_instance)
+        if (!m_env_map.Valid())
             return;
 
         command_buffer->BeginRenderPass(pass, framebuffer->Handle, false);
@@ -269,30 +212,36 @@ namespace ZEngine::Rendering::Renderers
             command_buffer->SetScissor(w, h);
         }
         command_buffer->BindPipeline(Specifications::PipelineBindPoint::GRAPHIC, pass->Pipeline);
-        command_buffer->BindVertexBuffer(s_upload_pass_instance->SkyboxVBHandle);
-        command_buffer->BindIndexBuffer(s_upload_pass_instance->SkyboxIBHandle, VK_INDEX_TYPE_UINT16);
+        command_buffer->BindVertexBuffer(VBHandle);
+        command_buffer->BindIndexBuffer(IBHandle, VK_INDEX_TYPE_UINT16);
         command_buffer->BindDescriptorSets(device->SwapchainPtr->CurrentFrame->Index, scene ? &scene->CameraHeapOffset : nullptr, scene ? 1u : 0u);
         command_buffer->DrawIndexed(36, 1, 0, 0, 0);
         command_buffer->EndRenderPass();
     }
 
+    void SkyboxPass::Deinitialize(Hardwares::VulkanDevicePtr const device)
+    {
+        if (VBHandle)
+            device->GpuMem.FreeBuffer(VBHandle);
+        if (IBHandle)
+            device->GpuMem.FreeBuffer(IBHandle);
+    }
+
     void GridPass::Setup(Hardwares::VulkanDevicePtr const device, cstring name, RenderGraphResourceBuilderPtr const res_builder, RenderGraphResourceInspectorPtr res_inspector)
     {
-        auto                          arena       = device->Arena;
+        static constexpr float    verts[] = {-1000.0f, 0.01f, -1000.0f, 1000.0f, 0.01f, -1000.0f, 1000.0f, 0.01f, 1000.0f, -1000.0f, 0.01f, 1000.0f};
+        static constexpr uint16_t idxs[]  = {0, 1, 2, 2, 3, 0};
 
-        const auto&                   grid_vb_set = res_inspector->GetResource("GridVbSet");
-        const auto&                   grid_ib_set = res_inspector->GetResource("GridIbSet");
+        VBHandle                          = device->GpuMem.AllocateBuffer(sizeof(verts), VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, Core::Memory::GpuMemoryDomain::HostUniform, "GridVb");
+        IBHandle                          = device->GpuMem.AllocateBuffer(sizeof(idxs), VK_BUFFER_USAGE_INDEX_BUFFER_BIT, Core::Memory::GpuMemoryDomain::HostUniform, "GridIb");
+        vmaCopyMemoryToAllocation(device->GpuMem.Allocator, verts, VBHandle.Allocation, 0, sizeof(verts));
+        vmaCopyMemoryToAllocation(device->GpuMem.Allocator, idxs, IBHandle.Allocation, 0, sizeof(idxs));
 
-        RenderGraphRenderPassCreation pass_node   = {.Name = name};
-
-        pass_node.Inputs.init(arena, 4);
-        pass_node.Outputs.init(arena, 1);
-
-        pass_node.Inputs.push(RenderGraphRenderPassInputOutputInfo{.Name = grid_vb_set.Name, .Type = grid_vb_set.Type});
-        pass_node.Inputs.push(RenderGraphRenderPassInputOutputInfo{.Name = grid_ib_set.Name, .Type = grid_ib_set.Type});
+        RenderGraphRenderPassCreation pass_node = {.Name = name};
+        pass_node.Inputs.init(device->Arena, 2);
+        pass_node.Outputs.init(device->Arena, 1);
         pass_node.Inputs.push(RenderGraphRenderPassInputOutputInfo{.Name = RendererResourceName::FrameDepthRenderTargetName});
         pass_node.Inputs.push(RenderGraphRenderPassInputOutputInfo{.Name = RendererResourceName::FrameColorRenderTargetName});
-
         res_builder->CreateRenderPassNode(pass_node);
     }
 
@@ -337,10 +286,6 @@ namespace ZEngine::Rendering::Renderers
 
     void GridPass::Execute(Hardwares::VulkanDevicePtr const device, RenderGraphResourceInspectorPtr res_inspector, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPass* const pass, Buffers::FramebufferVNext* const framebuffer, Hardwares::CommandBufferPtr const command_buffer)
     {
-
-        if (!s_upload_pass_instance)
-            return;
-
         command_buffer->BeginRenderPass(pass, framebuffer->Handle, false);
         {
             uint32_t w = pass->GetRenderAreaWidth();
@@ -349,12 +294,20 @@ namespace ZEngine::Rendering::Renderers
             command_buffer->SetScissor(w, h);
         }
         command_buffer->BindPipeline(Specifications::PipelineBindPoint::GRAPHIC, pass->Pipeline);
-        command_buffer->BindVertexBuffer(s_upload_pass_instance->GridVBHandle);
-        command_buffer->BindIndexBuffer(s_upload_pass_instance->GridIBHandle, VK_INDEX_TYPE_UINT16);
+        command_buffer->BindVertexBuffer(VBHandle);
+        command_buffer->BindIndexBuffer(IBHandle, VK_INDEX_TYPE_UINT16);
         command_buffer->BindDescriptorSets(device->SwapchainPtr->CurrentFrame->Index, scene ? &scene->CameraHeapOffset : nullptr, scene ? 1u : 0u);
         command_buffer->PushConstants(VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT, 0, sizeof(GridPushConstantData), &PushData);
         command_buffer->DrawIndexed(6, 1, 0, 0, 0);
         command_buffer->EndRenderPass();
+    }
+
+    void GridPass::Deinitialize(Hardwares::VulkanDevicePtr const device)
+    {
+        if (VBHandle)
+            device->GpuMem.FreeBuffer(VBHandle);
+        if (IBHandle)
+            device->GpuMem.FreeBuffer(IBHandle);
     }
 
     void GbufferPass::Setup(Hardwares::VulkanDevicePtr const device, cstring name, RenderGraphResourceBuilderPtr const res_builder, RenderGraphResourceInspectorPtr res_inspector)

--- a/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.h
+++ b/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.h
@@ -6,33 +6,8 @@
 #include <ZEngine/Rendering/Scenes/RenderScene.h>
 #include <ZEngine/ZEngineDef.h>
 
-#define WRITE_BUFFERS_ONCE(frame_index, body)          \
-    if (!m_write_once_control.contains(frame_index))   \
-    {                                                  \
-        body m_write_once_control[frame_index] = true; \
-    }
-
 namespace ZEngine::Rendering::Renderers
 {
-
-    struct UploadPass : public IRenderGraphCallbackPass
-    {
-        Core::Containers::Array<float>    SkyboxVertexData = {};
-        Core::Containers::Array<float>    GridVertexData   = {};
-        Core::Containers::Array<uint16_t> SkyboxIndexData  = {};
-        Core::Containers::Array<uint16_t> GridIndexData    = {};
-
-        Core::Memory::BufferView          SkyboxVBHandle   = {};
-        Core::Memory::BufferView          GridVBHandle     = {};
-        Core::Memory::BufferView          SkyboxIBHandle   = {};
-        Core::Memory::BufferView          GridIBHandle     = {};
-
-        Core::Containers::Array<uint8_t>  WriteOnceControl = {};
-
-        virtual void                      Setup(Hardwares::VulkanDevicePtr const device, cstring name, RenderGraphResourceBuilderPtr const res_builder, RenderGraphResourceInspectorPtr res_inspector) override;
-        virtual void                      Compile(Hardwares::VulkanDevicePtr const device, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPassBuilder* pass_builder, RenderGraphResourceInspectorPtr res_inspector, RenderPasses::RenderPass** const output_pass) override;
-        virtual void                      Execute(Hardwares::VulkanDevicePtr const device, RenderGraphResourceInspectorPtr res_inspector, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPass* const pass, Buffers::FramebufferVNext* const framebuffer, Hardwares::CommandBufferPtr const command_buffer) override;
-    };
 
     struct BasePass : public IRenderGraphCallbackPass
     {
@@ -51,11 +26,15 @@ namespace ZEngine::Rendering::Renderers
     struct SkyboxPass : public IRenderGraphCallbackPass
     {
         // Set before Setup() is called. Empty string = no env map, pass is disabled.
-        cstring      EnvMapPath = nullptr;
+        cstring                  EnvMapPath = nullptr;
 
-        virtual void Setup(Hardwares::VulkanDevicePtr const device, cstring name, RenderGraphResourceBuilderPtr const res_builder, RenderGraphResourceInspectorPtr res_inspector) override;
-        virtual void Compile(Hardwares::VulkanDevicePtr const device, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPassBuilder* pass_builder, RenderGraphResourceInspectorPtr res_inspector, RenderPasses::RenderPass** const output_pass) override;
-        virtual void Execute(Hardwares::VulkanDevicePtr const device, RenderGraphResourceInspectorPtr res_inspector, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPass* const pass, Buffers::FramebufferVNext* const framebuffer, Hardwares::CommandBufferPtr const command_buffer) override;
+        Core::Memory::BufferView VBHandle   = {};
+        Core::Memory::BufferView IBHandle   = {};
+
+        virtual void             Setup(Hardwares::VulkanDevicePtr const device, cstring name, RenderGraphResourceBuilderPtr const res_builder, RenderGraphResourceInspectorPtr res_inspector) override;
+        virtual void             Compile(Hardwares::VulkanDevicePtr const device, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPassBuilder* pass_builder, RenderGraphResourceInspectorPtr res_inspector, RenderPasses::RenderPass** const output_pass) override;
+        virtual void             Execute(Hardwares::VulkanDevicePtr const device, RenderGraphResourceInspectorPtr res_inspector, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPass* const pass, Buffers::FramebufferVNext* const framebuffer, Hardwares::CommandBufferPtr const command_buffer) override;
+        virtual void             Deinitialize(Hardwares::VulkanDevicePtr const device) override;
 
     private:
         Textures::TextureHandle m_env_map = {};
@@ -73,11 +52,14 @@ namespace ZEngine::Rendering::Renderers
 
     struct GridPass : public IRenderGraphCallbackPass
     {
-        GridPushConstantData PushData = {};
+        GridPushConstantData     PushData = {};
+        Core::Memory::BufferView VBHandle = {};
+        Core::Memory::BufferView IBHandle = {};
 
-        virtual void         Setup(Hardwares::VulkanDevicePtr const device, cstring name, RenderGraphResourceBuilderPtr const res_builder, RenderGraphResourceInspectorPtr res_inspector) override;
-        virtual void         Compile(Hardwares::VulkanDevicePtr const device, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPassBuilder* pass_builder, RenderGraphResourceInspectorPtr res_inspector, RenderPasses::RenderPass** const output_pass) override;
-        virtual void         Execute(Hardwares::VulkanDevicePtr const device, RenderGraphResourceInspectorPtr res_inspector, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPass* const pass, Buffers::FramebufferVNext* const framebuffer, Hardwares::CommandBufferPtr const command_buffer) override;
+        virtual void             Setup(Hardwares::VulkanDevicePtr const device, cstring name, RenderGraphResourceBuilderPtr const res_builder, RenderGraphResourceInspectorPtr res_inspector) override;
+        virtual void             Compile(Hardwares::VulkanDevicePtr const device, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPassBuilder* pass_builder, RenderGraphResourceInspectorPtr res_inspector, RenderPasses::RenderPass** const output_pass) override;
+        virtual void             Execute(Hardwares::VulkanDevicePtr const device, RenderGraphResourceInspectorPtr res_inspector, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPass* const pass, Buffers::FramebufferVNext* const framebuffer, Hardwares::CommandBufferPtr const command_buffer) override;
+        virtual void             Deinitialize(Hardwares::VulkanDevicePtr const device) override;
     };
 
     struct GbufferPass : public IRenderGraphCallbackPass

--- a/ZEngine/ZEngine/Rendering/Shaders/ShaderReader.cpp
+++ b/ZEngine/ZEngine/Rendering/Shaders/ShaderReader.cpp
@@ -1,4 +1,8 @@
+#include <ZEngine/Core/Containers/Array.h>
 #include <ZEngine/Core/Coroutine.h>
+#include <ZEngine/Core/VFS/IVFSFile.h>
+#include <ZEngine/Core/VFS/VFSPath.h>
+#include <ZEngine/Engine.h>
 #include <ZEngine/Logging/LoggerDefinition.h>
 #include <ZEngine/Rendering/Shaders/ShaderReader.h>
 
@@ -17,20 +21,35 @@ namespace ZEngine::Rendering::Shaders
 
     std::vector<uint32_t> ShaderReader::ReadAsBinary(std::string_view filename)
     {
-        std::ifstream file_stream = {};
-        file_stream.open(std::string(filename), std::ifstream::binary | std::ifstream::ate);
-        if (!file_stream.is_open())
+        auto* vfs      = Engine::GetContext()->VFS;
+        auto  path_res = Core::VFS::VFSPath::Parse(filename.data());
+        if (path_res.Failed())
+        {
+            ZENGINE_CORE_ERROR("====== Shader file : {} — invalid VFS path ======", filename.data())
+            ZENGINE_EXIT_FAILURE()
+        }
+
+        auto file_res = vfs->Open(path_res.Value(), Core::VFS::VFSOpenFlags::Read);
+        if (file_res.Failed())
         {
             ZENGINE_CORE_ERROR("====== Shader file : {} cannot be opened ======", filename.data())
             ZENGINE_EXIT_FAILURE()
         }
 
-        size_t                buffer_size = static_cast<size_t>(file_stream.tellg());
-        std::vector<uint32_t> buffer(buffer_size / 4);
-        file_stream.seekg(std::ifstream::beg);
-        file_stream.read(reinterpret_cast<char*>(buffer.data()), buffer_size);
-        file_stream.close();
+        auto* file     = file_res.Value();
+        auto  size_res = file->Size();
+        if (size_res.Failed())
+        {
+            vfs->Close(file);
+            ZENGINE_CORE_ERROR("====== Shader file : {} cannot get size ======", filename.data())
+            ZENGINE_EXIT_FAILURE()
+        }
 
+        const uint64_t                       byte_size = size_res.Value();
+        std::vector<uint32_t>                buffer(byte_size / 4);
+        Core::Containers::ArrayView<uint8_t> view{reinterpret_cast<uint8_t*>(buffer.data()), byte_size};
+        file->ReadAll(view);
+        vfs->Close(file);
         return buffer;
     }
 

--- a/ZEngine/tests/Misc/VFSScanner_test.cpp
+++ b/ZEngine/tests/Misc/VFSScanner_test.cpp
@@ -109,6 +109,10 @@ namespace
         {
             return VFSResult<void>::Fail(VFSError::Unsupported);
         }
+        VFSResult<void> RemoveAll(const VFSPath&) override
+        {
+            return VFSResult<void>::Fail(VFSError::Unsupported);
+        }
         VFSResult<void> Rename(const VFSPath&, const VFSPath&) override
         {
             return VFSResult<void>::Fail(VFSError::Unsupported);

--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -62,7 +62,7 @@ FetchContent_Declare(
   yaml-cpp
   GIT_REPOSITORY https://github.com/jbeder/yaml-cpp
   GIT_SHALLOW TRUE
-   
+  GIT_TAG yaml-cpp-0.9.0
   )
 
 
@@ -103,6 +103,7 @@ FetchContent_Declare(
     GIT_TAG vulkan-sdk-1.3.296.0
 )
 
+set(YAML_MSVC_SHARED_RT ON CACHE BOOL "" FORCE)
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 Fetchcontent_Declare(
     GTest


### PR DESCRIPTION
## Summary

- **VFS backend hierarchy**: `GameApplication` now accepts a `VFSBackend*` pointer and mounts it at `/` after engine init, so the Editor passes its workspace backend through the standard app path instead of mounting it directly on the VFS context.
- **ZodiacEngine/ asset layout**: Engine-internal assets (Shaders, Settings) are placed under a `ZodiacEngine/` subdirectory in the build output and mounted at `/ZodiacEngine/` with priority -1, keeping the workspace root clean of engine internals.
- **VFS longest-prefix-wins**: `VFSMountTable::Resolve` now picks the most-specific matching mount instead of the highest-priority one, preventing `/` from intercepting `/ZodiacEngine/...` paths.
- **Content browser overhaul**: UE-style icon-first cards (80px, 2-line wrapped names), type-specific vector icons via `ContentBrowserIcons.h` (Texture, Mesh, Shader, Material, Audio, Scene, Config, CppSource, Generic), VFS-backed file operations (Create/Rename/Delete), `.meta` file filtering, search cache, golden folder icon in the tree view.
- **ImGui font atlas upload via RRM**: Font atlas is now uploaded synchronously through `RRM::UploadFontAtlas`, stored as a `TextureHandle` member on `ImGUIRenderer`, and properly enqueued for GPU memory release on shutdown. Added `LinearClampSampler` at set=1 binding=2 in the ImGui shader to prevent UV wrap-bleed.
- **VMA crash on close fixed**: All GPU allocations are now freed before `vmaDestroyAllocator`:
  - `FrameColorRenderTarget` / `FrameDepthRenderTarget` enqueued to `TextureHandleToDispose` in `GraphicRenderer::Deinitialize`.
  - `FontTexture` enqueued in `ImGUIRenderer::Deinitialize`.
  - Non-external `RenderGraph` textures enqueued in `RenderGraph::Dispose`.
  - `UploadPass` removed from the render graph entirely — `SkyboxPass` and `GridPass` now own their geometry buffers (SkyboxVb/Ib, GridVb/Ib), allocated in `Setup` and freed via a new `Deinitialize` virtual on `IRenderGraphCallbackPass` called from `RenderGraph::Dispose`.

## Test plan

- [x] Build and launch Obelisk — engine starts, grid and scene render correctly
- [x] Drop a mesh into the scene viewport — asset imports and renders
- [x] Close the editor — no VMA assertion, no crash report generated
- [x] Content browser shows workspace assets (not engine internals like Shaders/Settings/Logs)
- [x] `.meta` files are absent from the content browser listing
- [x] Content browser cards show type-specific colored icons with 2-line names

Closes #595 tracking: migrate SkyboxPass/GridPass geometry into RRM global buffers