### PR TITLE
fix(vulkan): eliminate all vkDestroyDevice validation errors on shutdown

### DIFF
--- a/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
+++ b/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
@@ -176,6 +176,32 @@ namespace ZEngine::Hardwares
 
     void DeviceSwapchain::Dispose()
     {
+        // Destroy frame-context and swapchain-image Vulkan objects.
+        // All destructors use Device->DeferFree — the second PendingFree.Drain()
+        // at the end of VulkanDevice::Deinitialize() drains them before vkDestroyDevice.
+        for (uint32_t i = 0; i < FrameContexts.size(); ++i)
+        {
+            if (FrameContexts[i].Acquired)
+                FrameContexts[i].Acquired->~Semaphore();
+            if (FrameContexts[i].Fence)
+                FrameContexts[i].Fence->~Fence();
+        }
+        for (uint32_t i = 0; i < RenderCompletes.size(); ++i)
+        {
+            if (RenderCompletes[i])
+                RenderCompletes[i]->~Semaphore();
+        }
+        for (uint32_t i = 0; i < PresentCompletes.size(); ++i)
+        {
+            if (PresentCompletes[i])
+                PresentCompletes[i]->~Fence();
+        }
+        if (RenderTimeline)
+        {
+            RenderTimeline->~Semaphore();
+            RenderTimeline = nullptr;
+        }
+
         Clear();
         ZENGINE_DESTROY_VULKAN_HANDLE(Device->LogicalDevice, vkDestroySwapchainKHR, SwapchainHandle, nullptr)
         SwapchainAttachment->Dispose();

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
@@ -723,6 +723,10 @@ namespace ZEngine::Hardwares
 
     void VulkanDevice::Dispose()
     {
+        // Final drain: catches deferred VkHandle frees (framebuffers, render passes,
+        // pipelines, etc.) queued between the last Deinitialize drain and here.
+        PendingFree.Drain(&GpuMem, LogicalDevice, UINT64_MAX);
+
         GpuMem.Shutdown();
 
         if (__destroyDebugMessengerPtr)
@@ -1618,16 +1622,27 @@ namespace ZEngine::Hardwares
 
     void CommandBufferManager::Deinitialize()
     {
+        // Explicitly destroy each CommandPool — vkDestroyCommandPool implicitly frees
+        // all VkCommandBuffers allocated from it.  The Array::clear() that follows only
+        // zeroes the pointer list; it never invokes C++ destructors, so skipping this
+        // step leaks every VkCommandPool and VkCommandBuffer past vkDestroyDevice.
+        for (uint32_t i = 0; i < InstantGraphicsPools.size(); ++i)
+            InstantGraphicsPools[i]->~CommandPool();
+        for (uint32_t i = 0; i < CommandPools.size(); ++i)
+            CommandPools[i]->~CommandPool();
+        for (uint32_t i = 0; i < TransferCommandPools.size(); ++i)
+            TransferCommandPools[i]->~CommandPool();
+        for (uint32_t i = 0; i < InstantTransferPools.size(); ++i)
+            InstantTransferPools[i]->~CommandPool();
+
         InstantGraphicsPools.clear();
         InstantGraphicsCommandBuffers.clear();
         CommandBuffers.clear();
         TransferCommandBuffers.clear();
         InstantTransferCommandBuffers.clear();
-
         CommandPools.clear();
         TransferCommandPools.clear();
         InstantTransferPools.clear();
-
         EnqueuedCommandBuffers.clear();
     }
 

--- a/ZEngine/ZEngine/Rendering/Buffers/FrameBuffer.cpp
+++ b/ZEngine/ZEngine/Rendering/Buffers/FrameBuffer.cpp
@@ -75,10 +75,9 @@ namespace ZEngine::Rendering::Buffers
     {
         if (Handle)
         {
-            Hardwares::DeferredFreeEntry e = {};
-            e.EntryKind                    = Hardwares::DeferredFreeEntry::Kind::VkHandle;
-            e.Data.Vk                      = {Handle, Rendering::DeviceResourceType::FRAMEBUFFER, nullptr};
-            m_device->DeferFree(e);
+            // Direct destroy: Dispose() is always called at GPU-idle points
+            // (after QueueWaitAll at shutdown, after vkDeviceWaitIdle at resize).
+            vkDestroyFramebuffer(m_device->LogicalDevice, Handle, nullptr);
             Handle = VK_NULL_HANDLE;
         }
     }

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
@@ -152,6 +152,29 @@ namespace ZEngine::Rendering
         m_device->QueueWaitAll();
         ShutdownTextureTimelines();
 
+        // Free command buffers before destroying their parent pools, then destroy pools.
+        // Arena-allocated objects have no automatic destructor — explicit calls are required.
+        if (m_upload_cmd)
+        {
+            m_upload_cmd->Free();
+            m_upload_cmd = nullptr;
+        }
+        if (m_upload_pool)
+        {
+            m_upload_pool->~CommandPool();
+            m_upload_pool = nullptr;
+        }
+        if (m_transfer_cmd)
+        {
+            m_transfer_cmd->Free();
+            m_transfer_cmd = nullptr;
+        }
+        if (m_transfer_pool)
+        {
+            m_transfer_pool->~CommandPool();
+            m_transfer_pool = nullptr;
+        }
+
         auto destroy_fence = [&](VkFence& fence) {
             if (fence != VK_NULL_HANDLE)
             {
@@ -161,7 +184,6 @@ namespace ZEngine::Rendering
         };
         destroy_fence(m_upload_fence);
         destroy_fence(m_transfer_fence);
-        // m_upload_pool/cmd and m_transfer_pool/cmd are arena-allocated — destroyed with the arena.
 
         // Free all live buffer slots
         if (m_global_vertex_buf)
@@ -758,6 +780,14 @@ namespace ZEngine::Rendering
                         m_device->GpuMem.FreeBuffer(tsb);
                 }
             }
+
+            // Explicitly destroy arena-allocated Semaphore objects — VkSemaphore handles
+            // are never freed by the arena page release.
+            if (p < m_tex_timelines.size() && m_tex_timelines[p])
+                m_tex_timelines[p]->~Semaphore();
+
+            if (m_device->HasSeperateTransfertQueueFamily && p < m_tex_transfer_timelines.size() && m_tex_transfer_timelines[p])
+                m_tex_transfer_timelines[p]->~Semaphore();
         }
     }
 

--- a/ZEngine/ZEngine/Rendering/Renderers/ImGUIRenderer.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/ImGUIRenderer.cpp
@@ -150,6 +150,7 @@ namespace ZEngine::Rendering::Renderers
 
     void ImGUIRenderer::Deinitialize()
     {
+        RenderGraph->Dispose();
         UIPass->Dispose();
 
         if (FontTexture.Valid())

--- a/ZEngine/ZEngine/Rendering/Renderers/Pipelines/RendererPipeline.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/Pipelines/RendererPipeline.cpp
@@ -211,15 +211,16 @@ namespace ZEngine::Rendering::Renderers::Pipelines
     {
         Shader->Dispose();
 
-        Hardwares::DeferredFreeEntry pl = {};
-        pl.EntryKind                    = Hardwares::DeferredFreeEntry::Kind::VkHandle;
-        pl.Data.Vk                      = {Layout, Rendering::DeviceResourceType::PIPELINE_LAYOUT, nullptr};
-        Device->DeferFree(pl);
-        Hardwares::DeferredFreeEntry pp = {};
-        pp.EntryKind                    = Hardwares::DeferredFreeEntry::Kind::VkHandle;
-        pp.Data.Vk                      = {Handle, Rendering::DeviceResourceType::PIPELINE, nullptr};
-        Device->DeferFree(pp);
-        Layout = VK_NULL_HANDLE;
-        Handle = VK_NULL_HANDLE;
+        // Direct destroy: Dispose() is always called at GPU-idle points.
+        if (Layout != VK_NULL_HANDLE)
+        {
+            vkDestroyPipelineLayout(Device->LogicalDevice, Layout, nullptr);
+            Layout = VK_NULL_HANDLE;
+        }
+        if (Handle != VK_NULL_HANDLE)
+        {
+            vkDestroyPipeline(Device->LogicalDevice, Handle, nullptr);
+            Handle = VK_NULL_HANDLE;
+        }
     }
 } // namespace ZEngine::Rendering::Renderers::Pipelines

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.cpp
@@ -382,6 +382,8 @@ namespace ZEngine::Rendering::Renderers
                 .RenderTargets = node.Handle->RenderTargets,
                 .Attachment    = node.Handle->Attachment,
             };
+            if (node.Framebuffer)
+                node.Framebuffer->Dispose();
             node.Framebuffer = ZPushStructCtorArgs(Device->Arena, Buffers::FramebufferVNext, Device, framebuffer_spec);
         }
     }


### PR DESCRIPTION
## Summary

Fixes every `VUID-vkDestroyDevice-device-05137` validation error on engine shutdown. The dominant pattern was arena-allocated Vulkan objects whose C++ destructors are never called by the arena — each case required explicit teardown.

## Root causes and fixes

| Object | Root cause | Fix |
|---|---|---|
| `VkCommandBuffer` / `VkCommandPool` | `CommandBufferManager::Deinitialize()` called `Array::clear()` which only zeroes the pointer list — no destructors fired | Iterate each pool array and call `~CommandPool()` before clearing; `vkDestroyCommandPool` implicitly frees all its buffers |
| RRM upload/transfer `VkCommandPool` | `m_upload_pool` / `m_transfer_pool` arena-allocated; `Shutdown()` had a wrong comment claiming arena handles it | `Shutdown()` now calls `cmd->Free()` then `pool->~CommandPool()` before destroying the fences |
| Texture timeline `VkSemaphore` | `ShutdownTextureTimelines()` only freed staging buffers | Explicitly calls `~Semaphore()` on each `m_tex_timelines[p]` and `m_tex_transfer_timelines[p]` |
| Swapchain `VkSemaphore` / `VkFence` | `DeviceSwapchain::Dispose()` never iterated `FrameContexts`, `RenderCompletes`, or `PresentCompletes` | `Dispose()` now calls `~Semaphore()` / `~Fence()` on each; deferred entries drained by second `PendingFree.Drain()` at end of `Deinitialize()` |
| `VkFramebuffer` (render graph resize leak) | `RenderGraph::Resize()` overwrote `node.Framebuffer` without disposing the old one — one framebuffer leaked per resize per pass | Added `node.Framebuffer->Dispose()` guard before the overwrite |
| `VkFramebuffer` (shutdown) | `FramebufferVNext::Dispose()` used `DeferFree` which had unresolvable timing issues at shutdown | Changed to direct `vkDestroyFramebuffer`; always called at GPU-idle points |
| `VkPipeline` / `VkPipelineLayout` | `GraphicPipeline::Dispose()` used `DeferFree` with same timing issue | Changed to direct `vkDestroyPipeline[Layout]`; consistent with `CommandPool` pattern |
| ImGui `VkPipeline` | `ImGUIRenderer::Deinitialize()` replaced `UIPass->Dispose()` with `RenderGraph->Dispose()` but `UIPass` is outside the render graph's `NodeMap` | Restored `UIPass->Dispose()` alongside `RenderGraph->Dispose()` |
| Safety net | No final drain before `vkDestroyDevice` | Added `PendingFree.Drain()` in `VulkanDevice::Dispose()` before `vkDestroyDevice` |

## Test plan

- [x] Run engine, close normally — zero validation errors in stderr
- [x] Resize the window multiple times, then close — still zero framebuffer errors
- [x] Build Debug and Release without warnings