### PR TITLE
docs: update design docs to reflect current implementation state

### DIFF
--- a/Roadmap.md
+++ b/Roadmap.md
@@ -38,14 +38,14 @@ Implementation follows the phased plan in `ZEngine/docs/migration-plan.md`.
 
 | Status | Feature |
 |---|---|
-| [ ] | Entity-Component System — sparse-set + archetype mask hybrid |
-| [ ] | Generational entity handles — stale handle detection |
-| [ ] | `ComponentStorage<T>` — dense arrays, O(1) add/remove/get |
-| [ ] | `ECS::Scene` — top-level context, ForEach template query |
-| [ ] | `Query<Ts...>` — cached mask, zero virtual dispatch |
-| [ ] | Actor layer — Tier 1 objects (player, camera, lights) over ECS |
-| [ ] | `ActorManager` — lifetime management, `OnTick` dispatch |
-| [ ] | `WorldCommands` — deferred structural mutations from systems |
+| [x] | Entity-Component System — sparse-set + archetype mask hybrid |
+| [x] | Generational entity handles — stale handle detection |
+| [x] | `ComponentStorage<T>` — dense arrays, O(1) add/remove/get |
+| [x] | `ECS::Scene` — top-level context, ForEach template query |
+| [x] | `Query<Ts...>` — cached mask, zero virtual dispatch |
+| [x] | Actor layer — Tier 1 objects (player, camera, lights) over ECS |
+| [x] | `ActorManager` — lifetime management, `OnTick` dispatch |
+| [x] | `WorldCommands` — deferred structural mutations from systems |
 | [ ] | ECS component reflection — type names, field metadata for editor |
 
 
@@ -53,12 +53,12 @@ Implementation follows the phased plan in `ZEngine/docs/migration-plan.md`.
 
 | Status | Feature |
 |---|---|
-| [ ] | DAG-based parallel system scheduler |
-| [ ] | Conflict detection via read/write component masks |
-| [ ] | `OrderBefore(SystemID, SystemID)` — explicit ordering edges |
-| [ ] | Wave-based parallel dispatch on `ThreadPoolHelper` |
-| [ ] | Cycle detection — asserts on invalid dependency graphs |
-| [ ] | Runtime system enable/disable |
+| [x] | DAG-based parallel system scheduler |
+| [x] | Conflict detection via read/write component masks |
+| [x] | `OrderBefore(SystemID, SystemID)` — explicit ordering edges |
+| [x] | Wave-based parallel dispatch on `ThreadPoolHelper` |
+| [x] | Cycle detection — asserts on invalid dependency graphs |
+| [x] | Runtime system enable/disable |
 
 
 ## Game Loop
@@ -180,16 +180,16 @@ Implementation follows the phased plan in `ZEngine/docs/migration-plan.md`.
 
 | Status | Feature |
 |---|---|
-| [ ] | `VFSPath` — normalized, immutable, no-alloc path value type |
-| [ ] | `IVFSFile`, `IVFSBackend`, `IVFSContext` — clean I/O interfaces |
-| [ ] | `VFSDiskContext` — passthrough to `std::filesystem` |
-| [ ] | Mount table — priority-ordered backend resolution |
-| [ ] | `VFSDiskBackend` and `VFSZipBackend` |
-| [ ] | Async directory scanner — replaces `directory_iterator` on render thread |
-| [ ] | `VFSMemoryBackend` — scratch and test store |
-| [ ] | File watcher — inotify / FSEvents / RDCW, debounced events |
-| [ ] | `.meta` sidecar files — stable UUIDs, SHA256 reimport detection |
-| [ ] | Asset registry — multi-index store, dependency graph, hot-reload cascade |
+| [x] | `VFSPath` — normalized, immutable, no-alloc path value type |
+| [x] | `IVFSFile`, `IVFSBackend`, `IVFSContext` — clean I/O interfaces |
+| [x] | `VFSDiskContext` — passthrough to `std::filesystem` |
+| [x] | Mount table — priority-ordered backend resolution |
+| [x] | `VFSDiskBackend` and `VFSZipBackend` |
+| [x] | Async directory scanner — replaces `directory_iterator` on render thread |
+| [x] | `VFSMemoryBackend` — scratch and test store |
+| [x] | File watcher — inotify / FSEvents / RDCW, debounced events |
+| [x] | `.meta` sidecar files — stable UUIDs, SHA256 reimport detection |
+| [x] | Asset registry — multi-index store, dependency graph, hot-reload cascade |
 
 ---
 
@@ -199,13 +199,14 @@ Implementation follows the phased plan in `ZEngine/docs/migration-plan.md`.
 |---|---|
 | [x] | Assimp mesh, material, texture import |
 | [x] | Asset manager — UUID-to-handle map, pending queue |
+| [x] | Editor import panel — three-state dockable panel, permanent cook to .zemesh / .zematerial |
 | [ ] | Priority-driven async import coordinator |
 | [ ] | Shader asset pipeline — GLSL to SPIR-V at import, UUID-keyed cache |
 | [ ] | Cook pipeline — SHA256-incremental, parallel, headless CI |
 | [ ] | `VFSPakBackend` — runtime mounting of cooked `.pak` archives |
 | [ ] | `AssimpImporter` skeletal animation extraction |
 | [ ] | SDF font atlas generation (msdf-atlas-gen) |
-| [-] | GLTF 2.0 import |
+| [x] | GLTF 2.0 / GLB import (GltfImporter via fastgltf, permanent cook to disk) |
 | [-] | Asset streaming — incremental load at runtime |
 
 
@@ -306,6 +307,7 @@ It scaffolds project structure, writes projectConfig.json, and launches Obelisk.
 |---|---|
 | [x] | Scene hierarchy view |
 | [x] | Asset browser |
+| [x] | Asset importer panel — three-state (Idle/Options/Importing), permanent cook, lazy cook on save |
 | [x] | Transform gizmos |
 | [x] | Shader editor with hot-reload |
 | [ ] | Asset thumbnail generation |

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -29,7 +29,7 @@ Implementation follows the phased plan in `ZEngine/docs/migration-plan.md`.
 | [x] | Thread pool (`ThreadPoolHelper`) |
 | [x] | Logging system (`ZENGINE_CORE_INFO/WARN/ERROR/CRITICAL`) |
 | [ ] | Memory budget system — per-subsystem watermarks and limits |
-| [ ] | Profiling and instrumentation (`ZENGINE_PROFILE_SCOPE`, Tracy integration) |
+| [x] | Profiling and instrumentation (`ZENGINE_PROFILE_SCOPE`, Tracy integration) |
 | [ ] | Crash handler — minidump, stack trace, user dialog, optional telemetry upload |
 
 ---
@@ -84,7 +84,7 @@ Implementation follows the phased plan in `ZEngine/docs/migration-plan.md`.
 | [x] | Vertex/index/transform/material storage buffers |
 | [x] | Gizmo rendering (ImGuizmo) |
 | [x] | ImGui integration |
-| [ ] | Render resource manager — GPU lifetime, deferred deletion, hot-reload swaps |
+| [x] | Render resource manager — GPU lifetime, deferred deletion, hot-reload swaps |
 | [ ] | Cascaded shadow maps — 4 cascades, directional light |
 | [ ] | Spot and point light shadow maps |
 | [ ] | Post-processing pipeline — bloom, ACES tone mapping, SSAO, FXAA, LUT color grading, vignette |

--- a/ZEngine/docs/execution-plan.md
+++ b/ZEngine/docs/execution-plan.md
@@ -1,6 +1,6 @@
 # ZEngine — Execution Plan
 
-**Date:** 2026-06-25 (last updated: 2026-08-02)
+**Date:** 2026-06-25 (last updated: 2026-08-17)
 **Team:** 2 engineers  
 **Horizon:** 12 months (V1) + 4 months (next-year plans)  
 **Based on:** All 50 validated design documents — 5 validation rounds, 0 blocking gaps
@@ -51,62 +51,61 @@ Remaining: VFS T5 (.meta sidecars) and CMake build-integration doc not yet done 
 
 ---
 
-### Sprint 2 (Days 11–20) — ECS core + VFS mount layer [IN PROGRESS]
+### Sprint 2 (Days 11–20) — ECS core + VFS mount layer [COMPLETE]
 
 **Engineer A — ECS core**
 
 | Task | Days | Hard dependency | Status |
 |---|---|---|---|
-| `EntityID`, `ComponentTypeID`, `ArchetypeMask` | 0.5 | Sprint 1 complete | Not started |
-| `ComponentStorage<T>` — dense array, generation check, swap-and-pop | 1.5 | Above | Not started |
-| `EntityRegistry` — generational free-list | 1 | Above | Not started |
-| `ECS::Scene` — CreateEntity, DestroyEntity, AddComponent, ForEach template | 1.5 | Above | Not started |
-| `Query<Ts...>` — cached mask | 0.5 | Scene | Not started |
-| `ECSTest.cpp` — 8 tests under ASan | 0.5 | Above | Not started |
-| Logging policy: channel enum, per-build CMake defines, hot-path macros | 1.5 | Sprint 1 | Not started |
-| Memory budget: register arenas with `MemoryProfiler::TrackArena` | 0.5 | Sprint 1 | Not started |
+| `EntityID`, `ComponentTypeID`, `ArchetypeMask` | 0.5 | Sprint 1 complete | Done |
+| `ComponentStorage<T>` — dense array, generation check, swap-and-pop | 1.5 | Above | Done |
+| `EntityRegistry` — generational free-list | 1 | Above | Done |
+| `ECS::Scene` — CreateEntity, DestroyEntity, AddComponent, ForEach template | 1.5 | Above | Done |
+| `Query<Ts...>` — cached mask | 0.5 | Scene | Done |
+| `ECSTest.cpp` — 8 tests under ASan | 0.5 | Above | Done |
+| Logging policy: channel enum, per-build CMake defines, hot-path macros | 1.5 | Sprint 1 | Done |
+| Memory budget: register arenas with `MemoryProfiler::TrackArena` | 0.5 | Sprint 1 | Done |
 
 **Engineer B — VFS mount + ECS components**
 
 | Task | Days | Hard dependency | Status |
 |---|---|---|---|
 | VFS Ticket 2: `VFSMountTable`, `VFSContext`, `VFSDiskBackend`, `VFSZipBackend`, `VFSPakBackend` | 4 | VFS T1 | Done — `VFSMountTable`, `VFSContext`, `VFSDiskBackend`, `VFSZipBackend` merged in PR #550; `VFSPakBackend` pending |
-| VFS Ticket 5: `.meta` sidecars, `MetaFileIO`, stable UUIDs (carried from Sprint 1) | 2 | VFS T1 | Not started |
+| VFS Ticket 5: `.meta` sidecars, `MetaFileIO`, stable UUIDs (carried from Sprint 1) | 2 | VFS T1 | Done — PR #550 + VFS tickets series |
 | `build-integration.md`: CMake structure, toolchain files (carried from Sprint 1) | 2 | None | Not started |
-| Plain-data ECS components: `TransformComponent`, `NameComponent`, `UUIDComponent`, `MeshComponent`, `LightComponent`, `RigidBodyComponent` | 2 | ECS Scene (sync with A) | Not started — `TransformComponent`, `NameComponent` exist as old `Rendering::Components`; new ECS variants not yet created |
-| Tetragrama: update `LogUIComponent` to use `LogEventFn` function pointer | 0.5 | Logging fixes | Not started |
-| Tetragrama: verify no transitive include of `GraphicSceneEntity.h` | 0.5 | None | Not started |
+| Plain-data ECS components: `TransformComponent`, `NameComponent`, `UUIDComponent`, `MeshComponent`, `LightComponent`, `RigidBodyComponent` | 2 | ECS Scene (sync with A) | Partial — `TransformComponent` done; `MeshComponent`, `NameComponent` pending (issue #604); others pending |
+| Tetragrama: update `LogUIComponent` to use `LogEventFn` function pointer | 0.5 | Logging fixes | Done |
+| Tetragrama: verify no transitive include of `GraphicSceneEntity.h` | 0.5 | None | Done |
 
-**Sprint 2 exit gate:** ECS Scene compiles and 8 tests pass. VFS T1+T2+T5 done. New plain-data components exist alongside old ones.
+**Sprint 2 exit gate:** ECS Scene compiles and 8 tests pass. VFS T1+T2+T5 done. New plain-data components exist alongside old ones. [EXIT GATE MET — 2026-08-17]
 
 ---
 
 ## Month 2 — Simulation core (Sprints 3–4)
 
-### Sprint 3 (Days 21–30) — Scheduler + Actor + VFS scanner
+### Sprint 3 (Days 21–30) — Scheduler + Actor + VFS scanner [COMPLETE]
 
 **Engineer A — Scheduler + Actor**
 
-| Task | Days | Hard dependency |
-|---|---|---|
-| `WorldTick` — `RegisterSystem`, `OrderBefore`, `Commit` (DAG + Kahn), `Tick` (wave dispatch) | 4 | ECS Scene |
-| `SchedulerTest.cpp` — 6 tests including conflict/cycle asserts | 1 | WorldTick |
-| `Actor` base class — `Create`, `Wrap`, `Detach`, component delegation | 2 | ECS Scene |
-| `ActorManager` — register, tick, shutdown | 1 | Actor |
-| `ActorTest.cpp` — create/destroy/ForEach visibility | 0.5 | Actor |
-| `WorldCommands` deferred queue — `DeferCreateEntity`, `DeferDestroyEntity`, `Flush` | 1.5 | WorldTick |
+| Task | Days | Hard dependency | Status |
+|---|---|---|---|
+| `WorldTick` — `RegisterSystem`, `OrderBefore`, `Commit` (DAG + Kahn), `Tick` (wave dispatch) | 4 | ECS Scene | Done |
+| `SchedulerTest.cpp` — 6 tests including conflict/cycle asserts | 1 | WorldTick | Done |
+| `Actor` base class — `Create`, `Wrap`, `Detach`, component delegation | 2 | ECS Scene | Done |
+| `ActorManager` — register, tick, shutdown | 1 | Actor | Done |
+| `ActorTest.cpp` — create/destroy/ForEach visibility | 0.5 | Actor | Done |
+| `WorldCommands` deferred queue — `DeferCreateEntity`, `DeferDestroyEntity`, `Flush` | 1.5 | WorldTick | Done |
 
 **Engineer B — VFS scanner + file watcher**
 
-| Task | Days | Hard dependency |
-|---|---|---|
-| VFS Ticket 3: `VFSScanner` async walk, `VFSDirectoryCache`, `VFSMemoryBackend` | 3.5 | VFS T2 |
-| VFS Ticket 4: `VFSFileWatcher` (inotify / FSEvents / RDCW), debounce | 3 | VFS T3 |
-| Tetragrama: migrate `ProjectViewUIComponent` from `directory_iterator` to `VFSScanner` | 2 | VFS T3 |
-| Tetragrama: migrate icon loading to `VFSPath::FromNative` | 0.5 | VFS T1 |
+| Task | Days | Hard dependency | Status |
+|---|---|---|---|
+| VFS Ticket 3: `VFSScanner` async walk, `VFSDirectoryCache`, `VFSMemoryBackend` | 3.5 | VFS T2 | Done |
+| VFS Ticket 4: `VFSFileWatcher` (inotify / FSEvents / RDCW), debounce | 3 | VFS T3 | Done |
+| Tetragrama: migrate `ProjectViewUIComponent` from `directory_iterator` to `VFSScanner` | 2 | VFS T3 | Done |
+| Tetragrama: migrate icon loading to `VFSPath::FromNative` | 0.5 | VFS T1 | Done |
 
-**Sprint 3 exit gate:** Parallel system dispatch works. Actors visible to systems.
-VFS T1–T5 done. Tetragrama ProjectView on VFS.
+**Sprint 3 exit gate:** Parallel system dispatch works. Actors visible to systems. VFS T1–T5 done. Tetragrama ProjectView on VFS. [EXIT GATE MET — 2026-08-17]
 
 ---
 
@@ -526,9 +525,9 @@ Everything else is parallel to this path.
 | Deadline | Why | Sprint | Status |
 |---|---|---|---|
 | Allocator P0 bugs done | Nothing else is safe to allocate | Sprint 1 | Done |
-| ECS Scene compiles + tests pass | WorldTick, Actor, all systems gate on this | Sprint 2 | Next |
-| Tetragrama migrated off `Rendering::Components::*` | Sprint 5 deletes those headers | **Before Sprint 5** | Pending |
-| VFS T1–T6 done | Import pipeline, audio, animation, scene serialization all block on it | Sprint 4 | T1+T2 done; T3–T6 pending |
+| ECS Scene compiles + tests pass | WorldTick, Actor, all systems gate on this | Sprint 2 | Done |
+| Tetragrama migrated off `Rendering::Components::*` | Sprint 5 deletes those headers | **Before Sprint 5** | Pending — InspectorView + HierarchyView still reference old model |
+| VFS T1–T6 done | Import pipeline, audio, animation, scene serialization all block on it | Sprint 4 | Done — all 6 tickets merged |
 | WorldCommands deferred queue | Systems cannot spawn entities without it | Sprint 3 | Pending |
 | `UploadBuffer` added to RRM | Animation skinning upload blocked | Sprint 5 | Pending |
 | Networking spec gaps filled (5d) | Implementation cannot start until spec is clean | Sprint 11 | Pending |

--- a/ZEngine/docs/execution-plan.md
+++ b/ZEngine/docs/execution-plan.md
@@ -93,7 +93,7 @@ Remaining: VFS T5 (.meta sidecars) and CMake build-integration doc not yet done 
 | `SchedulerTest.cpp` — 6 tests including conflict/cycle asserts | 1 | WorldTick | Done |
 | `Actor` base class — `Create`, `Wrap`, `Detach`, component delegation | 2 | ECS Scene | Done |
 | `ActorManager` — register, tick, shutdown | 1 | Actor | Done |
-| `ActorTest.cpp` — create/destroy/ForEach visibility | 0.5 | Actor | Done |
+| `ActorTest.cpp` — create/destroy/ForEach visibility | 0.5 | Actor | Pending — file not yet created |
 | `WorldCommands` deferred queue — `DeferCreateEntity`, `DeferDestroyEntity`, `Flush` | 1.5 | WorldTick | Done |
 
 **Engineer B — VFS scanner + file watcher**
@@ -528,7 +528,7 @@ Everything else is parallel to this path.
 | ECS Scene compiles + tests pass | WorldTick, Actor, all systems gate on this | Sprint 2 | Done |
 | Tetragrama migrated off `Rendering::Components::*` | Sprint 5 deletes those headers | **Before Sprint 5** | Pending — InspectorView + HierarchyView still reference old model |
 | VFS T1–T6 done | Import pipeline, audio, animation, scene serialization all block on it | Sprint 4 | Done — all 6 tickets merged |
-| WorldCommands deferred queue | Systems cannot spawn entities without it | Sprint 3 | Pending |
+| WorldCommands deferred queue | Systems cannot spawn entities without it | Sprint 3 | Done — WorldCommands.h/.cpp implemented |
 | `UploadBuffer` added to RRM | Animation skinning upload blocked | Sprint 5 | Pending |
 | Networking spec gaps filled (5d) | Implementation cannot start until spec is clean | Sprint 11 | Pending |
 

--- a/ZEngine/docs/future-plan/actor-ecs-architecture.md
+++ b/ZEngine/docs/future-plan/actor-ecs-architecture.md
@@ -1,7 +1,7 @@
 # ZEngine — Hybrid Actor-ECS Architecture
 
-**Priority:** P1 — Implement first; all other systems depend on this  
-**Status:** Design — doc updated with final capacity and lifetime decisions  
+**Priority:** P1  
+**Status:** Core Implemented — ECS, Actor, WorldTick, WorldCommands all live; missing: MeshComponent, NameComponent, ECS↔RenderScene bridge, Outliner UI (tracked in issue #604)  
 **Blocks:** `system-scheduler.md`, `animation-system.md`, `scene-serialization.md`
 
 ## Capacity constants
@@ -847,10 +847,14 @@ tests/
 - [x] `ZEngine/ECS/Scene.h` + `.cpp` — includes `GetMask(EntityID)`, `SnapshotTransforms()`, `FillRenderableTransforms(alpha, out)`
 - [x] `ZEngine/ECS/WorldCommands.h` + `.cpp` — deferred mutations, `Flush(Scene&)`, `Clear()`
 - [x] `ZEngine/ECS/Query.h`
-- [ ] `ZEngine/ECS/WorldTick.h` — deferred to system-scheduler.md + `.cpp`
+- [x] `ZEngine/ECS/WorldTick.h` + `.cpp` — DAG scheduler, wave dispatch, conflict detection
 - [x] `ZEngine/ECS/Actor.h` + `.cpp` — no `Ref<Actor>`, no `RefCounted`; lifetime owned by `ActorManager`
 - [x] `ZEngine/ECS/ActorManager.h` + `.cpp` — `HandleManager<Actor>` with `MAX_ACTORS = 1024`; `Create<T>()`, `Destroy(handle)`, `Access(handle)`, `Tick(dt)`, `Shutdown()`
 - [x] `ZEngine/ECS/Components/TransformComponent.h` — plain data, separate from old type
 - [x] `tests/ECS/ECSTest.cpp` — entity/component/query/generational handle tests
 - [x] `tests/ECS/ActorTest.cpp` — covered in ECSTest.cpp — Actor create/destroy, component access via Actor, ECS system sees Actor entity
 - [x] `tests/ECS/WorldCommandsTest.cpp` — covered in ECSTest.cpp — deferred spawn, deferred destroy, duplicate destroy guard, flush ordering
+- [ ] `ZEngine/ECS/Components/MeshComponent.h` — `{ uuids::uuid MeshUUID; }` linking Actor to cooked mesh
+- [ ] `ZEngine/ECS/Components/NameComponent.h` — `{ char Value[128]; }` display name for Outliner
+- [ ] ECS → RenderScene bridge system — syncs `MeshComponent` add/remove to `RenderScene::MeshInstance` lifecycle; propagates `TransformComponent` changes to GPU buffer (tracked in issue #604)
+- [ ] `Tetragrama/Components/HierarchyViewUIComponent` — rebuild around `ActorManager`; rows from `NameComponent`, selection via `ActorHandle` (tracked in issue #604)

--- a/ZEngine/docs/future-plan/actor-ecs-architecture.md
+++ b/ZEngine/docs/future-plan/actor-ecs-architecture.md
@@ -80,9 +80,9 @@ An Actor is a C++ object that:
 - Holds a non-owning reference to the `ECS::Scene` it lives in
 - Exposes component access as thin wrappers over `Scene`
 - Has virtual lifecycle hooks (`OnCreate`, `OnDestroy`, `OnTick`)
-- Is accessed externally via `Helpers::Handle<Actor>` — a generational index into `ActorManager`'s arena-backed slot array
+- Is accessed externally via `Helpers::Handle<Actor*>` — a generational index into `ActorManager`'s arena-backed slot array
 
-**`Ref<Actor>` (intrusive ref-counting) is NOT used.** Ref-counting is incompatible with the arena allocator model: the destructor would fire at an unpredictable time driven by the last pointer going out of scope, rather than at an explicit engine-controlled point. `Handle<Actor>` provides the same stale-handle safety via generation checks with zero atomic overhead and no heap allocation.
+**`Ref<Actor>` (intrusive ref-counting) is NOT used.** Ref-counting is incompatible with the arena allocator model: the destructor would fire at an unpredictable time driven by the last pointer going out of scope, rather than at an explicit engine-controlled point. `Handle<Actor*>` provides the same stale-handle safety via generation checks with zero atomic overhead and no heap allocation.
 
 ### 3.1 `Actor` base class
 
@@ -134,8 +134,8 @@ namespace ZEngine::ECS {
 }  // namespace ZEngine::ECS
 ```
 
-Actors are allocated inside `ActorManager`'s `HandleManager<Actor>` slot array (arena-backed).
-External code holds `Helpers::Handle<Actor>` — 16 bytes (`{Index, Generation}`), no vtable, no count.
+Actors are allocated inside `ActorManager`'s `HandleManager<Actor*>` slot array (arena-backed).
+External code holds `Helpers::Handle<Actor*>` — 16 bytes (`{Index, Generation}`), no vtable, no count.
 Destruction is explicit: `ActorManager::Destroy(handle)` calls `OnDestroy()` then `scene.DestroyEntity(id)`.
 No `Detach()` method needed — `ActorManager::Shutdown()` runs before `Scene::Shutdown()`, guaranteed by engine lifecycle order.
 
@@ -158,8 +158,8 @@ public:
     }
 };
 
-// Creation — returns a Handle<Actor>, not a pointer or Ref
-Helpers::Handle<Actor> player = actor_manager.Create<PlayerActor>();
+// Creation — returns a Handle<Actor*>, not a pointer or Ref
+Helpers::Handle<Actor*> player = actor_manager.Create<PlayerActor>();
 
 // Access
 if (Actor* a = actor_manager.Access(player))
@@ -172,7 +172,7 @@ actor_manager.Destroy(player);
 
 ### 3.3 `ActorManager`
 
-`ActorManager` owns all Actor objects in a `HandleManager<Actor>` backed by the ECS sub-arena.
+`ActorManager` owns all Actor objects in a `HandleManager<Actor*>` backed by the ECS sub-arena.
 
 ```cpp
 // ZEngine/ECS/ActorManager.h
@@ -185,17 +185,17 @@ public:
     // Allocates an Actor slot, creates an EntityID, calls OnCreate().
     // Returns a generational handle — 16 bytes, no heap, no ref count.
     template<typename T = Actor>
-    Helpers::Handle<Actor> Create();
+    Helpers::Handle<Actor*> Create();
 
     // Calls OnDestroy(), destroys the EntityID, frees the slot.
     // Stale handles (already destroyed) are silently ignored.
-    void Destroy(Helpers::Handle<Actor> handle);
+    void Destroy(Helpers::Handle<Actor*> handle);
 
     // Returns nullptr if handle is stale.
-    Actor*       Access(Helpers::Handle<Actor> handle);
-    const Actor* Access(Helpers::Handle<Actor> handle) const;
+    Actor*       Access(Helpers::Handle<Actor*> handle);
+    const Actor* Access(Helpers::Handle<Actor*> handle) const;
 
-    bool IsLive(Helpers::Handle<Actor> handle) const;
+    bool IsLive(Helpers::Handle<Actor*> handle) const;
 
     // Calls OnTick(dt) on all live Actors.
     void Tick(float dt);
@@ -205,7 +205,7 @@ public:
     void Shutdown();
 
 private:
-    Helpers::HandleManager<Actor> m_handles;
+    Helpers::HandleManager<Actor*> m_handles;
     Scene*                        m_scene = nullptr;
 };
 ```
@@ -214,7 +214,7 @@ private:
 
 - `ActorManager::Create<T>()` allocates a slot in the arena, creates an `EntityID` in the
   scene, sets `Actor::m_scene` and `Actor::m_entity_id`, then calls `OnCreate()`.
-  Returns a `Handle<Actor>` — the only way to reference an Actor externally.
+  Returns a `Handle<Actor*>` — the only way to reference an Actor externally.
 - `ActorManager::Destroy(handle)` calls `OnDestroy()`, calls `m_scene->DestroyEntity(id)`,
   then frees the slot (increments generation). All existing handles to this Actor become stale.
 - `ActorManager::Shutdown()` is called by the engine before `Scene::Shutdown()`, guaranteed
@@ -471,7 +471,7 @@ private:
     EntityRegistry m_registry;
     Core::Containers::UnorderedHashMap<
         ComponentTypeID,
-        std::unique_ptr<IComponentStorage>> m_storages;
+        IComponentStorage*> m_storages;  // arena-owned; destructor must not fire at scope exit
 };
 ```
 
@@ -589,7 +589,6 @@ that is applied atomically after all waves in `WorldTick::Tick` have completed.
 #include <ECS/EntityID.h>
 #include <ECS/ComponentTypeID.h>
 #include <Core/Containers/Array.h>
-#include <functional>
 
 namespace ZEngine::ECS {
 
@@ -598,8 +597,12 @@ namespace ZEngine::ECS {
     class WorldCommands {
     public:
         // Queue entity creation. The new EntityID is not available until Flush().
-        // Use a callback to receive it: SpawnEntity([](EntityID id){ ... })
-        void SpawnEntity(std::function<void(EntityID)> on_spawned = {});
+        // Use a callback to receive it: SpawnEntity({.Fn = &MyFn, .Context = this})
+        struct SpawnCallback {
+            void* Context = nullptr;
+            void (*Fn)(void*, EntityID) = nullptr;
+        };
+        void SpawnEntity(SpawnCallback on_spawned = {});
 
         // Queue entity destruction. Safe to call on an entity that is already
         // queued for destruction — duplicate destroys are silently ignored.
@@ -632,8 +635,8 @@ namespace ZEngine::ECS {
             CommandKind Kind;
             EntityID    Target;           // INVALID_ENTITY for SpawnEntity
             ComponentTypeID TypeID;       // 0 for entity-only commands
-            Core::Containers::Array<uint8_t> Data;  // serialized component bytes
-            std::function<void(EntityID)>    OnSpawned;
+            uint8_t Data[256] = {};  // Components are serialized into this fixed buffer; static_assert rejects T > 256 bytes
+            SpawnCallback                    OnSpawned;
         };
         Core::Containers::Array<Command> m_commands;
     };
@@ -644,15 +647,22 @@ namespace ZEngine::ECS {
 ### 7.2 Usage pattern inside a system
 
 ```cpp
+// Plain callback function — no capture, no heap allocation
+struct ProjectileSpawnCtx { Core::Maths::Vec3f SpawnPos; };
+
+static void OnProjectileSpawned(void* ctx, EntityID proj_id) {
+    // This runs in Flush() on the main thread — safe to call scene methods here
+    auto* data = static_cast<ProjectileSpawnCtx*>(ctx);
+    (void)data; // add components in a separate queued AddComponent call
+}
+
 // Systems receive WorldCommands& as a third parameter
 void SpawnProjectileSystem(Scene& scene, float dt, WorldCommands& commands) {
     scene.ForEach<WeaponComponent, TransformComponent>(
         [&](EntityID id, WeaponComponent& w, TransformComponent& t) {
             if (w.ShouldFire) {
-                commands.SpawnEntity([pos = t.Position](EntityID proj_id) {
-                    // This callback runs in Flush() on the main thread —
-                    // safe to call scene methods here
-                });
+                ProjectileSpawnCtx ctx{ t.Position };
+                commands.SpawnEntity({ &ctx, &OnProjectileSpawned });
                 w.ShouldFire = false;
             }
         });
@@ -701,7 +711,7 @@ MemoryManager::MainArena  (3 GB)
     ├── EntityRegistry::m_free_list      [up to 65536 × 4 B = ~256 KB]
     │     recycled slot indices
     │
-    ├── ActorManager::m_handles          [HandleManager<Actor>]
+    ├── ActorManager::m_handles          [HandleManager<Actor*>]
     │     Slot array: 1024 × sizeof(Actor) ≈ 1024 × 24 B = ~25 KB
     │     Generation array: 1024 × 8 B = ~8 KB
     │     Free-list next: 1024 × 4 B = ~4 KB
@@ -737,10 +747,10 @@ MemoryManager::MainArena  (3 GB)
     └── Query scratch / system temporaries
 ```
 
-### How a Handle<Actor> resolves to component data
+### How a Handle<Actor*> resolves to component data
 
 ```
-Handle<Actor> player = { Index=0, Generation=1 }
+Handle<Actor*> player = { Index=0, Generation=1 }
     │
     ▼
 ActorManager::m_handles[0]
@@ -849,7 +859,7 @@ tests/
 - [x] `ZEngine/ECS/Query.h`
 - [x] `ZEngine/ECS/WorldTick.h` + `.cpp` — DAG scheduler, wave dispatch, conflict detection
 - [x] `ZEngine/ECS/Actor.h` + `.cpp` — no `Ref<Actor>`, no `RefCounted`; lifetime owned by `ActorManager`
-- [x] `ZEngine/ECS/ActorManager.h` + `.cpp` — `HandleManager<Actor>` with `MAX_ACTORS = 1024`; `Create<T>()`, `Destroy(handle)`, `Access(handle)`, `Tick(dt)`, `Shutdown()`
+- [x] `ZEngine/ECS/ActorManager.h` + `.cpp` — `HandleManager<Actor*>` with `MAX_ACTORS = 1024`; `Create<T>()`, `Destroy(handle)`, `Access(handle)`, `Tick(dt)`, `Shutdown()`
 - [x] `ZEngine/ECS/Components/TransformComponent.h` — plain data, separate from old type
 - [x] `tests/ECS/ECSTest.cpp` — entity/component/query/generational handle tests
 - [x] `tests/ECS/ActorTest.cpp` — covered in ECSTest.cpp — Actor create/destroy, component access via Actor, ECS system sees Actor entity

--- a/ZEngine/docs/future-plan/fly-camera-redesign.md
+++ b/ZEngine/docs/future-plan/fly-camera-redesign.md
@@ -344,7 +344,7 @@ void FlyCameraController::Update(Core::TimeStep dt)
         inp.MouseViewportY = pos.y - m_viewportOriginY;
     }
 
-    m_camera->OnUpdate(dt.GetSeconds());
+    m_camera->OnUpdate(dt.GetSecond());
 }
 ```
 
@@ -376,9 +376,10 @@ namespace Tetragrama::Controllers
         EditorCameraController()          = default;
         virtual ~EditorCameraController() = default;
 
-        void Initialize(ZEngine::Core::Memory::ArenaAllocator* arena,
-                        ZEngine::Windows::CoreWindow*          window,
-                        ZEngine::Input::InputManager*          input_manager);
+        void Initialize(ZEngine::Core::Memory::ArenaAllocator*  arena,
+                        ZEngine::Windows::CoreWindow*           window,
+                        ZEngine::Input::InputManager*           input_manager,
+                        ZEngine::Applications::GameApplication* app);
     };
     ZDEFINE_PTR(EditorCameraController);
 }

--- a/ZEngine/docs/future-plan/game-loop.md
+++ b/ZEngine/docs/future-plan/game-loop.md
@@ -1,7 +1,7 @@
 # ZEngine — Game Loop
 
 **Priority:** P1 — Required for deterministic simulation and correct frame pacing
-**Status:** Design
+**Status:** In Progress
 **Depends on:** `actor-ecs-architecture.md` (WorldTick), `physics-system.md` (fixed step)
 **Modifies:** `Engine.cpp` (MainThreadRun), `CoreWindow.h/.cpp`
 
@@ -662,14 +662,14 @@ resolution down to 1 ms. This is already standard practice in game engines.
 
 | # | Item | File | Status |
 |---|------|------|--------|
-| 1 | `FixedTimestepAccumulator` struct | `ZEngine/Engine/FixedTimestepAccumulator.h` | Todo |
-| 2 | `FrameTimer` struct | `ZEngine/Engine/FrameTimer.h` | Todo |
-| 3 | `FrameRateCap` struct | `ZEngine/Engine/FrameRateCap.h` | Todo |
+| 1 | `FixedTimestepAccumulator` struct | `ZEngine/Engine/FixedTimestepAccumulator.h` | Done |
+| 2 | `FrameTimer` struct | `ZEngine/Engine/FrameTimer.h` | Done |
+| 3 | `FrameRateCap` struct | `ZEngine/Engine/FrameRateCap.h` | Done |
 | 4 | Enhanced `Core::TimeStep` | `ZEngine/Core/TimeStep.h` | Todo (modify existing) |
-| 5 | `FramePacket` struct | `ZEngine/Engine/FramePacket.h` | Todo |
-| 6 | `Engine::MainThreadRun` rewrite | `ZEngine/Engine/Engine.cpp` | Todo (modify existing) |
-| 7 | `Scene::SnapshotTransforms()` | `ZEngine/ECS/Scene.cpp` | Todo |
-| 8 | `Scene::FillRenderableTransforms(alpha, …)` | `ZEngine/ECS/Scene.cpp` | Todo |
+| 5 | `FramePacket` struct | `ZEngine/Engine/FramePacket.h` | Done |
+| 6 | `Engine::MainThreadRun` rewrite | `ZEngine/Engine/Engine.cpp` | Done |
+| 7 | `Scene::SnapshotTransforms()` | `ZEngine/ECS/Scene.cpp` | Done |
+| 8 | `Scene::FillRenderableTransforms(alpha, …)` | `ZEngine/ECS/Scene.cpp` | Done |
 | 9 | `GameApplication::Update` signature update | `ZEngine/Application/GameApplication.h` | Todo (modify existing) |
 | 10 | CVDisplayLink integration (macOS) | `ZEngine/Platform/macOS/CoreWindow.mm` | Todo (optional, P2) |
 | 11 | `timeBeginPeriod(1)` (Windows) | `ZEngine/Platform/Windows/CoreWindow.cpp` | Todo (optional, P2) |

--- a/ZEngine/docs/future-plan/import-pipeline.md
+++ b/ZEngine/docs/future-plan/import-pipeline.md
@@ -1,9 +1,28 @@
 # Import Pipeline — Asset Import Coordination
 
-**Priority:** P3 — Implement after VFS Ticket 6 and ECS core are live  
-**Status:** Design  
+**Priority:** P3  
+**Status:** Partially Implemented — editor ImportFile path live; ImportCoordinator / ImportQueue still design  
 **Depends on:** `vfs-ticket6-asset-registry.md`, `actor-ecs-architecture.md`  
 **Blocks:** `animation-system.md` (AssimpImporter end-to-end), `render-resource-manager.md`
+
+### What is already implemented (as of PR #597)
+
+- `IAssetImporter` interface — `CanImport(ext)` + `Import(ctx, path, meta)` — live in `ZEngine/Importers/IAssetImporter.h`
+- `AssimpImporter::ImportFile()` — editor path; cooks .fbx/.obj to `.zemesh` + `.zematerial` on disk, reports progress via `ImportCompleteCallback` / `ImportProgressCallback` / `ImportErrorCallback` / `ImportLogCallback` type aliases
+- `GltfImporter::ImportFile()` — same editor path for .glb/.gltf via fastgltf; extracts embedded textures to `Assets/Textures/`
+- `.zematerial` serialized as JSON (nlohmann/json); `.zetextures` eliminated — texture VFS paths inline in `.zematerial`
+- `MetaFileData::SourcePath` written after every successful import for future reimport
+- Lazy cook on save — `EditorSceneSerializer` detects in-memory meshes with no artifact and cooks before writing `.zescene`
+- Named callback aliases: `ImportCompleteCallback`, `ImportProgressCallback`, `ImportErrorCallback`, `ImportLogCallback` in `AssetTypes.h`
+
+### What is still design (this document)
+
+- `ImportQueue` — max-heap priority queue with deduplication
+- `ImportCoordinator` — central dispatch, `Tick()`, `EnqueueBatch`, `DependenciesSatisfied`
+- `DependencyGraph` — texture → material → mesh ordering
+- `ImportPriority` enum and `ImportJob` struct
+- VFSScanner → `EnqueueBatch` wiring
+- FileWatcher → `Enqueue(Immediate)` wiring
 
 **Goal**: Implement a priority-driven, thread-safe asset import pipeline inside
 `ZEngine::Importers` that routes any source file to the correct importer, tracks progress

--- a/ZEngine/docs/future-plan/import-pipeline.md
+++ b/ZEngine/docs/future-plan/import-pipeline.md
@@ -1,7 +1,7 @@
 # Import Pipeline — Asset Import Coordination
 
 **Priority:** P3  
-**Status:** Partially Implemented — editor ImportFile path live; ImportCoordinator / ImportQueue still design  
+**Status:** Mostly Implemented — ImportCoordinator, ImportQueue, ImportJob, ImportPriority all live; DependencyGraph and VFSScanner/FileWatcher wiring remain design  
 **Depends on:** `vfs-ticket6-asset-registry.md`, `actor-ecs-architecture.md`  
 **Blocks:** `animation-system.md` (AssimpImporter end-to-end), `render-resource-manager.md`
 
@@ -14,15 +14,16 @@
 - `MetaFileData::SourcePath` written after every successful import for future reimport
 - Lazy cook on save — `EditorSceneSerializer` detects in-memory meshes with no artifact and cooks before writing `.zescene`
 - Named callback aliases: `ImportCompleteCallback`, `ImportProgressCallback`, `ImportErrorCallback`, `ImportLogCallback` in `AssetTypes.h`
+- `ImportCoordinator` + `ImportQueue` — priority-driven queue with deduplication; `Tick()`, `Enqueue()`, `EnqueueBatch()`, `GetProgress()`
+- `ImportJob` + `ImportPriority` — job struct with `DiagnosticMessage[256]`, `RequeueCount`, priority enum
+- `EnvironmentMapImporter` — implements `IAssetImporter` for .hdr/.exr environment map files
 
 ### What is still design (this document)
 
-- `ImportQueue` — max-heap priority queue with deduplication
-- `ImportCoordinator` — central dispatch, `Tick()`, `EnqueueBatch`, `DependenciesSatisfied`
-- `DependencyGraph` — texture → material → mesh ordering
-- `ImportPriority` enum and `ImportJob` struct
 - VFSScanner → `EnqueueBatch` wiring
 - FileWatcher → `Enqueue(Immediate)` wiring
+
+Note: ImportCoordinator, ImportQueue, ImportJob, and ImportPriority are implemented in `ZEngine/ZEngine/Importers/`. The DependencyGraph and VFSScanner/FileWatcher integration remain design.
 
 **Goal**: Implement a priority-driven, thread-safe asset import pipeline inside
 `ZEngine::Importers` that routes any source file to the correct importer, tracks progress
@@ -106,7 +107,10 @@ namespace ZEngine::Importers {
         Immediate  = 2    // user-initiated or dependency-resolved retry; runs next Tick
     };
 
-    using ImportCallback = std::function<void(const VFS::VFSPath&, bool success)>;
+    struct ImportCallback {
+        void* Context = nullptr;
+        void (*Fn)(void*, bool success) = nullptr;
+    };
 
     struct ImportJob {
         VFS::VFSPath      Path;
@@ -282,9 +286,10 @@ namespace ZEngine::Importers {
 
         // Enqueues a single asset for import. Reads meta from disk via MetaFileIO.
         // No-op if a job for the same path is already queued at equal or higher priority.
-        void Enqueue(VFS::VFSPath    path,
-                     ImportPriority  priority = ImportPriority::Normal,
-                     ImportCallback  cb       = {});
+        // Returns the asset UUID resolved at enqueue time.
+        uuids::uuid Enqueue(VFS::VFSPath    path,
+                            ImportPriority  priority = ImportPriority::Normal,
+                            ImportCallback  cb       = {});
 
         // Enqueues multiple paths at Normal priority. Suitable for VFSScanner batch.
         void EnqueueBatch(const Core::Containers::Array<VFS::VFSPath>& paths);

--- a/ZEngine/docs/future-plan/memory-budget.md
+++ b/ZEngine/docs/future-plan/memory-budget.md
@@ -38,7 +38,7 @@ All sizes are at process startup, allocated once, and never grown. The 2 GB tota
 |---|---|---|
 | VulkanDevice | 512 MB | VMA metadata, descriptor pool backing, command pool objects, synchronization primitives |
 | AssetManager | 100 MB | UUID maps, mesh/material/texture handle arrays (matches existing) |
-| ImporterArena | 350 MB | Assimp import scratch; cleared on `AssetManager::ImportComplete()` (matches existing) |
+| Importer | 350 MB | Assimp import scratch; cleared on `AssetManager::ImportComplete()` (matches existing) |
 | ECS::Scene | 128 MB | ComponentStorage dense arrays, EntityRegistry free-list, archetype metadata |
 | Animation::AnimationManager | 64 MB | SkeletonData, AnimationClip arrays, per-frame pose pools (double-buffered) |
 | Physics::PhysicsWorld | 64 MB | Jolt body data, broad-phase cell grid, constraint cache, contact manifold pool |
@@ -51,7 +51,7 @@ All sizes are at process startup, allocated once, and never grown. The 2 GB tota
 | Swapchain | 3 MB | Swapchain-specific allocations (matches existing) |
 | Logging | 4 MB | Logger ring buffer, event handler list, category filter table |
 | Scratch / general | 48 MB | Engine-internal scratch arenas, temporary string processing, debug overlay |
-| **Total** | **~1,643 MB** | **~357 MB headroom within the 2 GB block** |
+| **Total** | **~1,496 MB** | **~552 MB headroom within the 2 GB block** |
 
 ### Sizing rationale
 
@@ -59,7 +59,7 @@ All sizes are at process startup, allocated once, and never grown. The 2 GB tota
 
 **ECS::Scene (128 MB).** A ComponentStorage dense array for a 16-byte component with 65,536 entities costs 1 MB. With 30–40 component types and sparse archetypes, 128 MB provides comfortable room. The entity registry free-list and archetype metadata add another few MB.
 
-**ImporterArena (350 MB).** Assimp inflates mesh data to approximately 4–8x the on-disk size during processing (vertex deduplication, tangent generation, normal smoothing). A 30 MB mesh file can consume up to 240 MB mid-import. The scratch is cleared after each job completes, so this budget covers the single largest in-flight import, not the cumulative total.
+**Importer (350 MB).** Assimp inflates mesh data to approximately 4–8x the on-disk size during processing (vertex deduplication, tangent generation, normal smoothing). A 30 MB mesh file can consume up to 240 MB mid-import. The scratch is cleared after each job completes, so this budget covers the single largest in-flight import, not the cumulative total.
 
 **AnimationManager (64 MB).** A 256-bone skeleton with 60 fps at 10 minutes of animation data (float keyframes) costs roughly 12 MB. With 5 simultaneous skeletons and double-buffered pose pools for interpolation, 64 MB is adequate.
 
@@ -128,18 +128,18 @@ struct MemoryBudgetConfig
     SubArenaConfig VulkanDevice;
     SubArenaConfig ECSScene;
     SubArenaConfig AssetManager;
-    SubArenaConfig ImporterArena;
+    SubArenaConfig Importer;
     SubArenaConfig AnimationManager;
     SubArenaConfig PhysicsWorld;
     SubArenaConfig AudioEngine;
-    SubArenaConfig VFS;
+    SubArenaConfig VirtualFS;
     SubArenaConfig ShaderCache;
     SubArenaConfig UIContext;
     SubArenaConfig Network;
-    SubArenaConfig SerializerScratch;
+    SubArenaConfig Serializer;
     SubArenaConfig Swapchain;
     SubArenaConfig Logging;
-    SubArenaConfig Scratch;
+    SubArenaConfig Input;
 
     // Returns the budget matching Section 2 of memory-budget.md.
     static MemoryBudgetConfig Default();
@@ -172,21 +172,21 @@ inline MemoryBudgetConfig MemoryBudgetConfig::Default()
     MemoryBudgetConfig cfg = {};
     cfg.VulkanDevice       = { "VulkanDevice",       512ULL * 1024 * 1024 };
     cfg.AssetManager       = { "AssetManager",       100ULL * 1024 * 1024 };
-    cfg.ImporterArena      = { "ImporterArena",      350ULL * 1024 * 1024 };
+    cfg.Importer           = { "Importer",           350ULL * 1024 * 1024 };
     cfg.ECSScene           = { "ECSScene",           128ULL * 1024 * 1024 };
     cfg.AnimationManager   = { "AnimationManager",    64ULL * 1024 * 1024 };
     cfg.PhysicsWorld       = { "PhysicsWorld",        64ULL * 1024 * 1024 };
     cfg.AudioEngine        = { "AudioEngine",         32ULL * 1024 * 1024 };
-    cfg.VFS                = { "VFS",                 32ULL * 1024 * 1024 };
+    cfg.VirtualFS          = { "VirtualFS",           32ULL * 1024 * 1024 };
     cfg.ShaderCache        = { "ShaderCache",         16ULL * 1024 * 1024 };
     cfg.UIContext          = { "UIContext",             8ULL * 1024 * 1024 };
     cfg.Network            = { "Network",             32ULL * 1024 * 1024 };
-    cfg.SerializerScratch  = { "SerializerScratch",  150ULL * 1024 * 1024 };
+    cfg.Serializer         = { "Serializer",         150ULL * 1024 * 1024 };
     cfg.Swapchain          = { "Swapchain",            3ULL * 1024 * 1024 };
     cfg.Logging            = { "Logging",              4ULL * 1024 * 1024 };
-    cfg.Scratch            = { "Scratch",             48ULL * 1024 * 1024 };
+    cfg.Input              = { "Input",                1ULL * 1024 * 1024 };
     return cfg;
-    // Total: ~1,643 MB out of 2,048 MB; ~357 MB headroom
+    // Total: ~1,496 MB out of 2,048 MB; ~552 MB headroom
 }
 
 } // namespace ZEngine::Memory

--- a/ZEngine/docs/future-plan/render-resource-manager.md
+++ b/ZEngine/docs/future-plan/render-resource-manager.md
@@ -1,7 +1,8 @@
 # Render Resource Manager — GPU Lifetime & Hot-Reload
 
 **Priority:** P3 — Implement alongside import-pipeline.md  
-**Status:** Design  
+**Status:** Implemented  
+**Implemented in:** `ZEngine/ZEngine/Rendering/RenderResourceManager.h/.cpp`  
 **Depends on:** `import-pipeline.md`, `vfs-ticket6-asset-registry.md`, `gpu-allocator-rearchitecture.md`  
 **Blocks:** `animation-system.md` (SkinningUploadSystem), `shader-asset-pipeline.md`
 

--- a/ZEngine/docs/future-plan/rendering-flow.md
+++ b/ZEngine/docs/future-plan/rendering-flow.md
@@ -94,7 +94,7 @@ Frame index `fi` = `SwapchainPtr->CurrentFrame->Index` (0, 1, or 2 in a triple-b
         GpuMem.SampleBudgets()              <- per-heap pressure check
         FrameHeaps[fi].Reset()              <- bump pointer = 0, O(1)
     CommandBufferMgr->ResetPool(fi, thread)
-    AsyncResLoader->CompleteDeferrals()
+    RRM->CompleteDeferrals()
     GetCommandBuffer(GRAPHIC, fi, thread)
     CurrentCmdBuf->Begin()
 
@@ -111,7 +111,7 @@ Frame index `fi` = `SwapchainPtr->CurrentFrame->Index` (0, 1, or 2 in a triple-b
 
     [MESH DIRTY]  if MeshAllocationDirty[fi]:
       vtx_buffer_set->At(fi).Write(fi, 0, scene->Vertices)
-        AsyncResLoader->UploadBuffer()
+        RRM->UploadBuffer()
           vmaGetAllocationMemoryProperties -> HOST_VISIBLE?
           YES: vmaCopyMemoryToAllocation + vmaFlushAllocation (if !coherent)
           NO:  GpuMem.Ring.Allocate() -> vkCmdCopyBuffer -> Ring.Submit(signal_val)
@@ -181,7 +181,7 @@ Frame index `fi` = `SwapchainPtr->CurrentFrame->Index` (0, 1, or 2 in a triple-b
     EndRenderPass
 
 [4] EndFrame()
-    AsyncResLoader->SubmitAsyncJobs()       <- flush timeline semaphore job queue
+    RRM->SubmitTextureJobs()       <- flush timeline semaphore job queue
     CommandBufferMgr->EndEnqueuedBuffers()
     SwapchainPtr->Present()
       3-submit timeline pattern (acquire bridge -> render -> present bridge)
@@ -281,10 +281,10 @@ AppRenderPipeline::BeginFrame()
   swapchain->AcquireNextImage()       <- frame_index valid after this
   RRM::BeginFrame(fi)                 <- flush pending asset uploads
   CommandBufferMgr::ResetPool(fi)
-  AsyncResLoader::CompleteDeferrals()
+  RRM::CompleteDeferrals()
 
 AppRenderPipeline::EndFrame()
-  AsyncResLoader::SubmitAsyncJobs()   <- texture uploads only
+  RRM::SubmitTextureJobs()   <- texture uploads only
   Present()
   RRM::EndFrame(fi)                   <- drain aged swap entries
 

--- a/ZEngine/docs/future-plan/system-scheduler.md
+++ b/ZEngine/docs/future-plan/system-scheduler.md
@@ -1,7 +1,7 @@
 # ZEngine — System Scheduler
 
 **Priority:** P1 — Implement alongside ECS core (Phase 1 of migration-plan.md)  
-**Status:** Design  
+**Status:** Implemented  
 **Depends on:** `actor-ecs-architecture.md`  
 **Blocks:** `animation-system.md`
 
@@ -491,21 +491,21 @@ No new files beyond what `actor-ecs-architecture.md` already lists.
 
 ## 12. Deliverables Checklist
 
-- [ ] `SystemDeps` struct in `WorldTick.h`
-- [ ] `WorldTick::RegisterSystem(fn, deps)` — returns `SystemID`
-- [ ] `WorldTick::OrderBefore(SystemID a, SystemID b)`
-- [ ] `RegisterSystem` returns distinct IDs per system (monotonically increasing)
-- [ ] `WorldTick::Commit()` — edge insertion, cycle detection, topological sort into waves
-- [ ] `WorldTick::Tick()` — wave-by-wave dispatch via `ThreadPoolHelper`, barrier between waves
-- [ ] Assert on conflict with no ordering edge (debug builds)
-- [ ] Assert on cycle detected
-- [ ] Assert on `Tick()` called before `Commit()`
-- [ ] `tests/ECS/SchedulerTest.cpp`:
-  - [ ] Two independent systems run in the same wave
-  - [ ] Two conflicting systems with `OrderBefore` run in separate waves
-  - [ ] Two conflicting systems with no `OrderBefore` assert in debug
-  - [ ] Cycle detection asserts
-  - [ ] Systems execute in correct order (write before read verified via component state)
+- [x] `SystemDeps` struct in `WorldTick.h`
+- [x] `WorldTick::RegisterSystem(fn, deps)` — returns `SystemID`
+- [x] `WorldTick::OrderBefore(SystemID a, SystemID b)`
+- [x] `RegisterSystem` returns distinct IDs per system (monotonically increasing)
+- [x] `WorldTick::Commit()` — edge insertion, cycle detection, topological sort into waves
+- [x] `WorldTick::Tick()` — wave-by-wave dispatch via `ThreadPoolHelper`, barrier between waves
+- [x] Assert on conflict with no ordering edge (debug builds)
+- [x] Assert on cycle detected
+- [x] Assert on `Tick()` called before `Commit()`
+- [x] `tests/ECS/SchedulerTest.cpp`:
+  - [x] Two independent systems run in the same wave
+  - [x] Two conflicting systems with `OrderBefore` run in separate waves
+  - [x] Two conflicting systems with no `OrderBefore` assert in debug
+  - [x] Cycle detection asserts
+  - [x] Systems execute in correct order (write before read verified via component state)
 
 ---
 

--- a/ZEngine/docs/migration-plan.md
+++ b/ZEngine/docs/migration-plan.md
@@ -127,81 +127,81 @@ ZEngine/tests/ECS/
 ### Tasks
 
 **`EntityID.h`**
-- [ ] `struct EntityID { uint32_t Index; uint32_t Generation; bool IsValid(); operator==; }`
-- [ ] `constexpr EntityID INVALID_ENTITY = {0, 0}`
+- [x] `struct EntityID { uint32_t Index; uint32_t Generation; bool IsValid(); operator==; }`
+- [x] `constexpr EntityID INVALID_ENTITY = {0, 0}`
 
 **`ComponentTypeID.h`**
-- [ ] `using ComponentTypeID = uint32_t`
-- [ ] `NextTypeID()` — `static std::atomic<uint32_t>` counter, `fetch_add` relaxed
-- [ ] `ComponentTypeOf<T>()` — static local, calls `NextTypeID()` once per type
+- [x] `using ComponentTypeID = uint32_t`
+- [x] `NextTypeID()` — `static std::atomic<uint32_t>` counter, `fetch_add` relaxed
+- [x] `ComponentTypeOf<T>()` — static local, calls `NextTypeID()` once per type
 
 **`ArchetypeMask.h`**
-- [ ] `using ArchetypeMask = uint64_t`
-- [ ] `MaskBit(id)` — `ZENGINE_VALIDATE_ASSERT(id < 64, ...)` then `uint64_t(1) << id`
-- [ ] `MaskHas`, `MaskMatches`
+- [x] `using ArchetypeMask = uint64_t`
+- [x] `MaskBit(id)` — `ZENGINE_VALIDATE_ASSERT(id < 64, ...)` then `uint64_t(1) << id`
+- [x] `MaskHas`, `MaskMatches`
 
 **`IComponentStorage.h`**
-- [ ] `struct IComponentStorage { virtual void RemoveRaw(EntityID) = 0; }`
+- [x] `struct IComponentStorage { virtual void RemoveRaw(EntityID) = 0; }`
 
 **`ComponentStorage<T>` (header-only)**
-- [ ] `m_dense`, `m_dense_ids`, `m_sparse` (UINT32_MAX = absent)
-- [ ] `Add` — grow sparse, assert no double-add, append to dense
-- [ ] `Remove` — swap-and-pop, update moved entity's sparse entry
-- [ ] `Get` — bounds check, UINT32_MAX check, **generation check** (`m_dense_ids[dense_idx] != id → nullptr`)
-- [ ] `Has` — same generation check
-- [ ] `ForEach` — iterates dense arrays in tandem
+- [x] `m_dense`, `m_dense_ids`, `m_sparse` (UINT32_MAX = absent)
+- [x] `Add` — grow sparse, assert no double-add, append to dense
+- [x] `Remove` — swap-and-pop, update moved entity's sparse entry
+- [x] `Get` — bounds check, UINT32_MAX check, **generation check** (`m_dense_ids[dense_idx] != id → nullptr`)
+- [x] `Has` — same generation check
+- [x] `ForEach` — iterates dense arrays in tandem
 
 **`EntityRegistry`**
-- [ ] `struct EntitySlot { uint32_t Generation; ArchetypeMask Mask; }`
-- [ ] `Create()` — pop free-list or append; increment generation, skip 0
-- [ ] `Destroy(id)` — assert alive, increment generation (skip 0), push to free-list
-- [ ] `IsAlive(id)` — index bounds + generation match
-- [ ] `SetMask`, `GetMask`, `ForEachAlive`
+- [x] `struct EntitySlot { uint32_t Generation; ArchetypeMask Mask; }`
+- [x] `Create()` — pop free-list or append; increment generation, skip 0
+- [x] `Destroy(id)` — assert alive, increment generation (skip 0), push to free-list
+- [x] `IsAlive(id)` — index bounds + generation match
+- [x] `SetMask`, `GetMask`, `ForEachAlive`
 
 **`ECS::Scene`**
-- [ ] `CreateEntity`, `DestroyEntity` (calls `RemoveRaw` on all storages first)
-- [ ] `AddComponent<T>` — `GetOrCreateStorage`, `storage.Add`, update mask
-- [ ] `GetComponent<T>`, `RemoveComponent<T>`, `HasComponent<T>`
-- [ ] `GetMask(EntityID)`
-- [ ] `ForEach<Ts...>` — compute required mask, call `ForEachAlive`, skip non-matching
-- [ ] `m_storages` — `UnorderedHashMap<ComponentTypeID, std::unique_ptr<IComponentStorage>>`
+- [x] `CreateEntity`, `DestroyEntity` (calls `RemoveRaw` on all storages first)
+- [x] `AddComponent<T>` — `GetOrCreateStorage`, `storage.Add`, update mask
+- [x] `GetComponent<T>`, `RemoveComponent<T>`, `HasComponent<T>`
+- [x] `GetMask(EntityID)`
+- [x] `ForEach<Ts...>` — compute required mask, call `ForEachAlive`, skip non-matching
+- [x] `m_storages` — `UnorderedHashMap<ComponentTypeID, std::unique_ptr<IComponentStorage>>`
 
 **`Query<Ts...>` (header-only)**
-- [ ] Constructor pre-computes `ArchetypeMask`
-- [ ] `ForEach` delegates to `Scene::ForEach` with cached mask
+- [x] Constructor pre-computes `ArchetypeMask`
+- [x] `ForEach` delegates to `Scene::ForEach` with cached mask
 
 **`WorldTick`**
-- [ ] `using SystemID = uint32_t`
-- [ ] `struct SystemDeps { ArchetypeMask ReadMask; ArchetypeMask WriteMask; }`
-- [ ] `RegisterSystem(SystemFn, SystemDeps)` — returns `SystemID` (index into `m_nodes`)
-- [ ] `OrderBefore(SystemID a, SystemID b)` — records edge a→b
-- [ ] `Commit()`:
+- [x] `using SystemID = uint32_t`
+- [x] `struct SystemDeps { ArchetypeMask ReadMask; ArchetypeMask WriteMask; }`
+- [x] `RegisterSystem(SystemFn, SystemDeps)` — returns `SystemID` (index into `m_nodes`)
+- [x] `OrderBefore(SystemID a, SystemID b)` — records edge a→b
+- [x] `Commit()`:
   - Build adjacency list from `OrderBefore` calls
   - For every pair (A, B): check conflict rules; if conflict and no ordering edge → `ZENGINE_VALIDATE_ASSERT`
   - DFS cycle detection → `ZENGINE_VALIDATE_ASSERT` on back edge
   - Kahn's algorithm → `m_waves` (Array of Array of SystemID)
-- [ ] `Tick(scene, dt)`:
+- [x] `Tick(scene, dt)`:
   - Assert `m_committed`
   - For each wave: submit all systems to `ThreadPoolHelper`, wait with `condition_variable` + atomic counter
   - Comment explaining why predicate-wait is race-free
 
 **`ECSTest.cpp`** (8 tests)
-- [ ] `CreateEntity` returns valid ID
-- [ ] `DestroyEntity` makes ID invalid
-- [ ] `AddComponent` / `GetComponent` non-null
-- [ ] `RemoveComponent` → `GetComponent` null
-- [ ] `ForEach` only matches entities with all components
-- [ ] Generational handle rejected after destroy + recycle
-- [ ] `Query<A,B>` matches only entities with both
-- [ ] `DestroyEntity` cleans up all components
+- [x] `CreateEntity` returns valid ID
+- [x] `DestroyEntity` makes ID invalid
+- [x] `AddComponent` / `GetComponent` non-null
+- [x] `RemoveComponent` → `GetComponent` null
+- [x] `ForEach` only matches entities with all components
+- [x] Generational handle rejected after destroy + recycle
+- [x] `Query<A,B>` matches only entities with both
+- [x] `DestroyEntity` cleans up all components
 
 **`SchedulerTest.cpp`** (5 tests)
-- [ ] Two independent systems assigned to same wave
-- [ ] Conflicting systems with `OrderBefore` assigned to separate waves
-- [ ] Conflicting systems without `OrderBefore` asserts in debug
-- [ ] Cycle asserts
-- [ ] `Tick` before `Commit` asserts
-- [ ] `RegisterSystem` returns distinct IDs
+- [x] Two independent systems assigned to same wave
+- [x] Conflicting systems with `OrderBefore` assigned to separate waves
+- [x] Conflicting systems without `OrderBefore` asserts in debug
+- [x] Cycle asserts
+- [x] `Tick` before `Commit` asserts
+- [x] `RegisterSystem` returns distinct IDs
 
 ### Acceptance Criteria
 
@@ -259,27 +259,27 @@ ZEngine/ZEngine/Engine.h/.cpp   — add ECS::Scene + WorldTick + ActorManager to
 
 **`Actor`**
 
-- [ ] `class Actor : public Helpers::RefCounted`
-- [ ] `static Ref<Actor> Create(Scene& scene)` — `CreateEntity`, store ID, call `OnCreate`
-- [ ] `static Ref<Actor> Wrap(Scene& scene, EntityID id)` — does NOT call `OnCreate`
-- [ ] `~Actor()` — call `OnDestroy`, then `m_scene->DestroyEntity(m_entity_id)` (guard against null scene)
-- [ ] `GetEntityID()`, `IsAlive()`
-- [ ] `AddComponent<T>`, `GetComponent<T>`, `HasComponent<T>`, `RemoveComponent<T>` — all delegate to `m_scene`
-- [ ] `virtual void OnCreate() {}`, `virtual void OnDestroy() {}`, `virtual void OnTick(float dt) {}`
-- [ ] `EntityID m_entity_id`; `Scene* m_scene` (non-owning)
+- [x] `class Actor : public Helpers::RefCounted`
+- [x] `static Ref<Actor> Create(Scene& scene)` — `CreateEntity`, store ID, call `OnCreate`
+- [x] `static Ref<Actor> Wrap(Scene& scene, EntityID id)` — does NOT call `OnCreate`
+- [x] `~Actor()` — call `OnDestroy`, then `m_scene->DestroyEntity(m_entity_id)` (guard against null scene)
+- [x] `GetEntityID()`, `IsAlive()`
+- [x] `AddComponent<T>`, `GetComponent<T>`, `HasComponent<T>`, `RemoveComponent<T>` — all delegate to `m_scene`
+- [x] `virtual void OnCreate() {}`, `virtual void OnDestroy() {}`, `virtual void OnTick(float dt) {}`
+- [x] `EntityID m_entity_id`; `Scene* m_scene` (non-owning)
 
 **`ActorManager`**
 
-- [ ] Owns `Array<Ref<Actor>>` of live Actors
-- [ ] `Register(Ref<Actor>)`, `Unregister(EntityID)`
-- [ ] `Tick(float dt)` — call `OnTick` on each live Actor
+- [x] Owns `Array<Ref<Actor>>` of live Actors
+- [x] `Register(Ref<Actor>)`, `Unregister(EntityID)`
+- [x] `Tick(float dt)` — call `OnTick` on each live Actor
 
 **`Engine` integration**
 
-- [ ] Add `ECS::Scene Scene` to `EngineContext`
-- [ ] Add `ECS::WorldTick WorldTick` to `EngineContext`
-- [ ] Add `ECS::ActorManager ActorManager` to `EngineContext`
-- [ ] In `Engine::MainThreadRun`: call `WorldTick.Tick(Scene, dt)` then `ActorManager.Tick(dt)` each frame
+- [x] Add `ECS::Scene Scene` to `EngineContext`
+- [x] Add `ECS::WorldTick WorldTick` to `EngineContext`
+- [x] Add `ECS::ActorManager ActorManager` to `EngineContext`
+- [x] In `Engine::MainThreadRun`: call `WorldTick.Tick(Scene, dt)` then `ActorManager.Tick(dt)` each frame
 
 **`ActorTest.cpp`**
 
@@ -442,9 +442,9 @@ ZEngine/ZEngine/Rendering/Components/ValidComponent.h       — dead, no call si
 ZEngine/ZEngine/Rendering/Components/CameraComponent.h      — dead (only in #if 0 / comments)
 ```
 
-- [ ] `grep -rn "GeometryComponent\|ValidComponent\|CameraComponent"` outside `#if 0` → must be zero
-- [ ] Delete the three files
-- [ ] Remove from CMakeLists if listed
+- [x] `grep -rn "GeometryComponent\|ValidComponent\|CameraComponent"` outside `#if 0` → must be zero
+- [x] Delete the three files
+- [x] Remove from CMakeLists if listed
 
 ### Step 5.2 — Delete old `Rendering::Components` headers (after Phase 3)
 
@@ -464,9 +464,9 @@ ZEngine/ZEngine/Rendering/Components/MaterialComponent.h
 
 `GraphicSceneEntity` is used only by `GraphicScene3DSerializer` (already migrated in Phase 3).
 
-- [ ] `grep -rn "GraphicSceneEntity"` outside `#if 0` → must be zero after Phase 3
-- [ ] Delete `Rendering/Entities/GraphicSceneEntity.h`
-- [ ] Delete `Rendering/Entities/GraphicSceneEntity.cpp`
+- [x] `grep -rn "GraphicSceneEntity"` outside `#if 0` → must be zero after Phase 3
+- [x] Delete `Rendering/Entities/GraphicSceneEntity.h`
+- [x] Delete `Rendering/Entities/GraphicSceneEntity.cpp`
 
 ### Step 5.4 — Delete `#if 0` block in `GraphicScene.h/.cpp`
 

--- a/ZEngine/docs/obelisk-tetragrama-impact.md
+++ b/ZEngine/docs/obelisk-tetragrama-impact.md
@@ -127,31 +127,30 @@ That is the **only** change Obelisk needs. Everything else is already correct.
 ### Phase 2 — ECS Components + Actor layer (old Rendering::Components removed)
 
 **Obelisk:** No impact.  
-**Tetragrama:** Moderate impact.
+**Tetragrama:** Done — `Rendering/Components/` has been deleted.
 
-The editor's `InspectorViewUIComponent` and `HierarchyViewUIComponent` reference old
-`Rendering::Components::TransformComponent`, `LightComponent`, `NameComponent`,
-`UUIComponent`, `MaterialComponent`. These are removed in Phase 2/3.
+`Rendering/Components/` no longer exists. `InspectorViewUIComponent` and
+`HierarchyViewUIComponent` had their component display code commented out rather than
+replaced inline. The old references to `Rendering::Components::TransformComponent`,
+`LightComponent`, `NameComponent`, `UUIComponent`, and `MaterialComponent` are gone.
 
-**Required changes:**
-- `HierarchyViewUIComponent.cpp` — replace `Rendering::Components::*` with `ECS::Components::*`
-- `InspectorViewUIComponent.cpp` — replace component type references
-- `EditorSceneSerializer.cpp` — binary format uses component type names; update to new names
+**Remaining work:**
+- `HierarchyViewUIComponent.cpp` — write new component display panels against
+  `ECS::Components::NameComponent` (pending that header landing)
+- `InspectorViewUIComponent.cpp` — write new inspector panels against
+  `ECS::Components::MeshComponent`, `TransformComponent`, etc. (pending those headers)
+- `EditorSceneSerializer.cpp` — binary format must be updated to new ECS component type names
 
-The new `ECS::Components::TransformComponent` is plain data (`Vec3f Position/Rotation/Scale`)
-vs. the old one which had methods. The inspector must adapt to display fields differently.
-
-**Estimate:** 2 days
+**Estimate:** 2 days (new panel writing, not search-and-replace)
 
 ---
 
 ### Phase 3 — Migrate Rendering::Components call sites
 
 **Obelisk:** No impact.  
-**Tetragrama:** Same as Phase 2 — this is when the old headers are deleted. Tetragrama
-must already have been migrated in Phase 2 or it will fail to compile here.
-
-**Required:** Tetragrama migration must be done **before** Phase 3 deletes the old headers.
+**Tetragrama:** Done — old headers are already deleted. Tetragrama has no remaining
+references to `Rendering::Components::*`; the component display code has been
+commented out and will be rewritten against the ECS component headers.
 
 ---
 
@@ -173,18 +172,16 @@ feature gap to fill after the animation system is implemented.
 ### Phase 5 — Dead code removal (entt, #if 0, GraphicSceneEntity)
 
 **Obelisk:** No impact.  
-**Tetragrama:** `GraphicSceneEntity` is referenced in `GraphicScene3DSerializer.h`
-(already included in Tetragrama's serializers). When `GraphicSceneEntity` is deleted
-in Phase 5.3, this file's include breaks.
+**Tetragrama:** Done — `GraphicSceneEntity.h/.cpp` have been deleted.
+
+`GraphicSceneEntity.h` and `GraphicSceneEntity.cpp` no longer exist.
+`GraphicScene3DSerializer.h` had its include of `GraphicSceneEntity.h` removed as
+part of the deletion.
 
 `EditorSceneSerializer` is separate from `GraphicScene3DSerializer` and does not
 depend on `GraphicSceneEntity` directly — it uses `EditorScene` which uses `RenderScene`.
 
-**Required changes:**
-- `GraphicScene3DSerializer.h/.cpp` (in ZEngine, not Tetragrama) — already targeted for migration
-- Verify `EditorSceneSerializer.cpp` does not transitively include `GraphicSceneEntity.h`
-
-**Estimate:** 1 day verification + potential fix
+**Verified:** `EditorSceneSerializer.cpp` has no transitive include of `GraphicSceneEntity.h`.
 
 ---
 
@@ -328,15 +325,18 @@ These constraints are imposed by the editor and must not be violated by migratio
 
 ### Tetragrama (phased)
 
-**Before Phase 2 completes (component migration):**
-- [ ] `Components/HierarchyViewUIComponent.cpp` — replace `Rendering::Components::*` with `ECS::Components::*`
-- [ ] `Components/InspectorViewUIComponent.cpp` — same
+**Phase 2 (component migration) — Rendering/Components/ deleted:**
+- [x] `Rendering/Components/` directory deleted; `GraphicSceneEntity.h/.cpp` deleted
+- [x] `Components/HierarchyViewUIComponent.cpp` — old `Rendering::Components::*` references removed (code commented out)
+- [x] `Components/InspectorViewUIComponent.cpp` — old component type references removed (code commented out)
+- [ ] `Components/HierarchyViewUIComponent.cpp` — write new panels against `ECS::Components::NameComponent` (pending header)
+- [ ] `Components/InspectorViewUIComponent.cpp` — write new panels against `ECS::Components::MeshComponent`, `TransformComponent`, etc. (pending headers)
 - [ ] `Serializers/EditorSceneSerializer.cpp` — update component type names in binary format
 - [ ] Add `ParentComponent` + `TransformHierarchySystem` (N-2 above) to enable hierarchy
 
-**Before Phase 3 completes (header deletion):**
-- [ ] Verify no transitive include of `GraphicSceneEntity.h` in Tetragrama
-- [ ] Verify no transitive include of `Rendering/Components/TransformComponent.h` (old)
+**Phase 3 (header deletion) — already complete:**
+- [x] No transitive include of `GraphicSceneEntity.h` in Tetragrama — verified
+- [x] No transitive include of `Rendering/Components/TransformComponent.h` (old) — verified
 
 **Before Phase 4 completes (VFS Ticket 3):**
 - [ ] `Components/ProjectViewUIComponent.cpp` — migrate `directory_iterator` to `VFSScanner`
@@ -374,6 +374,8 @@ They represent the cost of keeping the editor functional throughout the migratio
 new feature work. They should be distributed across the relevant phases — not treated
 as a separate block of work.
 
-**The single most important constraint:** Tetragrama must be migrated off
-`Rendering::Components::*` before Phase 3 deletes those headers, or the editor will
-not compile. This is a hard dependency on the migration timeline.
+**Previously the single most important constraint — now resolved:** Tetragrama has been
+migrated off `Rendering::Components::*`. The old headers are deleted. Component display
+code in `InspectorViewUIComponent` and `HierarchyViewUIComponent` is in commented-out
+blocks; the remaining work is writing new panels against the ECS component headers
+(pending `MeshComponent`, `NameComponent`, etc.).

--- a/ZEngine/docs/vfs-ticket3-scanner-memory-backend.md
+++ b/ZEngine/docs/vfs-ticket3-scanner-memory-backend.md
@@ -445,7 +445,7 @@ namespace ZEngine::Core::VFS
         // Called from UI thread every frame.
         // Returns empty span if directory not yet cached.
         // O(1) hash lookup + shared_lock acquire.
-        std::span<const VFSDirEntry> GetListing(const VFSPath& dir) const;
+        Core::Containers::ArrayView<const VFSDirEntry> GetListing(const VFSPath& dir) const;
 
         // Called by VFSScanner from a worker thread.
         // Moves the Array into the cache and marks the entry non-stale.
@@ -470,7 +470,7 @@ namespace ZEngine::Core::VFS
         // visitor(dir_path, entries_span)
         void ForEachDir(
             std::function<void(const VFSPath&,
-                               std::span<const VFSDirEntry>)> visitor) const;
+                               Core::Containers::ArrayView<const VFSDirEntry>)> visitor) const;
 
     private:
         struct CacheEntry
@@ -529,8 +529,8 @@ namespace ZEngine::Core::VFS
     // VFSScanner
     //
     // Usage:
-    //   scanner.SetOnScanComplete([](ScanStats s){ /* marshal to UI if needed */ });
-    //   scanner.Scan(ctx, rootPath, &arena, &cache);
+    //   scanner.SetOnScanComplete(ctx, [](void* ctx, ScanStats s){ /* marshal to UI if needed */ });
+    //   scanner.Scan(ctx, rootPath, &cache);
     //
     // Thread model:
     //   Scan()          → called from UI/engine thread; returns immediately.
@@ -547,7 +547,6 @@ namespace ZEngine::Core::VFS
         // Starts async scan. If already scanning, cancels the current scan first.
         void Scan(IVFSContext*            context,
                   VFSPath                 root,
-                  Core::Memory::ArenaAllocator* arena,
                   VFSDirectoryCache*      cache);
 
         // Cancels in-flight scan. Completion callback will NOT fire.
@@ -558,7 +557,7 @@ namespace ZEngine::Core::VFS
 
         // Called before Scan(). Fires on last scanner worker thread.
         // Caller marshals to UI thread if needed.
-        void SetOnScanComplete(std::function<void(ScanStats)> callback);
+        void SetOnScanComplete(void* context, void (*callback)(void*, ScanStats));
 
     private:
         struct ScanContext
@@ -572,7 +571,8 @@ namespace ZEngine::Core::VFS
         void ScanDirectory(ScanContext ctx, VFSPath dir);
         void OnTaskComplete(bool cancelled);
 
-        std::function<void(ScanStats)>        m_complete_callback;
+        void*                                 m_complete_ctx      = nullptr;
+        void                                (*m_complete_callback)(void*, ScanStats) = nullptr;
 
         std::atomic<bool>                     m_is_scanning{false};
         std::atomic<bool>                     m_cancel_requested{false};
@@ -591,7 +591,7 @@ namespace ZEngine::Core::VFS
 ### 7.2 Async Walk Algorithm
 
 ```
-VFSScanner::Scan(context, root, arena, cache):
+VFSScanner::Scan(context, root, cache):
     if IsScanning():
         m_cancel_requested.store(true, release)
         while m_pending_tasks.load(acquire) > 0:
@@ -604,7 +604,7 @@ VFSScanner::Scan(context, root, arena, cache):
     m_is_scanning.store(true, release)
     m_scan_start = steady_clock::now()
 
-    ScanContext ctx = { context, root, arena, cache }
+    ScanContext ctx = { context, root, cache }
 
     ThreadPoolHelper::Submit([this, ctx, root]() {
         ScanDirectory(ctx, root)
@@ -651,7 +651,7 @@ VFSScanner::OnTaskComplete(cancelled):
         stats.DirsFound  = m_dirs_found.load()
         stats.DurationMs = duration_cast<milliseconds>(
                                steady_clock::now() - m_scan_start).count()
-        m_complete_callback(stats)
+        m_complete_callback(m_complete_ctx, stats)
 ```
 
 ### 7.3 Critical Concurrency Invariants
@@ -741,14 +741,15 @@ ZENGINE_VALIDATE_ASSERT(parse_result.Succeeded(), "WorkingSpacePath is not a val
 m_assets_vfs_root = parse_result.Value();
 m_current_vfs_dir = m_assets_vfs_root;
 
-m_scanner->SetOnScanComplete([this](ZEngine::Core::VFS::ScanStats stats) {
+m_scanner->SetOnScanComplete(this, [](void* ctx, ZEngine::Core::VFS::ScanStats stats) {
+    auto* self = static_cast<ProjectViewUIComponent*>(ctx);
     ZENGINE_CORE_INFO("VFS scan complete: {} files, {} dirs, {}ms",
         stats.FilesFound, stats.DirsFound, stats.DurationMs)
-    m_scan_refresh_ready.store(true, std::memory_order_release);
+    self->m_scan_refresh_ready.store(true, std::memory_order_release);
 });
 
 auto* vfs_context = ParentLayer->CurrentApp->GetVFSContext();  // IVFSContext*
-m_scanner->Scan(vfs_context, m_assets_vfs_root, &m_local_arena, m_directory_cache);
+m_scanner->Scan(vfs_context, m_assets_vfs_root, m_directory_cache);
 ```
 
 ### 9.3 `RenderContentBrowser()` — Before / After
@@ -843,7 +844,7 @@ char name_lower[MAX_FILE_PATH_COUNT] = {};
 
 m_directory_cache->ForEachDir(
     [&](const ZEngine::Core::VFS::VFSPath& /*dir*/,
-        std::span<const ZEngine::Core::VFS::VFSDirEntry> entries)
+        Core::Containers::ArrayView<const ZEngine::Core::VFS::VFSDirEntry> entries)
     {
         for (const auto& entry : entries)
         {
@@ -939,7 +940,7 @@ Add to `Render()` alongside the back button:
 if (ImGui::Button("  Refresh  "))
 {
     auto* vfs_context = ParentLayer->CurrentApp->GetVFSContext();
-    m_scanner->Scan(vfs_context, m_assets_vfs_root, &m_local_arena, m_directory_cache);
+    m_scanner->Scan(vfs_context, m_assets_vfs_root, m_directory_cache);
 }
 ```
 
@@ -961,7 +962,7 @@ if (m_scan_refresh_ready.exchange(false, std::memory_order_acquire))
 // Add at the end of each successful mutation handler:
 {
     auto* vfs_context = ParentLayer->CurrentApp->GetVFSContext();
-    m_scanner->Scan(vfs_context, m_assets_vfs_root, &m_local_arena, m_directory_cache);
+    m_scanner->Scan(vfs_context, m_assets_vfs_root, m_directory_cache);
 }
 ```
 
@@ -1066,7 +1067,7 @@ These tests use a `MockVFSContext` that implements `IVFSContext::List()` with co
 Scan_EmptyRoot_FiresComplete
   MockContext: List("/") → empty Array
   scanner.SetOnScanComplete(capture stats)
-  scanner.Scan(&mock, "/", &arena, &cache)
+  scanner.Scan(&mock, "/", &cache)
   Wait 100ms for callback
   stats.FilesFound == 0, stats.DirsFound == 0
 

--- a/ZEngine/docs/vfs-ticket4-filewatcher.md
+++ b/ZEngine/docs/vfs-ticket4-filewatcher.md
@@ -20,7 +20,7 @@ into the engine's existing callback system, driving `VFSDirectoryCache::Invalida
 #pragma once
 #include <Core/ZEngineDef.h>
 
-namespace ZEngine::VFS
+namespace ZEngine::Core::VFS
 {
     enum class WatchEventKind : uint8_t
     {
@@ -48,7 +48,7 @@ namespace ZEngine::VFS
 #pragma once
 #include <cstdint>
 
-namespace ZEngine::VFS
+namespace ZEngine::Core::VFS
 {
     using WatchHandle = uint32_t;
     constexpr WatchHandle INVALID_WATCH_HANDLE = 0xFFFF'FFFFu;
@@ -62,9 +62,9 @@ namespace ZEngine::VFS
 #include <functional>
 #include <VFS/VFSWatchEvent.h>
 
-namespace ZEngine::VFS
+namespace ZEngine::Core::VFS
 {
-    using RawEventCallback = std::function<void(const VFSWatchEvent&)>;
+    using RawEventCallback = void (*)(void* ctx, const VFSWatchEvent&);
 
     class IVFSPlatformWatcher
     {
@@ -77,7 +77,7 @@ namespace ZEngine::VFS
 
         // Called once per frame (or from a dedicated watcher thread) to drain
         // pending OS events and fire cb for each one.
-        virtual void Poll(const RawEventCallback& cb) = 0;
+        virtual void Poll(void* ctx, RawEventCallback cb) = 0;
 
         // Start/stop a background thread that calls Poll internally
         virtual void StartThread() = 0;
@@ -100,7 +100,7 @@ namespace ZEngine::VFS
 #include <VFS/IVFSPlatformWatcher.h>
 #include <VFS/VFSWatchEvent.h>
 
-namespace ZEngine::VFS
+namespace ZEngine::Core::VFS
 {
     using WatchCallback = std::function<void(const VFSWatchEvent&)>;
 
@@ -108,6 +108,7 @@ namespace ZEngine::VFS
     {
         VFSWatchEvent                           Event;
         std::chrono::steady_clock::time_point   LastSeen;
+        VFSPath                                 Owner;
     };
 
     class VFSFileWatcher
@@ -119,11 +120,15 @@ namespace ZEngine::VFS
 
         ~VFSFileWatcher();
 
+        void        Initialize(Core::Memory::ArenaAllocator* arena, uint32_t capacity);
+
         WatchHandle Watch(const char* native_path, bool recursive, WatchCallback cb);
         void        Unwatch(WatchHandle handle);
 
         // Called once per frame from the main/editor thread
-        void Tick();
+        void        Tick();
+
+        uint32_t    PendingCount() const;
 
     private:
         void OnRawEvent(const VFSWatchEvent& ev);
@@ -183,7 +188,7 @@ changed files (similar to how Xcode's source editor works).
 #include <unordered_map>
 #include <atomic>
 
-namespace ZEngine::VFS
+namespace ZEngine::Core::VFS
 {
     class VFSFSEventsWatcher final : public IVFSPlatformWatcher
     {
@@ -193,7 +198,7 @@ namespace ZEngine::VFS
 
         WatchHandle AddWatch(const char* native_path, bool recursive) override;
         void        RemoveWatch(WatchHandle handle)                    override;
-        void        Poll(const RawEventCallback& cb)                   override;
+        void        Poll(void* ctx, RawEventCallback cb)               override;
         void        StartThread()                                      override;
         void        StopThread()                                       override;
 
@@ -241,7 +246,7 @@ namespace ZEngine::VFS
 #include <unordered_map>
 #include <atomic>
 
-namespace ZEngine::VFS
+namespace ZEngine::Core::VFS
 {
     class VFSInotifyWatcher final : public IVFSPlatformWatcher
     {
@@ -251,7 +256,7 @@ namespace ZEngine::VFS
 
         WatchHandle AddWatch(const char* native_path, bool recursive) override;
         void        RemoveWatch(WatchHandle handle)                    override;
-        void        Poll(const RawEventCallback& cb)                   override;
+        void        Poll(void* ctx, RawEventCallback cb)               override;
         void        StartThread()                                      override;
         void        StopThread()                                       override;
 
@@ -298,7 +303,7 @@ namespace ZEngine::VFS
 #include <unordered_map>
 #include <atomic>
 
-namespace ZEngine::VFS
+namespace ZEngine::Core::VFS
 {
     class VFSRDCWatcher final : public IVFSPlatformWatcher
     {
@@ -308,7 +313,7 @@ namespace ZEngine::VFS
 
         WatchHandle AddWatch(const char* native_path, bool recursive) override;
         void        RemoveWatch(WatchHandle handle)                    override;
-        void        Poll(const RawEventCallback& cb)                   override;
+        void        Poll(void* ctx, RawEventCallback cb)               override;
         void        StartThread()                                      override;
         void        StopThread()                                       override;
 

--- a/ZEngine/docs/vfs-ticket5-meta-uuid.md
+++ b/ZEngine/docs/vfs-ticket5-meta-uuid.md
@@ -35,7 +35,7 @@ read the UUID from it. If not, generate once, write it, never regenerate.
 #pragma once
 #include <cstdint>
 
-namespace ZEngine::VFS
+namespace ZEngine::Core::VFS
 {
     enum class ImportStatus : uint8_t
     {
@@ -56,7 +56,7 @@ namespace ZEngine::VFS
 #include <uuid.h>
 #include <VFS/Meta/ImportStatus.h>
 
-namespace ZEngine::VFS
+namespace ZEngine::Core::VFS
 {
     constexpr uint32_t META_MAX_SETTINGS = 32;
 
@@ -70,7 +70,8 @@ namespace ZEngine::VFS
     {
         uuids::uuid      AssetUUID                           = {};
         char             ImporterName[64]                    = {};
-        char             LastSourceSha256[65]                = {};  // hex + null
+        uint64_t         SourceHash                          = 0;
+        char             SourcePath[256]                     = {};
         int64_t          LastImportTimeNs                    = 0;
         char             ArtifactPath[MAX_FILE_PATH_COUNT]   = {};
         MetaKeyValuePair Settings[META_MAX_SETTINGS]         = {};
@@ -91,7 +92,7 @@ namespace ZEngine::VFS
 #include <VFS/Meta/MetaFileData.h>
 #include <VFS/VFSResult.h>
 
-namespace ZEngine::VFS
+namespace ZEngine::Core::VFS
 {
     class MetaFileIO
     {
@@ -122,12 +123,9 @@ namespace ZEngine::VFS
         static VFSResult<MetaFileData> GetOrCreate(IVFSContext& ctx,
                                                    const VFSPath& asset_path,
                                                    const char*    importer_name,
-                                                   const char*    current_sha256);
+                                                   uint64_t       current_hash);
 
-        // Compute SHA-256 of the asset file content (for change detection)
-        static VFSResult<void> ComputeSHA256(IVFSContext& ctx,
-                                             const VFSPath& asset_path,
-                                             char out_hex[65]);
+        static VFSResult<uint64_t> ComputeHash(IVFSContext& ctx, const VFSPath& path);
     };
 }
 ```
@@ -142,7 +140,8 @@ A `.meta` file is a UTF-8 JSON object. Example for `mesh.glb.meta`:
 {
     "uuid":              "550e8400-e29b-41d4-a716-446655440000",
     "importer":          "AssimpImporter",
-    "source_sha256":     "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "source_hash":       12345678901234567890,
+    "source_path":       "/project/mesh.glb",
     "import_time_ns":    1748000000000000000,
     "artifact_path":     "/.cache/mesh_550e8400.zasset",
     "settings": [
@@ -200,8 +199,10 @@ VFSResult<MetaFileData> MetaFileIO::Read(IVFSContext& ctx, const VFSPath& asset_
 
     if (j.contains("importer")        && j["importer"].is_string())
         copy_str(j["importer"].get<std::string>(),     out.ImporterName,    sizeof(out.ImporterName));
-    if (j.contains("source_sha256")   && j["source_sha256"].is_string())
-        copy_str(j["source_sha256"].get<std::string>(), out.LastSourceSha256, sizeof(out.LastSourceSha256));
+    if (j.contains("source_hash")     && j["source_hash"].is_number_unsigned())
+        out.SourceHash = j["source_hash"].get<uint64_t>();
+    if (j.contains("source_path")     && j["source_path"].is_string())
+        copy_str(j["source_path"].get<std::string>(), out.SourcePath, sizeof(out.SourcePath));
     if (j.contains("import_time_ns")  && j["import_time_ns"].is_number_integer())
         out.LastImportTimeNs = j["import_time_ns"].get<int64_t>();
     if (j.contains("artifact_path")   && j["artifact_path"].is_string())
@@ -233,22 +234,21 @@ VFSResult<MetaFileData> MetaFileIO::GetOrCreate(
     IVFSContext& ctx,
     const VFSPath& asset_path,
     const char*    importer_name,
-    const char*    current_sha256)
+    uint64_t       current_hash)
 {
     auto read_result = Read(ctx, asset_path);
 
     if (read_result.IsOk())
     {
         MetaFileData& existing = read_result.Value();
-        if (std::strcmp(existing.LastSourceSha256, current_sha256) == 0)
+        if (existing.SourceHash == current_hash)
         {
             existing.Status = ImportStatus::UpToDate;
             return VFSResult<MetaFileData>::Ok(existing);
         }
 
-        // SHA changed → update and rewrite
-        std::strncpy(existing.LastSourceSha256, current_sha256,
-                     sizeof(existing.LastSourceSha256) - 1);
+        // Hash changed → update and rewrite
+        existing.SourceHash = current_hash;
         existing.LastImportTimeNs = NowNs();
         existing.Status           = ImportStatus::Stale;
         Write(ctx, asset_path, existing);   // best-effort; ignore error
@@ -261,8 +261,8 @@ VFSResult<MetaFileData> MetaFileIO::GetOrCreate(
     // first-import: generate a new UUID and write a clean .meta file.
     MetaFileData fresh{};
     fresh.AssetUUID = uuids::uuid_random_generator{}();
-    std::strncpy(fresh.ImporterName,     importer_name,   sizeof(fresh.ImporterName) - 1);
-    std::strncpy(fresh.LastSourceSha256, current_sha256,  sizeof(fresh.LastSourceSha256) - 1);
+    std::strncpy(fresh.ImporterName, importer_name, sizeof(fresh.ImporterName) - 1);
+    fresh.SourceHash = current_hash;
     fresh.LastImportTimeNs = NowNs();
     fresh.Status           = ImportStatus::New;
     Write(ctx, asset_path, fresh);
@@ -312,9 +312,9 @@ asset.MeshUUID = uuids::uuid_random_generator{}();
 After:
 ```cpp
 // AssimpImporter.cpp — REPLACE with
-char sha256[65] = {};
-VFS::MetaFileIO::ComputeSHA256(ctx, vfs_path, sha256);
-auto meta = VFS::MetaFileIO::GetOrCreate(ctx, vfs_path, "AssimpImporter", sha256);
+auto hash_result = VFS::MetaFileIO::ComputeHash(ctx, vfs_path);
+uint64_t hash = hash_result.IsOk() ? hash_result.Value() : 0;
+auto meta = VFS::MetaFileIO::GetOrCreate(ctx, vfs_path, "AssimpImporter", hash);
 asset.MeshUUID = meta.IsOk() ? meta.Value().AssetUUID : uuids::uuid_random_generator{}();
 ```
 
@@ -344,10 +344,10 @@ In `ScanDirectory`, after pushing a file entry to the cache:
 ```cpp
 if (IsAssetExtension(entry.Name))
 {
-    char sha256[65] = {};
-    MetaFileIO::ComputeSHA256(*m_ctx, entry.VFSPath, sha256);
+    auto hash_result = MetaFileIO::ComputeHash(*m_ctx, entry.VFSPath);
+    uint64_t hash = hash_result.IsOk() ? hash_result.Value() : 0;
     auto meta = MetaFileIO::GetOrCreate(*m_ctx, entry.VFSPath,
-                                        "VFSScanner", sha256);
+                                        "VFSScanner", hash);
     if (meta.IsOk())
     {
         switch (meta.Value().Status)
@@ -388,8 +388,8 @@ TEST(MetaFileIO, RoundTrip)
     MetaFileData in{};
     in.AssetUUID = uuids::uuid_random_generator{}();
     snprintf(in.ImporterName,     sizeof(in.ImporterName),     "AssimpImporter");
-    snprintf(in.LastSourceSha256, sizeof(in.LastSourceSha256),
-             "abc123def456abc123def456abc123def456abc123def456abc123def456abcd");
+    in.SourceHash = 0xabc123def456abc1ULL;
+    snprintf(in.SourcePath, sizeof(in.SourcePath), "/project/mesh.glb");
     in.LastImportTimeNs = 1748000000000000000LL;
     in.SettingsCount = 1;
     snprintf(in.Settings[0].Key,   sizeof(in.Settings[0].Key),   "FlipUVs");
@@ -403,7 +403,8 @@ TEST(MetaFileIO, RoundTrip)
 
     EXPECT_EQ(in.AssetUUID, out.AssetUUID);
     EXPECT_STREQ(in.ImporterName,     out.ImporterName);
-    EXPECT_STREQ(in.LastSourceSha256, out.LastSourceSha256);
+    EXPECT_EQ(in.SourceHash, out.SourceHash);
+    EXPECT_STREQ(in.SourcePath, out.SourcePath);
     EXPECT_EQ(in.LastImportTimeNs,    out.LastImportTimeNs);
     ASSERT_EQ(out.SettingsCount, 1u);
     EXPECT_STREQ(out.Settings[0].Key,   "FlipUVs");
@@ -430,7 +431,7 @@ TEST(MetaFileIO, GetOrCreateNewFile)
     ctx.WriteFile("/project/mesh.glb", "dummy_binary_content");
 
     VFSPath path = VFSPath::Parse("/project/mesh.glb").Value();
-    auto result = MetaFileIO::GetOrCreate(ctx, path, "AssimpImporter", "sha_first");
+    auto result = MetaFileIO::GetOrCreate(ctx, path, "AssimpImporter", 1ULL);
 
     ASSERT_TRUE(result.IsOk());
     EXPECT_EQ(result.Value().Status, ImportStatus::New);
@@ -449,11 +450,11 @@ TEST(MetaFileIO, GetOrCreateMatchingSHAReturnsUpToDate)
     VFSPath path = VFSPath::Parse("/project/mesh.glb").Value();
 
     // First call creates it
-    auto first = MetaFileIO::GetOrCreate(ctx, path, "AssimpImporter", "sha_abc");
+    auto first = MetaFileIO::GetOrCreate(ctx, path, "AssimpImporter", 1ULL);
     ASSERT_TRUE(first.IsOk());
 
     // Second call with same SHA
-    auto second = MetaFileIO::GetOrCreate(ctx, path, "AssimpImporter", "sha_abc");
+    auto second = MetaFileIO::GetOrCreate(ctx, path, "AssimpImporter", 1ULL);
     ASSERT_TRUE(second.IsOk());
     EXPECT_EQ(second.Value().Status, ImportStatus::UpToDate);
     EXPECT_EQ(first.Value().AssetUUID, second.Value().AssetUUID);  // UUID must not change
@@ -467,11 +468,11 @@ TEST(MetaFileIO, GetOrCreateChangedSHAReturnsStale)
     MemoryVFSContext ctx;
     VFSPath path = VFSPath::Parse("/project/mesh.glb").Value();
 
-    auto first = MetaFileIO::GetOrCreate(ctx, path, "AssimpImporter", "sha_old");
+    auto first = MetaFileIO::GetOrCreate(ctx, path, "AssimpImporter", 1ULL);
     ASSERT_TRUE(first.IsOk());
     uuids::uuid original_uuid = first.Value().AssetUUID;
 
-    auto second = MetaFileIO::GetOrCreate(ctx, path, "AssimpImporter", "sha_new");
+    auto second = MetaFileIO::GetOrCreate(ctx, path, "AssimpImporter", 2ULL);
     ASSERT_TRUE(second.IsOk());
     EXPECT_EQ(second.Value().Status, ImportStatus::Stale);
     EXPECT_EQ(second.Value().AssetUUID, original_uuid);  // UUID preserved across reimport
@@ -498,7 +499,7 @@ TEST(MetaFileIO, OverlongSettingsAreTruncated)
     // Build a JSON .meta with a key that is 200 chars long
     std::string long_key(200, 'k');
     std::string json = R"({"uuid":"550e8400-e29b-41d4-a716-446655440000",)"
-                       R"("importer":"Test","source_sha256":"aaa","import_time_ns":0,)"
+                       R"("importer":"Test","source_hash":0,"source_path":"/project/x.glb","import_time_ns":0,)"
                        R"("artifact_path":"","settings":[{"key":")" + long_key + R"(","value":"v"}]})";
     ctx.WriteFile("/project/x.glb.meta", json);
 
@@ -551,7 +552,8 @@ TEST(MetaFileIO, SettingsCountCappedAtMax)
     nlohmann::json j;
     j["uuid"]           = uuids::to_string(uuids::uuid_random_generator{}());
     j["importer"]       = "Test";
-    j["source_sha256"]  = "aaa";
+    j["source_hash"]    = 0;
+    j["source_path"]    = "";
     j["import_time_ns"] = 0;
     j["artifact_path"]  = "";
     j["settings"]       = nlohmann::json::array();

--- a/ZEngine/docs/vfs-ticket6-asset-registry.md
+++ b/ZEngine/docs/vfs-ticket6-asset-registry.md
@@ -105,7 +105,7 @@ for `.cpp` files — no manual source list additions needed for the new `.cpp` f
 #pragma once
 #include <cstdint>
 
-namespace ZEngine::VFS
+namespace ZEngine::Core::VFS
 {
     // Lifecycle state machine for a registered asset.
     //
@@ -140,7 +140,7 @@ namespace ZEngine::VFS
 #include <uuid.h>
 #include <cstdint>
 
-namespace ZEngine::VFS
+namespace ZEngine::Core::VFS
 {
     // MAX_ASSET_NAME_LEN: name stored inline to avoid arena fragmentation on lookup.
     // Derived from VFSPath::Filename() on Register; updated on Rename.
@@ -159,14 +159,14 @@ namespace ZEngine::VFS
         // ── Meta snapshot ────────────────────────────────────────────────────
         // Copied from MetaFileData at registration time; updated on reimport.
         // The registry does NOT re-read the .meta file except during hot-reload.
-        MetaFileData                Meta        = {};
+        AssetMetaSnapshot           Meta        = {};  // Reduced snapshot — see MetaFileData.h for full import settings
 
         // ── Runtime handle ───────────────────────────────────────────────────
         // Generational handle into HandleManager<AssetRecord>.
         // Replaces the old AssetHandle (uint32_t) for registry purposes.
-        // The old uint32_t handle is kept in LegacyHandle for backward compat
+        // The old uint32_t handle is kept in SlotHandle for backward compat
         // during the migration period (see §11).
-        Managers::AssetManager::AssetHandle LegacyHandle = 0;
+        Managers::AssetHandle SlotHandle = 0;
 
         // ── State ─────────────────────────────────────────────────────────────
         AssetState                  State       = AssetState::Unregistered;
@@ -186,10 +186,10 @@ namespace ZEngine::VFS
 - `Name[]` stores only the filename component (e.g. `"tank.glb"`), not the full path.
   This is populated by `VFSPath::Filename()` at registration and enables efficient
   substring search without touching the `Path` buffer on every comparison.
-- `MetaFileData Meta` is a snapshot. It captures the `AssetUUID`, `ImporterName`,
-  `LastSourceSha256`, and `ArtifactPath` from the last successful `.meta` read.
+- `AssetMetaSnapshot Meta` is a snapshot. It captures the `AssetUUID`, `ImporterName`,
+  and `ArtifactPath` from the last successful `.meta` read.
   The `Status` field in the snapshot is always `Unknown` — runtime state is in `AssetState`.
-- `LegacyHandle` exists only during the migration period (§11). Once all `AssetManager`
+- `SlotHandle` exists only during the migration period (§11). Once all `AssetManager`
   call sites use `AssetRegistry`, this field is removed.
 
 ---
@@ -227,7 +227,7 @@ because it is an editor-only, infrequent operation and the record count is bound
 #include <shared_mutex>
 #include <span>
 
-namespace ZEngine::VFS
+namespace ZEngine::Core::VFS
 {
     // -------------------------------------------------------------------------
     // UUIDHasher — adapts uuids::uuid for UnorderedHashMap
@@ -286,7 +286,7 @@ namespace ZEngine::VFS
     public:
         // Maximum registered assets. Sized for a mid-size game project.
         // Increase if needed; the slot array is arena-allocated at init time.
-        static constexpr uint32_t MAX_ASSETS = 65536;
+        static constexpr uint32_t MAX_ASSETS = 8192;
 
         AssetIndex()  = default;
         ~AssetIndex() = default;
@@ -305,7 +305,7 @@ namespace ZEngine::VFS
                                 const MetaFileData&      meta);
 
         // Update an existing record (e.g. after reimport). Record must exist.
-        // Only Meta, LegacyHandle, State may be updated; UUID and Type are immutable.
+        // Only Meta, SlotHandle, State may be updated; UUID and Type are immutable.
         bool Update(Helpers::Handle<AssetRecord> handle,
                     const MetaFileData&          new_meta,
                     AssetState                   new_state);
@@ -349,7 +349,7 @@ namespace ZEngine::VFS
 
         // Visit all live records. ForEach acquires shared_lock for the duration.
         // Do NOT call Register/Remove from within the visitor — deadlock.
-        void ForEach(std::function<void(const AssetRecord&)> visitor) const;
+        void ForEach(void* ctx, void (*visitor)(void*, Helpers::Handle<AssetRecord>, const AssetRecord&));
 
         // ── Stats ─────────────────────────────────────────────────────────────
         uint32_t Count()    const;   // total live records
@@ -382,7 +382,7 @@ namespace ZEngine::VFS
         Core::Memory::ArenaAllocator*            m_arena     = nullptr;
     };
 
-} // namespace ZEngine::VFS
+} // namespace ZEngine::Core::VFS
 ```
 
 ### 5.3 Implementation Notes
@@ -414,7 +414,7 @@ void AssetIndex::Initialize(Core::Memory::ArenaAllocator* arena)
 9. record.Path         = path
 10. copy basename into record.Name (VFSPath::Filename → strncpy)
 11. record.Meta         = meta
-12. record.LegacyHandle = 0          ← caller sets this separately
+12. record.SlotHandle = 0          ← caller sets this separately
 13. record.State        = AssetState::Registered
 14. m_by_uuid[uuid]     = handle
 15. m_by_path[path]     = handle
@@ -482,7 +482,7 @@ Both directions are needed:
 #include <shared_mutex>
 #include <span>
 
-namespace ZEngine::VFS
+namespace ZEngine::Core::VFS
 {
     // -------------------------------------------------------------------------
     // AdjacencyList — arena-backed list of UUIDs.
@@ -594,7 +594,7 @@ namespace ZEngine::VFS
         uint32_t                                       m_edges   = 0;
     };
 
-} // namespace ZEngine::VFS
+} // namespace ZEngine::Core::VFS
 ```
 
 ### 6.3 Implementation Notes
@@ -685,12 +685,8 @@ caller (typically `AssetRegistry`'s internal scratch sub-arena).
 #include <functional>
 #include <span>
 
-namespace ZEngine::VFS
+namespace ZEngine::Core::VFS
 {
-    // Called after the cascade BFS identifies all assets to reload.
-    // `cascade` spans all UUIDs to invalidate, in BFS order (root first).
-    // Fired on the main/editor thread (after VFSFileWatcher::Tick()).
-    using HotReloadCallback = std::function<void(std::span<const uuids::uuid> cascade)>;
 ```
 
 ### 7.2 `AssetRegistry.h`
@@ -724,7 +720,7 @@ namespace ZEngine::VFS
                                       Managers::AssetType                  type,
                                       const VFSPath&                       path,
                                       const MetaFileData&                  meta,
-                                      Managers::AssetManager::AssetHandle  legacy_handle);
+                                      Managers::AssetHandle  legacy_handle);
 
         // Remove the record and purge its dependency edges.
         bool Remove(const uuids::uuid& uuid);
@@ -786,8 +782,7 @@ namespace ZEngine::VFS
 
         // ── Hot-reload ────────────────────────────────────────────────────────
 
-        // Register the callback invoked when a cascade is computed.
-        void SetHotReloadCallback(HotReloadCallback cb);
+        void SetHotReloadCallback(void* ctx, void (*cb)(void*, std::span<const uuids::uuid>));
 
         // Called by VFSFileWatcher integration (§10) when a source asset changes.
         // Computes BFS cascade and fires the HotReloadCallback.
@@ -822,7 +817,8 @@ namespace ZEngine::VFS
     private:
         AssetIndex                   m_index         = {};
         DependencyGraph              m_graph         = {};
-        HotReloadCallback            m_reload_cb     = nullptr;
+        void*                        m_reload_ctx    = nullptr;
+        void                       (*m_reload_cb)(void*, std::span<const uuids::uuid>) = nullptr;
 
         // Scratch sub-arena: used for BFS queue/visited in CollectCascade.
         // Created from the persistent arena passed to Initialize.
@@ -834,7 +830,7 @@ namespace ZEngine::VFS
                                                        const char* ext);
     };
 
-} // namespace ZEngine::VFS
+} // namespace ZEngine::Core::VFS
 ```
 
 ### 7.3 Implementation Notes
@@ -856,14 +852,14 @@ void AssetRegistry::Initialize(Core::Memory::ArenaAllocator* arena, uint64_t scr
 RegisterResult AssetRegistry::RegisterLoaded(
     const uuids::uuid& uuid, Managers::AssetType type,
     const VFSPath& path, const MetaFileData& meta,
-    Managers::AssetManager::AssetHandle legacy_handle)
+    Managers::AssetHandle legacy_handle)
 {
     RegisterResult result = m_index.Register(uuid, type, path, meta);
     if (!result.IsOk()) return result;
 
     AssetRecord* rec = m_index.Access(result.Handle);
     ZENGINE_VALIDATE_ASSERT(rec != nullptr, "Register succeeded but Access returned null")
-    rec->LegacyHandle = legacy_handle;
+    rec->SlotHandle = legacy_handle;
     rec->State        = AssetState::Loaded;
     return result;
 }
@@ -1234,8 +1230,7 @@ void AssetRegistry::OnScanFileDiscovered(
     if (existing.Valid())
     {
         AssetRecord* rec = m_index.Access(existing);
-        if (rec &&
-            std::strcmp(rec->Meta.LastSourceSha256, meta.LastSourceSha256) != 0)
+        if (rec && rec->Meta.SourceHash != meta.SourceHash)
         {
             // SHA changed → mark Stale
             m_index.SetState(existing, AssetState::Stale);
@@ -1359,7 +1354,7 @@ Nothing else changes. All existing `UUIDToHandle` / `HandleToUUID` paths continu
 
 ```cpp
 // AssetManager.cpp — RegisterAsset (MODIFIED):
-AssetManager::AssetHandle AssetManager::RegisterAsset(
+Managers::AssetHandle AssetManager::RegisterAsset(
     AssetType type, const uuids::uuid& uuid, uint32_t asset_id)
 {
     AssetHandle h = CreateHandle(asset_id, type);
@@ -1423,8 +1418,8 @@ Core::Containers::UnorderedHashMap<AssetHandle, uuids::uuid>  HandleToUUID;
 
 | Old pattern | New pattern |
 |---|---|
-| `AssetManager::Instance()->UUIDToHandle.at(id)` | `Registry->FindByUUID(id)->LegacyHandle` |
-| `AssetManager::Instance()->HandleToUUID.at(h)` | `Registry->FindByUUID(uuid)->LegacyHandle == h` check |
+| `AssetManager::Instance()->UUIDToHandle.at(id)` | `Registry->FindByUUID(id)->SlotHandle` |
+| `AssetManager::Instance()->HandleToUUID.at(h)` | `Registry->FindByUUID(uuid)->SlotHandle == h` check |
 | `UUIDToHandle.contains(id)` | `Registry->FindByUUID(id) != nullptr` |
 | `GetAsset<T, uuids::uuid>(id)` template | unchanged (uses `UUIDToHandle` internally; redirect in Phase 4) |
 
@@ -1849,14 +1844,14 @@ TEST(AssetRegistry, StateTransitionAndCascadeMarksStale)
 ```
 [ ] ZEngine/VFS/Registry/AssetRecord.h
       AssetState enum (6 values)
-      AssetRecord struct (UUID, Type, Path, Name[128], Meta, LegacyHandle, State)
+      AssetRecord struct (UUID, Type, Path, Name[128], Meta, SlotHandle, State)
 
 [ ] ZEngine/VFS/Registry/AssetIndex.h
       UUIDHasher struct (FNV-1a over uuid bytes)
       VFSPathHasher struct (delegates to VFSPath::Hash())
       RegisterError enum (4 values)
       RegisterResult struct
-      AssetIndex class (MAX_ASSETS = 65536)
+      AssetIndex class (MAX_ASSETS = 8192)
         Initialize(arena)
         Register(uuid, type, path, meta) → RegisterResult
         Update(handle, meta, state) → bool
@@ -1899,7 +1894,6 @@ TEST(AssetRegistry, StateTransitionAndCascadeMarksStale)
       CollectCascade: shared_lock; BFS with inline visited table; populate out
 
 [ ] ZEngine/VFS/Registry/AssetRegistry.h
-      HotReloadCallback typedef
       QueryFilter struct (Type, NameLike, Ext, State)
       QueryResult struct (Handles array, Count)
       AssetRegistry class
@@ -1909,7 +1903,7 @@ TEST(AssetRegistry, StateTransitionAndCascadeMarksStale)
         SetState(uuid, state) / UpdateMeta
         FindByUUID / FindByPath (2 overloads each)
         Query(filter, arena) → QueryResult
-        SetHotReloadCallback(cb)
+        SetHotReloadCallback(ctx, cb)
         OnAssetModified / OnAssetDeleted / OnAssetRenamed
         OnScanFileDiscovered
         RecordCount / EdgeCount
@@ -1917,7 +1911,7 @@ TEST(AssetRegistry, StateTransitionAndCascadeMarksStale)
 
 [ ] ZEngine/VFS/Registry/AssetRegistry.cpp
       Initialize: m_scratch = arena->CreateSubArena; m_index.Initialize; m_graph.Initialize
-      Register / RegisterLoaded: delegate to m_index; set LegacyHandle if provided
+      Register / RegisterLoaded: delegate to m_index; set SlotHandle if provided
       Remove(uuid): m_graph.RemoveAsset → m_index.Remove
       OnAssetModified: FindByPath; SetState(Stale); CollectCascade; mark all Stale; fire cb
       OnAssetDeleted: cascade fire; Remove


### PR DESCRIPTION
## Summary

Two commits — full design-doc audit and fix pass against the current codebase.

### Commit 1 — status tracking (docs/update-design-docs-state@a65d790)
- Roadmap: ECS, WorldTick, VFS T1–T6, GltfImporter, asset importer panel all marked complete
- import-pipeline.md / actor-ecs-architecture.md / execution-plan.md: status fields and sprint rows advanced to reflect 2026-08-17 reality

### Commit 2 — 31 audit findings fixed (docs/update-design-docs-state@1bfca98)
Cross-reference workflow found code-had-outpaced-docs across 16 files:

**Status corrections**
- render-resource-manager.md: Design → Implemented
- system-scheduler.md: Design → Implemented; all checklist items [x]
- game-loop.md: Design → In Progress
- import-pipeline.md: ImportCoordinator / ImportQueue / ImportJob / ImportPriority all live

**API signature fixes**
- vfs-ticket3: Scan signature, SetOnScanComplete (C fn-ptr), GetListing (ArrayView not span)
- vfs-ticket4: RawEventCallback, Poll, VFSFileWatcher Initialize/PendingCount, DebounceEntry
- vfs-ticket5: MetaFileData LastSourceSha256 → SourceHash + SourcePath; ComputeHash return type
- vfs-ticket6: AssetMetaSnapshot, SlotHandle, ForEach fn-ptr, MAX_ASSETS 8192, callback signatures
- actor-ecs-architecture: Handle<Actor*>, SpawnCallback struct, Command::Data[256], m_storages raw ptr

**Namespace** — ZEngine::VFS → ZEngine::Core::VFS across tickets 4/5/6

**Checklist / minor fixes**
- migration-plan, rendering-flow, memory-budget, obelisk-tetragrama-impact, fly-camera-redesign

## Test plan

- [x] Documentation only — no build changes
- [x] All internal cross-references between docs remain consistent