### PR TITLE
fix(rendering): restore DeferFree in FramebufferVNext::Dispose

### DIFF
--- a/ZEngine/ZEngine/Rendering/Buffers/FrameBuffer.cpp
+++ b/ZEngine/ZEngine/Rendering/Buffers/FrameBuffer.cpp
@@ -70,9 +70,14 @@ namespace ZEngine::Rendering::Buffers
     {
         if (Handle)
         {
-            // Direct destroy: Dispose() is always called at GPU-idle points
-            // (after QueueWaitAll at shutdown, after vkDeviceWaitIdle at resize).
-            vkDestroyFramebuffer(m_device->LogicalDevice, Handle, nullptr);
+            // Deferred: Dispose() is called during resize while the render thread
+            // may still be recording commands that reference this framebuffer.
+            // DeferFree queues the handle for destruction at the next safe drain
+            // in RRM::EndFrame or the final VulkanDevice::Dispose drain.
+            Hardwares::DeferredFreeEntry e = {};
+            e.EntryKind                    = Hardwares::DeferredFreeEntry::Kind::VkHandle;
+            e.Data.Vk                      = {Handle, Rendering::DeviceResourceType::FRAMEBUFFER, nullptr};
+            m_device->DeferFree(e);
             Handle = VK_NULL_HANDLE;
         }
     }


### PR DESCRIPTION
## Problem

PR #612 changed `FramebufferVNext::Dispose()` to direct `vkDestroyFramebuffer`, assuming GPU-idle. This caused a validation error on window resize:

```
vkDestroyFramebuffer(): can't be called on VkFramebuffer that is currently in use by VkCommandBuffer
```

`RenderGraph::Resize()` calls `Dispose()` while the render thread may still be recording commands that reference the framebuffer. `vkDeviceWaitIdle` before resize is only called on macOS and would be too expensive to add on all platforms.

## Fix

Restore `DeferFree` in `Dispose()`. The final `PendingFree.Drain()` added to `VulkanDevice::Dispose()` in PR #612 ensures deferred framebuffers are freed before `vkDestroyDevice`, so the shutdown case stays correct.

`GraphicPipeline::Dispose()` keeps direct destroy — pipelines are only disposed at shutdown, never during resize.