### PR TITLE
refactor(rendering): migrate SkyboxPass/GridPass geometry into RRM global buffers

### DIFF
--- a/Tetragrama/EditorScene.cpp
+++ b/Tetragrama/EditorScene.cpp
@@ -1,4 +1,5 @@
 #include <Tetragrama/EditorScene.h>
+#include <ZEngine/Engine.h>
 #include <ZEngine/Importers/AssetCodec.h>
 #include <ZEngine/Managers/AssetManager.h>
 using namespace ZEngine::Core::Containers;
@@ -80,6 +81,12 @@ namespace Tetragrama
 
     void EditorScene::ExtractAsync(const EditorScene& scene)
     {
+        // Compact the global geometry buffers before ingesting a new scene so
+        // orphaned data from the previous scene is reclaimed starting from offset 0.
+        auto* ctx = ZEngine::Engine::GetContext();
+        if (ctx && ctx->RenderResourceManager)
+            ctx->RenderResourceManager->ResetGeometryBuffers();
+
         for (const auto& file : scene.AssetFiles)
         {
             auto& f = AssetFiles.push_use({});

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
@@ -285,40 +285,86 @@ namespace ZEngine::Rendering
         m_idx_cursor   += idx_bytes;
     }
 
+    void RenderResourceManager::ResetGeometryBuffers()
+    {
+        m_pending_reset.store(true, std::memory_order_release);
+    }
+
+    void RenderResourceManager::ResetGeometryBuffersInternal()
+    {
+        m_vtx_cursor = 0;
+        m_idx_cursor = 0;
+        for (uint32_t i = 0; i < m_mesh_slot_count; ++i)
+            m_mesh_slots[i] = {};
+        m_mesh_slot_count = 0;
+
+        std::lock_guard lock(m_uuid_map_mutex);
+        for (uint32_t i = 0; i < m_uuid_to_buffer_count; ++i)
+            m_uuid_to_buffer[i] = {};
+        m_uuid_to_buffer_count = 0;
+    }
+
+    void RenderResourceManager::BeginBatchUpload()
+    {
+        vkWaitForFences(m_device->LogicalDevice, 1, &m_upload_fence, VK_TRUE, UINT64_MAX);
+        vkResetFences(m_device->LogicalDevice, 1, &m_upload_fence);
+        m_upload_cmd->ResetState();
+        vkResetCommandBuffer(m_upload_cmd->GetHandle(), 0);
+        m_upload_cmd->Begin();
+        m_batch_mode          = true;
+        m_batch_staging_count = 0;
+    }
+
+    void RenderResourceManager::EndBatchUpload()
+    {
+        m_upload_cmd->End();
+        VkCommandBuffer cmd_handle = m_upload_cmd->GetHandle();
+        VkQueue         gfx_queue  = m_device->GetQueue(QueueType::GRAPHIC_QUEUE).Handle;
+        VkSubmitInfo    submit{VK_STRUCTURE_TYPE_SUBMIT_INFO, nullptr, 0, nullptr, nullptr, 1, &cmd_handle, 0, nullptr};
+        vkQueueSubmit(gfx_queue, 1, &submit, m_upload_fence);
+        vkWaitForFences(m_device->LogicalDevice, 1, &m_upload_fence, VK_TRUE, UINT64_MAX);
+        m_upload_cmd->ResetState();
+        for (uint32_t i = 0; i < m_batch_staging_count; ++i)
+            m_device->GpuMem.FreeBuffer(m_batch_stagings[i]);
+        m_batch_staging_count = 0;
+        m_batch_mode          = false;
+    }
+
     void RenderResourceManager::AppendToGlobalBuffer(BufferView& global_buf, const void* data, size_t byte_size, VkDeviceSize byte_offset, uint32_t frame_index)
     {
         BufferView staging = m_device->GpuMem.AllocateBuffer(static_cast<VkDeviceSize>(byte_size), VK_BUFFER_USAGE_TRANSFER_SRC_BIT, GpuMemoryDomain::HostStaging, "RRM::Staging");
         ZENGINE_VALIDATE_ASSERT(staging, "RRM::AppendToGlobalBuffer: staging alloc failed")
-
         ZENGINE_VALIDATE_ASSERT(vmaCopyMemoryToAllocation(m_device->GpuMem.Allocator, data, staging.Allocation, 0, byte_size) == VK_SUCCESS, "RRM::AppendToGlobalBuffer: staging copy failed")
 
-        VkSemaphore render_timeline = m_device->SwapchainPtr ? m_device->SwapchainPtr->RenderTimeline->GetHandle() : VK_NULL_HANDLE;
-        uint64_t    render_value    = m_device->SwapchainPtr ? m_device->SwapchainPtr->RenderTimelineNextValue : 0;
-        VkQueue     gfx_queue       = m_device->GetQueue(QueueType::GRAPHIC_QUEUE).Handle;
+        auto record = [&](VkCommandBuffer cmd) {
+            VkBufferCopy region{.srcOffset = 0, .dstOffset = byte_offset, .size = byte_size};
+            vkCmdCopyBuffer(cmd, staging.Handle, global_buf.Handle, 1, &region);
 
-        RecordAndSubmit(
-            m_device->LogicalDevice,
-            m_upload_cmd,
-            m_upload_fence,
-            gfx_queue,
-            [&](VkCommandBuffer cmd) {
-                VkBufferCopy region{.srcOffset = 0, .dstOffset = byte_offset, .size = byte_size};
-                vkCmdCopyBuffer(cmd, staging.Handle, global_buf.Handle, 1, &region);
+            VkBufferMemoryBarrier barrier{VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER};
+            barrier.srcAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
+            barrier.dstAccessMask       = VK_ACCESS_SHADER_READ_BIT;
+            barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+            barrier.buffer              = global_buf.Handle;
+            barrier.offset              = byte_offset;
+            barrier.size                = byte_size;
+            vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, nullptr, 1, &barrier, 0, nullptr);
+        };
 
-                VkBufferMemoryBarrier barrier{VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER};
-                barrier.srcAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
-                barrier.dstAccessMask       = VK_ACCESS_SHADER_READ_BIT;
-                barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-                barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-                barrier.buffer              = global_buf.Handle;
-                barrier.offset              = byte_offset;
-                barrier.size                = byte_size;
-                vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, nullptr, 1, &barrier, 0, nullptr);
-            },
-            render_timeline,
-            render_value);
-
-        m_device->GpuMem.FreeBuffer(staging);
+        if (m_batch_mode)
+        {
+            record(m_upload_cmd->GetHandle());
+            ZENGINE_VALIDATE_ASSERT(m_batch_staging_count < MAX_PENDING * 2, "RRM::AppendToGlobalBuffer: batch staging overflow")
+            m_batch_stagings[m_batch_staging_count++] = staging;
+        }
+        else
+        {
+            VkSemaphore render_timeline = m_device->SwapchainPtr ? m_device->SwapchainPtr->RenderTimeline->GetHandle() : VK_NULL_HANDLE;
+            uint64_t    render_value    = m_device->SwapchainPtr ? m_device->SwapchainPtr->RenderTimelineNextValue : 0;
+            VkQueue     gfx_queue       = m_device->GetQueue(QueueType::GRAPHIC_QUEUE).Handle;
+            RecordAndSubmit(m_device->LogicalDevice, m_upload_cmd, m_upload_fence, gfx_queue, record, render_timeline, render_value);
+            m_device->GpuMem.FreeBuffer(staging);
+        }
     }
 
     BufferHandle RenderResourceManager::DoUploadMesh(AssetHandle asset, uint32_t frame_index)
@@ -377,6 +423,10 @@ namespace ZEngine::Rendering
 
     void RenderResourceManager::FlushPendingUploads(uint32_t frame_index)
     {
+        // Compact geometry buffers if a scene reload was requested
+        if (m_pending_reset.exchange(false, std::memory_order_acq_rel))
+            ResetGeometryBuffersInternal();
+
         uint32_t      count = 0;
         PendingUpload local[MAX_PENDING];
         {
@@ -385,33 +435,51 @@ namespace ZEngine::Rendering
             secure_memcpy(local, sizeof(local), m_pending, count * sizeof(PendingUpload));
             m_pending_count = 0;
         }
+        if (count == 0)
+            return;
 
+        // Partition into mesh and texture uploads
+        PendingUpload mesh_local[MAX_PENDING];
+        PendingUpload tex_local[MAX_PENDING];
+        uint32_t      mesh_count = 0, tex_count = 0;
         for (uint32_t i = 0; i < count; ++i)
         {
-            const PendingUpload& p = local[i];
-            if (p.Kind == UploadKind::Mesh)
+            if (local[i].Kind == UploadKind::Mesh)
+                mesh_local[mesh_count++] = local[i];
+            else
+                tex_local[tex_count++] = local[i];
+        }
+
+        // Batch all mesh uploads into one GPU command buffer submission
+        if (mesh_count > 0)
+        {
+            BeginBatchUpload();
+            for (uint32_t i = 0; i < mesh_count; ++i)
             {
-                BufferHandle h = DoUploadMesh(p.Asset, frame_index);
+                BufferHandle h = DoUploadMesh(mesh_local[i].Asset, frame_index);
                 if (h.IsValid())
                 {
                     std::lock_guard lock(m_uuid_map_mutex);
                     if (m_uuid_to_buffer_count < MAX_UUID_MAP)
-                        m_uuid_to_buffer[m_uuid_to_buffer_count++] = {p.UUID, h};
+                        m_uuid_to_buffer[m_uuid_to_buffer_count++] = {mesh_local[i].UUID, h};
                 }
                 else
                 {
-                    ZENGINE_CORE_ERROR("[RRM] Mesh upload failed for asset handle {}", p.Asset)
+                    ZENGINE_CORE_ERROR("[RRM] Mesh upload failed for asset handle {}", mesh_local[i].Asset)
                 }
             }
-            else
+            EndBatchUpload();
+        }
+
+        // Texture uploads: per-texture path (independent submission chain)
+        for (uint32_t i = 0; i < tex_count; ++i)
+        {
+            ImageHandle h = DoUploadTexture(tex_local[i].Asset);
+            if (h.IsValid())
             {
-                ImageHandle h = DoUploadTexture(p.Asset);
-                if (h.IsValid())
-                {
-                    std::lock_guard lock(m_uuid_map_mutex);
-                    if (m_uuid_to_image_count < MAX_UUID_MAP)
-                        m_uuid_to_image[m_uuid_to_image_count++] = {p.UUID, h};
-                }
+                std::lock_guard lock(m_uuid_map_mutex);
+                if (m_uuid_to_image_count < MAX_UUID_MAP)
+                    m_uuid_to_image[m_uuid_to_image_count++] = {tex_local[i].UUID, h};
             }
         }
     }

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
@@ -259,15 +259,30 @@ namespace ZEngine::Rendering
 
     void RenderResourceManager::InitGlobalBuffers()
     {
-        m_global_vertex_buf = m_device->GpuMem.AllocateBuffer(GLOBAL_VTX_CAPACITY, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, GpuMemoryDomain::DeviceGeometry, "RRM::GlobalVertexBuffer");
+        m_global_vertex_buf = m_device->GpuMem.AllocateBuffer(GLOBAL_VTX_CAPACITY, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, GpuMemoryDomain::DeviceGeometry, "RRM::GlobalVertexBuffer");
 
-        m_global_index_buf  = m_device->GpuMem.AllocateBuffer(GLOBAL_IDX_CAPACITY, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, GpuMemoryDomain::DeviceGeometry, "RRM::GlobalIndexBuffer");
+        m_global_index_buf  = m_device->GpuMem.AllocateBuffer(GLOBAL_IDX_CAPACITY, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, GpuMemoryDomain::DeviceGeometry, "RRM::GlobalIndexBuffer");
 
         m_vtx_cursor        = 0;
         m_idx_cursor        = 0;
 
         ZENGINE_VALIDATE_ASSERT(m_global_vertex_buf, "RRM: global vertex buffer allocation failed")
         ZENGINE_VALIDATE_ASSERT(m_global_index_buf, "RRM: global index buffer allocation failed")
+    }
+
+    void RenderResourceManager::RegisterBuiltinGeometry(const void* vtx_data, size_t vtx_bytes, const uint32_t* idx_data, uint32_t idx_count, uint32_t& out_vtx_offset, uint32_t& out_idx_offset)
+    {
+        const size_t idx_bytes = idx_count * sizeof(uint32_t);
+        ZENGINE_VALIDATE_ASSERT(m_vtx_cursor + vtx_bytes <= GLOBAL_VTX_CAPACITY, "RRM::RegisterBuiltinGeometry: global vertex buffer out of space")
+        ZENGINE_VALIDATE_ASSERT(m_idx_cursor + idx_bytes <= GLOBAL_IDX_CAPACITY, "RRM::RegisterBuiltinGeometry: global index buffer out of space")
+
+        AppendToGlobalBuffer(m_global_vertex_buf, vtx_data, vtx_bytes, m_vtx_cursor, 0);
+        AppendToGlobalBuffer(m_global_index_buf, idx_data, idx_bytes, m_idx_cursor, 0);
+
+        out_vtx_offset  = static_cast<uint32_t>(m_vtx_cursor / (8 * sizeof(float)));
+        out_idx_offset  = static_cast<uint32_t>(m_idx_cursor / sizeof(uint32_t));
+        m_vtx_cursor   += vtx_bytes;
+        m_idx_cursor   += idx_bytes;
     }
 
     void RenderResourceManager::AppendToGlobalBuffer(BufferView& global_buf, const void* data, size_t byte_size, VkDeviceSize byte_offset, uint32_t frame_index)

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.h
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.h
@@ -232,6 +232,13 @@ namespace ZEngine::Rendering
         /// @param out_idx_offset  Out: first uint32 element index in the global IB.
         void         RegisterBuiltinGeometry(const void* vtx_data, size_t vtx_bytes, const uint32_t* idx_data, uint32_t idx_count, uint32_t& out_vtx_offset, uint32_t& out_idx_offset);
 
+        /// @brief Request a geometry compaction on the next BeginFrame.
+        ///        Resets the global vertex/index buffer cursors and slot map so the
+        ///        next batch of mesh uploads starts at byte offset 0, reclaiming all
+        ///        space occupied by the previous scene's geometry.
+        ///        Thread-safe — may be called from the import/asset thread.
+        void         ResetGeometryBuffers();
+
         /// @brief Find the BufferHandle registered for a mesh asset by UUID.
         /// @details Returns an invalid handle if the mesh has not been uploaded yet or
         ///          the UUID is not in the uuid-to-buffer map.
@@ -363,6 +370,11 @@ namespace ZEngine::Rendering
 
         void                            FlushPendingUploads(uint32_t frame_index);
 
+        // Batch upload helpers — render-thread only
+        void                            BeginBatchUpload();
+        void                            EndBatchUpload();
+        void                            ResetGeometryBuffersInternal();
+
         Core::Memory::BufferImage*      GetImageMutable(ImageHandle handle);
 
         void                            InitUploadPool();
@@ -407,37 +419,45 @@ namespace ZEngine::Rendering
             uuids::uuid UUID;
             ImageHandle Handle;
         };
-        static constexpr uint32_t      MAX_UUID_MAP                   = 4096;
-        UUIDBufferPair                 m_uuid_to_buffer[MAX_UUID_MAP] = {};
-        uint32_t                       m_uuid_to_buffer_count         = 0;
-        UUIDImagePair                  m_uuid_to_image[MAX_UUID_MAP]  = {};
-        uint32_t                       m_uuid_to_image_count          = 0;
+        static constexpr uint32_t      MAX_UUID_MAP                      = 4096;
+        UUIDBufferPair                 m_uuid_to_buffer[MAX_UUID_MAP]    = {};
+        uint32_t                       m_uuid_to_buffer_count            = 0;
+        UUIDImagePair                  m_uuid_to_image[MAX_UUID_MAP]     = {};
+        uint32_t                       m_uuid_to_image_count             = 0;
 
         // Swap list — written from asset thread, drained in EndFrame
-        static constexpr uint32_t      MAX_SWAPS                      = 256;
-        SwapEntry                      m_swaps[MAX_SWAPS]             = {};
-        uint32_t                       m_swap_count                   = 0;
+        static constexpr uint32_t      MAX_SWAPS                         = 256;
+        SwapEntry                      m_swaps[MAX_SWAPS]                = {};
+        uint32_t                       m_swap_count                      = 0;
 
         // Pending uploads — written from asset thread, flushed in BeginFrame
-        static constexpr uint32_t      MAX_PENDING                    = 256;
-        PendingUpload                  m_pending[MAX_PENDING]         = {};
-        uint32_t                       m_pending_count                = 0;
+        static constexpr uint32_t      MAX_PENDING                       = 256;
+        PendingUpload                  m_pending[MAX_PENDING]            = {};
+        uint32_t                       m_pending_count                   = 0;
 
-        uint32_t                       m_current_frame                = 0;
+        // Geometry compaction request — set by asset thread, executed on render thread
+        std::atomic<bool>              m_pending_reset                   = false;
+
+        // Batch upload state — render-thread only, no locking needed
+        bool                           m_batch_mode                      = false;
+        Core::Memory::BufferView       m_batch_stagings[MAX_PENDING * 2] = {};
+        uint32_t                       m_batch_staging_count             = 0;
+
+        uint32_t                       m_current_frame                   = 0;
 
         // Dedicated command pools for geometry uploads — isolated from the swapchain
         // timeline semaphore chain. Geometry uploads must not share the graphics queue
         // submission path with Present; a private pool + fence ensures safe isolation.
-        Rendering::Pools::CommandPool* m_upload_pool                  = nullptr;
-        Hardwares::CommandBuffer*      m_upload_cmd                   = nullptr;
-        VkFence                        m_upload_fence                 = VK_NULL_HANDLE;
-        Rendering::Pools::CommandPool* m_transfer_pool                = nullptr;
-        Hardwares::CommandBuffer*      m_transfer_cmd                 = nullptr;
-        VkFence                        m_transfer_fence               = VK_NULL_HANDLE;
+        Rendering::Pools::CommandPool* m_upload_pool                     = nullptr;
+        Hardwares::CommandBuffer*      m_upload_cmd                      = nullptr;
+        VkFence                        m_upload_fence                    = VK_NULL_HANDLE;
+        Rendering::Pools::CommandPool* m_transfer_pool                   = nullptr;
+        Hardwares::CommandBuffer*      m_transfer_cmd                    = nullptr;
+        VkFence                        m_transfer_fence                  = VK_NULL_HANDLE;
 
         // Upper bound for texture timeline slot search — keeps textures out of the
         // geometry slots and caps the retire loop to the same range.
-        static constexpr uint32_t      GEOMETRY_UPLOAD_SLOT           = 15;
+        static constexpr uint32_t      GEOMETRY_UPLOAD_SLOT              = 15;
 
         struct TextureTimelineJob
         {

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.h
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.h
@@ -221,6 +221,17 @@ namespace ZEngine::Rendering
         /// @return true if the handle is valid and the offsets were written; false otherwise.
         bool         GetMeshOffsets(BufferHandle handle, uint32_t& vtx_offset, uint32_t& idx_offset) const;
 
+        /// @brief Upload builtin geometry (skybox, grid, etc.) into the global vertex/index
+        ///        buffers and return the element-count offsets.  Vertices must already be
+        ///        laid out as DrawVertex (8 floats: xyz nxnynz uv). Indices must be uint32_t.
+        /// @param vtx_data   Pointer to tightly-packed DrawVertex float data.
+        /// @param vtx_bytes  Total byte size of the vertex data.
+        /// @param idx_data   Pointer to uint32_t index array.
+        /// @param idx_count  Number of indices.
+        /// @param out_vtx_offset  Out: first DrawVertex element index in the global VB.
+        /// @param out_idx_offset  Out: first uint32 element index in the global IB.
+        void         RegisterBuiltinGeometry(const void* vtx_data, size_t vtx_bytes, const uint32_t* idx_data, uint32_t idx_count, uint32_t& out_vtx_offset, uint32_t& out_idx_offset);
+
         /// @brief Find the BufferHandle registered for a mesh asset by UUID.
         /// @details Returns an invalid handle if the mesh has not been uploaded yet or
         ///          the UUID is not in the uuid-to-buffer map.

--- a/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.cpp
@@ -116,15 +116,16 @@ namespace ZEngine::Rendering::Renderers
 
     void SkyboxPass::Setup(Hardwares::VulkanDevicePtr const device, cstring name, RenderGraphResourceBuilderPtr const res_builder, RenderGraphResourceInspectorPtr res_inspector)
     {
+        // DrawVertex layout: x y z nx ny nz u v (8 floats = 32 bytes)
+        // Normals and UVs zeroed — skybox shader only reads position (location 0, offset 0).
         static constexpr float verts[] = {
-            -1.0f, -1.0f, 1.0f, 1.0f, -1.0f, 1.0f, 1.0f, 1.0f, 1.0f, -1.0f, 1.0f, 1.0f, -1.0f, -1.0f, -1.0f, 1.0f, -1.0f, -1.0f, 1.0f, 1.0f, -1.0f, -1.0f, 1.0f, -1.0f,
+            -1.f, -1.f, 1.f, 0.f, 0.f, 0.f, 0.f, 0.f, 1.f, -1.f, 1.f, 0.f, 0.f, 0.f, 0.f, 0.f, 1.f, 1.f, 1.f, 0.f, 0.f, 0.f, 0.f, 0.f, -1.f, 1.f, 1.f, 0.f, 0.f, 0.f, 0.f, 0.f, -1.f, -1.f, -1.f, 0.f, 0.f, 0.f, 0.f, 0.f, 1.f, -1.f, -1.f, 0.f, 0.f, 0.f, 0.f, 0.f, 1.f, 1.f, -1.f, 0.f, 0.f, 0.f, 0.f, 0.f, -1.f, 1.f, -1.f, 0.f, 0.f, 0.f, 0.f, 0.f,
         };
-        static constexpr uint16_t idxs[] = {0, 1, 2, 2, 3, 0, 1, 5, 6, 6, 2, 1, 5, 4, 7, 7, 6, 5, 4, 0, 3, 3, 7, 4, 3, 2, 6, 6, 7, 3, 4, 5, 1, 1, 0, 4};
+        static constexpr uint32_t idxs[] = {0, 1, 2, 2, 3, 0, 1, 5, 6, 6, 2, 1, 5, 4, 7, 7, 6, 5, 4, 0, 3, 3, 7, 4, 3, 2, 6, 6, 7, 3, 4, 5, 1, 1, 0, 4};
 
-        VBHandle                         = device->GpuMem.AllocateBuffer(sizeof(verts), VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, Core::Memory::GpuMemoryDomain::HostUniform, "SkyboxVb");
-        IBHandle                         = device->GpuMem.AllocateBuffer(sizeof(idxs), VK_BUFFER_USAGE_INDEX_BUFFER_BIT, Core::Memory::GpuMemoryDomain::HostUniform, "SkyboxIb");
-        vmaCopyMemoryToAllocation(device->GpuMem.Allocator, verts, VBHandle.Allocation, 0, sizeof(verts));
-        vmaCopyMemoryToAllocation(device->GpuMem.Allocator, idxs, IBHandle.Allocation, 0, sizeof(idxs));
+        auto*                     rrm    = ZEngine::Engine::GetContext()->RenderResourceManager;
+        ZENGINE_VALIDATE_ASSERT(rrm, "SkyboxPass::Setup: RenderResourceManager not available")
+        rrm->RegisterBuiltinGeometry(verts, sizeof(verts), idxs, 36, m_vtx_offset, m_idx_offset);
 
         bool env_map_available = false;
         if (EnvMapPath && EnvMapPath[0] != '\0')
@@ -167,7 +168,7 @@ namespace ZEngine::Rendering::Renderers
         {
             auto pass_spec = pass_builder->SetPipelineName("Skybox-Pipeline")
                                  .SetInputBindingCount(1)
-                                 .SetStride(0, sizeof(float) * 3)
+                                 .SetStride(0, sizeof(float) * 8)
                                  .SetRate(0, VK_VERTEX_INPUT_RATE_VERTEX)
                                  .SetInputAttributeCount(1)
                                  .SetLocation(0, 0)
@@ -211,32 +212,28 @@ namespace ZEngine::Rendering::Renderers
             command_buffer->SetViewport(w, h);
             command_buffer->SetScissor(w, h);
         }
+        auto* rrm = ZEngine::Engine::GetContext()->RenderResourceManager;
         command_buffer->BindPipeline(Specifications::PipelineBindPoint::GRAPHIC, pass->Pipeline);
-        command_buffer->BindVertexBuffer(VBHandle);
-        command_buffer->BindIndexBuffer(IBHandle, VK_INDEX_TYPE_UINT16);
+        command_buffer->BindVertexBuffer(*rrm->GetGlobalVertexBuffer());
+        command_buffer->BindIndexBuffer(*rrm->GetGlobalIndexBuffer(), VK_INDEX_TYPE_UINT32);
         command_buffer->BindDescriptorSets(device->SwapchainPtr->CurrentFrame->Index, scene ? &scene->CameraHeapOffset : nullptr, scene ? 1u : 0u);
-        command_buffer->DrawIndexed(36, 1, 0, 0, 0);
+        command_buffer->DrawIndexed(36, 1, m_idx_offset, static_cast<int32_t>(m_vtx_offset), 0);
         command_buffer->EndRenderPass();
-    }
-
-    void SkyboxPass::Deinitialize(Hardwares::VulkanDevicePtr const device)
-    {
-        if (VBHandle)
-            device->GpuMem.FreeBuffer(VBHandle);
-        if (IBHandle)
-            device->GpuMem.FreeBuffer(IBHandle);
     }
 
     void GridPass::Setup(Hardwares::VulkanDevicePtr const device, cstring name, RenderGraphResourceBuilderPtr const res_builder, RenderGraphResourceInspectorPtr res_inspector)
     {
-        // Y=0 — the vertex shader adds groundY + 0.001 epsilon for z-fighting prevention
-        static constexpr float    verts[] = {-1000.0f, 0.0f, -1000.0f, 1000.0f, 0.0f, -1000.0f, 1000.0f, 0.0f, 1000.0f, -1000.0f, 0.0f, 1000.0f};
-        static constexpr uint16_t idxs[]  = {0, 1, 2, 2, 3, 0};
+        // Y=0 — the vertex shader adds groundY + 0.001 epsilon for z-fighting prevention.
+        // DrawVertex layout: x y z nx ny nz u v (8 floats = 32 bytes)
+        // Normal points up (0,1,0); UVs mapped to world XZ position.
+        static constexpr float verts[] = {
+            -1000.f, 0.f, -1000.f, 0.f, 1.f, 0.f, 0.f, 0.f, 1000.f, 0.f, -1000.f, 0.f, 1.f, 0.f, 1.f, 0.f, 1000.f, 0.f, 1000.f, 0.f, 1.f, 0.f, 1.f, 1.f, -1000.f, 0.f, 1000.f, 0.f, 1.f, 0.f, 0.f, 1.f,
+        };
+        static constexpr uint32_t idxs[] = {0, 1, 2, 2, 3, 0};
 
-        VBHandle                          = device->GpuMem.AllocateBuffer(sizeof(verts), VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, Core::Memory::GpuMemoryDomain::HostUniform, "GridVb");
-        IBHandle                          = device->GpuMem.AllocateBuffer(sizeof(idxs), VK_BUFFER_USAGE_INDEX_BUFFER_BIT, Core::Memory::GpuMemoryDomain::HostUniform, "GridIb");
-        vmaCopyMemoryToAllocation(device->GpuMem.Allocator, verts, VBHandle.Allocation, 0, sizeof(verts));
-        vmaCopyMemoryToAllocation(device->GpuMem.Allocator, idxs, IBHandle.Allocation, 0, sizeof(idxs));
+        auto*                     rrm    = ZEngine::Engine::GetContext()->RenderResourceManager;
+        ZENGINE_VALIDATE_ASSERT(rrm, "GridPass::Setup: RenderResourceManager not available")
+        rrm->RegisterBuiltinGeometry(verts, sizeof(verts), idxs, 6, m_vtx_offset, m_idx_offset);
 
         RenderGraphRenderPassCreation pass_node = {.Name = name};
         pass_node.Inputs.init(device->Arena, 2);
@@ -254,7 +251,7 @@ namespace ZEngine::Rendering::Renderers
         {
             auto pass_spec = pass_builder->SetPipelineName("Infinite-Grid-Pipeline")
                                  .SetInputBindingCount(1)
-                                 .SetStride(0, sizeof(float) * 3)
+                                 .SetStride(0, sizeof(float) * 8)
                                  .SetRate(0, VK_VERTEX_INPUT_RATE_VERTEX)
                                  .SetInputAttributeCount(1)
                                  .SetLocation(0, 0)
@@ -294,21 +291,14 @@ namespace ZEngine::Rendering::Renderers
             command_buffer->SetViewport(w, h);
             command_buffer->SetScissor(w, h);
         }
+        auto* rrm = ZEngine::Engine::GetContext()->RenderResourceManager;
         command_buffer->BindPipeline(Specifications::PipelineBindPoint::GRAPHIC, pass->Pipeline);
-        command_buffer->BindVertexBuffer(VBHandle);
-        command_buffer->BindIndexBuffer(IBHandle, VK_INDEX_TYPE_UINT16);
+        command_buffer->BindVertexBuffer(*rrm->GetGlobalVertexBuffer());
+        command_buffer->BindIndexBuffer(*rrm->GetGlobalIndexBuffer(), VK_INDEX_TYPE_UINT32);
         command_buffer->BindDescriptorSets(device->SwapchainPtr->CurrentFrame->Index, scene ? &scene->CameraHeapOffset : nullptr, scene ? 1u : 0u);
         command_buffer->PushConstants(VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT, 0, sizeof(GridPushConstantData), &PushData);
-        command_buffer->DrawIndexed(6, 1, 0, 0, 0);
+        command_buffer->DrawIndexed(6, 1, m_idx_offset, static_cast<int32_t>(m_vtx_offset), 0);
         command_buffer->EndRenderPass();
-    }
-
-    void GridPass::Deinitialize(Hardwares::VulkanDevicePtr const device)
-    {
-        if (VBHandle)
-            device->GpuMem.FreeBuffer(VBHandle);
-        if (IBHandle)
-            device->GpuMem.FreeBuffer(IBHandle);
     }
 
     void GbufferPass::Setup(Hardwares::VulkanDevicePtr const device, cstring name, RenderGraphResourceBuilderPtr const res_builder, RenderGraphResourceInspectorPtr res_inspector)

--- a/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.h
+++ b/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.h
@@ -26,18 +26,16 @@ namespace ZEngine::Rendering::Renderers
     struct SkyboxPass : public IRenderGraphCallbackPass
     {
         // Set before Setup() is called. Empty string = no env map, pass is disabled.
-        cstring                  EnvMapPath = nullptr;
+        cstring      EnvMapPath = nullptr;
 
-        Core::Memory::BufferView VBHandle   = {};
-        Core::Memory::BufferView IBHandle   = {};
-
-        virtual void             Setup(Hardwares::VulkanDevicePtr const device, cstring name, RenderGraphResourceBuilderPtr const res_builder, RenderGraphResourceInspectorPtr res_inspector) override;
-        virtual void             Compile(Hardwares::VulkanDevicePtr const device, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPassBuilder* pass_builder, RenderGraphResourceInspectorPtr res_inspector, RenderPasses::RenderPass** const output_pass) override;
-        virtual void             Execute(Hardwares::VulkanDevicePtr const device, RenderGraphResourceInspectorPtr res_inspector, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPass* const pass, Buffers::FramebufferVNext* const framebuffer, Hardwares::CommandBufferPtr const command_buffer) override;
-        virtual void             Deinitialize(Hardwares::VulkanDevicePtr const device) override;
+        virtual void Setup(Hardwares::VulkanDevicePtr const device, cstring name, RenderGraphResourceBuilderPtr const res_builder, RenderGraphResourceInspectorPtr res_inspector) override;
+        virtual void Compile(Hardwares::VulkanDevicePtr const device, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPassBuilder* pass_builder, RenderGraphResourceInspectorPtr res_inspector, RenderPasses::RenderPass** const output_pass) override;
+        virtual void Execute(Hardwares::VulkanDevicePtr const device, RenderGraphResourceInspectorPtr res_inspector, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPass* const pass, Buffers::FramebufferVNext* const framebuffer, Hardwares::CommandBufferPtr const command_buffer) override;
 
     private:
-        Textures::TextureHandle m_env_map = {};
+        Textures::TextureHandle m_env_map    = {};
+        uint32_t                m_vtx_offset = 0;
+        uint32_t                m_idx_offset = 0;
     };
 
     struct GridPushConstantData
@@ -57,14 +55,15 @@ namespace ZEngine::Rendering::Renderers
 
     struct GridPass : public IRenderGraphCallbackPass
     {
-        GridPushConstantData     PushData = {};
-        Core::Memory::BufferView VBHandle = {};
-        Core::Memory::BufferView IBHandle = {};
+        GridPushConstantData PushData = {};
 
-        virtual void             Setup(Hardwares::VulkanDevicePtr const device, cstring name, RenderGraphResourceBuilderPtr const res_builder, RenderGraphResourceInspectorPtr res_inspector) override;
-        virtual void             Compile(Hardwares::VulkanDevicePtr const device, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPassBuilder* pass_builder, RenderGraphResourceInspectorPtr res_inspector, RenderPasses::RenderPass** const output_pass) override;
-        virtual void             Execute(Hardwares::VulkanDevicePtr const device, RenderGraphResourceInspectorPtr res_inspector, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPass* const pass, Buffers::FramebufferVNext* const framebuffer, Hardwares::CommandBufferPtr const command_buffer) override;
-        virtual void             Deinitialize(Hardwares::VulkanDevicePtr const device) override;
+        virtual void         Setup(Hardwares::VulkanDevicePtr const device, cstring name, RenderGraphResourceBuilderPtr const res_builder, RenderGraphResourceInspectorPtr res_inspector) override;
+        virtual void         Compile(Hardwares::VulkanDevicePtr const device, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPassBuilder* pass_builder, RenderGraphResourceInspectorPtr res_inspector, RenderPasses::RenderPass** const output_pass) override;
+        virtual void         Execute(Hardwares::VulkanDevicePtr const device, RenderGraphResourceInspectorPtr res_inspector, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPass* const pass, Buffers::FramebufferVNext* const framebuffer, Hardwares::CommandBufferPtr const command_buffer) override;
+
+    private:
+        uint32_t m_vtx_offset = 0;
+        uint32_t m_idx_offset = 0;
     };
 
     struct GbufferPass : public IRenderGraphCallbackPass


### PR DESCRIPTION
Closes #595

## Summary

**RenderResourceManager**
- `InitGlobalBuffers`: add `VERTEX_BUFFER_BIT` / `INDEX_BUFFER_BIT` to global vertex/index buffers so they can be bound as vertex/index input sources in addition to storage buffers
- `RegisterBuiltinGeometry`: new public method — appends pre-padded DrawVertex data and uint32 indices into the global buffers via the existing `AppendToGlobalBuffer` path, returns element-count offsets

**SkyboxPass / GridPass**
- `VBHandle`, `IBHandle`, `Deinitialize` removed from both structs
- `m_vtx_offset`, `m_idx_offset` (private) replace them
- `Setup`: vertices padded to 8-float DrawVertex (normals zeroed for skybox, Y-up normal for grid); indices upcast to uint32_t; calls `RRM::RegisterBuiltinGeometry`
- `Compile`: stride changed from `sizeof(float)*3` (12 B) to `sizeof(float)*8` (32 B)
- `Execute`: binds `GetGlobalVertexBuffer()` / `GetGlobalIndexBuffer()` with `VK_INDEX_TYPE_UINT32`; passes `m_idx_offset` / `m_vtx_offset` to `DrawIndexed`

## Test plan

- [x] Build Debug — no errors
- [x] Run engine — grid and skybox render correctly
- [x] No Vulkan validation errors on startup or shutdown
- [x] No VMA leak warnings (SkyboxVb/GridVb/SkyboxIb/GridIb buffers gone from leak report)