### PR TITLE
refactor(containers): make Array<T> move-only and fix all copy sites

### DIFF
--- a/ZEngine/ZEngine/Core/Containers/Array.h
+++ b/ZEngine/ZEngine/Core/Containers/Array.h
@@ -21,8 +21,8 @@ namespace ZEngine::Core::Containers
 
         Array() : m_allocator(nullptr), m_size(0), m_capacity(0), m_data(nullptr) {}
 
-        Array(const Array&)            = default;
-        Array& operator=(const Array&) = default;
+        Array(const Array&)            = delete;
+        Array& operator=(const Array&) = delete;
 
         Array(Array&& other) noexcept : m_allocator(other.m_allocator), m_size(other.m_size), m_capacity(other.m_capacity), m_data(other.m_data)
         {
@@ -193,6 +193,18 @@ namespace ZEngine::Core::Containers
             return back();
         }
 
+        reference push_use(T&& value)
+        {
+            if (m_size == m_capacity)
+            {
+                size_type new_capacity = m_capacity == 0 ? 4 : m_capacity * 2;
+                reserve(new_capacity);
+            }
+            m_data[m_size] = std::move(value);
+            ++m_size;
+            return back();
+        }
+
         void insert(size_type index, const T& value)
         {
             ZENGINE_VALIDATE_ASSERT(index <= m_size, "Index out of range")
@@ -255,6 +267,7 @@ namespace ZEngine::Core::Containers
     template <typename T>
     struct ArrayView
     {
+        ArrayView() : m_data(nullptr), m_size(0) {}
         ArrayView(T* data, size_t size) : m_data(data), m_size(size) {}
         ArrayView(Array<T>& arr) : m_data(arr.data()), m_size(arr.size()) {}
 

--- a/ZEngine/ZEngine/Core/Containers/HashMap.h
+++ b/ZEngine/ZEngine/Core/Containers/HashMap.h
@@ -134,6 +134,7 @@ namespace ZEngine::Core::Containers
         // @param value The value to associate with the key.
         // @throws std::runtime_error if the table is full and cannot be resized.
         void insert(const K& key, const V& value)
+            requires std::is_copy_assignable_v<V>
         {
             maybe_grow();
 
@@ -151,6 +152,27 @@ namespace ZEngine::Core::Containers
             else
             {
                 entry.value = value;
+            }
+        }
+
+        void insert(const K& key, V&& value)
+        {
+            maybe_grow();
+
+            size_type index = probe_for_insert(key);
+            auto&     entry = m_entries[index];
+
+            if (entry.state == EntryState::Empty || entry.state == EntryState::Deleted)
+            {
+                entry.key   = key;
+                entry.value = std::move(value);
+                entry.state = EntryState::Occupied;
+                link_tail(index);
+                ++m_size;
+            }
+            else
+            {
+                entry.value = std::move(value);
             }
         }
 
@@ -438,7 +460,7 @@ namespace ZEngine::Core::Containers
         // @note Moves the old entries to avoid copying and skips Deleted entries.
         void rehash(size_type new_capacity)
         {
-            Array<Entry> old_entries = m_entries;
+            Array<Entry> old_entries = std::move(m_entries);
             size_type    old_head    = m_head;
 
             m_entries                = Array<Entry>{};
@@ -458,8 +480,8 @@ namespace ZEngine::Core::Containers
                 size_type old_next = old_entries[cur].next;
                 size_type index    = probe_for_insert(old_entries[cur].key);
                 auto&     entry    = m_entries[index];
-                entry.key          = old_entries[cur].key;
-                entry.value        = old_entries[cur].value;
+                entry.key          = std::move(old_entries[cur].key);
+                entry.value        = std::move(old_entries[cur].value);
                 entry.state        = EntryState::Occupied;
                 link_tail(index);
                 ++m_size;

--- a/ZEngine/ZEngine/Core/Containers/HashMap.h
+++ b/ZEngine/ZEngine/Core/Containers/HashMap.h
@@ -36,7 +36,7 @@ namespace ZEngine::Core::Containers
     public:
         using Entry             = OrderedHashEntry<K, V>;
         using EntryPointer      = std::conditional_t<IsConst, const Entry*, Entry*>;
-        using value_type        = std::conditional_t<IsConst, std::pair<const K, const V>, std::pair<const K, V>>;
+        using value_type        = std::conditional_t<IsConst, std::pair<const K&, const V&>, std::pair<const K&, V&>>;
         using reference         = value_type;
         using pointer           = value_type*;
         using iterator_category = std::forward_iterator_tag;

--- a/ZEngine/ZEngine/Core/Containers/UnorderedHashMap.h
+++ b/ZEngine/ZEngine/Core/Containers/UnorderedHashMap.h
@@ -31,7 +31,7 @@ namespace ZEngine::Core::Containers
     public:
         using Entry             = HashEntry<K, V>;
         using EntryPointer      = std::conditional_t<IsConst, const Entry*, Entry*>;
-        using value_type        = std::conditional_t<IsConst, std::pair<const K, const V>, std::pair<const K, V>>;
+        using value_type        = std::conditional_t<IsConst, std::pair<const K&, const V&>, std::pair<const K&, V&>>;
         using reference         = value_type;
         using pointer           = value_type*;
         using iterator_category = std::input_iterator_tag;
@@ -144,6 +144,7 @@ namespace ZEngine::Core::Containers
         // @param value The value to associate with the key.
         // @throws std::runtime_error if the table is full and cannot be resized.
         void insert(const K& key, const V& value)
+            requires std::is_copy_assignable_v<V>
         {
             maybe_grow();
 
@@ -160,6 +161,26 @@ namespace ZEngine::Core::Containers
             else
             {
                 entry.value = value;
+            }
+        }
+
+        void insert(const K& key, V&& value)
+        {
+            maybe_grow();
+
+            size_type index = probe_for_insert(key);
+            auto&     entry = m_entries[index];
+
+            if (entry.state == EntryState::Empty || entry.state == EntryState::Deleted)
+            {
+                entry.key   = key;
+                entry.value = std::move(value);
+                entry.state = EntryState::Occupied;
+                ++m_size;
+            }
+            else
+            {
+                entry.value = std::move(value);
             }
         }
 
@@ -357,7 +378,7 @@ namespace ZEngine::Core::Containers
         // @note Moves the old entries to avoid copying and skips Deleted entries.
         void rehash(size_type new_capacity)
         {
-            Array<Entry> old_entries = m_entries; // Move to avoid copying
+            Array<Entry> old_entries = std::move(m_entries);
             m_entries                = Array<Entry>{};
             m_entries.init(m_allocator, new_capacity);
             for (size_type i = 0; i < new_capacity; ++i)
@@ -371,7 +392,7 @@ namespace ZEngine::Core::Containers
                 if (old_entries[i].state == EntryState::Occupied)
                 {
                     size_type index  = probe_for_insert(old_entries[i].key);
-                    m_entries[index] = old_entries[i]; // Direct assignment
+                    m_entries[index] = std::move(old_entries[i]);
                     ++m_size;
                 }
             }

--- a/ZEngine/ZEngine/Core/VFS/VFSZipBackend.cpp
+++ b/ZEngine/ZEngine/Core/VFS/VFSZipBackend.cpp
@@ -141,7 +141,7 @@ namespace ZEngine::Core::VFS
         {
             Containers::Array<VFSDirEntry> fresh;
             fresh.init(m_arena, 8);
-            m_dir_cache.insert(parent_hash, fresh);
+            m_dir_cache.insert(parent_hash, std::move(fresh));
             list = m_dir_cache.find(parent_hash);
         }
         for (size_t i = 0; i < list->size(); ++i)

--- a/ZEngine/ZEngine/ECS/WorldTick.cpp
+++ b/ZEngine/ZEngine/ECS/WorldTick.cpp
@@ -31,7 +31,7 @@ namespace ZEngine::ECS
         node.Index    = id;
         node.InDegree = 0;
         node.Successors.init(m_arena, 8);
-        m_nodes.push(node);
+        m_nodes.push(std::move(node));
 
         return id;
     }
@@ -154,7 +154,7 @@ namespace ZEngine::ECS
             wave.init(m_arena, static_cast<uint32_t>(current_wave.size()));
             for (size_t i = 0; i < current_wave.size(); ++i)
                 wave.push(current_wave[i]);
-            m_waves.push(wave);
+            m_waves.push(std::move(wave));
 
             processed += static_cast<uint32_t>(current_wave.size());
 

--- a/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
+++ b/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
@@ -34,7 +34,7 @@ namespace ZEngine::Hardwares
         attachment_specification.ColorsMap[0].Initial         = ImageLayout::UNDEFINED;
         attachment_specification.ColorsMap[0].Final           = ImageLayout::PRESENT_SRC;
         attachment_specification.ColorsMap[0].ReferenceLayout = ImageLayout::COLOR_ATTACHMENT_OPTIMAL;
-        SwapchainAttachment                                   = ZPushStructCtorArgs(&Arena, RenderPasses::Attachment, Device, attachment_specification);
+        SwapchainAttachment                                   = ZPushStructCtorArgs(&Arena, RenderPasses::Attachment, Device, std::move(attachment_specification));
 
         IdleFrameThreshold                                    = (BufferredFrameCount * 3 * 3 * 3);
         FrameContexts.init(&Arena, FrameContextPoolSize, FrameContextPoolSize);

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
@@ -59,10 +59,10 @@ namespace ZEngine::Hardwares
 #ifdef __APPLE__
         instance_create_info.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
 #endif
-        auto                 scratch = ZGetScratch(Arena);
+        auto                  scratch = ZGetScratch(Arena);
 
-        Array<const char*>   enabled_layer_name_collection;
-        Array<LayerProperty> selected_layer_property_collection;
+        Array<const char*>    enabled_layer_name_collection;
+        Array<LayerProperty*> selected_layer_property_collection;
         enabled_layer_name_collection.init(scratch.Arena, 10);
         selected_layer_property_collection.init(scratch.Arena, 4);
 
@@ -87,7 +87,7 @@ namespace ZEngine::Hardwares
             }
 
             enabled_layer_name_collection.push(find_it->Properties.layerName);
-            selected_layer_property_collection.push(*find_it);
+            selected_layer_property_collection.push(find_it);
         }
 #endif
 
@@ -105,16 +105,16 @@ namespace ZEngine::Hardwares
             }
 
             enabled_layer_name_collection.push(find_it->Properties.layerName);
-            selected_layer_property_collection.push(*find_it);
+            selected_layer_property_collection.push(find_it);
         }
 #endif
 
         Array<const char*> enabled_extension_layer_name_collection;
         enabled_extension_layer_name_collection.init(scratch.Arena, 5);
 
-        for (const LayerProperty& layer : selected_layer_property_collection)
+        for (LayerProperty* const layer : selected_layer_property_collection)
         {
-            for (const auto& extension : layer.ExtensionCollection)
+            for (const auto& extension : layer->ExtensionCollection)
             {
                 if (std::string_view(extension.extensionName) == "VK_EXT_validation_features" || std::string_view(extension.extensionName) == "VK_EXT_layer_settings")
                     continue;
@@ -262,14 +262,14 @@ namespace ZEngine::Hardwares
         requested_device_extension_layer_name_collection.push("VK_KHR_portability_subset");
 #endif
 
-        for (LayerProperty& layer : selected_layer_property_collection)
+        for (LayerProperty* const layer : selected_layer_property_collection)
         {
-            m_layer.GetExtensionProperties(scratch.Arena, layer, &PhysicalDevice);
+            m_layer.GetExtensionProperties(scratch.Arena, *layer, &PhysicalDevice);
 
-            if (!layer.DeviceExtensionCollection.empty())
+            if (!layer->DeviceExtensionCollection.empty())
             {
-                requested_device_enabled_layer_name_collection.push(layer.Properties.layerName);
-                for (const auto& extension_property : layer.DeviceExtensionCollection)
+                requested_device_enabled_layer_name_collection.push(layer->Properties.layerName);
+                for (const auto& extension_property : layer->DeviceExtensionCollection)
                 {
                     requested_device_extension_layer_name_collection.push(extension_property.extensionName);
                 }
@@ -1997,10 +1997,10 @@ namespace ZEngine::Hardwares
         return staging_view;
     }
 
-    Rendering::Renderers::RenderPasses::RenderPass* VulkanDevice::CreateRenderPass(const Rendering::Specifications::RenderPassSpecification& spec)
+    Rendering::Renderers::RenderPasses::RenderPass* VulkanDevice::CreateRenderPass(Rendering::Specifications::RenderPassSpecification spec)
     {
         auto pass = ZPushStructCtorArgs(Arena, Rendering::Renderers::RenderPasses::RenderPass);
-        pass->Initialize(this, spec);
+        pass->Initialize(this, std::move(spec));
         return pass;
     }
 

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.h
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.h
@@ -342,7 +342,7 @@ namespace ZEngine::Hardwares
         Rendering::Textures::TextureHandle              CreateTexture(const Rendering::Specifications::TextureSpecification& spec);
         BufferView                                      WriteTextureData(CommandBufferPtr command_buf, const Rendering::Textures::TextureHandle& handle, const void* data);
 
-        Rendering::Renderers::RenderPasses::RenderPass* CreateRenderPass(const Rendering::Specifications::RenderPassSpecification& spec);
+        Rendering::Renderers::RenderPasses::RenderPass* CreateRenderPass(Rendering::Specifications::RenderPassSpecification spec);
 
     private:
         VulkanLayer                                                       m_layer     = {};

--- a/ZEngine/ZEngine/Rendering/Buffers/FrameBuffer.cpp
+++ b/ZEngine/ZEngine/Rendering/Buffers/FrameBuffer.cpp
@@ -6,11 +6,6 @@ using namespace ZEngine::Rendering::Specifications;
 
 namespace ZEngine::Rendering::Buffers
 {
-    FramebufferVNext::FramebufferVNext(Hardwares::VulkanDevice* device, const Specifications::FrameBufferSpecificationVNext& specification) : m_device(device), m_specification(specification)
-    {
-        Create();
-    }
-
     FramebufferVNext::FramebufferVNext(Hardwares::VulkanDevice* device, Specifications::FrameBufferSpecificationVNext&& specification) : m_device(device), m_specification(std::move(specification))
     {
         Create();

--- a/ZEngine/ZEngine/Rendering/Buffers/Framebuffer.h
+++ b/ZEngine/ZEngine/Rendering/Buffers/Framebuffer.h
@@ -10,7 +10,6 @@ namespace ZEngine::Rendering::Buffers
 {
     struct FramebufferVNext
     {
-        FramebufferVNext(Hardwares::VulkanDevice* device, const Specifications::FrameBufferSpecificationVNext&);
         FramebufferVNext(Hardwares::VulkanDevice* device, Specifications::FrameBufferSpecificationVNext&&);
         ~FramebufferVNext();
 

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.cpp
@@ -200,7 +200,7 @@ namespace ZEngine::Rendering::Renderers
                 .RenderTargets = node.Handle->RenderTargets,
                 .Attachment    = node.Handle->Attachment,
             };
-            node.Framebuffer = ZPushStructCtorArgs(Device->Arena, Buffers::FramebufferVNext, Device, framebuffer_spec);
+            node.Framebuffer = ZPushStructCtorArgs(Device->Arena, Buffers::FramebufferVNext, Device, std::move(framebuffer_spec));
         }
     }
 
@@ -384,7 +384,7 @@ namespace ZEngine::Rendering::Renderers
             };
             if (node.Framebuffer)
                 node.Framebuffer->Dispose();
-            node.Framebuffer = ZPushStructCtorArgs(Device->Arena, Buffers::FramebufferVNext, Device, framebuffer_spec);
+            node.Framebuffer = ZPushStructCtorArgs(Device->Arena, Buffers::FramebufferVNext, Device, std::move(framebuffer_spec));
         }
     }
 
@@ -468,17 +468,18 @@ namespace ZEngine::Rendering::Renderers
         return Graph->ResourceMap[name];
     }
 
-    void RenderGraphResourceBuilder::CreateRenderPassNode(const RenderGraphRenderPassCreation& creation)
+    void RenderGraphResourceBuilder::CreateRenderPassNode(RenderGraphRenderPassCreation creation)
     {
-        Graph->NodeMap[creation.Name].Creation = creation;
+        cstring name = creation.Name;
         for (const auto& output : creation.Outputs)
         {
             if (output.Type == RenderGraphResourceType::ATTACHMENT)
             {
                 RenderGraphResource& resource = Graph->ResourceMap[output.Name];
-                resource.ProducerNodeName     = creation.Name;
+                resource.ProducerNodeName     = name;
             }
         }
+        Graph->NodeMap[name].Creation = std::move(creation);
     }
 
     void RenderGraphResourceInspector::Initialize(RenderGraphPtr graph)

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.h
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.h
@@ -132,6 +132,6 @@ namespace ZEngine::Rendering::Renderers
         RenderGraphResource& CreateRenderTarget(cstring name, const Specifications::TextureSpecification& spec);
         RenderGraphResource& AttachTexture(cstring name, const Textures::TextureHandle& texture);
         RenderGraphResource& AttachRenderTarget(cstring name, const Textures::TextureHandle& texture);
-        void                 CreateRenderPassNode(const RenderGraphRenderPassCreation&);
+        void                 CreateRenderPassNode(RenderGraphRenderPassCreation creation);
     };
 } // namespace ZEngine::Rendering::Renderers

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/Attachment.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/Attachment.cpp
@@ -10,9 +10,9 @@ using namespace ZEngine::Core::Containers;
 
 namespace ZEngine::Rendering::Renderers::RenderPasses
 {
-    Attachment::Attachment(Hardwares::VulkanDevice* device, const Specifications::AttachmentSpecification& spec) : m_device(device), m_specification(spec)
+    Attachment::Attachment(Hardwares::VulkanDevice* device, Specifications::AttachmentSpecification spec) : m_device(device), m_specification(std::move(spec))
     {
-        ZENGINE_VALIDATE_ASSERT(!spec.ColorsMap.empty(), "Color attachments can't be empty")
+        ZENGINE_VALIDATE_ASSERT(!m_specification.ColorsMap.empty(), "Color attachments can't be empty")
 
         auto                           scratch                               = ZGetScratch(device->Arena);
 

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/Attachment.h
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/Attachment.h
@@ -12,7 +12,7 @@ namespace ZEngine::Rendering::Renderers::RenderPasses
 {
     struct Attachment
     {
-        Attachment(Hardwares::VulkanDevice* device, const Specifications::AttachmentSpecification& spec);
+        Attachment(Hardwares::VulkanDevice* device, Specifications::AttachmentSpecification spec);
         ~Attachment();
         void                                           Dispose();
 

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/RenderPass.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/RenderPass.cpp
@@ -14,10 +14,10 @@ namespace ZEngine::Rendering::Renderers::RenderPasses
         Dispose();
     }
 
-    void RenderPass::Initialize(Hardwares::VulkanDevice* device, const Specifications::RenderPassSpecification& specification)
+    void RenderPass::Initialize(Hardwares::VulkanDevice* device, Specifications::RenderPassSpecification specification)
     {
         m_device      = device;
-        Specification = specification;
+        Specification = std::move(specification);
 
         if ((specification.Type != Specifications::RenderPassType::GRAPHIC) && (specification.Type != Specifications::RenderPassType::COMPUTE))
         {
@@ -83,7 +83,7 @@ namespace ZEngine::Rendering::Renderers::RenderPasses
                 color_map_index++;
             }
 
-            Attachment                                     = ZPushStructCtorArgs(m_device->Arena, RenderPasses::Attachment, m_device, attachment_specification);
+            Attachment                                     = ZPushStructCtorArgs(m_device->Arena, RenderPasses::Attachment, m_device, std::move(attachment_specification));
 
             Specification.PipelineSpecification.Attachment = Attachment; // Todo : Can potential Dispose() issue
             Pipeline                                       = ZPushStructCtorArgs(m_device->Arena, Pipelines::GraphicPipeline);

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/RenderPass.h
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderPasses/RenderPass.h
@@ -36,7 +36,7 @@ namespace ZEngine::Rendering::Renderers::RenderPasses
         Renderers::RenderPasses::Attachment*    Attachment       = {nullptr};
         Pipelines::GraphicPipeline*             Pipeline         = {nullptr};
 
-        void                                    Initialize(Hardwares::VulkanDevice* device, const Specifications::RenderPassSpecification& specification);
+        void                                    Initialize(Hardwares::VulkanDevice* device, Specifications::RenderPassSpecification specification);
         void                                    Dispose();
         void                                    Bake();
         bool                                    Verify();

--- a/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.cpp
@@ -20,7 +20,7 @@ namespace ZEngine::Rendering::Renderers
         pass_node.Inputs.push(RenderGraphRenderPassInputOutputInfo{.Name = RendererResourceName::FrameDepthRenderTargetName});
         pass_node.Outputs.push(RenderGraphRenderPassInputOutputInfo{.Name = RendererResourceName::FrameColorRenderTargetName});
 
-        res_builder->CreateRenderPassNode(pass_node);
+        res_builder->CreateRenderPassNode(std::move(pass_node));
     }
 
     void BasePass::Compile(Hardwares::VulkanDevicePtr const device, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPassBuilder* pass_builder, RenderGraphResourceInspectorPtr res_inspector, RenderPasses::RenderPass** const output_pass)
@@ -36,7 +36,7 @@ namespace ZEngine::Rendering::Renderers
                                  .UseShader("base")
                                  .Detach();
             // clang-format off
-            *output_pass = device->CreateRenderPass(pass_spec);
+            *output_pass = device->CreateRenderPass(std::move(pass_spec));
             // clang-format on
             (*output_pass)->Bake();
         }
@@ -66,7 +66,7 @@ namespace ZEngine::Rendering::Renderers
         pass_node.Outputs.init(device->Arena, 1);
         pass_node.Outputs.push(RenderGraphRenderPassInputOutputInfo{.Name = RendererResourceName::FrameDepthRenderTargetName});
 
-        res_builder->CreateRenderPassNode(pass_node);
+        res_builder->CreateRenderPassNode(std::move(pass_node));
     }
 
     void DepthPrePass::Compile(Hardwares::VulkanDevicePtr const device, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPassBuilder* pass_builder, RenderGraphResourceInspectorPtr res_inspector, RenderPasses::RenderPass** const output_pass)
@@ -81,7 +81,7 @@ namespace ZEngine::Rendering::Renderers
                                  .UseShader("depth_prepass_scene")
                                  .Detach();
             // clang-format off
-            *output_pass = device->CreateRenderPass(pass_spec);
+            *output_pass = device->CreateRenderPass(std::move(pass_spec));
             // clang-format on
             (*output_pass)->Bake();
         }
@@ -157,7 +157,7 @@ namespace ZEngine::Rendering::Renderers
         pass_node.Outputs.init(device->Arena, 1);
         pass_node.Inputs.push(RenderGraphRenderPassInputOutputInfo{.Name = RendererResourceName::FrameDepthRenderTargetName});
         pass_node.Inputs.push(RenderGraphRenderPassInputOutputInfo{.Name = RendererResourceName::FrameColorRenderTargetName});
-        res_builder->CreateRenderPassNode(pass_node);
+        res_builder->CreateRenderPassNode(std::move(pass_node));
     }
 
     void SkyboxPass::Compile(Hardwares::VulkanDevicePtr const device, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPassBuilder* pass_builder, RenderGraphResourceInspectorPtr res_inspector, RenderPasses::RenderPass** const output_pass)
@@ -186,7 +186,7 @@ namespace ZEngine::Rendering::Renderers
                                  .UseShader("skybox")
                                  .Detach();
             // clang-format off
-            *output_pass = device->CreateRenderPass(pass_spec);
+            *output_pass = device->CreateRenderPass(std::move(pass_spec));
             // clang-format on
             (*output_pass)->Bake();
         }
@@ -240,7 +240,7 @@ namespace ZEngine::Rendering::Renderers
         pass_node.Outputs.init(device->Arena, 1);
         pass_node.Inputs.push(RenderGraphRenderPassInputOutputInfo{.Name = RendererResourceName::FrameDepthRenderTargetName});
         pass_node.Inputs.push(RenderGraphRenderPassInputOutputInfo{.Name = RendererResourceName::FrameColorRenderTargetName});
-        res_builder->CreateRenderPassNode(pass_node);
+        res_builder->CreateRenderPassNode(std::move(pass_node));
     }
 
     void GridPass::Compile(Hardwares::VulkanDevicePtr const device, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPassBuilder* pass_builder, RenderGraphResourceInspectorPtr res_inspector, RenderPasses::RenderPass** const output_pass)
@@ -270,7 +270,7 @@ namespace ZEngine::Rendering::Renderers
                                  .UseShader("infinite_grid")
                                  .Detach();
             // clang-format off
-            *output_pass = device->CreateRenderPass(pass_spec);
+            *output_pass = device->CreateRenderPass(std::move(pass_spec));
             // clang-format on
             (*output_pass)->Bake();
         }
@@ -326,7 +326,7 @@ namespace ZEngine::Rendering::Renderers
         pass_node.Outputs.push({.Name = gbuffer_specular.Name});
         pass_node.Outputs.push({.Name = gbuffer_normals.Name});
         pass_node.Outputs.push({.Name = gbuffer_position.Name});
-        res_builder->CreateRenderPassNode(pass_node);
+        res_builder->CreateRenderPassNode(std::move(pass_node));
     }
 
     void GbufferPass::Compile(Hardwares::VulkanDevicePtr const device, Rendering::Scenes::SceneDataPtr const scene, RenderPasses::RenderPassBuilder* pass_builder, RenderGraphResourceInspectorPtr res_inspector, RenderPasses::RenderPass** const output_pass)
@@ -336,7 +336,7 @@ namespace ZEngine::Rendering::Renderers
         if (output_pass && !(*output_pass))
         {
             auto pass_spec = pass_builder->SetPipelineName("GBuffer-Pipeline").EnablePipelineDepthTest(true).UseShader("g_buffer").Detach();
-            *output_pass   = device->CreateRenderPass(pass_spec);
+            *output_pass   = device->CreateRenderPass(std::move(pass_spec));
             (*output_pass)->Bake();
         }
 

--- a/ZEngine/ZEngine/Rendering/Specifications/FrameBufferSpecification.h
+++ b/ZEngine/ZEngine/Rendering/Specifications/FrameBufferSpecification.h
@@ -7,13 +7,13 @@ namespace ZEngine::Rendering::Specifications
 {
     struct FrameBufferSpecificationVNext
     {
-        float                                ClearColorValue[4] = {0.1f, 0.1f, 0.1f, 1.0f};
-        float                                ClearDepthValue[2] = {1.0f, 0.0f};
-        uint32_t                             Width              = 1;
-        uint32_t                             Height             = 1;
-        uint32_t                             Layers             = 1;
-        Core::Containers::Array<uint32_t>    RenderTargets      = {};
-        Renderers::RenderPasses::Attachment* Attachment         = {};
+        float                                 ClearColorValue[4] = {0.1f, 0.1f, 0.1f, 1.0f};
+        float                                 ClearDepthValue[2] = {1.0f, 0.0f};
+        uint32_t                              Width              = 1;
+        uint32_t                              Height             = 1;
+        uint32_t                              Layers             = 1;
+        Core::Containers::ArrayView<uint32_t> RenderTargets      = {};
+        Renderers::RenderPasses::Attachment*  Attachment         = {};
     };
 
 } // namespace ZEngine::Rendering::Specifications


### PR DESCRIPTION
Closes #534

## Root cause

`Array<T>` had `= default` copy constructor and copy assignment, which produced a **shallow copy**: two Arrays sharing the same arena buffer. As soon as one was reallocated or its owner went out of scope, the other pointed at stale memory.

## Changes

### `Array<T>` (`Array.h`)
- `Array(const Array&) = delete` / `operator=(const Array&) = delete`
- `push_use(T&&)` rvalue overload added
- `ArrayView` default constructor added (required by `FrameBufferSpecificationVNext`)

### `HashMap` / `UnorderedHashMap`
- `rehash()`: `= m_entries` → `= std::move(m_entries)`; individual entry re-inserts use `std::move`
- `insert(const K&, const V&)`: gated with `requires std::is_copy_assignable_v<V>` — instantiation with move-only V no longer fails
- `insert(const K&, V&&)`: new move overload in both maps
- `UnorderedHashMap` iterator `value_type`: `std::pair<const K, V>` → `std::pair<const K&, V&>` — avoids copying non-copyable values during range-for

### Rendering
- `RenderPass::Initialize`, `VulkanDevice::CreateRenderPass`, `Attachment` constructor: const-ref → by-value + `std::move`
- `FrameBufferSpecificationVNext::RenderTargets`: `Array<uint32_t>` → `ArrayView<uint32_t>` (non-owning; spec is transient, `RenderPass` outlives it)
- `FramebufferVNext`: const-ref constructor removed; rvalue constructor only
- `RenderGraph::CreateRenderPassNode`: by-value + `std::move`; all callers updated

### ECS, VFS, Hardware
- `WorldTick`: `push(std::move(node/wave))`
- `VulkanDevice`: `Array<LayerProperty>` → `Array<LayerProperty*>` (stable pointers into `m_layer.InstanceLayers`)
- `VFSZipBackend`: `insert(..., std::move(fresh))`

## Test results

```
[  PASSED  ] 463 tests.
```