### PR TITLE
feat(editor,importer):  asset importer panel — permanent cook + lazy cook on save

### DIFF
--- a/Tetragrama/Components/AssetImporterUIComponent.cpp
+++ b/Tetragrama/Components/AssetImporterUIComponent.cpp
@@ -120,7 +120,8 @@ namespace Tetragrama::Components
         auto* config = ZPushStruct(&LocalArena, AssetCodec::ImportConfiguration);
         config->OutputWorkingSpacePath.init(&LocalArena, cfg.WorkingSpacePath.c_str());
         config->OutputTextureFilesPath.init(&LocalArena, cfg.TexturePath.c_str());
-        config->OutputAssetsPath.init(&LocalArena, cfg.SceneDataPath.c_str());
+        config->OutputAssetsPath.init(&LocalArena, cfg.MeshPath.c_str());
+        config->OutputMaterialPath.init(&LocalArena, cfg.MaterialPath.c_str());
         config->AssetName.init(&LocalArena, asset_name.c_str());
         config->OutputAssetFile.init(&LocalArena, asset_file.c_str());
         config->InputBaseAssetFilePath.init(&LocalArena, parent_dir.c_str());

--- a/Tetragrama/Components/AssetImporterUIComponent.cpp
+++ b/Tetragrama/Components/AssetImporterUIComponent.cpp
@@ -27,10 +27,14 @@ namespace Tetragrama::Components
 
         parent->LocalArena.CreateSubArena(ZMega(2), &LocalArena);
 
+        // Each importer gets its own dedicated scratch arena sized to its budget.
+        parent->Arena->CreateSubArena(ZMega(64), &GltfImporterArena);
+        parent->Arena->CreateSubArena(ZMega(350), &AssimpImporterArena);
+
         m_gltf_importer   = ZPushStructCtor(parent->Arena, ZEngine::Importers::GltfImporter);
         m_assimp_importer = ZPushStructCtor(parent->Arena, ZEngine::Importers::AssimpImporter);
-        m_gltf_importer->Initialize(&LocalArena);
-        m_assimp_importer->Initialize(&LocalArena);
+        m_gltf_importer->Initialize(&GltfImporterArena);
+        m_assimp_importer->Initialize(&AssimpImporterArena);
     }
 
     void AssetImporterUIComponent::Update(ZEngine::Core::TimeStep /*dt*/) {}

--- a/Tetragrama/Components/AssetImporterUIComponent.cpp
+++ b/Tetragrama/Components/AssetImporterUIComponent.cpp
@@ -204,12 +204,32 @@ namespace Tetragrama::Components
                 }
             }
 
+            // If triggered by viewport drag-drop, add the mesh instance to the scene
+            if (self->m_add_to_scene && mesh_path)
+            {
+                ZEngine::Importers::AssetCodec::AssetMeshFileHeader header{};
+                if (ZEngine::Importers::AssetCodec::ReadAssetMeshFileHeader(mesh_path, header))
+                {
+                    auto* app   = reinterpret_cast<Tetragrama::EditorPtr>(self->ParentLayer->CurrentApp);
+                    auto* scene = app ? reinterpret_cast<Tetragrama::EditorScenePtr>(app->CurrentScene) : nullptr;
+                    if (scene)
+                    {
+                        cstring iname = self->m_instance_name[0] ? self->m_instance_name : fs::path(self->m_path_buf).filename().replace_extension().string().c_str();
+                        scene->AddMeshInstance(header.Id, iname);
+                    }
+                }
+                self->m_add_to_scene     = false;
+                self->m_instance_name[0] = '\0';
+            }
+
             self->PushLog("Completed", kGreen);
             cstring filename = fs::path(self->m_path_buf).filename().string().c_str();
             self->PushHistory(filename, true, "Completed");
         }
         else
         {
+            self->m_add_to_scene     = false;
+            self->m_instance_name[0] = '\0';
             self->PushLog("Import failed — no mesh output", kRed);
             cstring filename = fs::path(self->m_path_buf).filename().string().c_str();
             self->PushHistory(filename, false, "No mesh output");
@@ -409,6 +429,17 @@ namespace Tetragrama::Components
 
         if (m_pending_scan.value.exchange(false))
             TriggerScan();
+
+        // Consume viewport drag-drop: auto-import and add mesh to scene when done
+        if (app->Configuration->PendingImportPath[0] != '\0' && m_state.value.load() == ImporterState::Idle)
+        {
+            secure_strncpy(m_path_buf, sizeof(m_path_buf), app->Configuration->PendingImportPath, sizeof(m_path_buf) - 1);
+            secure_strncpy(m_instance_name, sizeof(m_instance_name), app->Configuration->PendingImportName, sizeof(m_instance_name) - 1);
+            app->Configuration->PendingImportPath[0] = '\0';
+            app->Configuration->PendingImportName[0] = '\0';
+            m_add_to_scene                           = true;
+            StartImport();
+        }
 
         switch (m_state.value.load())
         {

--- a/Tetragrama/Components/AssetImporterUIComponent.cpp
+++ b/Tetragrama/Components/AssetImporterUIComponent.cpp
@@ -1,0 +1,428 @@
+#include <Tetragrama/Components/AssetImporterUIComponent.h>
+#include <Tetragrama/Editor.h>
+#include <Tetragrama/Helpers/UIDispatcher.h>
+#include <ZEngine/Core/Coroutine.h>
+#include <ZEngine/Core/VFS/Meta/MetaFileData.h>
+#include <ZEngine/Core/VFS/Meta/MetaFileIO.h>
+#include <ZEngine/Core/VFS/VFSPath.h>
+#include <ZEngine/Engine.h>
+#include <ZEngine/Helpers/MemoryOperations.h>
+#include <ZEngine/Helpers/ThreadPool.h>
+#include <ZEngine/Importers/AssetCodec.h>
+#include <imgui.h>
+#include <cstdio>
+#include <filesystem>
+
+namespace fs = std::filesystem;
+
+using namespace ZEngine::Core::VFS;
+using namespace ZEngine::Helpers;
+using namespace ZEngine::Importers;
+
+namespace Tetragrama::Components
+{
+    void AssetImporterUIComponent::Initialize(Layers::ImguiLayer* parent, cstring name, bool visibility, bool closed)
+    {
+        UIComponent::Initialize(parent, name, visibility, closed);
+
+        parent->LocalArena.CreateSubArena(ZMega(2), &LocalArena);
+
+        m_gltf_importer   = ZPushStructCtor(parent->Arena, ZEngine::Importers::GltfImporter);
+        m_assimp_importer = ZPushStructCtor(parent->Arena, ZEngine::Importers::AssimpImporter);
+        m_gltf_importer->Initialize(&LocalArena);
+        m_assimp_importer->Initialize(&LocalArena);
+    }
+
+    void AssetImporterUIComponent::Update(ZEngine::Core::TimeStep /*dt*/) {}
+
+    // ─── Utilities ───────────────────────────────────────────────────────────
+
+    void AssetImporterUIComponent::PushLog(cstring text, const float color[4])
+    {
+        std::lock_guard<std::mutex> lock(m_log_mutex);
+        auto&                       e = m_log[m_log_head];
+        secure_strncpy(e.Text, sizeof(e.Text), text, sizeof(e.Text) - 1);
+        e.Color[0] = color[0];
+        e.Color[1] = color[1];
+        e.Color[2] = color[2];
+        e.Color[3] = color[3];
+        m_log_head = (m_log_head + 1) % kLogMax;
+        if (m_log_count < kLogMax)
+            ++m_log_count;
+        m_scroll_log = true;
+    }
+
+    void AssetImporterUIComponent::PushHistory(cstring name, bool success, cstring msg)
+    {
+        if (m_history_count < kHistMax)
+        {
+            auto& e = m_history[m_history_count++];
+            secure_strncpy(e.Name, sizeof(e.Name), name, sizeof(e.Name) - 1);
+            secure_strncpy(e.Message, sizeof(e.Message), msg, sizeof(e.Message) - 1);
+            e.Success = success;
+        }
+        else
+        {
+            for (int i = 0; i < kHistMax - 1; ++i)
+                m_history[i] = m_history[i + 1];
+            auto& e = m_history[kHistMax - 1];
+            secure_strncpy(e.Name, sizeof(e.Name), name, sizeof(e.Name) - 1);
+            secure_strncpy(e.Message, sizeof(e.Message), msg, sizeof(e.Message) - 1);
+            e.Success = success;
+        }
+    }
+
+    void AssetImporterUIComponent::TriggerScan()
+    {
+        auto* vfs = static_cast<ZEngine::Core::VFS::IVFSContext*>(ZEngine::Engine::GetContext()->VFS);
+        if (vfs && ParentLayer)
+            ParentLayer->Scanner.Scan(vfs, ZEngine::Core::VFS::VFSPath::Root(), &ParentLayer->Cache);
+    }
+
+    void AssetImporterUIComponent::BrowseFile()
+    {
+        Helpers::UIDispatcher::RunAsync([this]() -> std::future<void> {
+            if (!ParentLayer || !ParentLayer->CurrentApp)
+                co_return;
+            auto                          window  = ParentLayer->CurrentApp->CurrentWindow;
+            std::vector<std::string_view> filters = {".glb", ".gltf", ".fbx", ".obj"};
+            std::string                   picked  = co_await window->OpenFileDialogAsync(filters);
+            if (!picked.empty())
+            {
+                secure_strncpy(m_path_buf, sizeof(m_path_buf), picked.c_str(), picked.size());
+                m_state.value.store(ImporterState::Options);
+            }
+        });
+    }
+
+    // ─── Import ──────────────────────────────────────────────────────────────
+
+    void AssetImporterUIComponent::StartImport()
+    {
+        if (!m_gltf_importer || !m_assimp_importer)
+            return;
+
+        auto* app = reinterpret_cast<Tetragrama::EditorPtr>(ParentLayer->CurrentApp);
+        if (!app || !app->Configuration)
+            return;
+
+        static constexpr float kRed[]     = {1.0f, 0.3f, 0.3f, 1.0f};
+        static constexpr float kWhite[]   = {0.8f, 0.8f, 0.8f, 1.0f};
+
+        // Build ImportConfiguration from project settings
+        const auto&            cfg        = *app->Configuration;
+        auto                   asset_name = fs::path(m_path_buf).filename().replace_extension().string();
+        auto                   asset_file = asset_name + ".zemesh";
+        auto                   parent_dir = fs::path(m_path_buf).parent_path().string();
+
+        // Use the arena-local config (arena will be cleared after import)
+        LocalArena.Clear();
+        auto* config = ZPushStruct(&LocalArena, AssetCodec::ImportConfiguration);
+        config->OutputWorkingSpacePath.init(&LocalArena, cfg.WorkingSpacePath.c_str());
+        config->OutputTextureFilesPath.init(&LocalArena, cfg.TexturePath.c_str());
+        config->OutputAssetsPath.init(&LocalArena, cfg.SceneDataPath.c_str());
+        config->AssetName.init(&LocalArena, asset_name.c_str());
+        config->OutputAssetFile.init(&LocalArena, asset_file.c_str());
+        config->InputBaseAssetFilePath.init(&LocalArena, parent_dir.c_str());
+
+        char msg[512];
+        snprintf(msg, sizeof(msg), "Importing %s", fs::path(m_path_buf).filename().string().c_str());
+        PushLog(msg, kWhite);
+
+        m_state.value.store(ImporterState::Importing);
+        m_progress.value.store(0.0f);
+
+        // Route by extension to the appropriate importer
+        auto ext = fs::path(m_path_buf).extension().string();
+        // Normalize: remove leading dot, lowercase
+        if (!ext.empty() && ext[0] == '.')
+            ext = ext.substr(1);
+        for (auto& c : ext)
+            c = static_cast<char>(::tolower(static_cast<unsigned char>(c)));
+
+        std::string src_path = m_path_buf;
+        auto        cfg_copy = *config;
+
+        if (ext == "glb" || ext == "gltf")
+        {
+            ZEngine::Helpers::ThreadPoolHelper::Submit([this, src = src_path, cfg_copy, arena = &LocalArena, app]() mutable { m_gltf_importer->ImportFile(src.c_str(), cfg_copy, arena, this, OnImportFileComplete, OnImportProgress, OnImportError, OnImportLog); });
+        }
+        else
+        {
+            ZEngine::Helpers::ThreadPoolHelper::Submit([this, src = src_path, cfg_copy, arena = &LocalArena, app]() mutable { m_assimp_importer->ImportFile(src.c_str(), cfg_copy, arena, this, OnImportFileComplete, OnImportProgress, OnImportError, OnImportLog); });
+        }
+    }
+
+    // ─── Callbacks (background thread) ───────────────────────────────────────
+
+    void AssetImporterUIComponent::OnImportFileComplete(void* ctx, ZEngine::Core::Containers::ArrayView<ZEngine::Importers::AssetImporterOutput> outputs)
+    {
+        auto*                  self      = static_cast<AssetImporterUIComponent*>(ctx);
+
+        static constexpr float kGreen[]  = {0.3f, 1.0f, 0.4f, 1.0f};
+        static constexpr float kRed[]    = {1.0f, 0.3f, 0.3f, 1.0f};
+
+        bool                   has_mesh  = false;
+        cstring                mesh_path = nullptr;
+        for (unsigned i = 0; i < outputs.size(); ++i)
+        {
+            if (outputs[i].Type == ZEngine::Importers::AssetFileType::MESH)
+            {
+                has_mesh  = true;
+                mesh_path = outputs[i].Path.c_str();
+            }
+        }
+
+        if (has_mesh)
+        {
+            // Write meta file with SourcePath so reimport is possible later
+            auto* ctx_engine = ZEngine::Engine::GetContext();
+            if (ctx_engine && ctx_engine->VFS && mesh_path)
+            {
+                auto*   vfs    = static_cast<ZEngine::Core::VFS::IVFSContext*>(ctx_engine->VFS);
+                auto*   app    = reinterpret_cast<Tetragrama::EditorPtr>(self->ParentLayer->CurrentApp);
+                cstring ws     = app ? app->WorkingSpacePath : "";
+                size_t  ws_len = secure_strlen(ws);
+
+                // Build VFSPath for the .zemesh artifact
+                if (ws_len > 0 && strncmp(mesh_path, ws, ws_len) == 0)
+                {
+                    auto rel_result = VFSPath::Parse(mesh_path + ws_len);
+                    if (rel_result.Succeeded())
+                    {
+                        // Read existing meta or create a new one
+                        auto                             meta_result = ZEngine::Core::VFS::MetaFileIO::Read(*vfs, rel_result.Value());
+                        ZEngine::Core::VFS::MetaFileData meta        = meta_result.Succeeded() ? meta_result.Value() : ZEngine::Core::VFS::MetaFileData{};
+
+                        // Store source path, artifact path, importer
+                        ZEngine::Helpers::secure_strncpy(meta.SourcePath, sizeof(meta.SourcePath), self->m_path_buf, sizeof(meta.SourcePath) - 1);
+                        ZEngine::Helpers::secure_strncpy(meta.ArtifactPath, sizeof(meta.ArtifactPath), mesh_path, sizeof(meta.ArtifactPath) - 1);
+                        ZEngine::Helpers::secure_strncpy(meta.ImporterName, sizeof(meta.ImporterName), "GltfImporter/AssimpImporter", sizeof(meta.ImporterName) - 1);
+
+                        ZEngine::Core::VFS::MetaFileIO::Write(*vfs, rel_result.Value(), meta);
+                    }
+                }
+            }
+
+            self->PushLog("Completed", kGreen);
+            cstring filename = fs::path(self->m_path_buf).filename().string().c_str();
+            self->PushHistory(filename, true, "Completed");
+        }
+        else
+        {
+            self->PushLog("Import failed — no mesh output", kRed);
+            cstring filename = fs::path(self->m_path_buf).filename().string().c_str();
+            self->PushHistory(filename, false, "No mesh output");
+        }
+
+        self->m_progress.value.store(1.0f);
+        self->m_state.value.store(ImporterState::Idle);
+        self->m_pending_scan.value.store(true);
+    }
+
+    void AssetImporterUIComponent::OnImportProgress(void* ctx, float pct)
+    {
+        auto*                  self     = static_cast<AssetImporterUIComponent*>(ctx);
+        static constexpr float kWhite[] = {0.8f, 0.8f, 0.8f, 1.0f};
+        char                   msg[128];
+        snprintf(msg, sizeof(msg), "Processing… %.0f%%", pct * 100.0f);
+        self->PushLog(msg, kWhite);
+        self->m_progress.value.store(pct);
+    }
+
+    void AssetImporterUIComponent::OnImportError(void* ctx, std::string_view err)
+    {
+        auto*                  self   = static_cast<AssetImporterUIComponent*>(ctx);
+        static constexpr float kRed[] = {1.0f, 0.3f, 0.3f, 1.0f};
+        char                   msg[512];
+        snprintf(msg, sizeof(msg), "Error: %.*s", static_cast<int>(err.size()), err.data());
+        self->PushLog(msg, kRed);
+        cstring filename = fs::path(self->m_path_buf).filename().string().c_str();
+        self->PushHistory(filename, false, msg);
+        self->m_state.value.store(ImporterState::Idle);
+        self->m_pending_scan.value.store(true);
+    }
+
+    void AssetImporterUIComponent::OnImportLog(void* ctx, std::string_view msg)
+    {
+        auto*                  self     = static_cast<AssetImporterUIComponent*>(ctx);
+        static constexpr float kWhite[] = {0.8f, 0.8f, 0.8f, 1.0f};
+        char                   buf[256];
+        snprintf(buf, sizeof(buf), "%.*s", static_cast<int>(msg.size()), msg.data());
+        self->PushLog(buf, kWhite);
+    }
+
+    // ─── Sub-renders ─────────────────────────────────────────────────────────
+
+    void AssetImporterUIComponent::RenderIdle()
+    {
+        if (ImGui::Button("+ Import File", ImVec2(-1, 0)))
+            BrowseFile();
+
+        ImGui::TextDisabled("or drag a 3D file here");
+
+        if (ImGui::BeginDragDropTarget())
+        {
+            if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("CONTENT_BROWSER_FILE_DRAG_OP"))
+            {
+                char buf[1024] = {};
+                ZEngine::Helpers::secure_memcpy(buf, sizeof(buf), payload->Data, payload->DataSize);
+                auto ext = fs::path(buf).extension().string();
+                if (ext == ".glb" || ext == ".gltf" || ext == ".fbx" || ext == ".obj")
+                {
+                    secure_strncpy(m_path_buf, sizeof(m_path_buf), buf, sizeof(m_path_buf) - 1);
+                    m_state.value.store(ImporterState::Options);
+                }
+            }
+            ImGui::EndDragDropTarget();
+        }
+
+        if (m_history_count > 0)
+        {
+            ImGui::Separator();
+            ImGui::TextDisabled("Recent Imports");
+            for (int i = m_history_count - 1; i >= 0; --i)
+            {
+                const auto& h = m_history[i];
+                if (h.Success)
+                    ImGui::TextColored({0.3f, 1.0f, 0.4f, 1.0f}, "[OK]  %s", h.Name);
+                else
+                {
+                    ImGui::TextColored({1.0f, 0.3f, 0.3f, 1.0f}, "[ERR] %s", h.Name);
+                    ImGui::SameLine();
+                    ImGui::TextDisabled("(%s)", h.Message);
+                }
+            }
+        }
+    }
+
+    void AssetImporterUIComponent::RenderOptions()
+    {
+        cstring filename = fs::path(m_path_buf).filename().string().c_str();
+        ImGui::TextUnformatted(filename);
+        ImGui::SameLine(ImGui::GetContentRegionAvail().x + ImGui::GetCursorPosX() - 22.0f);
+        if (ImGui::SmallButton("X"))
+        {
+            m_path_buf[0] = '\0';
+            m_state.value.store(ImporterState::Idle);
+            return;
+        }
+
+        ImGui::Separator();
+
+        static constexpr cstring kAxes[] = {"Y-Up", "Z-Up"};
+
+        if (ImGui::CollapsingHeader("Transform", ImGuiTreeNodeFlags_DefaultOpen))
+        {
+            ImGui::SetNextItemWidth(80.0f);
+            ImGui::DragFloat("Scale", &m_scale, 0.01f, 0.001f, 100.0f, "%.3f");
+            ImGui::SameLine(0.0f, 16.0f);
+            ImGui::SetNextItemWidth(80.0f);
+            ImGui::Combo("Axis", &m_axis_index, kAxes, 2);
+        }
+
+        if (ImGui::CollapsingHeader("Mesh", ImGuiTreeNodeFlags_DefaultOpen))
+        {
+            ImGui::Checkbox("Generate Normals", &m_gen_normals);
+            ImGui::Checkbox("Merge Identical Vertices", &m_merge_vertices);
+        }
+
+        if (ImGui::CollapsingHeader("Material", ImGuiTreeNodeFlags_DefaultOpen))
+        {
+            ImGui::Checkbox("Import Materials", &m_import_materials);
+            ImGui::SameLine(0.0f, 16.0f);
+            ImGui::Checkbox("Import Textures", &m_import_textures);
+        }
+
+        ImGui::Separator();
+
+        if (ImGui::Button("Import All", ImVec2(-108.0f, 0)))
+            StartImport();
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel", ImVec2(-1, 0)))
+        {
+            m_path_buf[0] = '\0';
+            m_state.value.store(ImporterState::Idle);
+        }
+
+        // Show last log entry for immediate error feedback
+        {
+            std::lock_guard<std::mutex> lk(m_log_mutex);
+            if (m_log_count > 0)
+            {
+                const auto& last = m_log[(m_log_head - 1 + kLogMax) % kLogMax];
+                ImGui::Spacing();
+                ImGui::TextColored({last.Color[0], last.Color[1], last.Color[2], last.Color[3]}, "%s", last.Text);
+            }
+        }
+    }
+
+    void AssetImporterUIComponent::RenderImporting()
+    {
+        cstring filename = fs::path(m_path_buf).filename().string().c_str();
+        ImGui::Text("Importing  %s", filename);
+        ImGui::ProgressBar(m_progress.value.load(), ImVec2(-1, 0));
+
+        ImGui::Separator();
+
+        ImGui::BeginChild("##imp_log", ImVec2(0, 0), false, ImGuiWindowFlags_HorizontalScrollbar);
+        {
+            std::lock_guard<std::mutex> lock(m_log_mutex);
+            int                         count = m_log_count < kLogMax ? m_log_count : kLogMax;
+            int                         start = (m_log_count >= kLogMax) ? m_log_head : 0;
+            for (int i = 0; i < count; ++i)
+            {
+                const auto& e = m_log[(start + i) % kLogMax];
+                ImGui::TextColored({e.Color[0], e.Color[1], e.Color[2], e.Color[3]}, "> %s", e.Text);
+            }
+            if (m_scroll_log)
+            {
+                ImGui::SetScrollHereY(1.0f);
+                m_scroll_log = false;
+            }
+        }
+        ImGui::EndChild();
+    }
+
+    // ─── Main render ─────────────────────────────────────────────────────────
+
+    void AssetImporterUIComponent::Render(ZEngine::Rendering::Renderers::GraphicRenderer* const, ZEngine::Hardwares::CommandBuffer* const)
+    {
+        if (!ParentLayer || !ParentLayer->CurrentApp)
+            return;
+
+        auto* app = reinterpret_cast<Tetragrama::EditorPtr>(ParentLayer->CurrentApp);
+        if (!app || !app->Configuration->ShowImporter)
+            return;
+
+        if (app->Configuration->FocusImporter)
+        {
+            ImGui::SetNextWindowFocus();
+            app->Configuration->FocusImporter = false;
+        }
+
+        if (!ImGui::Begin(Name, &app->Configuration->ShowImporter, ImGuiWindowFlags_NoCollapse))
+        {
+            ImGui::End();
+            return;
+        }
+
+        if (m_pending_scan.value.exchange(false))
+            TriggerScan();
+
+        switch (m_state.value.load())
+        {
+            case ImporterState::Idle:
+                RenderIdle();
+                break;
+            case ImporterState::Options:
+                RenderOptions();
+                break;
+            case ImporterState::Importing:
+                RenderImporting();
+                break;
+        }
+
+        ImGui::End();
+    }
+} // namespace Tetragrama::Components

--- a/Tetragrama/Components/AssetImporterUIComponent.cpp
+++ b/Tetragrama/Components/AssetImporterUIComponent.cpp
@@ -76,7 +76,7 @@ namespace Tetragrama::Components
 
     void AssetImporterUIComponent::TriggerScan()
     {
-        auto* vfs = static_cast<ZEngine::Core::VFS::IVFSContext*>(ZEngine::Engine::GetContext()->VFS);
+        auto* vfs = reinterpret_cast<ZEngine::Core::VFS::IVFSContext*>(ZEngine::Engine::GetContext()->VFS);
         if (vfs && ParentLayer)
             ParentLayer->Scanner.Scan(vfs, ZEngine::Core::VFS::VFSPath::Root(), &ParentLayer->Cache);
     }
@@ -106,7 +106,6 @@ namespace Tetragrama::Components
         if (!app || !app->Configuration)
             return;
 
-        static constexpr float kRed[]     = {1.0f, 0.3f, 0.3f, 1.0f};
         static constexpr float kWhite[]   = {0.8f, 0.8f, 0.8f, 1.0f};
 
         // Build ImportConfiguration from project settings
@@ -156,7 +155,7 @@ namespace Tetragrama::Components
 
     void AssetImporterUIComponent::OnImportFileComplete(void* ctx, ZEngine::Core::Containers::ArrayView<ZEngine::Importers::AssetImporterOutput> outputs)
     {
-        auto*                  self      = static_cast<AssetImporterUIComponent*>(ctx);
+        auto*                  self      = reinterpret_cast<AssetImporterUIComponent*>(ctx);
 
         static constexpr float kGreen[]  = {0.3f, 1.0f, 0.4f, 1.0f};
         static constexpr float kRed[]    = {1.0f, 0.3f, 0.3f, 1.0f};
@@ -178,7 +177,7 @@ namespace Tetragrama::Components
             auto* ctx_engine = ZEngine::Engine::GetContext();
             if (ctx_engine && ctx_engine->VFS && mesh_path)
             {
-                auto*   vfs    = static_cast<ZEngine::Core::VFS::IVFSContext*>(ctx_engine->VFS);
+                auto*   vfs    = reinterpret_cast<ZEngine::Core::VFS::IVFSContext*>(ctx_engine->VFS);
                 auto*   app    = reinterpret_cast<Tetragrama::EditorPtr>(self->ParentLayer->CurrentApp);
                 cstring ws     = app ? app->WorkingSpacePath : "";
                 size_t  ws_len = secure_strlen(ws);
@@ -241,7 +240,7 @@ namespace Tetragrama::Components
 
     void AssetImporterUIComponent::OnImportProgress(void* ctx, float pct)
     {
-        auto*                  self     = static_cast<AssetImporterUIComponent*>(ctx);
+        auto*                  self     = reinterpret_cast<AssetImporterUIComponent*>(ctx);
         static constexpr float kWhite[] = {0.8f, 0.8f, 0.8f, 1.0f};
         char                   msg[128];
         snprintf(msg, sizeof(msg), "Processing… %.0f%%", pct * 100.0f);
@@ -251,7 +250,7 @@ namespace Tetragrama::Components
 
     void AssetImporterUIComponent::OnImportError(void* ctx, std::string_view err)
     {
-        auto*                  self   = static_cast<AssetImporterUIComponent*>(ctx);
+        auto*                  self   = reinterpret_cast<AssetImporterUIComponent*>(ctx);
         static constexpr float kRed[] = {1.0f, 0.3f, 0.3f, 1.0f};
         char                   msg[512];
         snprintf(msg, sizeof(msg), "Error: %.*s", static_cast<int>(err.size()), err.data());
@@ -264,7 +263,7 @@ namespace Tetragrama::Components
 
     void AssetImporterUIComponent::OnImportLog(void* ctx, std::string_view msg)
     {
-        auto*                  self     = static_cast<AssetImporterUIComponent*>(ctx);
+        auto*                  self     = reinterpret_cast<AssetImporterUIComponent*>(ctx);
         static constexpr float kWhite[] = {0.8f, 0.8f, 0.8f, 1.0f};
         char                   buf[256];
         snprintf(buf, sizeof(buf), "%.*s", static_cast<int>(msg.size()), msg.data());

--- a/Tetragrama/Components/AssetImporterUIComponent.cpp
+++ b/Tetragrama/Components/AssetImporterUIComponent.cpp
@@ -39,8 +39,6 @@ namespace Tetragrama::Components
 
     void AssetImporterUIComponent::Update(ZEngine::Core::TimeStep /*dt*/) {}
 
-    // ─── Utilities ───────────────────────────────────────────────────────────
-
     void AssetImporterUIComponent::PushLog(cstring text, const float color[4])
     {
         std::lock_guard<std::mutex> lock(m_log_mutex);
@@ -99,8 +97,6 @@ namespace Tetragrama::Components
         });
     }
 
-    // ─── Import ──────────────────────────────────────────────────────────────
-
     void AssetImporterUIComponent::StartImport()
     {
         if (!m_gltf_importer || !m_assimp_importer)
@@ -156,8 +152,6 @@ namespace Tetragrama::Components
             ZEngine::Helpers::ThreadPoolHelper::Submit([this, src = src_path, cfg_copy, arena = &LocalArena, app]() mutable { m_assimp_importer->ImportFile(src.c_str(), cfg_copy, arena, this, OnImportFileComplete, OnImportProgress, OnImportError, OnImportLog); });
         }
     }
-
-    // ─── Callbacks (background thread) ───────────────────────────────────────
 
     void AssetImporterUIComponent::OnImportFileComplete(void* ctx, ZEngine::Core::Containers::ArrayView<ZEngine::Importers::AssetImporterOutput> outputs)
     {
@@ -275,8 +269,6 @@ namespace Tetragrama::Components
         snprintf(buf, sizeof(buf), "%.*s", static_cast<int>(msg.size()), msg.data());
         self->PushLog(buf, kWhite);
     }
-
-    // ─── Sub-renders ─────────────────────────────────────────────────────────
 
     void AssetImporterUIComponent::RenderIdle()
     {
@@ -407,8 +399,6 @@ namespace Tetragrama::Components
         }
         ImGui::EndChild();
     }
-
-    // ─── Main render ─────────────────────────────────────────────────────────
 
     void AssetImporterUIComponent::Render(ZEngine::Rendering::Renderers::GraphicRenderer* const, ZEngine::Hardwares::CommandBuffer* const)
     {

--- a/Tetragrama/Components/AssetImporterUIComponent.h
+++ b/Tetragrama/Components/AssetImporterUIComponent.h
@@ -86,7 +86,6 @@ namespace Tetragrama::Components
         void                                RenderOptions();
         void                                RenderImporting();
 
-        // Callback for ImportFile — receives cooked output paths
         static void                         OnImportFileComplete(void* ctx, ZEngine::Core::Containers::ArrayView<ZEngine::Importers::AssetImporterOutput> outputs);
         static void                         OnImportProgress(void* ctx, float pct);
         static void                         OnImportError(void* ctx, std::string_view msg);

--- a/Tetragrama/Components/AssetImporterUIComponent.h
+++ b/Tetragrama/Components/AssetImporterUIComponent.h
@@ -35,15 +35,17 @@ namespace Tetragrama::Components
         PaddedAtomic<bool>          m_pending_scan{}; // drained on main thread after background import
 
         // Selected file
-        char                        m_path_buf[1024]   = {};
+        char                        m_path_buf[1024]     = {};
+        bool                        m_add_to_scene       = false; // import was triggered by viewport drag-drop
+        char                        m_instance_name[256] = {};
 
         // Import settings (shown in Options state)
-        float                       m_scale            = 1.0f;
-        int                         m_axis_index       = 0; // 0 = Y-Up, 1 = Z-Up
-        bool                        m_gen_normals      = true;
-        bool                        m_merge_vertices   = true;
-        bool                        m_import_materials = true;
-        bool                        m_import_textures  = true;
+        float                       m_scale              = 1.0f;
+        int                         m_axis_index         = 0; // 0 = Y-Up, 1 = Z-Up
+        bool                        m_gen_normals        = true;
+        bool                        m_merge_vertices     = true;
+        bool                        m_import_materials   = true;
+        bool                        m_import_textures    = true;
 
         // Compact import log (Importing state — ring buffer)
         struct LogEntry

--- a/Tetragrama/Components/AssetImporterUIComponent.h
+++ b/Tetragrama/Components/AssetImporterUIComponent.h
@@ -20,10 +20,12 @@ namespace Tetragrama::Components
     class AssetImporterUIComponent : public UIComponent
     {
     public:
-        AssetImporterUIComponent()                       = default;
-        ~AssetImporterUIComponent() override             = default;
+        AssetImporterUIComponent()                                = default;
+        ~AssetImporterUIComponent() override                      = default;
 
-        ZEngine::Core::Memory::ArenaAllocator LocalArena = {};
+        ZEngine::Core::Memory::ArenaAllocator LocalArena          = {};
+        ZEngine::Core::Memory::ArenaAllocator GltfImporterArena   = {}; // 64 MB scratch for GltfImporter
+        ZEngine::Core::Memory::ArenaAllocator AssimpImporterArena = {}; // 350 MB scratch for AssimpImporter
 
         void                                  Initialize(Layers::ImguiLayer* parent = nullptr, cstring name = "Asset Importer", bool visibility = true, bool closed = false) override;
         void                                  Update(ZEngine::Core::TimeStep dt) override;

--- a/Tetragrama/Components/AssetImporterUIComponent.h
+++ b/Tetragrama/Components/AssetImporterUIComponent.h
@@ -1,0 +1,91 @@
+#pragma once
+#include <Tetragrama/Components/UIComponent.h>
+#include <ZEngine/Core/Containers/Array.h>
+#include <ZEngine/Core/Memory/Allocator.h>
+#include <ZEngine/Importers/AssetTypes.h>
+#include <ZEngine/Importers/AssimpImporter.h>
+#include <ZEngine/Importers/GltfImporter.h>
+#include <ZEngine/ZEngineDef.h>
+#include <mutex>
+
+namespace Tetragrama::Components
+{
+    enum class ImporterState : uint8_t
+    {
+        Idle      = 0,
+        Options   = 1,
+        Importing = 2,
+    };
+
+    class AssetImporterUIComponent : public UIComponent
+    {
+    public:
+        AssetImporterUIComponent()                       = default;
+        ~AssetImporterUIComponent() override             = default;
+
+        ZEngine::Core::Memory::ArenaAllocator LocalArena = {};
+
+        void                                  Initialize(Layers::ImguiLayer* parent = nullptr, cstring name = "Asset Importer", bool visibility = true, bool closed = false) override;
+        void                                  Update(ZEngine::Core::TimeStep dt) override;
+        virtual void                          Render(ZEngine::Rendering::Renderers::GraphicRenderer* const renderer, ZEngine::Hardwares::CommandBuffer* const command_buffer) override;
+
+    private:
+        PaddedAtomic<ImporterState> m_state{}; // default = Idle (0)
+        PaddedAtomic<float>         m_progress{};
+        PaddedAtomic<bool>          m_pending_scan{}; // drained on main thread after background import
+
+        // Selected file
+        char                        m_path_buf[1024]   = {};
+
+        // Import settings (shown in Options state)
+        float                       m_scale            = 1.0f;
+        int                         m_axis_index       = 0; // 0 = Y-Up, 1 = Z-Up
+        bool                        m_gen_normals      = true;
+        bool                        m_merge_vertices   = true;
+        bool                        m_import_materials = true;
+        bool                        m_import_textures  = true;
+
+        // Compact import log (Importing state — ring buffer)
+        struct LogEntry
+        {
+            char  Text[256] = {};
+            float Color[4]  = {0.8f, 0.8f, 0.8f, 1.0f};
+        };
+        static constexpr int kLogMax        = 64;
+        LogEntry             m_log[kLogMax] = {};
+        int                  m_log_head     = 0;
+        int                  m_log_count    = 0;
+        std::mutex           m_log_mutex;
+        bool                 m_scroll_log = false;
+
+        // Recent imports history (Idle state)
+        struct HistoryEntry
+        {
+            char Name[256]    = {};
+            char Message[256] = {};
+            bool Success      = false;
+        };
+        static constexpr int                kHistMax            = 16;
+        HistoryEntry                        m_history[kHistMax] = {};
+        int                                 m_history_count     = 0;
+
+        // Importers — allocated from parent arena in Initialize()
+        ZEngine::Importers::GltfImporter*   m_gltf_importer     = nullptr;
+        ZEngine::Importers::AssimpImporter* m_assimp_importer   = nullptr;
+
+        void                                PushLog(cstring text, const float color[4]);
+        void                                PushHistory(cstring name, bool success, cstring msg);
+        void                                TriggerScan(); // main-thread only
+        void                                StartImport();
+        void                                BrowseFile();
+        void                                RenderIdle();
+        void                                RenderOptions();
+        void                                RenderImporting();
+
+        // Callback for ImportFile — receives cooked output paths
+        static void                         OnImportFileComplete(void* ctx, ZEngine::Core::Containers::ArrayView<ZEngine::Importers::AssetImporterOutput> outputs);
+        static void                         OnImportProgress(void* ctx, float pct);
+        static void                         OnImportError(void* ctx, std::string_view msg);
+        static void                         OnImportLog(void* ctx, std::string_view msg);
+    };
+} // namespace Tetragrama::Components

--- a/Tetragrama/Components/DockspaceUIComponent.cpp
+++ b/Tetragrama/Components/DockspaceUIComponent.cpp
@@ -14,6 +14,7 @@
 #include <filesystem>
 
 namespace fs = std::filesystem;
+using ZEngine::Core::VFS::VFSPath;
 
 using namespace ZEngine::Helpers;
 
@@ -303,13 +304,15 @@ namespace Tetragrama::Components
 
         m_editor_serializer->Initialize(parent->Arena);
 
-        m_dockspace_node_flag                 = ImGuiDockNodeFlags_NoWindowMenuButton | static_cast<decltype(ImGuiDockNodeFlags_NoWindowMenuButton)>(ImGuiDockNodeFlags_PassthruCentralNode);
-        m_window_flags                        = ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavFocus;
+        m_dockspace_node_flag                                  = ImGuiDockNodeFlags_NoWindowMenuButton | static_cast<decltype(ImGuiDockNodeFlags_NoWindowMenuButton)>(ImGuiDockNodeFlags_PassthruCentralNode);
+        m_window_flags                                         = ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavFocus;
 
-        auto app                              = reinterpret_cast<EditorPtr>(ParentLayer->CurrentApp);
-        m_editor_serializer->Context          = app;
+        auto app                                               = reinterpret_cast<EditorPtr>(ParentLayer->CurrentApp);
+        m_editor_serializer->Context                           = app;
 
-        auto editor_serializer_default_output = fmt::format("{0}{1}{2}", app->Configuration->WorkingSpacePath.c_str(), PLATFORM_OS_BACKSLASH, app->Configuration->ScenePath.c_str());
+        char editor_serializer_output_buf[MAX_FILE_PATH_COUNT] = {};
+        VFSPath::Parse(app->Configuration->ScenePath.c_str()).Value().ResolveNative(app->Configuration->WorkingSpacePath.c_str(), editor_serializer_output_buf, sizeof(editor_serializer_output_buf));
+        std::string editor_serializer_default_output = editor_serializer_output_buf;
 
         m_editor_serializer->SetDefaultOutput(editor_serializer_default_output);
         m_editor_serializer->SetOnProgressCallback(OnEditorSceneSerializerProgress);

--- a/Tetragrama/Components/DockspaceUIComponent.cpp
+++ b/Tetragrama/Components/DockspaceUIComponent.cpp
@@ -4,6 +4,7 @@
 #include <Tetragrama/MessageToken.h>
 #include <Tetragrama/Messengers/Messenger.h>
 #include <ZEngine/Engine.h>
+#include <ZEngine/Importers/AssetCodec.h>
 #include <ZEngine/Importers/ImportJob.h>
 #include <ZEngine/Logging/LoggerDefinition.h>
 #include <ZEngine/Profiling/MemoryProfiler.h>
@@ -18,17 +19,14 @@ using namespace ZEngine::Helpers;
 
 namespace Tetragrama::Components
 {
-    ImVec4                   DockspaceUIComponent::s_asset_importer_report_msg_color   = {1, 1, 1, 1};
-    char                     DockspaceUIComponent::s_asset_importer_input_buffer[1024] = {0};
-    char                     DockspaceUIComponent::s_save_as_input_buffer[1024]        = {0};
-    std::string              DockspaceUIComponent::s_asset_importer_report_msg         = "";
-    float                    DockspaceUIComponent::s_editor_scene_serializer_progress  = 0.0f;
+    char                     DockspaceUIComponent::s_save_as_input_buffer[1024]       = {0};
+    float                    DockspaceUIComponent::s_editor_scene_serializer_progress = 0.0f;
 
-    static bool              s_is_scene_loading                                        = false;
-    static char              s_scene_serializer_log[DEFAULT_STR_BUFFER]                = {0};
-    static ImVec4            s_scene_serializer_log_color                              = {1, 1, 1, 1};
+    static bool              s_is_scene_loading                                       = false;
+    static char              s_scene_serializer_log[DEFAULT_STR_BUFFER]               = {0};
+    static ImVec4            s_scene_serializer_log_color                             = {1, 1, 1, 1};
 
-    static constexpr cstring kLayoutsDir                                               = "ZodiacEngine/Settings/Layouts";
+    static constexpr cstring kLayoutsDir                                              = "ZodiacEngine/Settings/Layouts";
 
     // Serialize the live dock tree as a pre-order sequence of SPLIT/LEAF lines.
     // Format: SPLIT <X|Y> <ratio>  or  LEAF <window_name> [window_name ...]
@@ -112,6 +110,7 @@ namespace Tetragrama::Components
         ImGui::DockBuilderDockWindow("Scene", main);
         ImGui::DockBuilderDockWindow("Project", down_right);
         ImGui::DockBuilderDockWindow("Console", down);
+        ImGui::DockBuilderDockWindow("Asset Importer", down);
         return down;
     }
 
@@ -300,11 +299,9 @@ namespace Tetragrama::Components
 
         parent->LocalArena.CreateSubArena(ZMega(1), &LocalArena);
 
-        m_asset_importer    = ZPushStructCtor(parent->Arena, ZEngine::Importers::AssimpImporter);
         m_editor_serializer = ZPushStructCtor(parent->Arena, Serializers::EditorSceneSerializer);
 
         m_editor_serializer->Initialize(parent->Arena);
-        m_asset_importer->Initialize(parent->Arena);
 
         m_dockspace_node_flag                 = ImGuiDockNodeFlags_NoWindowMenuButton | static_cast<decltype(ImGuiDockNodeFlags_NoWindowMenuButton)>(ImGuiDockNodeFlags_PassthruCentralNode);
         m_window_flags                        = ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNavFocus;
@@ -404,98 +401,12 @@ namespace Tetragrama::Components
         RenderSaveLayoutModal();
         RenderManageLayoutsModal();
 
-        RenderImporter();
         RenderEngineSettingsWindow();
         RenderMemoryProfilerWindow();
 
         RenderExitPopup();
 
         ImGui::End();
-    }
-
-    void DockspaceUIComponent::RenderImporter()
-    {
-        if (!m_open_asset_importer)
-        {
-            std::string_view buffer_view = s_asset_importer_input_buffer;
-            if (!buffer_view.empty())
-            {
-                ResetImporterBuffers();
-            }
-            return;
-        }
-
-        const char* str_id = "Model Importer";
-        ImGui::OpenPopup(str_id);
-        ImVec2 center = ImGui::GetMainViewport()->GetCenter();
-        ImGui::SetNextWindowPos(center, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
-        ImGui::SetNextWindowSize(ImVec2(700, 100), ImGuiCond_Always);
-
-        bool is_import_button_enabled = true;
-
-        if (ImGui::BeginPopupModal(str_id, NULL, ImGuiWindowFlags_AlwaysAutoResize))
-        {
-            ImGui::PushItemWidth(620);
-            ImGui::InputText("##ModelImporterUI", s_asset_importer_input_buffer, IM_ARRAYSIZE(s_asset_importer_input_buffer), ImGuiInputTextFlags_ReadOnly);
-            ImGui::PopItemWidth();
-
-            ImGui::SameLine();
-
-            if (ImGui::Button("...", ImVec2(50, 0)) && is_import_button_enabled)
-            {
-                Helpers::UIDispatcher::RunAsync([this]() -> std::future<void> {
-                    if (ParentLayer && ParentLayer->CurrentApp)
-                    {
-                        auto                          window = ParentLayer->CurrentApp->CurrentWindow;
-                        std::vector<std::string_view> filters{".obj", ".gltf"};
-                        std::string                   filename = co_await window->OpenFileDialogAsync(filters);
-
-                        if (!filename.empty())
-                        {
-                            ZEngine::Helpers::secure_memset(s_asset_importer_input_buffer, 0, IM_ARRAYSIZE(s_asset_importer_input_buffer), IM_ARRAYSIZE(s_asset_importer_input_buffer));
-                            ZEngine::Helpers::secure_memcpy(s_asset_importer_input_buffer, IM_ARRAYSIZE(s_asset_importer_input_buffer), filename.c_str(), filename.size());
-                        }
-                    }
-                });
-            }
-
-            ImGui::Separator();
-
-            ImGui::SetCursorPosX(ImGui::GetWindowSize().x - 180);
-            ImGui::SetCursorPosY(ImGui::GetWindowSize().y - ImGui::GetFrameHeightWithSpacing() - 5);
-
-            if (!is_import_button_enabled || std::string_view(s_asset_importer_input_buffer).empty())
-            {
-                ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.5f, 0.5f, 0.5f, 1.0f)); // Grayed out color
-                ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
-                ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
-            }
-
-            if (ImGui::Button("Launch", ImVec2(80, 0)) && is_import_button_enabled)
-            {
-                OnImportAssetAsync(s_asset_importer_input_buffer);
-            }
-
-            if (!is_import_button_enabled || std::string_view(s_asset_importer_input_buffer).empty())
-            {
-                ImGui::PopStyleColor(3); // Pop the grayed out color
-            }
-
-            ImGui::SameLine();
-            if (ImGui::Button("Close", ImVec2(80, 0)))
-            {
-                m_open_asset_importer = false;
-                ResetImporterBuffers();
-                ImGui::CloseCurrentPopup();
-            }
-
-            ImGui::PushFont(ImGui::GetIO().Fonts->Fonts[0]);
-            ImGui::SetCursorPos(ImVec2(10, ImGui::GetWindowSize().y - 30));
-            ImGui::TextColored(s_asset_importer_report_msg_color, "%s", s_asset_importer_report_msg.c_str());
-            ImGui::PopFont();
-
-            ImGui::EndPopup();
-        }
     }
 
     void DockspaceUIComponent::RenderLoadScene()
@@ -694,13 +605,6 @@ namespace Tetragrama::Components
             }
             ImGui::EndPopup();
         }
-    }
-
-    void DockspaceUIComponent::ResetImporterBuffers()
-    {
-        s_asset_importer_report_msg       = "";
-        s_asset_importer_report_msg_color = {1.0f, 1.0f, 1.0f, 1.0f};
-        ZEngine::Helpers::secure_memset(s_asset_importer_input_buffer, 0, IM_ARRAYSIZE(s_asset_importer_input_buffer), IM_ARRAYSIZE(s_asset_importer_input_buffer));
     }
 
     void DockspaceUIComponent::DrawSettingsIcon(ImDrawList* dl, ImVec2 pos, SettingsPageId id, bool selected)
@@ -1129,32 +1033,6 @@ namespace Tetragrama::Components
         ZEngine::Helpers::secure_memset(s_save_as_input_buffer, 0, IM_ARRAYSIZE(s_save_as_input_buffer), IM_ARRAYSIZE(s_save_as_input_buffer));
     }
 
-    void DockspaceUIComponent::OnAssetImporterComplete(void* const context, ZEngine::Core::Containers::ArrayView<ZEngine::Importers::AssetImporterOutput> result)
-    {
-        auto app           = reinterpret_cast<EditorPtr>(context);
-        auto current_scene = reinterpret_cast<EditorScenePtr>(app->CurrentScene);
-
-        for (unsigned i = 0; i < result.size(); ++i)
-        {
-            current_scene->PushAssetFile(result[i]);
-        }
-
-        s_asset_importer_report_msg_color = {0.0f, 1.0f, 0.0f, 1.0f};
-        s_asset_importer_report_msg       = "Completed";
-    }
-
-    void DockspaceUIComponent::OnAssetImporterProgress(void* const context, float value)
-    {
-        s_asset_importer_report_msg_color = {1.0f, 1.0f, 1.0f, 1.0f};
-        s_asset_importer_report_msg       = fmt::format("Reading file: {:.1f} %%", (value * 100.f));
-    }
-
-    void DockspaceUIComponent::OnAssetImporterError(void* const, std::string_view msg)
-    {
-        s_asset_importer_report_msg_color = {1.0f, 0.0f, 0.0f, 1.0f};
-        s_asset_importer_report_msg       = msg;
-    }
-
     void DockspaceUIComponent::OnEditorSceneSerializerError(void* const, std::string_view msg)
     {
         ZENGINE_CORE_ERROR("{}", msg)
@@ -1163,12 +1041,6 @@ namespace Tetragrama::Components
     void DockspaceUIComponent::OnEditorSceneSerializerLog(void* const, std::string_view msg)
     {
         ZEngine::Helpers::secure_strcpy(s_scene_serializer_log, DEFAULT_STR_BUFFER, msg.data());
-    }
-
-    void DockspaceUIComponent::OnAssetImporterLog(void* const, std::string_view msg)
-    {
-        s_asset_importer_report_msg_color = {1.0f, 1.0f, 1.0f, 1.0f};
-        s_asset_importer_report_msg       = msg;
     }
 
     void DockspaceUIComponent::RenderMenuBar()
@@ -1187,7 +1059,12 @@ namespace Tetragrama::Components
                     Helpers::UIDispatcher::RunAsync([this] { OnOpenSceneAsync(); });
                 }
 
-                ImGui::MenuItem("Import New Asset...", NULL, &m_open_asset_importer);
+                if (ImGui::MenuItem("Import New Asset..."))
+                {
+                    auto app_ptr                          = reinterpret_cast<EditorPtr>(ParentLayer->CurrentApp);
+                    app_ptr->Configuration->ShowImporter  = true;
+                    app_ptr->Configuration->FocusImporter = true;
+                }
                 ImGui::Separator();
 
                 if (ImGui::MenuItem("Save"))
@@ -1331,35 +1208,6 @@ namespace Tetragrama::Components
                 current_scene->AddMeshInstance(asset_mesh->MeshUUID, name);
             }
         }
-        co_return;
-    }
-
-    std::future<void> DockspaceUIComponent::OnImportAssetAsync(const char* filename)
-    {
-        if (ZEngine::Helpers::secure_strlen(filename) == 0)
-        {
-            co_return;
-        }
-
-        LocalArena.Clear();
-
-        auto        app               = reinterpret_cast<EditorPtr>(ParentLayer->CurrentApp);
-        auto        arena             = &LocalArena;
-        const auto& editor_config     = *(app->Configuration);
-        auto        parent_path       = std::filesystem::path(filename).parent_path().string();
-        auto        asset_name        = fs::path(filename).filename().replace_extension().string();
-        auto        output_asset_file = fmt::format("{}.zemesh", asset_name.c_str());
-
-        auto        config            = ZPushStruct(arena, ZEngine::Importers::AssetCodec::ImportConfiguration);
-        config->OutputWorkingSpacePath.init(arena, editor_config.WorkingSpacePath.c_str());
-        config->OutputTextureFilesPath.init(arena, editor_config.TexturePath.c_str());
-        config->OutputAssetsPath.init(arena, editor_config.SceneDataPath.c_str());
-        config->AssetName.init(arena, asset_name.c_str());
-        config->OutputAssetFile.init(arena, output_asset_file.c_str());
-        config->InputBaseAssetFilePath.init(arena, parent_path.c_str());
-
-        ZEngine::Helpers::ThreadPoolHelper::Submit([this, fn = std::string(filename), cfg = *config, app, arena]() mutable { m_asset_importer->ImportFile(fn.c_str(), cfg, arena, app, OnAssetImporterComplete, OnAssetImporterProgress, OnAssetImporterError, nullptr); });
-
         co_return;
     }
 

--- a/Tetragrama/Components/DockspaceUIComponent.h
+++ b/Tetragrama/Components/DockspaceUIComponent.h
@@ -2,8 +2,6 @@
 #include <Tetragrama/Components/UIComponent.h>
 #include <Tetragrama/Messengers/Message.h>
 #include <Tetragrama/Serializers/EditorSceneSerializer.h>
-#include <ZEngine/Importers/AssetCodec.h>
-#include <ZEngine/Importers/AssimpImporter.h>
 #include <imgui.h>
 
 namespace Tetragrama::Components
@@ -44,16 +42,6 @@ namespace Tetragrama::Components
         void                                  RenderMenuBar();
         void                                  ResetSaveAsBuffers();
         void                                  RenderExitPopup();
-
-        /*
-         * Model Importer Funcs
-         */
-        void                                  RenderImporter();
-        void                                  ResetImporterBuffers();
-        static void                           OnAssetImporterComplete(void* const context, ZEngine::Core::Containers::ArrayView<ZEngine::Importers::AssetImporterOutput> result);
-        static void                           OnAssetImporterProgress(void* const, float value);
-        static void                           OnAssetImporterError(void* const, std::string_view);
-        static void                           OnAssetImporterLog(void* const, std::string_view);
 
         /*
          * Performances Menu Windows
@@ -97,18 +85,13 @@ namespace Tetragrama::Components
         std::future<void>                     OnOpenSceneAsync();
         std::future<void>                     OnOpenSceneRequestAsync(const char* filename);
         std::future<void>                     OnOpenMeshRequestAsync(const char* filename);
-        std::future<void>                     OnImportAssetAsync(const char* filename);
         std::future<void>                     OnExitAsync();
 
     private:
-        static ImVec4      s_asset_importer_report_msg_color;
-        static std::string s_asset_importer_report_msg;
-        static char        s_asset_importer_input_buffer[1024];
-        static char        s_save_as_input_buffer[1024];
-        static float       s_editor_scene_serializer_progress;
+        static char  s_save_as_input_buffer[1024];
+        static float s_editor_scene_serializer_progress;
 
     private:
-        bool                 m_open_asset_importer{false};
         bool                 m_open_engine_settings{false};
         bool                 m_open_memory_profiler{false};
 
@@ -120,19 +103,17 @@ namespace Tetragrama::Components
             int      head                     = 0;
             uint32_t count                    = 0;
         };
-        ArenaHistory                                        m_arena_history[kMaxArenas] = {};
-        uint32_t                                            m_arena_history_count       = 0;
-        bool                                                m_open_exit{false};
-        ThemeId                                             m_active_theme{ThemeId::Light};
-        bool                                                m_pending_shutdown{false};
-        bool                                                m_open_save_scene{false};
-        bool                                                m_open_save_scene_as{false};
-        bool                                                m_request_save_scene_ui_close{false};
-        SettingsPageId                                      m_active_settings_page{SettingsPageId::Theme};
-        ImGuiDockNodeFlags                                  m_dockspace_node_flag;
-        ImGuiWindowFlags                                    m_window_flags;
-        ZEngine::Importers::AssetCodec::ImportConfiguration m_default_import_configuration;
-        ZRawPtr(ZEngine::Importers::AssimpImporter) m_asset_importer;
+        ArenaHistory       m_arena_history[kMaxArenas] = {};
+        uint32_t           m_arena_history_count       = 0;
+        bool               m_open_exit{false};
+        ThemeId            m_active_theme{ThemeId::Light};
+        bool               m_pending_shutdown{false};
+        bool               m_open_save_scene{false};
+        bool               m_open_save_scene_as{false};
+        bool               m_request_save_scene_ui_close{false};
+        SettingsPageId     m_active_settings_page{SettingsPageId::Theme};
+        ImGuiDockNodeFlags m_dockspace_node_flag;
+        ImGuiWindowFlags   m_window_flags;
         ZRawPtr(Serializers::EditorSceneSerializer) m_editor_serializer;
 
         struct BuiltinLayoutDef

--- a/Tetragrama/Components/DockspaceUIComponent.h
+++ b/Tetragrama/Components/DockspaceUIComponent.h
@@ -106,7 +106,7 @@ namespace Tetragrama::Components
         ArenaHistory       m_arena_history[kMaxArenas] = {};
         uint32_t           m_arena_history_count       = 0;
         bool               m_open_exit{false};
-        ThemeId            m_active_theme{ThemeId::Light};
+        ThemeId            m_active_theme{ThemeId::Dark};
         bool               m_pending_shutdown{false};
         bool               m_open_save_scene{false};
         bool               m_open_save_scene_as{false};

--- a/Tetragrama/Components/SceneViewportUIComponent.cpp
+++ b/Tetragrama/Components/SceneViewportUIComponent.cpp
@@ -148,55 +148,23 @@ namespace Tetragrama::Components
                     }
                     else if (file_ext == ".glb" || file_ext == ".gltf" || file_ext == ".fbx" || file_ext == ".obj")
                     {
-                        ZENGINE_CORE_INFO("SceneViewport: dropped native='{}'", buf)
-                        auto* ctx = ZEngine::Engine::GetContext();
-                        if (!ctx || !ctx->ImportCoordinator || !ctx->VFS)
+                        // Route through AssetImporterUIComponent so the import produces
+                        // cooked artifacts (.zemesh / .zetextures / .zematerial) on disk.
+                        // The importer will call AddMeshInstance after cooking completes.
+                        auto* app = reinterpret_cast<Tetragrama::EditorPtr>(ParentLayer->CurrentApp);
+                        if (app && app->Configuration)
                         {
-                            ZENGINE_CORE_ERROR("SceneViewport: missing engine context, coordinator, or VFS")
-                        }
-                        else
-                        {
-                            // buf is a native absolute path. Strip WorkingSpacePath prefix to get
-                            // the VFS-relative path that the VFS backend is mounted on.
-                            auto                        app = reinterpret_cast<Tetragrama::EditorPtr>(ParentLayer->CurrentApp);
-                            const char*                 ws  = app ? app->WorkingSpacePath : "";
+                            ZEngine::Helpers::secure_strncpy(app->Configuration->PendingImportPath, sizeof(app->Configuration->PendingImportPath), buf, sizeof(app->Configuration->PendingImportPath) - 1);
 
-                            ZEngine::Core::VFS::VFSPath vfs_path;
-                            size_t                      ws_len = ZEngine::Helpers::secure_strlen(ws);
-                            if (ws_len > 0 && std::strncmp(buf, ws, ws_len) == 0)
-                            {
-                                auto relative = ZEngine::Core::VFS::VFSPath::Parse(buf + ws_len);
-                                if (relative.Succeeded())
-                                {
-                                    vfs_path = relative.Value();
-                                    ZENGINE_CORE_INFO("SceneViewport: VFS path='{}'", vfs_path.CStr())
+                            const char* p    = buf;
+                            const char* name = strrchr(p, '/');
+                            name             = name ? name + 1 : p;
+                            ZEngine::Helpers::secure_strncpy(app->Configuration->PendingImportName, sizeof(app->Configuration->PendingImportName), name, sizeof(app->Configuration->PendingImportName) - 1);
 
-                                    // Enqueue returns the asset UUID from the meta file — valid
-                                    // regardless of whether the import runs now (first drop) or
-                                    // was already cached (re-drop). Create the scene instance
-                                    // immediately; the render system shows it once the mesh uploads.
-                                    auto uuid = ctx->ImportCoordinator->Enqueue(vfs_path, ZEngine::Importers::ImportPriority::Immediate);
-                                    if (uuid != uuids::uuid{})
-                                    {
-                                        auto* scene = reinterpret_cast<Tetragrama::EditorScenePtr>(app->CurrentScene);
-                                        if (scene)
-                                        {
-                                            const char* p    = vfs_path.CStr();
-                                            const char* name = strrchr(p, '/');
-                                            name             = name ? name + 1 : p;
-                                            scene->AddMeshInstance(uuid, name);
-                                        }
-                                    }
-                                }
-                                else
-                                {
-                                    ZENGINE_CORE_ERROR("SceneViewport: failed to parse VFS path from '{}'", buf + ws_len)
-                                }
-                            }
-                            else
-                            {
-                                ZENGINE_CORE_WARN("SceneViewport: native path '{}' is outside working space '{}'", buf, ws)
-                            }
+                            app->Configuration->ShowImporter  = true;
+                            app->Configuration->FocusImporter = true;
+
+                            ZENGINE_CORE_INFO("SceneViewport: queued '{}' for import via panel", buf)
                         }
                     }
                 }

--- a/Tetragrama/Components/StatusBarUIComponent.cpp
+++ b/Tetragrama/Components/StatusBarUIComponent.cpp
@@ -106,6 +106,36 @@ namespace Tetragrama::Components
             dl->AddRectFilled({ip.x, ip.y + th - 1.5f}, {ip.x + tw, ip.y + th + 1.5f}, ic);
         }
 
+        ImGui::SameLine(0.0f, 6.0f);
+
+        // Importer button — indigo import-arrow icon
+        {
+            static constexpr ImU32 kImporterOn  = IM_COL32(170, 130, 255, 255);
+            static constexpr ImU32 kImporterOff = IM_COL32(95, 70, 150, 180);
+            bool                   on           = app->Configuration->ShowImporter;
+            ImGui::PushStyleColor(ImGuiCol_Button, on ? btn_on : btn_off);
+            ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, 3.0f);
+            if (ImGui::SmallButton("     Importer "))
+            {
+                app->Configuration->ShowImporter  = !on;
+                app->Configuration->FocusImporter = !on;
+            }
+            ImGui::PopStyleVar();
+            ImGui::PopStyleColor();
+            ImVec2      bmin = ImGui::GetItemRectMin();
+            ImVec2      bmax = ImGui::GetItemRectMax();
+            float       cy   = (bmin.y + bmax.y) * 0.5f;
+            const float isz2 = 10.0f;
+            ImVec2      ip2  = {bmin.x + 4.0f, cy - isz2 * 0.5f};
+            ImDrawList* dl2  = ImGui::GetWindowDrawList();
+            ImU32       ic2  = on ? kImporterOn : kImporterOff;
+            // Import arrow icon: box at bottom + down-arrow above
+            dl2->AddRect({ip2.x, ip2.y + isz2 * 0.45f}, {ip2.x + isz2, ip2.y + isz2}, ic2, 1.0f, 0, 1.0f);
+            float ax = ip2.x + isz2 * 0.5f, ay = ip2.y + isz2 * 0.4f;
+            dl2->AddLine({ax, ip2.y}, {ax, ay}, ic2, 1.5f);
+            dl2->AddTriangleFilled({ax, ay + isz2 * 0.18f}, {ax - isz2 * 0.22f, ay}, {ax + isz2 * 0.22f, ay}, ic2);
+        }
+
         ImGui::SameLine(0.0f, 10.0f);
         ImGui::TextDisabled("|");
         ImGui::SameLine(0.0f, 10.0f);

--- a/Tetragrama/Editor.cpp
+++ b/Tetragrama/Editor.cpp
@@ -120,7 +120,6 @@ namespace Tetragrama
         if (working_space_path == ".")
         {
             expand(config, "sceneDir");
-            expand(config, "sceneDataDir");
             // Expand all fields inside assetDirs (new format)
             if (config.contains("assetDirs"))
             {
@@ -140,7 +139,6 @@ namespace Tetragrama
         ProjectName.init(arena, config["projectName"].get<std::string>().c_str());
         WorkingSpacePath.init(arena, ws.c_str());
         ScenePath.init(arena, config["sceneDir"].get<std::string>().c_str());
-        SceneDataPath.init(arena, config["sceneDataDir"].get<std::string>().c_str());
 
         // Asset directories — new assetDirs format, fall back to defaultImportDir
         auto asset_path = [&](const char* asset_key, const char* legacy_section, const char* legacy_key, const char* default_suffix) -> std::string {

--- a/Tetragrama/Editor.h
+++ b/Tetragrama/Editor.h
@@ -18,7 +18,6 @@ namespace Tetragrama
     {
         ZEngine::Core::Containers::String WorkingSpacePath         = {};
         ZEngine::Core::Containers::String ScenePath                = {};
-        ZEngine::Core::Containers::String SceneDataPath            = {};
         // Asset import directories (all under Assets/)
         ZEngine::Core::Containers::String TexturePath              = {};
         ZEngine::Core::Containers::String SoundPath                = {};

--- a/Tetragrama/Editor.h
+++ b/Tetragrama/Editor.h
@@ -34,6 +34,8 @@ namespace Tetragrama
         bool                              FocusContentBrowser      = false;
         bool                              ShowConsole              = false;
         bool                              FocusConsole             = false;
+        bool                              ShowImporter             = false;
+        bool                              FocusImporter            = false;
 
         void                              ReadConfig(ZEngine::Core::Memory::ArenaAllocator* arena, const char* file);
     };

--- a/Tetragrama/Editor.h
+++ b/Tetragrama/Editor.h
@@ -36,6 +36,8 @@ namespace Tetragrama
         bool                              FocusConsole             = false;
         bool                              ShowImporter             = false;
         bool                              FocusImporter            = false;
+        char                              PendingImportPath[1024]  = {};
+        char                              PendingImportName[256]   = {};
 
         void                              ReadConfig(ZEngine::Core::Memory::ArenaAllocator* arena, const char* file);
     };

--- a/Tetragrama/Editor.h
+++ b/Tetragrama/Editor.h
@@ -27,7 +27,7 @@ namespace Tetragrama
         ZEngine::Core::Containers::String EnvironmentMapImportPath = {};
         ZEngine::Core::Containers::String ProjectName              = {};
         ZEngine::Core::Containers::String ActiveSceneName          = {};
-        bool                              DarkTheme                = false;
+        bool                              DarkTheme                = true;
         int                               GizmoOperation           = -1;
         bool                              ShowContentBrowser       = true;
         bool                              FocusContentBrowser      = false;

--- a/Tetragrama/EditorScene.cpp
+++ b/Tetragrama/EditorScene.cpp
@@ -89,7 +89,41 @@ namespace Tetragrama
             f.RootPath.init(&LocalArena, file.RootPath.c_str());
         }
 
-        // Re-ingest cooked mesh assets on scene load.
+        // Re-ingest cooked assets on scene load.
+        // Materials are processed before meshes so their texture handles are available
+        // when the mesh submeshes reference them.
+        for (const auto& file : AssetFiles)
+        {
+            if (file.Type == ZEngine::Importers::AssetFileType::MATERIAL)
+            {
+                ZEngine::Importers::AssetMaterial mat{};
+                auto                              path = ZEngine::Core::Containers::String{};
+                path.init(&LocalArena, fmt::format("{0}{1}{2}", file.RootPath.c_str(), PLATFORM_OS_BACKSLASH, file.Path.c_str()).c_str());
+                ZEngine::Importers::AssetCodec::DeserializeMaterialAssetFile(&LocalArena, path.c_str(), mat);
+
+                // Reconstruct AssetTexture entries from the inline path fields so
+                // IngestTextures can upload them to the GPU.
+                ZEngine::Core::Containers::Array<ZEngine::Importers::AssetTexture> textures{};
+                textures.init(&LocalArena, 5);
+                auto add_tex = [&](const uuids::uuid& uuid, const ZEngine::Core::Containers::String& tex_path) {
+                    if (!uuid.is_nil() && !tex_path.empty())
+                    {
+                        auto& t       = textures.push_use({});
+                        t.TextureUUID = uuid;
+                        t.Path.init(&LocalArena, tex_path.c_str());
+                    }
+                };
+                add_tex(mat.AlbedoTexUUID, mat.AlbedoTexPath);
+                add_tex(mat.EmissiveTexUUID, mat.EmissiveTexPath);
+                add_tex(mat.NormalTexUUID, mat.NormalTexPath);
+                add_tex(mat.OpacityTexUUID, mat.OpacityTexPath);
+                add_tex(mat.SpecularTexUUID, mat.SpecularTexPath);
+
+                AssetManager::IngestTextures(std::move(textures));
+                AssetManager::IngestMaterial(std::move(mat));
+            }
+        }
+
         for (const auto& file : AssetFiles)
         {
             if (file.Type == ZEngine::Importers::AssetFileType::MESH)

--- a/Tetragrama/EditorScene.cpp
+++ b/Tetragrama/EditorScene.cpp
@@ -1,9 +1,9 @@
 #include <Tetragrama/EditorScene.h>
 #include <ZEngine/Importers/AssetCodec.h>
 #include <ZEngine/Managers/AssetManager.h>
-
 using namespace ZEngine::Core::Containers;
 using namespace ZEngine::Managers;
+using ZEngine::Core::VFS::VFSPath;
 
 namespace Tetragrama
 {
@@ -97,8 +97,10 @@ namespace Tetragrama
             if (file.Type == ZEngine::Importers::AssetFileType::MATERIAL)
             {
                 ZEngine::Importers::AssetMaterial mat{};
-                auto                              path = ZEngine::Core::Containers::String{};
-                path.init(&LocalArena, fmt::format("{0}{1}{2}", file.RootPath.c_str(), PLATFORM_OS_BACKSLASH, file.Path.c_str()).c_str());
+                auto                              path                            = ZEngine::Core::Containers::String{};
+                char                              native_buf[MAX_FILE_PATH_COUNT] = {};
+                VFSPath::Parse(file.Path.c_str()).Value().ResolveNative(file.RootPath.c_str(), native_buf, sizeof(native_buf));
+                path.init(&LocalArena, native_buf);
                 ZEngine::Importers::AssetCodec::DeserializeMaterialAssetFile(&LocalArena, path.c_str(), mat);
 
                 // Reconstruct AssetTexture entries from the inline path fields so
@@ -130,8 +132,10 @@ namespace Tetragrama
             {
                 ZEngine::Importers::AssetMesh          mesh{};
                 ZEngine::Importers::AssetNodeHierarchy hier{};
-                auto                                   path = ZEngine::Core::Containers::String{};
-                path.init(&LocalArena, fmt::format("{0}{1}{2}", file.RootPath.c_str(), PLATFORM_OS_BACKSLASH, file.Path.c_str()).c_str());
+                auto                                   path                            = ZEngine::Core::Containers::String{};
+                char                                   native_buf[MAX_FILE_PATH_COUNT] = {};
+                VFSPath::Parse(file.Path.c_str()).Value().ResolveNative(file.RootPath.c_str(), native_buf, sizeof(native_buf));
+                path.init(&LocalArena, native_buf);
                 ZEngine::Importers::AssetCodec::DeserializeMeshAssetFile(&LocalArena, path.c_str(), mesh, hier);
                 AssetManager::IngestMesh(std::move(mesh), std::move(hier));
             }

--- a/Tetragrama/Layers/ImguiLayer.cpp
+++ b/Tetragrama/Layers/ImguiLayer.cpp
@@ -1,3 +1,4 @@
+#include <Tetragrama/Components/AssetImporterUIComponent.h>
 #include <Tetragrama/Components/DockspaceUIComponent.h>
 #include <Tetragrama/Components/HierarchyViewUIComponent.h>
 #include <Tetragrama/Components/InspectorViewUIComponent.h>
@@ -57,6 +58,7 @@ namespace Tetragrama::Layers
         auto inspector_view_cmp              = ZPushStructCtor(arena, Components::InspectorViewUIComponent);
         auto hierarchy_view_cmp              = ZPushStructCtor(arena, Components::HierarchyViewUIComponent);
         auto log_cmp                         = ZPushStructCtor(arena, Components::LogUIComponent);
+        auto importer_cmp                    = ZPushStructCtor(arena, Components::AssetImporterUIComponent);
         auto status_bar_cmp                  = ZPushStructCtor(arena, Components::StatusBarUIComponent);
 
         dockspace_cmp->Initialize(this);
@@ -65,14 +67,16 @@ namespace Tetragrama::Layers
         inspector_view_cmp->Initialize(this);
         hierarchy_view_cmp->Initialize(this);
         log_cmp->Initialize(this);
+        importer_cmp->Initialize(this);
         status_bar_cmp->Initialize(this);
 
-        dockspace_cmp->Children.init(arena, 6);
+        dockspace_cmp->Children.init(arena, 7);
         dockspace_cmp->Children.push(scene_cmp);
         dockspace_cmp->Children.push(project_view_cmp);
         dockspace_cmp->Children.push(inspector_view_cmp);
         dockspace_cmp->Children.push(hierarchy_view_cmp);
         dockspace_cmp->Children.push(log_cmp);
+        dockspace_cmp->Children.push(importer_cmp);
         dockspace_cmp->Children.push(status_bar_cmp);
 
         dockspace_cmp->ChildrenCount = dockspace_cmp->Children.size();

--- a/Tetragrama/Serializers/EditorSceneSerializer.cpp
+++ b/Tetragrama/Serializers/EditorSceneSerializer.cpp
@@ -80,7 +80,8 @@ namespace Tetragrama::Serializers
                     ZEngine::Importers::AssetCodec::ImportConfiguration cook_cfg    = {};
                     cook_cfg.OutputWorkingSpacePath.init(scratch.Arena, cfg.WorkingSpacePath.c_str());
                     cook_cfg.OutputTextureFilesPath.init(scratch.Arena, cfg.TexturePath.c_str());
-                    cook_cfg.OutputAssetsPath.init(scratch.Arena, cfg.SceneDataPath.c_str());
+                    cook_cfg.OutputAssetsPath.init(scratch.Arena, cfg.MeshPath.c_str());
+                    cook_cfg.OutputMaterialPath.init(scratch.Arena, cfg.MaterialPath.c_str());
                     cook_cfg.AssetName.init(scratch.Arena, asset_name.c_str());
                     cook_cfg.OutputAssetFile.init(scratch.Arena, output_file.c_str());
                     cook_cfg.InputBaseAssetFilePath.init(scratch.Arena, cfg.WorkingSpacePath.c_str());

--- a/Tetragrama/Serializers/EditorSceneSerializer.cpp
+++ b/Tetragrama/Serializers/EditorSceneSerializer.cpp
@@ -1,9 +1,13 @@
+#include <Tetragrama/Editor.h>
 #include <Tetragrama/Serializers/EditorSceneSerializer.h>
 #include <ZEngine/Core/Containers/Array.h>
 #include <ZEngine/Helpers/SerializerCommonHelper.h>
 #include <ZEngine/Helpers/ThreadPool.h>
+#include <ZEngine/Importers/AssetCodec.h>
 #include <ZEngine/Importers/IAssetImporter.h>
+#include <ZEngine/Managers/AssetManager.h>
 #include <fmt/format.h>
+#include <filesystem>
 #include <fstream>
 
 using namespace ZEngine::Helpers;
@@ -42,6 +46,56 @@ namespace Tetragrama::Serializers
             }
 
             out.seekp(std::ios::beg);
+
+            // Lazy cook: find mesh instances that are in RAM (from drag-drop)
+            // but have no cooked .zemesh artifact on disk. Cook them now so
+            // the saved scene can be reloaded on the next session.
+            {
+                auto                                                                       scratch = ZGetScratch(&Arena);
+                ZEngine::Core::Containers::Array<ZEngine::Rendering::Scenes::MeshInstance> instances;
+                scene->GetInstancesSnapshot(scratch.Arena, instances);
+
+                auto*       mgr = ZEngine::Managers::AssetManager::Instance();
+                auto*       app = reinterpret_cast<EditorPtr>(Context);
+                const auto& cfg = app ? *app->Configuration : EditorConfiguration{};
+
+                for (uint32_t i = 0; i < instances.size(); ++i)
+                {
+                    if (!mgr || !mgr->Registry)
+                        break;
+                    const uuids::uuid& uid = instances[i].MeshUUID;
+                    const auto*        rec = mgr->Registry->FindByUUID(uid);
+                    if (!rec || rec->Meta.ArtifactPath[0] != '\0')
+                        continue; // already cooked or not found
+
+                    // In-memory mesh with no .zemesh — cook it now
+                    auto* mesh      = mgr->GetMeshAsset(uid);
+                    auto* hierarchy = mgr->GetMeshNodeHierarchy(uid);
+                    if (!mesh || !hierarchy)
+                        continue;
+
+                    std::string                                         asset_name  = instances[i].Name[0] ? instances[i].Name : "UnknownMesh";
+                    std::string                                         output_file = asset_name + ".zemesh";
+
+                    ZEngine::Importers::AssetCodec::ImportConfiguration cook_cfg    = {};
+                    cook_cfg.OutputWorkingSpacePath.init(scratch.Arena, cfg.WorkingSpacePath.c_str());
+                    cook_cfg.OutputTextureFilesPath.init(scratch.Arena, cfg.TexturePath.c_str());
+                    cook_cfg.OutputAssetsPath.init(scratch.Arena, cfg.SceneDataPath.c_str());
+                    cook_cfg.AssetName.init(scratch.Arena, asset_name.c_str());
+                    cook_cfg.OutputAssetFile.init(scratch.Arena, output_file.c_str());
+                    cook_cfg.InputBaseAssetFilePath.init(scratch.Arena, cfg.WorkingSpacePath.c_str());
+
+                    auto output = ZEngine::Importers::AssetCodec::SerializeMeshAssetFile(scratch.Arena, *mesh, *hierarchy, cook_cfg);
+                    if (!output.Path.empty())
+                    {
+                        // Register the artifact path so future saves don't re-cook
+                        ZEngine::Helpers::secure_strncpy(const_cast<ZEngine::Core::VFS::AssetRecord*>(rec)->Meta.ArtifactPath, MAX_FILE_PATH_COUNT, output.Path.c_str(), output.Path.size());
+
+                        scene->PushAssetFile(output);
+                    }
+                }
+                ZReleaseScratch(scratch);
+            }
 
             WriteBinary(out, ZESCENE_MAGIC);
             WriteBinary(out, SCENE_FILE_VERSION);

--- a/Tetragrama/Serializers/EditorSceneSerializer.cpp
+++ b/Tetragrama/Serializers/EditorSceneSerializer.cpp
@@ -12,6 +12,7 @@
 
 using namespace ZEngine::Helpers;
 using namespace ZEngine::Core::Containers;
+using ZEngine::Core::VFS::VFSPath;
 
 namespace Tetragrama::Serializers
 {
@@ -33,7 +34,9 @@ namespace Tetragrama::Serializers
                 return;
             }
 
-            auto          full_scenename = fmt::format("{0}{1}{2}.zescene", m_default_output, PLATFORM_OS_BACKSLASH, scene->Name);
+            std::string scene_filename                      = std::string(scene->Name) + ".zescene";
+            char        full_scenename[MAX_FILE_PATH_COUNT] = {};
+            VFSPath::Parse(scene_filename.c_str()).Value().ResolveNative(m_default_output.c_str(), full_scenename, sizeof(full_scenename));
             std::ofstream out(full_scenename, std::ios::binary | std::ios::trunc | std::ios::out);
             if (!out.is_open())
             {

--- a/ZEngine/ZEngine/CMakeLists.txt
+++ b/ZEngine/ZEngine/CMakeLists.txt
@@ -82,6 +82,9 @@ if(APPLE)
     list(APPEND ZENGINE_SOURCES_CORE
         ${CMAKE_CURRENT_SOURCE_DIR}/Core/VFS/Platform/VFSFSEventsWatcher.mm
     )
+    list(APPEND ZENGINE_SOURCES_WINDOWS
+        ${CMAKE_CURRENT_SOURCE_DIR}/Windows/Platform/MacOSFileDialog.mm
+    )
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     list(APPEND ZENGINE_SOURCES_CRASH_HANDLERS
         ${CMAKE_CURRENT_SOURCE_DIR}/CrashHandlers/CrashHandlerWindows.cpp

--- a/ZEngine/ZEngine/Core/VFS/Meta/MetaFileData.h
+++ b/ZEngine/ZEngine/Core/VFS/Meta/MetaFileData.h
@@ -18,7 +18,8 @@ namespace ZEngine::Core::VFS
     {
         uuids::uuid      AssetUUID                         = {};
         char             ImporterName[64]                  = {};
-        uint64_t         SourceHash                        = 0; // rapidhash of source bytes at last import
+        char             SourcePath[MAX_FILE_PATH_COUNT]   = {}; // absolute native path to the original source file
+        uint64_t         SourceHash                        = 0;  // rapidhash of source bytes at last import
         int64_t          LastImportTimeNs                  = 0;
         char             ArtifactPath[MAX_FILE_PATH_COUNT] = {};
         MetaKeyValuePair Settings[META_MAX_SETTINGS]       = {};

--- a/ZEngine/ZEngine/Core/VFS/Meta/MetaFileIO.cpp
+++ b/ZEngine/ZEngine/Core/VFS/Meta/MetaFileIO.cpp
@@ -95,6 +95,9 @@ namespace ZEngine::Core::VFS
         if (j.contains("importer") && j["importer"].is_string())
             CopyStr(j["importer"].get<std::string>(), out.ImporterName, sizeof(out.ImporterName));
 
+        if (j.contains("source_path") && j["source_path"].is_string())
+            CopyStr(j["source_path"].get<std::string>(), out.SourcePath, sizeof(out.SourcePath));
+
         if (j.contains("source_hash") && j["source_hash"].is_number_unsigned())
             out.SourceHash = j["source_hash"].get<uint64_t>();
 
@@ -127,6 +130,7 @@ namespace ZEngine::Core::VFS
         nlohmann::json j;
         j["uuid"]           = uuids::to_string(data.AssetUUID);
         j["importer"]       = data.ImporterName;
+        j["source_path"]    = data.SourcePath;
         j["source_hash"]    = data.SourceHash;
         j["import_time_ns"] = data.LastImportTimeNs;
         j["artifact_path"]  = data.ArtifactPath;

--- a/ZEngine/ZEngine/Engine.cpp
+++ b/ZEngine/ZEngine/Engine.cpp
@@ -112,6 +112,9 @@ namespace ZEngine
         g_engine_ctx->RenderResourceManager->Initialize(g_engine_ctx->Device, Managers::AssetManager::Instance()->Registry);
         g_engine_ctx->Device->RRM = g_engine_ctx->RenderResourceManager;
 
+        // Now that RRM is live, create the hot-pink fallback texture for missing assets
+        Managers::AssetManager::InitFallbackTexture();
+
         // Wire FileWatcher: Modified → AssetRegistry + ImportCoordinator::Enqueue(Immediate)
         if (app->WorkingSpacePath && app->WorkingSpacePath[0] != '\0')
         {

--- a/ZEngine/ZEngine/Importers/AssetCodec.cpp
+++ b/ZEngine/ZEngine/Importers/AssetCodec.cpp
@@ -68,7 +68,9 @@ namespace ZEngine::Importers::AssetCodec
     {
         AssetImporterOutput output             = {};
         std::string         asset_mat_filename = fmt::format("{0}{1}", material.Name.c_str(), ".zematerial");
-        std::string         fullname_path      = fmt::format("{0}{1}{2}{3}{4}", config.OutputWorkingSpacePath.c_str(), PLATFORM_OS_BACKSLASH, config.OutputAssetsPath.c_str(), PLATFORM_OS_BACKSLASH, asset_mat_filename.c_str());
+        // Use dedicated material output dir if set, otherwise fall back to mesh output dir
+        const char*         mat_dir            = !config.OutputMaterialPath.empty() ? config.OutputMaterialPath.c_str() : config.OutputAssetsPath.c_str();
+        std::string         fullname_path      = fmt::format("{0}{1}{2}{3}{4}", config.OutputWorkingSpacePath.c_str(), PLATFORM_OS_BACKSLASH, mat_dir, PLATFORM_OS_BACKSLASH, asset_mat_filename.c_str());
 
         auto                tex_obj            = [](const uuids::uuid& uuid, const Core::Containers::String& path) {
             nlohmann::json t;
@@ -98,7 +100,7 @@ namespace ZEngine::Importers::AssetCodec
         out << j.dump(4);
         out.close();
 
-        output = {.Type = AssetFileType::MATERIAL, .Path = fmt::format("{0}{1}{2}", config.OutputAssetsPath.c_str(), PLATFORM_OS_BACKSLASH, asset_mat_filename.c_str()), .RootPath = config.OutputWorkingSpacePath.c_str()};
+        output = {.Type = AssetFileType::MATERIAL, .Path = fmt::format("{0}{1}{2}", mat_dir, PLATFORM_OS_BACKSLASH, asset_mat_filename.c_str()), .RootPath = config.OutputWorkingSpacePath.c_str()};
         return output;
     }
 

--- a/ZEngine/ZEngine/Importers/AssetCodec.cpp
+++ b/ZEngine/ZEngine/Importers/AssetCodec.cpp
@@ -15,6 +15,7 @@ using namespace uuids;
 using namespace ZEngine::Helpers;
 using namespace ZEngine::Core::Containers;
 using namespace ZEngine::Core::Maths;
+using ZEngine::Core::VFS::VFSPath;
 
 namespace ZEngine::Importers::AssetCodec
 {
@@ -24,7 +25,8 @@ namespace ZEngine::Importers::AssetCodec
         if (config.OutputAssetFile.empty())
             return output;
 
-        std::string   fullname_path = fmt::format("{0}{1}{2}{3}{4}", config.OutputWorkingSpacePath.c_str(), PLATFORM_OS_BACKSLASH, config.OutputAssetsPath.c_str(), PLATFORM_OS_BACKSLASH, config.OutputAssetFile.c_str());
+        char fullname_path[MAX_FILE_PATH_COUNT] = {};
+        (VFSPath::Parse(config.OutputAssetsPath.c_str()).Value() / config.OutputAssetFile.c_str()).ResolveNative(config.OutputWorkingSpacePath.c_str(), fullname_path, sizeof(fullname_path));
         std::ofstream out(fullname_path, std::ios::binary | std::ios::trunc);
         if (!out.is_open())
         {
@@ -60,19 +62,20 @@ namespace ZEngine::Importers::AssetCodec
         WriteBinaryHashMap(out, hierarchies.NodeMaterials);
         out.close();
 
-        output = {.Type = AssetFileType::MESH, .Path = fmt::format("{0}{1}{2}", config.OutputAssetsPath.c_str(), PLATFORM_OS_BACKSLASH, config.OutputAssetFile.c_str()), .RootPath = config.OutputWorkingSpacePath.c_str()};
+        output = {.Type = AssetFileType::MESH, .Path = (VFSPath::Parse(config.OutputAssetsPath.c_str()).Value() / config.OutputAssetFile.c_str()).CStr(), .RootPath = config.OutputWorkingSpacePath.c_str()};
         return output;
     }
 
     AssetImporterOutput SerializeMaterialAssetFile(Core::Memory::ArenaAllocator* /*arena*/, AssetMaterial& material, const ImportConfiguration& config)
     {
-        AssetImporterOutput output             = {};
-        std::string         asset_mat_filename = fmt::format("{0}{1}", material.Name.c_str(), ".zematerial");
+        AssetImporterOutput output                             = {};
+        std::string         asset_mat_filename                 = fmt::format("{0}{1}", material.Name.c_str(), ".zematerial");
         // Use dedicated material output dir if set, otherwise fall back to mesh output dir
-        const char*         mat_dir            = !config.OutputMaterialPath.empty() ? config.OutputMaterialPath.c_str() : config.OutputAssetsPath.c_str();
-        std::string         fullname_path      = fmt::format("{0}{1}{2}{3}{4}", config.OutputWorkingSpacePath.c_str(), PLATFORM_OS_BACKSLASH, mat_dir, PLATFORM_OS_BACKSLASH, asset_mat_filename.c_str());
+        const char*         mat_dir                            = !config.OutputMaterialPath.empty() ? config.OutputMaterialPath.c_str() : config.OutputAssetsPath.c_str();
+        char                fullname_path[MAX_FILE_PATH_COUNT] = {};
+        (VFSPath::Parse(mat_dir).Value() / asset_mat_filename.c_str()).ResolveNative(config.OutputWorkingSpacePath.c_str(), fullname_path, sizeof(fullname_path));
 
-        auto                tex_obj            = [](const uuids::uuid& uuid, const Core::Containers::String& path) {
+        auto tex_obj = [](const uuids::uuid& uuid, const Core::Containers::String& path) {
             nlohmann::json t;
             t["uuid"] = uuids::to_string(uuid);
             t["path"] = path.empty() ? "" : path.c_str();
@@ -100,16 +103,17 @@ namespace ZEngine::Importers::AssetCodec
         out << j.dump(4);
         out.close();
 
-        output = {.Type = AssetFileType::MATERIAL, .Path = fmt::format("{0}{1}{2}", mat_dir, PLATFORM_OS_BACKSLASH, asset_mat_filename.c_str()), .RootPath = config.OutputWorkingSpacePath.c_str()};
+        output = {.Type = AssetFileType::MATERIAL, .Path = (VFSPath::Parse(mat_dir).Value() / asset_mat_filename.c_str()).CStr(), .RootPath = config.OutputWorkingSpacePath.c_str()};
         return output;
     }
 
     AssetImporterOutput SerializeTextureAssetFiles(Core::Memory::ArenaAllocator* arena, ArrayView<AssetTexture> textures, const ImportConfiguration& config)
     {
-        AssetImporterOutput output             = {};
-        std::string         asset_tex_filename = fmt::format("{0}{1}", config.AssetName.c_str(), ".zetextures");
-        std::string         fullname_path      = fmt::format("{0}{1}{2}{3}{4}", config.OutputWorkingSpacePath.c_str(), PLATFORM_OS_BACKSLASH, config.OutputAssetsPath.c_str(), PLATFORM_OS_BACKSLASH, asset_tex_filename.c_str());
-        std::ofstream       out(fullname_path, std::ios::binary | std::ios::trunc);
+        AssetImporterOutput output                             = {};
+        std::string         asset_tex_filename                 = fmt::format("{0}{1}", config.AssetName.c_str(), ".zetextures");
+        char                fullname_path[MAX_FILE_PATH_COUNT] = {};
+        (VFSPath::Parse(config.OutputAssetsPath.c_str()).Value() / asset_tex_filename.c_str()).ResolveNative(config.OutputWorkingSpacePath.c_str(), fullname_path, sizeof(fullname_path));
+        std::ofstream out(fullname_path, std::ios::binary | std::ios::trunc);
         if (!out.is_open())
         {
             out.close();
@@ -128,7 +132,7 @@ namespace ZEngine::Importers::AssetCodec
         }
         out.close();
 
-        output = {.Type = AssetFileType::TEXTURES, .Path = fmt::format("{0}{1}{2}", config.OutputAssetsPath.c_str(), PLATFORM_OS_BACKSLASH, asset_tex_filename.c_str()), .RootPath = config.OutputWorkingSpacePath.c_str()};
+        output = {.Type = AssetFileType::TEXTURES, .Path = (VFSPath::Parse(config.OutputAssetsPath.c_str()).Value() / asset_tex_filename.c_str()).CStr(), .RootPath = config.OutputWorkingSpacePath.c_str()};
         return output;
     }
 
@@ -307,8 +311,10 @@ namespace ZEngine::Importers::AssetCodec
         if (config.OutputAssetFile.empty())
             return output;
 
-        std::string     dir_path      = fmt::format("{0}{1}{2}", config.OutputWorkingSpacePath.c_str(), PLATFORM_OS_BACKSLASH, config.OutputAssetsPath.c_str());
-        std::string     fullname_path = fmt::format("{0}{1}{2}", dir_path, PLATFORM_OS_BACKSLASH, config.OutputAssetFile.c_str());
+        char dir_path[MAX_FILE_PATH_COUNT] = {};
+        VFSPath::Parse(config.OutputAssetsPath.c_str()).Value().ResolveNative(config.OutputWorkingSpacePath.c_str(), dir_path, sizeof(dir_path));
+        char fullname_path[MAX_FILE_PATH_COUNT] = {};
+        (VFSPath::Parse(config.OutputAssetsPath.c_str()).Value() / config.OutputAssetFile.c_str()).ResolveNative(config.OutputWorkingSpacePath.c_str(), fullname_path, sizeof(fullname_path));
 
         std::error_code ec;
         std::filesystem::create_directories(dir_path, ec);

--- a/ZEngine/ZEngine/Importers/AssetCodec.cpp
+++ b/ZEngine/ZEngine/Importers/AssetCodec.cpp
@@ -5,6 +5,8 @@
 #include <ZEngine/Helpers/SerializerCommonHelper.h>
 #include <ZEngine/Importers/AssetCodec.h>
 #include <fmt/format.h>
+#include <nlohmann/json.hpp>
+#include <uuid.h>
 #include <filesystem>
 #include <fstream>
 #include <string>
@@ -62,40 +64,38 @@ namespace ZEngine::Importers::AssetCodec
         return output;
     }
 
-    AssetImporterOutput SerializeMaterialAssetFile(Core::Memory::ArenaAllocator* arena, AssetMaterial& material, const ImportConfiguration& config)
+    AssetImporterOutput SerializeMaterialAssetFile(Core::Memory::ArenaAllocator* /*arena*/, AssetMaterial& material, const ImportConfiguration& config)
     {
         AssetImporterOutput output             = {};
         std::string         asset_mat_filename = fmt::format("{0}{1}", material.Name.c_str(), ".zematerial");
         std::string         fullname_path      = fmt::format("{0}{1}{2}{3}{4}", config.OutputWorkingSpacePath.c_str(), PLATFORM_OS_BACKSLASH, config.OutputAssetsPath.c_str(), PLATFORM_OS_BACKSLASH, asset_mat_filename.c_str());
-        std::ofstream       out(fullname_path, std::ios::binary | std::ios::trunc);
-        if (!out.is_open())
-        {
-            out.close();
-            return output;
-        }
 
-        out.seekp(std::ios::beg);
-        WriteBinary(out, ZEMATERIAL_MAGIC);
-        WriteBinary(out, ASSET_FILE_VERSION);
-        WriteBinaryString(out, material.Name);
-        WriteBinary(out, material.MaterialUUID);
-        WriteBinary(out, material.AlbedoTexUUID);
-        WriteBinary(out, material.EmissiveTexUUID);
-        WriteBinary(out, material.NormalTexUUID);
-        WriteBinary(out, material.OpacityTexUUID);
-        WriteBinary(out, material.SpecularTexUUID);
-        // Texture paths — project-relative VFS paths to extracted image files
-        WriteBinaryString(out, material.AlbedoTexPath);
-        WriteBinaryString(out, material.EmissiveTexPath);
-        WriteBinaryString(out, material.NormalTexPath);
-        WriteBinaryString(out, material.OpacityTexPath);
-        WriteBinaryString(out, material.SpecularTexPath);
-        out.write(reinterpret_cast<const char*>(material.AmbientColor), sizeof(material.AmbientColor));
-        out.write(reinterpret_cast<const char*>(material.AlbedoColor), sizeof(material.AlbedoColor));
-        out.write(reinterpret_cast<const char*>(material.EmissiveColor), sizeof(material.EmissiveColor));
-        out.write(reinterpret_cast<const char*>(material.RoughnessColor), sizeof(material.RoughnessColor));
-        out.write(reinterpret_cast<const char*>(material.SpecularColor), sizeof(material.SpecularColor));
-        out.write(reinterpret_cast<const char*>(material.Factors), sizeof(material.Factors));
+        auto                tex_obj            = [](const uuids::uuid& uuid, const Core::Containers::String& path) {
+            nlohmann::json t;
+            t["uuid"] = uuids::to_string(uuid);
+            t["path"] = path.empty() ? "" : path.c_str();
+            return t;
+        };
+
+        nlohmann::json j;
+        j["name"]                 = material.Name.empty() ? "" : material.Name.c_str();
+        j["uuid"]                 = uuids::to_string(material.MaterialUUID);
+        j["textures"]["albedo"]   = tex_obj(material.AlbedoTexUUID, material.AlbedoTexPath);
+        j["textures"]["emissive"] = tex_obj(material.EmissiveTexUUID, material.EmissiveTexPath);
+        j["textures"]["normal"]   = tex_obj(material.NormalTexUUID, material.NormalTexPath);
+        j["textures"]["opacity"]  = tex_obj(material.OpacityTexUUID, material.OpacityTexPath);
+        j["textures"]["specular"] = tex_obj(material.SpecularTexUUID, material.SpecularTexPath);
+        j["ambient_color"]        = nlohmann::json::array({material.AmbientColor[0], material.AmbientColor[1], material.AmbientColor[2], material.AmbientColor[3]});
+        j["albedo_color"]         = nlohmann::json::array({material.AlbedoColor[0], material.AlbedoColor[1], material.AlbedoColor[2], material.AlbedoColor[3]});
+        j["emissive_color"]       = nlohmann::json::array({material.EmissiveColor[0], material.EmissiveColor[1], material.EmissiveColor[2], material.EmissiveColor[3]});
+        j["roughness_color"]      = nlohmann::json::array({material.RoughnessColor[0], material.RoughnessColor[1], material.RoughnessColor[2], material.RoughnessColor[3]});
+        j["specular_color"]       = nlohmann::json::array({material.SpecularColor[0], material.SpecularColor[1], material.SpecularColor[2], material.SpecularColor[3]});
+        j["factors"]              = nlohmann::json::array({material.Factors[0], material.Factors[1], material.Factors[2], material.Factors[3]});
+
+        std::ofstream out(fullname_path, std::ios::trunc);
+        if (!out.is_open())
+            return output;
+        out << j.dump(4);
         out.close();
 
         output = {.Type = AssetFileType::MATERIAL, .Path = fmt::format("{0}{1}{2}", config.OutputAssetsPath.c_str(), PLATFORM_OS_BACKSLASH, asset_mat_filename.c_str()), .RootPath = config.OutputWorkingSpacePath.c_str()};
@@ -183,42 +183,64 @@ namespace ZEngine::Importers::AssetCodec
     {
         if (!secure_strlen(asset_file))
             return;
-        std::ifstream in(asset_file, std::ios::binary);
+        std::ifstream in(asset_file);
         if (!in.is_open())
-        {
-            in.close();
             return;
-        }
 
-        in.seekg(std::ios::beg);
-        uint32_t scene_magic, scene_version;
-        ReadBinary(in, scene_magic);
-        ReadBinary(in, scene_version);
-        if (scene_magic != ZEMATERIAL_MAGIC && scene_version != ASSET_FILE_VERSION)
-        {
-            in.close();
-            return;
-        }
-
-        ReadBinaryString(arena, in, material.Name);
-        ReadBinary(in, material.MaterialUUID);
-        ReadBinary(in, material.AlbedoTexUUID);
-        ReadBinary(in, material.EmissiveTexUUID);
-        ReadBinary(in, material.NormalTexUUID);
-        ReadBinary(in, material.OpacityTexUUID);
-        ReadBinary(in, material.SpecularTexUUID);
-        ReadBinaryString(arena, in, material.AlbedoTexPath);
-        ReadBinaryString(arena, in, material.EmissiveTexPath);
-        ReadBinaryString(arena, in, material.NormalTexPath);
-        ReadBinaryString(arena, in, material.OpacityTexPath);
-        ReadBinaryString(arena, in, material.SpecularTexPath);
-        in.read(reinterpret_cast<char*>(material.AmbientColor), sizeof(material.AmbientColor));
-        in.read(reinterpret_cast<char*>(material.AlbedoColor), sizeof(material.AlbedoColor));
-        in.read(reinterpret_cast<char*>(material.EmissiveColor), sizeof(material.EmissiveColor));
-        in.read(reinterpret_cast<char*>(material.RoughnessColor), sizeof(material.RoughnessColor));
-        in.read(reinterpret_cast<char*>(material.SpecularColor), sizeof(material.SpecularColor));
-        in.read(reinterpret_cast<char*>(material.Factors), sizeof(material.Factors));
+        std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
         in.close();
+
+        auto j = nlohmann::json::parse(content, nullptr, /*allow_exceptions=*/false);
+        if (j.is_discarded())
+            return;
+
+        auto read_str = [&](const char* key, Core::Containers::String& out) {
+            if (j.contains(key) && j[key].is_string())
+                out.init(arena, j[key].get<std::string>().c_str());
+        };
+        auto read_uuid = [&](const nlohmann::json& node, const char* key, uuids::uuid& out) {
+            if (node.contains(key) && node[key].is_string())
+            {
+                auto parsed = uuids::uuid::from_string(node[key].get<std::string>());
+                if (parsed.has_value())
+                    out = parsed.value();
+            }
+        };
+        auto read_color = [&](const char* key, float* dst, int n) {
+            if (j.contains(key) && j[key].is_array())
+            {
+                const auto& arr = j[key];
+                for (int i = 0; i < n && i < (int) arr.size(); ++i)
+                    if (arr[i].is_number())
+                        dst[i] = arr[i].get<float>();
+            }
+        };
+        auto read_tex = [&](const char* slot, uuids::uuid& uuid_out, Core::Containers::String& path_out) {
+            if (!j.contains("textures") || !j["textures"].contains(slot))
+                return;
+            const auto& t = j["textures"][slot];
+            read_uuid(t, "uuid", uuid_out);
+            if (t.contains("path") && t["path"].is_string())
+            {
+                auto s = t["path"].get<std::string>();
+                if (!s.empty())
+                    path_out.init(arena, s.c_str());
+            }
+        };
+
+        read_str("name", material.Name);
+        read_uuid(j, "uuid", material.MaterialUUID);
+        read_tex("albedo", material.AlbedoTexUUID, material.AlbedoTexPath);
+        read_tex("emissive", material.EmissiveTexUUID, material.EmissiveTexPath);
+        read_tex("normal", material.NormalTexUUID, material.NormalTexPath);
+        read_tex("opacity", material.OpacityTexUUID, material.OpacityTexPath);
+        read_tex("specular", material.SpecularTexUUID, material.SpecularTexPath);
+        read_color("ambient_color", material.AmbientColor, 4);
+        read_color("albedo_color", material.AlbedoColor, 4);
+        read_color("emissive_color", material.EmissiveColor, 4);
+        read_color("roughness_color", material.RoughnessColor, 4);
+        read_color("specular_color", material.SpecularColor, 4);
+        read_color("factors", material.Factors, 4);
     }
 
     void DeserializeTextureAssetFile(Core::Memory::ArenaAllocator* arena, const char* asset_file, Core::Containers::Array<AssetTexture>& textures)

--- a/ZEngine/ZEngine/Importers/AssetCodec.cpp
+++ b/ZEngine/ZEngine/Importers/AssetCodec.cpp
@@ -84,6 +84,12 @@ namespace ZEngine::Importers::AssetCodec
         WriteBinary(out, material.NormalTexUUID);
         WriteBinary(out, material.OpacityTexUUID);
         WriteBinary(out, material.SpecularTexUUID);
+        // Texture paths — project-relative VFS paths to extracted image files
+        WriteBinaryString(out, material.AlbedoTexPath);
+        WriteBinaryString(out, material.EmissiveTexPath);
+        WriteBinaryString(out, material.NormalTexPath);
+        WriteBinaryString(out, material.OpacityTexPath);
+        WriteBinaryString(out, material.SpecularTexPath);
         out.write(reinterpret_cast<const char*>(material.AmbientColor), sizeof(material.AmbientColor));
         out.write(reinterpret_cast<const char*>(material.AlbedoColor), sizeof(material.AlbedoColor));
         out.write(reinterpret_cast<const char*>(material.EmissiveColor), sizeof(material.EmissiveColor));
@@ -201,6 +207,11 @@ namespace ZEngine::Importers::AssetCodec
         ReadBinary(in, material.NormalTexUUID);
         ReadBinary(in, material.OpacityTexUUID);
         ReadBinary(in, material.SpecularTexUUID);
+        ReadBinaryString(arena, in, material.AlbedoTexPath);
+        ReadBinaryString(arena, in, material.EmissiveTexPath);
+        ReadBinaryString(arena, in, material.NormalTexPath);
+        ReadBinaryString(arena, in, material.OpacityTexPath);
+        ReadBinaryString(arena, in, material.SpecularTexPath);
         in.read(reinterpret_cast<char*>(material.AmbientColor), sizeof(material.AmbientColor));
         in.read(reinterpret_cast<char*>(material.AlbedoColor), sizeof(material.AlbedoColor));
         in.read(reinterpret_cast<char*>(material.EmissiveColor), sizeof(material.EmissiveColor));

--- a/ZEngine/ZEngine/Importers/AssetCodec.h
+++ b/ZEngine/ZEngine/Importers/AssetCodec.h
@@ -17,7 +17,8 @@ namespace ZEngine::Importers::AssetCodec
     {
         Core::Containers::String AssetName;
         Core::Containers::String OutputAssetFile;
-        Core::Containers::String OutputAssetsPath;
+        Core::Containers::String OutputAssetsPath;   // mesh output dir (Assets/Meshes)
+        Core::Containers::String OutputMaterialPath; // material output dir (Assets/Materials); falls back to OutputAssetsPath if empty
         Core::Containers::String InputBaseAssetFilePath;
         Core::Containers::String OutputWorkingSpacePath;
         Core::Containers::String OutputTextureFilesPath;

--- a/ZEngine/ZEngine/Importers/AssetTypes.h
+++ b/ZEngine/ZEngine/Importers/AssetTypes.h
@@ -7,6 +7,7 @@
 #include <ZEngine/Rendering/Textures/Texture.h>
 #include <uuid.h>
 #include <string>
+#include <string_view>
 
 namespace ZEngine::Importers
 {
@@ -114,4 +115,10 @@ namespace ZEngine::Importers
         std::string   Path     = "";
         std::string   RootPath = "";
     };
+
+    using ImportCompleteCallback = void (*)(void* ctx, Core::Containers::ArrayView<AssetImporterOutput> outputs);
+    using ImportProgressCallback = void (*)(void* ctx, float progress);
+    using ImportErrorCallback    = void (*)(void* ctx, std::string_view message);
+    using ImportLogCallback      = void (*)(void* ctx, std::string_view message);
+
 } // namespace ZEngine::Importers

--- a/ZEngine/ZEngine/Importers/AssetTypes.h
+++ b/ZEngine/ZEngine/Importers/AssetTypes.h
@@ -45,11 +45,19 @@ namespace ZEngine::Importers
     {
         Core::Containers::String Name              = {};
         uuids::uuid              MaterialUUID      = {};
+        // Texture UUIDs — runtime lookup key into AssetManager
         uuids::uuid              AlbedoTexUUID     = {};
         uuids::uuid              EmissiveTexUUID   = {};
         uuids::uuid              NormalTexUUID     = {};
         uuids::uuid              OpacityTexUUID    = {};
         uuids::uuid              SpecularTexUUID   = {};
+        // Texture paths — project-relative VFS path to the extracted image file
+        // Stored in .zematerial so no separate .zetextures file is needed
+        Core::Containers::String AlbedoTexPath     = {};
+        Core::Containers::String EmissiveTexPath   = {};
+        Core::Containers::String NormalTexPath     = {};
+        Core::Containers::String OpacityTexPath    = {};
+        Core::Containers::String SpecularTexPath   = {};
         float                    AmbientColor[4]   = {0};
         float                    AlbedoColor[4]    = {0};
         float                    EmissiveColor[4]  = {0};

--- a/ZEngine/ZEngine/Importers/AssimpImporter.cpp
+++ b/ZEngine/ZEngine/Importers/AssimpImporter.cpp
@@ -135,10 +135,30 @@ namespace ZEngine::Importers
             CreateHierachy(arena, scene, gen, hierarchies, mesh, materials);
             CopyTextureFiles(arena, textures, config);
 
+            // Propagate tex.Path (set by CopyTextureFiles) → material.*TexPath
+            for (size_t m = 0; m < materials.size(); ++m)
+            {
+                auto set_path = [&](const uuids::uuid& uuid, Core::Containers::String& path_out) {
+                    for (size_t t = 0; t < textures.size(); ++t)
+                    {
+                        if (textures[t].TextureUUID == uuid && !textures[t].Path.empty())
+                        {
+                            path_out.init(arena, textures[t].Path.c_str());
+                            return;
+                        }
+                    }
+                };
+                set_path(materials[m].AlbedoTexUUID, materials[m].AlbedoTexPath);
+                set_path(materials[m].EmissiveTexUUID, materials[m].EmissiveTexPath);
+                set_path(materials[m].NormalTexUUID, materials[m].NormalTexPath);
+                set_path(materials[m].OpacityTexUUID, materials[m].OpacityTexPath);
+                set_path(materials[m].SpecularTexUUID, materials[m].SpecularTexPath);
+            }
+
+            // Serialize .zemesh + .zematerial — no .zetextures (paths are inline in material)
             Array<AssetImporterOutput> outputs = {};
             outputs.init(arena, 100);
             outputs.push(AssetCodec::SerializeMeshAssetFile(arena, mesh, hierarchies, config));
-            outputs.push(AssetCodec::SerializeTextureAssetFiles(arena, ArrayView{textures}, config));
             for (size_t i = 0; i < materials.size(); ++i)
                 outputs.push(AssetCodec::SerializeMaterialAssetFile(arena, materials[i], config));
 

--- a/ZEngine/ZEngine/Importers/AssimpImporter.cpp
+++ b/ZEngine/ZEngine/Importers/AssimpImporter.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 
 using namespace ZEngine::Helpers;
+using ZEngine::Core::VFS::VFSPath;
 using namespace ZEngine::Rendering::Meshes;
 using namespace ZEngine::Core::Containers;
 using namespace ZEngine::Core::Maths;
@@ -492,9 +493,11 @@ namespace ZEngine::Importers
         /*
          * Normalize file naming
          */
-        auto dst_dir               = fmt::format("{0}{1}{2}{3}{4}", config.OutputWorkingSpacePath.c_str(), PLATFORM_OS_BACKSLASH, config.OutputTextureFilesPath.c_str(), PLATFORM_OS_BACKSLASH, config.AssetName.c_str());
+        char dst_dir_buf[MAX_FILE_PATH_COUNT] = {};
+        (VFSPath::Parse(config.OutputTextureFilesPath.c_str()).Value() / config.AssetName.c_str()).ResolveNative(config.OutputWorkingSpacePath.c_str(), dst_dir_buf, sizeof(dst_dir_buf));
+        std::string dst_dir               = dst_dir_buf;
 
-        auto CreateBaseDirectoryFn = [](std::string_view filename) -> void {
+        auto        CreateBaseDirectoryFn = [](std::string_view filename) -> void {
             auto            base_dir = fs::absolute(filename).parent_path();
 
             std::error_code err      = {};
@@ -517,8 +520,8 @@ namespace ZEngine::Importers
                 continue;
             }
 
-            auto src_file = fmt::format("{0}{1}{2}", config.InputBaseAssetFilePath.c_str(), PLATFORM_OS_BACKSLASH, tex.Path.c_str());
-            auto dst_file = fmt::format("{0}{1}{2}", dst_dir, PLATFORM_OS_BACKSLASH, tex.Path.c_str());
+            auto src_file = (fs::path(config.InputBaseAssetFilePath.c_str()) / tex.Path.c_str()).string();
+            auto dst_file = (fs::path(dst_dir) / tex.Path.c_str()).string();
 
             CreateBaseDirectoryFn(dst_file);
 
@@ -563,7 +566,7 @@ namespace ZEngine::Importers
          */
         for (auto& tex : textures)
         {
-            auto new_path = fmt::format("{0}{1}{2}{3}{4}", config.OutputTextureFilesPath.c_str(), PLATFORM_OS_BACKSLASH, config.AssetName.c_str(), PLATFORM_OS_BACKSLASH, tex.Path.c_str());
+            auto new_path = std::string((VFSPath::Parse(config.OutputTextureFilesPath.c_str()).Value() / config.AssetName.c_str() / tex.Path.c_str()).CStr());
             tex.Path.clear();
             tex.Path.append(new_path.c_str());
         }

--- a/ZEngine/ZEngine/Importers/AssimpImporter.cpp
+++ b/ZEngine/ZEngine/Importers/AssimpImporter.cpp
@@ -99,7 +99,7 @@ namespace ZEngine::Importers
         return Core::VFS::VFSResult<void>::Ok();
     }
 
-    void AssimpImporter::ImportFile(const char* filename, const AssetCodec::ImportConfiguration& cfg, Core::Memory::ArenaAllocator* arena, void* context, void (*on_complete)(void*, Core::Containers::ArrayView<AssetImporterOutput>), void (*on_progress)(void*, float), void (*on_error)(void*, std::string_view), void (*on_log)(void*, std::string_view))
+    void AssimpImporter::ImportFile(const char* filename, const AssetCodec::ImportConfiguration& cfg, Core::Memory::ArenaAllocator* arena, void* context, ImportCompleteCallback on_complete, ImportProgressCallback on_progress, ImportErrorCallback on_error, ImportLogCallback on_log)
     {
         AssetCodec::ImportConfiguration config = {};
         config.OutputWorkingSpacePath.init(arena, cfg.OutputWorkingSpacePath.c_str());

--- a/ZEngine/ZEngine/Importers/AssimpImporter.h
+++ b/ZEngine/ZEngine/Importers/AssimpImporter.h
@@ -37,7 +37,7 @@ namespace ZEngine::Importers
 
         // Editor helper — called directly by DockspaceUIComponent for the
         // file-picker import path (produces cooked .zasset artifacts).
-        void                         ImportFile(const char* filename, const AssetCodec::ImportConfiguration& config, Core::Memory::ArenaAllocator* arena, void* context, void (*on_complete)(void*, Core::Containers::ArrayView<AssetImporterOutput>), void (*on_progress)(void*, float), void (*on_error)(void*, std::string_view), void (*on_log)(void*, std::string_view));
+        void                         ImportFile(const char* filename, const AssetCodec::ImportConfiguration& config, Core::Memory::ArenaAllocator* arena, void* context, ImportCompleteCallback on_complete, ImportProgressCallback on_progress, ImportErrorCallback on_error, ImportLogCallback on_log);
 
         void                         CopyTextureFiles(Core::Memory::ArenaAllocator*, Core::Containers::Array<AssetTexture>&, const AssetCodec::ImportConfiguration&);
 

--- a/ZEngine/ZEngine/Importers/GltfImporter.cpp
+++ b/ZEngine/ZEngine/Importers/GltfImporter.cpp
@@ -581,7 +581,7 @@ namespace ZEngine::Importers
 
                 if (!bytes || nbytes == 0)
                 {
-                    ZENGINE_CORE_WARN("[GltfImporter] tex {} image data not accessible (unsupported source variant)", tex_idx)
+                    ZENGINE_LOG_ASSET_WARN("GltfImporter: tex {} image data not accessible (unsupported source variant)", tex_idx)
                     continue;
                 }
 
@@ -592,7 +592,7 @@ namespace ZEngine::Importers
                 {
                     fout.write(reinterpret_cast<const char*>(bytes), static_cast<std::streamsize>(nbytes));
                     fout.close();
-                    ZENGINE_CORE_INFO("[GltfImporter] extracted texture '{}' ({} bytes)", out_file.string(), nbytes)
+                    ZENGINE_LOG_ASSET_INFO("GltfImporter: extracted texture '{}' ({} bytes)", out_file.string(), nbytes)
 
                     // Project-relative path (forward-slash for VFS)
                     auto rel = std::filesystem::path(config.OutputTextureFilesPath.c_str()) / config.AssetName.c_str() / (filename_stem + ext);

--- a/ZEngine/ZEngine/Importers/GltfImporter.cpp
+++ b/ZEngine/ZEngine/Importers/GltfImporter.cpp
@@ -1,5 +1,6 @@
 #include <ZEngine/Core/Maths/Matrix.h>
 #include <ZEngine/Helpers/MemoryOperations.h>
+#include <ZEngine/Importers/AssetCodec.h>
 #include <ZEngine/Importers/AssetTypes.h>
 #include <ZEngine/Importers/GltfImporter.h>
 #include <ZEngine/Importers/IAssetImporter.h>
@@ -466,5 +467,91 @@ namespace ZEngine::Importers
 
         Arena.Clear();
         return Core::VFS::VFSResult<void>::Ok();
+    }
+
+    void GltfImporter::ImportFile(const char* filename, const AssetCodec::ImportConfiguration& cfg, Core::Memory::ArenaAllocator* arena, void* context, void (*on_complete)(void*, Core::Containers::ArrayView<AssetImporterOutput>), void (*on_progress)(void*, float), void (*on_error)(void*, std::string_view), void (*on_log)(void*, std::string_view))
+    {
+        // Build arena-allocated config copy (same pattern as AssimpImporter::ImportFile)
+        AssetCodec::ImportConfiguration config = {};
+        config.OutputWorkingSpacePath.init(arena, cfg.OutputWorkingSpacePath.c_str());
+        config.OutputTextureFilesPath.init(arena, cfg.OutputTextureFilesPath.c_str());
+        config.OutputAssetsPath.init(arena, cfg.OutputAssetsPath.c_str());
+        config.AssetName.init(arena, cfg.AssetName.c_str());
+        config.OutputAssetFile.init(arena, cfg.OutputAssetFile.c_str());
+        config.InputBaseAssetFilePath.init(arena, cfg.InputBaseAssetFilePath.c_str());
+
+        auto fs_path = std::filesystem::path(filename);
+        auto buf     = fastgltf::GltfDataBuffer::FromPath(fs_path);
+        if (buf.error() != fastgltf::Error::None)
+        {
+            if (on_error)
+                on_error(context, fastgltf::getErrorMessage(buf.error()));
+            return;
+        }
+
+        if (on_progress)
+            on_progress(context, 0.1f);
+
+        fastgltf::Parser parser;
+        auto             result = parser.loadGltf(buf.get(), fs_path.parent_path(), fastgltf::Options::LoadExternalBuffers | fastgltf::Options::LoadExternalImages | fastgltf::Options::GenerateMeshIndices);
+
+        if (result.error() != fastgltf::Error::None)
+        {
+            if (on_error)
+                on_error(context, fastgltf::getErrorMessage(result.error()));
+            return;
+        }
+
+        if (on_progress)
+            on_progress(context, 0.3f);
+
+        fastgltf::Asset&             asset = result.get();
+
+        Core::Memory::ArenaAllocator scratch{};
+        Arena.CreateSubArena(ZMega(32), &scratch);
+
+        std::random_device    rd;
+        std::mt19937          gen_mt(rd());
+        uuid_random_generator gen(&gen_mt);
+
+        AssetMesh             mesh      = {};
+        AssetNodeHierarchy    hierarchy = {};
+        Array<AssetMaterial>  materials = {};
+        Array<AssetTexture>   textures  = {};
+
+        ExtractMeshes(&scratch, asset, mesh);
+        mesh.MeshUUID = gen();
+        ExtractMaterials(&scratch, asset, gen, materials);
+        ExtractTextures(&scratch, asset, gen, textures, materials);
+        BuildHierarchy(&scratch, asset, gen, hierarchy, mesh, materials);
+
+        if (on_progress)
+            on_progress(context, 0.7f);
+
+        // Serialize to disk first — before any std::move into AssetManager
+        Array<AssetImporterOutput> outputs = {};
+        outputs.init(arena, 16);
+        outputs.push(AssetCodec::SerializeMeshAssetFile(arena, mesh, hierarchy, config));
+        outputs.push(AssetCodec::SerializeTextureAssetFiles(arena, ArrayView{textures}, config));
+        for (size_t i = 0; i < materials.size(); ++i)
+            outputs.push(AssetCodec::SerializeMaterialAssetFile(arena, materials[i], config));
+
+        // Also ingest into AssetManager so the asset is usable this session without a reload
+        auto* mgr = Managers::AssetManager::Instance();
+        if (mgr)
+        {
+            Managers::AssetManager::IngestTextures(std::move(textures));
+            for (size_t i = 0; i < materials.size(); ++i)
+                Managers::AssetManager::IngestMaterial(std::move(materials[i]));
+            Managers::AssetManager::IngestMesh(std::move(mesh), std::move(hierarchy));
+        }
+
+        if (on_progress)
+            on_progress(context, 1.0f);
+
+        if (on_complete)
+            on_complete(context, ArrayView{outputs});
+
+        Arena.Clear();
     }
 } // namespace ZEngine::Importers

--- a/ZEngine/ZEngine/Importers/GltfImporter.cpp
+++ b/ZEngine/ZEngine/Importers/GltfImporter.cpp
@@ -536,19 +536,28 @@ namespace ZEngine::Importers
                 const auto& fgltf_tex = asset.textures[tex_idx];
                 if (!fgltf_tex.imageIndex.has_value())
                     continue;
-                const auto&    img    = asset.images[fgltf_tex.imageIndex.value()];
+                const auto&    img      = asset.images[fgltf_tex.imageIndex.value()];
 
-                std::string    ext    = ".png";
-                const uint8_t* bytes  = nullptr;
-                size_t         nbytes = 0;
+                std::string    ext      = ".png";
+                const uint8_t* bytes    = nullptr;
+                size_t         nbytes   = 0;
+
+                auto           set_mime = [&](fastgltf::MimeType mt) {
+                    if (mt == fastgltf::MimeType::JPEG)
+                        ext = ".jpg";
+                };
 
                 std::visit(
                     fastgltf::visitor{
                     [&](const fastgltf::sources::Array& arr) {
                         bytes  = reinterpret_cast<const uint8_t*>(arr.bytes.data());
                         nbytes = arr.bytes.size();
-                        if (arr.mimeType == fastgltf::MimeType::JPEG)
-                            ext = ".jpg";
+                        set_mime(arr.mimeType);
+                    },
+                    [&](const fastgltf::sources::ByteView& bv_data) {
+                        bytes  = reinterpret_cast<const uint8_t*>(bv_data.bytes.data());
+                        nbytes = bv_data.bytes.size();
+                        set_mime(bv_data.mimeType);
                     },
                     [&](const fastgltf::sources::BufferView& bv_src) {
                         const auto& bv = asset.bufferViews[bv_src.bufferViewIndex];
@@ -557,8 +566,12 @@ namespace ZEngine::Importers
                             [&](const fastgltf::sources::Array& arr) {
                                 bytes  = reinterpret_cast<const uint8_t*>(arr.bytes.data()) + bv.byteOffset;
                                 nbytes = bv.byteLength;
-                                if (bv_src.mimeType == fastgltf::MimeType::JPEG)
-                                    ext = ".jpg";
+                                set_mime(bv_src.mimeType);
+                            },
+                            [&](const fastgltf::sources::ByteView& bvd) {
+                                bytes  = reinterpret_cast<const uint8_t*>(bvd.bytes.data()) + bv.byteOffset;
+                                nbytes = bv.byteLength;
+                                set_mime(bv_src.mimeType);
                             },
                             [](auto&&) {}},
                             asset.buffers[bv.bufferIndex].data);
@@ -567,7 +580,10 @@ namespace ZEngine::Importers
                     img.data);
 
                 if (!bytes || nbytes == 0)
+                {
+                    ZENGINE_CORE_WARN("[GltfImporter] tex {} image data not accessible (unsupported source variant)", tex_idx)
                     continue;
+                }
 
                 auto          filename_stem = !img.name.empty() ? std::string(img.name) : ("tex_" + std::to_string(tex_idx));
                 auto          out_file      = dest_dir / (filename_stem + ext);
@@ -576,6 +592,7 @@ namespace ZEngine::Importers
                 {
                     fout.write(reinterpret_cast<const char*>(bytes), static_cast<std::streamsize>(nbytes));
                     fout.close();
+                    ZENGINE_CORE_INFO("[GltfImporter] extracted texture '{}' ({} bytes)", out_file.string(), nbytes)
 
                     // Project-relative path (forward-slash for VFS)
                     auto rel = std::filesystem::path(config.OutputTextureFilesPath.c_str()) / config.AssetName.c_str() / (filename_stem + ext);

--- a/ZEngine/ZEngine/Importers/GltfImporter.cpp
+++ b/ZEngine/ZEngine/Importers/GltfImporter.cpp
@@ -525,14 +525,92 @@ namespace ZEngine::Importers
         ExtractTextures(&scratch, asset, gen, textures, materials);
         BuildHierarchy(&scratch, asset, gen, hierarchy, mesh, materials);
 
+        // Extract texture image bytes to disk and record project-relative paths
+        {
+            auto            dest_dir = std::filesystem::path(config.OutputWorkingSpacePath.c_str()) / config.OutputTextureFilesPath.c_str() / config.AssetName.c_str();
+            std::error_code ec;
+            std::filesystem::create_directories(dest_dir, ec);
+
+            for (size_t tex_idx = 0; tex_idx < textures.size() && tex_idx < asset.textures.size(); ++tex_idx)
+            {
+                const auto& fgltf_tex = asset.textures[tex_idx];
+                if (!fgltf_tex.imageIndex.has_value())
+                    continue;
+                const auto&    img    = asset.images[fgltf_tex.imageIndex.value()];
+
+                std::string    ext    = ".png";
+                const uint8_t* bytes  = nullptr;
+                size_t         nbytes = 0;
+
+                std::visit(
+                    fastgltf::visitor{
+                    [&](const fastgltf::sources::Array& arr) {
+                        bytes  = reinterpret_cast<const uint8_t*>(arr.bytes.data());
+                        nbytes = arr.bytes.size();
+                        if (arr.mimeType == fastgltf::MimeType::JPEG)
+                            ext = ".jpg";
+                    },
+                    [&](const fastgltf::sources::BufferView& bv_src) {
+                        const auto& bv = asset.bufferViews[bv_src.bufferViewIndex];
+                        std::visit(
+                            fastgltf::visitor{
+                            [&](const fastgltf::sources::Array& arr) {
+                                bytes  = reinterpret_cast<const uint8_t*>(arr.bytes.data()) + bv.byteOffset;
+                                nbytes = bv.byteLength;
+                                if (bv_src.mimeType == fastgltf::MimeType::JPEG)
+                                    ext = ".jpg";
+                            },
+                            [](auto&&) {}},
+                            asset.buffers[bv.bufferIndex].data);
+                    },
+                    [](auto&&) {}},
+                    img.data);
+
+                if (!bytes || nbytes == 0)
+                    continue;
+
+                auto          filename_stem = !img.name.empty() ? std::string(img.name) : ("tex_" + std::to_string(tex_idx));
+                auto          out_file      = dest_dir / (filename_stem + ext);
+                std::ofstream fout(out_file, std::ios::binary | std::ios::trunc);
+                if (fout.is_open())
+                {
+                    fout.write(reinterpret_cast<const char*>(bytes), static_cast<std::streamsize>(nbytes));
+                    fout.close();
+
+                    // Project-relative path (forward-slash for VFS)
+                    auto rel = std::filesystem::path(config.OutputTextureFilesPath.c_str()) / config.AssetName.c_str() / (filename_stem + ext);
+                    textures[tex_idx].Path.init(&scratch, rel.generic_string().c_str());
+                }
+            }
+
+            // Propagate tex.Path → material.*TexPath by UUID match
+            for (size_t m = 0; m < materials.size(); ++m)
+            {
+                auto set_path = [&](const uuids::uuid& uuid, Core::Containers::String& path_out) {
+                    for (size_t t = 0; t < textures.size(); ++t)
+                    {
+                        if (textures[t].TextureUUID == uuid && !textures[t].Path.empty())
+                        {
+                            path_out.init(&scratch, textures[t].Path.c_str());
+                            return;
+                        }
+                    }
+                };
+                set_path(materials[m].AlbedoTexUUID, materials[m].AlbedoTexPath);
+                set_path(materials[m].EmissiveTexUUID, materials[m].EmissiveTexPath);
+                set_path(materials[m].NormalTexUUID, materials[m].NormalTexPath);
+                set_path(materials[m].OpacityTexUUID, materials[m].OpacityTexPath);
+                set_path(materials[m].SpecularTexUUID, materials[m].SpecularTexPath);
+            }
+        }
+
         if (on_progress)
             on_progress(context, 0.7f);
 
-        // Serialize to disk first — before any std::move into AssetManager
+        // Serialize to disk — .zemesh + .zematerial (no .zetextures: paths are inline in material)
         Array<AssetImporterOutput> outputs = {};
         outputs.init(arena, 16);
         outputs.push(AssetCodec::SerializeMeshAssetFile(arena, mesh, hierarchy, config));
-        outputs.push(AssetCodec::SerializeTextureAssetFiles(arena, ArrayView{textures}, config));
         for (size_t i = 0; i < materials.size(); ++i)
             outputs.push(AssetCodec::SerializeMaterialAssetFile(arena, materials[i], config));
 

--- a/ZEngine/ZEngine/Importers/GltfImporter.cpp
+++ b/ZEngine/ZEngine/Importers/GltfImporter.cpp
@@ -469,7 +469,7 @@ namespace ZEngine::Importers
         return Core::VFS::VFSResult<void>::Ok();
     }
 
-    void GltfImporter::ImportFile(const char* filename, const AssetCodec::ImportConfiguration& cfg, Core::Memory::ArenaAllocator* arena, void* context, void (*on_complete)(void*, Core::Containers::ArrayView<AssetImporterOutput>), void (*on_progress)(void*, float), void (*on_error)(void*, std::string_view), void (*on_log)(void*, std::string_view))
+    void GltfImporter::ImportFile(const char* filename, const AssetCodec::ImportConfiguration& cfg, Core::Memory::ArenaAllocator* arena, void* context, ImportCompleteCallback on_complete, ImportProgressCallback on_progress, ImportErrorCallback on_error, ImportLogCallback on_log)
     {
         // Build arena-allocated config copy (same pattern as AssimpImporter::ImportFile)
         AssetCodec::ImportConfiguration config = {};

--- a/ZEngine/ZEngine/Importers/GltfImporter.h
+++ b/ZEngine/ZEngine/Importers/GltfImporter.h
@@ -1,5 +1,9 @@
 #pragma once
+#include <ZEngine/Core/Containers/Array.h>
+#include <ZEngine/Importers/AssetCodec.h>
+#include <ZEngine/Importers/AssetTypes.h>
 #include <ZEngine/Importers/IAssetImporter.h>
+#include <string_view>
 
 namespace ZEngine::Importers
 {
@@ -12,7 +16,13 @@ namespace ZEngine::Importers
         void                         Initialize(Core::Memory::ArenaAllocator* arena);
 
         bool                         CanImport(const char* extension) const override;
+
+        // Coordinator path — ingests into AssetManager RAM (no disk output).
         Core::VFS::VFSResult<void>   Import(Core::VFS::IVFSContext& ctx, const Core::VFS::VFSPath& path, const Core::VFS::MetaFileData& meta) override;
+
+        // Importer-panel path — writes .zemesh / .zetextures / .zematerial to disk
+        // and ingests into AssetManager so the asset is immediately usable this session.
+        void                         ImportFile(const char* filename, const AssetCodec::ImportConfiguration& config, Core::Memory::ArenaAllocator* arena, void* context, void (*on_complete)(void*, Core::Containers::ArrayView<AssetImporterOutput>), void (*on_progress)(void*, float), void (*on_error)(void*, std::string_view), void (*on_log)(void*, std::string_view));
 
         Core::Memory::ArenaAllocator Arena = {};
     };

--- a/ZEngine/ZEngine/Importers/GltfImporter.h
+++ b/ZEngine/ZEngine/Importers/GltfImporter.h
@@ -22,7 +22,7 @@ namespace ZEngine::Importers
 
         // Importer-panel path — writes .zemesh / .zetextures / .zematerial to disk
         // and ingests into AssetManager so the asset is immediately usable this session.
-        void                         ImportFile(const char* filename, const AssetCodec::ImportConfiguration& config, Core::Memory::ArenaAllocator* arena, void* context, void (*on_complete)(void*, Core::Containers::ArrayView<AssetImporterOutput>), void (*on_progress)(void*, float), void (*on_error)(void*, std::string_view), void (*on_log)(void*, std::string_view));
+        void                         ImportFile(const char* filename, const AssetCodec::ImportConfiguration& config, Core::Memory::ArenaAllocator* arena, void* context, ImportCompleteCallback on_complete, ImportProgressCallback on_progress, ImportErrorCallback on_error, ImportLogCallback on_log);
 
         Core::Memory::ArenaAllocator Arena = {};
     };

--- a/ZEngine/ZEngine/Managers/AssetManager.cpp
+++ b/ZEngine/ZEngine/Managers/AssetManager.cpp
@@ -54,6 +54,15 @@ namespace ZEngine::Managers
         s_Instance->Registry = &s_registry;
     }
 
+    void AssetManager::InitFallbackTexture()
+    {
+        if (!s_Instance || !s_Instance->Device || !s_Instance->Device->RRM)
+            return;
+        auto* rrm                         = static_cast<Rendering::RenderResourceManager*>(s_Instance->Device->RRM);
+        s_Instance->FallbackTextureHandle = rrm->GetOrCreateFallbackTexture();
+        ZENGINE_LOG_ASSET_INFO("Fallback texture ready")
+    }
+
     void        AssetManager::Shutdown() {}
 
     AssetHandle AssetManager::RegisterAsset(AssetType type, const uuids::uuid& uuid, uint32_t slot_index, const Core::VFS::VFSPath& path, const Core::VFS::MetaFileData& meta)
@@ -151,13 +160,23 @@ namespace ZEngine::Managers
             // Store the path in the arena first so the pointer is stable
             // for the async GPU upload that outlives this stack frame.
             new_tex.Path.init(&s_Instance->Arena, tex.Path.c_str());
-            if (!new_tex.Path.empty())
+            if (!new_tex.Path.empty() && s_Instance->Device->RRM)
             {
                 const auto               path = fmt::format("{0}{1}{2}", s_Instance->CurrentWorkingSpacePath, PLATFORM_OS_BACKSLASH, new_tex.Path.c_str());
-                // Copy path into arena-backed storage for the async job.
                 Core::Containers::String stable_path;
                 stable_path.init(&s_Instance->Arena, path.c_str());
-                new_tex.Handle = s_Instance->Device->RRM ? static_cast<Rendering::RenderResourceManager*>(s_Instance->Device->RRM)->SubmitTextureFile(0, 0, stable_path.c_str()) : Rendering::Textures::TextureHandle{};
+                auto* rrm      = static_cast<Rendering::RenderResourceManager*>(s_Instance->Device->RRM);
+                new_tex.Handle = rrm->SubmitTextureFile(0, 0, stable_path.c_str());
+                if (!new_tex.Handle.Valid())
+                {
+                    ZENGINE_LOG_ASSET_WARN("Texture not found: '{}' — using fallback", stable_path.c_str())
+                    new_tex.Handle = s_Instance->FallbackTextureHandle;
+                }
+            }
+            else if (new_tex.Path.empty())
+            {
+                // No path at all — use fallback so the slot is never null
+                new_tex.Handle = s_Instance->FallbackTextureHandle;
             }
 
             RegisterAsset(AssetType::TEXTURE, new_tex.TextureUUID, slot);
@@ -253,7 +272,16 @@ namespace ZEngine::Managers
             const auto               tex_path_str = absolute ? std::string(file) : fmt::format("{0}{1}{2}", s_Instance->CurrentWorkingSpacePath, PLATFORM_OS_BACKSLASH, file);
             Core::Containers::String stable_path;
             stable_path.init(&s_Instance->Arena, tex_path_str.c_str());
-            new_tex.Handle = s_Instance->Device->RRM ? static_cast<Rendering::RenderResourceManager*>(s_Instance->Device->RRM)->SubmitTextureFile(0, 0, stable_path.c_str()) : Rendering::Textures::TextureHandle{};
+            if (s_Instance->Device->RRM)
+            {
+                auto* rrm      = static_cast<Rendering::RenderResourceManager*>(s_Instance->Device->RRM);
+                new_tex.Handle = rrm->SubmitTextureFile(0, 0, stable_path.c_str());
+                if (!new_tex.Handle.Valid())
+                {
+                    ZENGINE_LOG_ASSET_WARN("Texture not found: '{}' — using fallback", stable_path.c_str())
+                    new_tex.Handle = s_Instance->FallbackTextureHandle;
+                }
+            }
         }
 
         RegisterAsset(AssetType::TEXTURE, new_tex.TextureUUID, asset_id);

--- a/ZEngine/ZEngine/Managers/AssetManager.h
+++ b/ZEngine/ZEngine/Managers/AssetManager.h
@@ -32,6 +32,9 @@ namespace ZEngine::Managers
         // GPU texture handle map — needed to resolve material → texture handles at upload time.
         Core::Containers::UnorderedHashMap<uuids::uuid, Rendering::Textures::TextureHandle> UUIDToTextureHandle     = {};
 
+        // (255, 20, 147) fallback handle used when a texture file cannot be resolved.
+        Rendering::Textures::TextureHandle                                                  FallbackTextureHandle   = {};
+
         // Mutex guards direct-ingest methods called from import threads.
         mutable std::mutex                                                                  IngestMutex;
 
@@ -47,6 +50,7 @@ namespace ZEngine::Managers
 
         static AssetManager*                                                                Instance();
         static AssetHandle                                                                  CreateHandle(uint32_t index, AssetType type);
+        static void                                                                         InitFallbackTexture(); // call after RRM is assigned to Device
         static uint32_t                                                                     ReadAssetHandleIndex(AssetHandle h);
         static AssetType                                                                    ReadAssetHandleType(AssetHandle h);
 

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
@@ -1245,4 +1245,27 @@ namespace ZEngine::Rendering
         return tex_handle;
     }
 
+    Rendering::Textures::TextureHandle RenderResourceManager::GetOrCreateFallbackTexture()
+    {
+        static constexpr const char* kFallbackPath = "ZodiacEngine/Settings/FallbackTexture.png";
+
+        if (!std::filesystem::exists(kFallbackPath))
+        {
+            // 4×4 (255, 20, 147, 255) fallback color for missing textures
+            static constexpr int     W = 4, H = 4;
+            static constexpr uint8_t R = 255, G = 20, B = 147, A = 255;
+            uint8_t                  pixels[W * H * 4];
+            for (int i = 0; i < W * H; ++i)
+            {
+                pixels[i * 4 + 0] = R;
+                pixels[i * 4 + 1] = G;
+                pixels[i * 4 + 2] = B;
+                pixels[i * 4 + 3] = A;
+            }
+            stbi_write_png(kFallbackPath, W, H, 4, pixels, W * 4);
+        }
+
+        return SubmitTextureFile(0, 0, kFallbackPath);
+    }
+
 } // namespace ZEngine::Rendering

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.h
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.h
@@ -105,6 +105,9 @@ namespace ZEngine::Rendering
         /// @return A valid TextureHandle that will become readable once the upload drains.
         Rendering::Textures::TextureHandle SubmitTextureFile(uint8_t frame_index, uint8_t thread_index, const char* filename);
 
+        /// @brief Return the (255, 20, 147) fallback TextureHandle for missing textures, creating it on first call.
+        Rendering::Textures::TextureHandle GetOrCreateFallbackTexture();
+
         /// @brief Payload for a deferred texture upload.
         /// @details IsLarge = true stores an owned copy of the pixel data (std::vector<uint8_t>).
         ///          IsLarge = false stores a raw pointer valid until CompleteDeferrals runs.

--- a/ZEngine/ZEngine/Windows/GameWindow.cpp
+++ b/ZEngine/ZEngine/Windows/GameWindow.cpp
@@ -1,5 +1,13 @@
 #include <ZEngine/Core/Coroutine.h>
 #include <ZEngine/Engine.h>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#if defined(__APPLE__)
+// Implemented in Windows/Platform/MacOSFileDialog.mm
+extern "C" std::string ZEngineOpenFileDialog(const char** extensions, int count);
+#endif
 #include <ZEngine/Event/EngineClosedEvent.h>
 #include <ZEngine/Logging/LoggerDefinition.h>
 #include <ZEngine/Windows/GameWindow.h>
@@ -342,34 +350,87 @@ namespace ZEngine::Windows
 
     std::future<std::string> GameWindow::OpenFileDialogAsync(std::span<std::string_view> type_filters)
     {
-        std::string path{""};
-#ifdef _WIN32
+        std::string path{};
 
-        auto           native_hwnd = glfwGetWin32Window(m_native_window);
-
-        FileOpenPicker file_picker;
-        file_picker.ViewMode(PickerViewMode::Thumbnail);
-        file_picker.SuggestedStartLocation(PickerLocationId::ComputerFolder);
-        file_picker.as<::IInitializeWithWindow>()->Initialize(native_hwnd);
-
-        if (!type_filters.empty())
+#if defined(_WIN32)
         {
-            auto filters = file_picker.FileTypeFilter();
-            filters.Clear();
+            auto           native_hwnd = glfwGetWin32Window(m_native_window);
+            FileOpenPicker file_picker;
+            file_picker.ViewMode(PickerViewMode::Thumbnail);
+            file_picker.SuggestedStartLocation(PickerLocationId::ComputerFolder);
+            file_picker.as<::IInitializeWithWindow>()->Initialize(native_hwnd);
 
-            for (std::string_view type : type_filters)
+            if (!type_filters.empty())
             {
-                filters.Append(winrt::to_hstring(type));
+                auto filters = file_picker.FileTypeFilter();
+                filters.Clear();
+                for (std::string_view type : type_filters)
+                    filters.Append(winrt::to_hstring(type));
+            }
+
+            IStorageFile file = co_await file_picker.PickSingleFileAsync();
+            if (file)
+                path = winrt::to_string(file.Path());
+        }
+
+#elif defined(__APPLE__)
+        {
+            std::vector<const char*> exts;
+            exts.reserve(type_filters.size());
+            for (auto& f : type_filters)
+                exts.push_back(f.data());
+
+            path = ZEngineOpenFileDialog(exts.data(), static_cast<int>(exts.size()));
+        }
+
+#elif defined(__linux__)
+        {
+            // Try zenity first, then kdialog.
+            // Build the --file-filter argument (e.g. "*.glb *.gltf *.fbx *.obj").
+            std::string filter;
+            for (auto& f : type_filters)
+            {
+                if (!filter.empty())
+                    filter += ' ';
+                filter += '*';
+                filter += std::string(f);
+            }
+
+            std::string cmd;
+            if (system("which zenity > /dev/null 2>&1") == 0)
+            {
+                cmd = "zenity --file-selection --title='Import Asset'";
+                if (!filter.empty())
+                    cmd += " --file-filter='" + filter + "'";
+            }
+            else if (system("which kdialog > /dev/null 2>&1") == 0)
+            {
+                cmd = "kdialog --getopenfilename . '";
+                for (auto& f : type_filters)
+                    cmd += '*' + std::string(f) + ' ';
+                if (!cmd.empty() && cmd.back() == ' ')
+                    cmd.pop_back();
+                cmd += "'";
+            }
+
+            if (!cmd.empty())
+            {
+                FILE* pipe = popen(cmd.c_str(), "r");
+                if (pipe)
+                {
+                    char buf[4096] = {};
+                    if (fgets(buf, sizeof(buf), pipe))
+                    {
+                        path = buf;
+                        if (!path.empty() && path.back() == '\n')
+                            path.pop_back();
+                    }
+                    pclose(pipe);
+                }
             }
         }
-
-        IStorageFile file = co_await file_picker.PickSingleFileAsync();
-
-        if (file)
-        {
-            path = winrt::to_string(file.Path());
-        }
 #endif
+
         co_return path;
     }
 

--- a/ZEngine/ZEngine/Windows/Platform/MacOSFileDialog.mm
+++ b/ZEngine/ZEngine/Windows/Platform/MacOSFileDialog.mm
@@ -1,0 +1,48 @@
+// macOS native file-open dialog using NSOpenPanel.
+// Must be compiled as Objective-C++ (.mm) because it uses AppKit.
+// Called from C++ via the ZEngineOpenFileDialog extern "C" entry point.
+#import <AppKit/AppKit.h>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+extern "C" std::string ZEngineOpenFileDialog(const char** extensions, int count)
+{
+    __block std::string result;
+
+    // NSOpenPanel must run on the main thread.
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        NSOpenPanel* panel = [NSOpenPanel openPanel];
+        [panel setAllowsMultipleSelection:NO];
+        [panel setCanChooseFiles:YES];
+        [panel setCanChooseDirectories:NO];
+        [panel setMessage:@"Select a 3D asset file"];
+
+        if (count > 0)
+        {
+            NSMutableArray<NSString*>* types = [NSMutableArray array];
+            for (int i = 0; i < count; ++i)
+            {
+                std::string ext(extensions[i]);
+                if (!ext.empty() && ext[0] == '.')
+                    ext = ext.substr(1);
+                [types addObject:[NSString stringWithUTF8String:ext.c_str()]];
+            }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+            [panel setAllowedFileTypes:types];
+#pragma clang diagnostic pop
+        }
+
+        if ([panel runModal] == NSModalResponseOK)
+        {
+            NSURL* url = [panel URL];
+            if (url)
+                result = [[url path] UTF8String];
+        }
+    });
+
+    return result;
+}


### PR DESCRIPTION
## Summary

Replaces the 700×100 modal importer with a proper dockable panel following the Unreal Engine 5 import pipeline. Introduces a clean cook-based asset pipeline where raw source files never need to live in the project.

## Asset pipeline design

- Raw source files (.glb/.fbx/.obj) live **anywhere** — not copied into the project
- `MetaFileData` gains `SourcePath` field so the original file is always reachable for reimport; `SourceHash` detects staleness
- Cooked artifacts (.zemesh/.zetextures/.zematerial) written to `SceneData/`
- Content browser shows `.zemesh`; drag-drop to viewport still uses the fast coordinator/in-memory path for quick iteration

## Changes

**`GltfImporter::ImportFile()`** — mirrors `AssimpImporter::ImportFile`, loads .glb/.gltf via fastgltf, serializes cooked artifacts to disk, ingests into AssetManager for immediate session use, progress callbacks at 10/30/70/100%

**`AssetImporterUIComponent`** — new dockable panel with three states:
- Idle: browse button + drag-drop target + recent imports history
- Options: collapsible settings sections (Transform: scale/axis, Mesh: normals/merge, Material: textures/materials)
- Importing: non-blocking progress bar + live log

Routes .glb/.gltf to `GltfImporter::ImportFile`, .fbx/.obj to `AssimpImporter::ImportFile`. On-complete writes `.meta` with `SourcePath`.

**Platform file pickers**
- macOS: `NSOpenPanel` via `dispatch_sync` to main thread (`MacOSFileDialog.mm`)
- Windows: WinRT `FileOpenPicker` (existing)
- Linux: `zenity`/`kdialog` subprocess fallback

**Lazy cook on save** — `EditorSceneSerializer` checks each mesh instance before writing `.zescene`. Instances ingested via coordinator (RAM-only, no artifact path) are cooked to `.zemesh` on the spot so scenes survive restarts.

**Status bar** — Importer toggle button with indigo icon added alongside Console and Content Browser.

**`DockspaceUIComponent`** — all old modal importer code removed.

## Test plan

- [x] Click Importer button in status bar — panel opens in Idle state
- [x] Click `+ Import File` — native file picker opens (macOS: NSOpenPanel)
- [x] Select a .glb or .fbx — Options state shows with collapsible sections
- [x] Click `Import All` — Importing state with progress bar and log messages
- [x] Import completes — `.zemesh` written to `SceneData/`, content browser refreshes, history shows `[OK]`
- [x] Drag `.zemesh` from content browser onto scene — mesh appears
- [x] Drag raw `.glb` onto viewport — mesh appears in-session via coordinator
- [x] Save scene after drag-raw — `.zemesh` auto-generated, scene reloads correctly
- [x] File → Import New Asset... — opens the same panel