### PR TITLE
docs: fix 12 design docs based on codebase audit

### DIFF
--- a/ZEngine/docs/execution-plan.md
+++ b/ZEngine/docs/execution-plan.md
@@ -93,7 +93,7 @@ Remaining: VFS T5 (.meta sidecars) and CMake build-integration doc not yet done 
 | `SchedulerTest.cpp` — 6 tests including conflict/cycle asserts | 1 | WorldTick | Done |
 | `Actor` base class — `Create`, `Wrap`, `Detach`, component delegation | 2 | ECS Scene | Done |
 | `ActorManager` — register, tick, shutdown | 1 | Actor | Done |
-| `ActorTest.cpp` — create/destroy/ForEach visibility | 0.5 | Actor | Pending — file not yet created |
+| `ActorTest.cpp` — create/destroy/ForEach visibility | 0.5 | Actor | Pending — file not yet created (issue #608) |
 | `WorldCommands` deferred queue — `DeferCreateEntity`, `DeferDestroyEntity`, `Flush` | 1.5 | WorldTick | Done |
 
 **Engineer B — VFS scanner + file watcher**
@@ -529,7 +529,7 @@ Everything else is parallel to this path.
 | Tetragrama migrated off `Rendering::Components::*` | Sprint 5 deletes those headers | **Before Sprint 5** | Pending — InspectorView + HierarchyView still reference old model |
 | VFS T1–T6 done | Import pipeline, audio, animation, scene serialization all block on it | Sprint 4 | Done — all 6 tickets merged |
 | WorldCommands deferred queue | Systems cannot spawn entities without it | Sprint 3 | Done — WorldCommands.h/.cpp implemented |
-| `UploadBuffer` added to RRM | Animation skinning upload blocked | Sprint 5 | Pending |
+| `UploadBuffer` added to RRM | Animation skinning upload blocked | Sprint 5 | Done — UpdateBuffer implemented in RRM |
 | Networking spec gaps filled (5d) | Implementation cannot start until spec is clean | Sprint 11 | Pending |
 
 ---

--- a/ZEngine/docs/future-plan/draw-call-sorting.md
+++ b/ZEngine/docs/future-plan/draw-call-sorting.md
@@ -566,12 +566,7 @@ void DrawCommandBuffer::Flush(
         frame_index, thread_index,
         Core::Containers::ArrayView<VkDrawIndirectCommand>{gpu_cmds, total});
 
-    render_data_buf->Write(
-        frame_index, thread_index,
-        gpu_cmds,     // re-used pointer; actual write is draw_data below
-        0);           // placeholder; real call below
-
-    // Correct call:
+    // see RRM::UpdateBuffer for the actual implementation
     render_data_buf->Write(frame_index, thread_index, draw_data, total * sizeof(DrawData));
 
     ZReleaseScratch(scratch);

--- a/ZEngine/docs/future-plan/editor-entity-selection.md
+++ b/ZEngine/docs/future-plan/editor-entity-selection.md
@@ -7,6 +7,11 @@
 
 ---
 
+> **NOTE: NameComponent and MeshComponent do not yet exist — they are tracked in issue #609.
+> EditorSelectionSystemTick cannot be implemented until those components land.**
+
+---
+
 ## 1. Overview
 
 Entity selection is the mechanism by which the editor user picks which entity to inspect and

--- a/ZEngine/docs/future-plan/game-loop.md
+++ b/ZEngine/docs/future-plan/game-loop.md
@@ -579,6 +579,10 @@ void Engine::MainThreadRun() {
             m_ecs_scene.SnapshotTransforms();  // ← must be AFTER Tick, not before
         }
 
+        // ── 5b. Per-frame background work ───────────────────────────────────
+        ImportCoordinator::Tick();       // dispatches up to N import jobs per frame
+        MainThreadScheduler::Drain();    // executes callbacks posted by background threads
+
         // ── 6. Interpolation alpha ──────────────────────────────────────────
         timestep.Alpha = accumulator.Alpha();
 

--- a/ZEngine/docs/future-plan/import-pipeline.md
+++ b/ZEngine/docs/future-plan/import-pipeline.md
@@ -137,10 +137,7 @@ namespace ZEngine::Importers {
 - `DiagnosticMessage[256]` is a fixed-size char array. No `std::string`, no allocation.
   The importer or coordinator writes the null-terminated message via `snprintf`. The
   editor reads it when displaying failure details.
-- `ImportCallback` is a `std::function` — the one allocation in the struct. Callbacks are
-  optional; the coordinator checks `if (job.Callback)` before invoking. For batch imports
-  from `VFSScanner`, callbacks are typically null and progress is tracked via atomics
-  (Section 5).
+- `ImportCallback` is a C-style struct `{ void* Context; void (*Fn)(void*, bool); }` — zero allocation, consistent with `ImportCompleteCallback` and other engine callback conventions. Callbacks are optional; the coordinator checks `if (job.Callback.Fn)` before invoking. For batch imports from `VFSScanner`, callbacks are typically null and progress is tracked via atomics (Section 5).
 - `VFS::MetaFileData` is stored by value because jobs live in the queue between frames and
   the on-disk meta file may be rewritten while the job waits. The copy is made at enqueue
   time.
@@ -842,10 +839,10 @@ TEST(ImportCoordinator, DependenciesSatisfiedBlocksMeshUntilTextureReady)
 ## 12. Deliverables Checklist
 
 - [ ] `ZEngine/Importers/IAssetImporter.h` — `CanImport(ext)` + `Import(ctx, path, meta)` interface; no UUID generation inside importers
-- [ ] `ZEngine/Importers/ImportJob.h` — `ImportPriority` enum, `ImportCallback` typedef, `ImportJob` struct with `DiagnosticMessage[256]` and `RequeueCount`
-- [ ] `ZEngine/Importers/ImportQueue.h` + `.cpp` — max-heap by priority, `m_index` deduplication map, `Enqueue` upgrades priority on duplicate, `TryPop` maintains heap invariant, all operations under `m_mtx`
-- [ ] `ZEngine/Importers/ImportCoordinator.h` + `.cpp` — `RegisterImporter`, `Enqueue`, `EnqueueBatch`, `Tick`, `GetProgress`, `Route`, `DependenciesSatisfied`
-- [ ] `Tick()` pops up to `m_jobs_per_tick` jobs per call and dispatches each to `ThreadPool`; never blocks the main thread
+- [x] `ZEngine/Importers/ImportJob.h` — `ImportPriority` enum, `ImportCallback` typedef, `ImportJob` struct with `DiagnosticMessage[256]` and `RequeueCount`
+- [x] `ZEngine/Importers/ImportQueue.h` + `.cpp` — max-heap by priority, `m_index` deduplication map, `Enqueue` upgrades priority on duplicate, `TryPop` maintains heap invariant, all operations under `m_mtx`
+- [x] `ZEngine/Importers/ImportCoordinator.h` + `.cpp` — `RegisterImporter`, `Enqueue`, `EnqueueBatch`, `Tick`, `GetProgress`, `Route`, `DependenciesSatisfied`
+- [x] `Tick()` pops up to `m_jobs_per_tick` jobs per call and dispatches each to `ThreadPool`; never blocks the main thread
 - [ ] `DependenciesSatisfied` queries `DependencyGraph`; stalled jobs requeued with `RequeueCount++`; at `RequeueCount == 3` asset is marked `Failed` with diagnostic
 - [ ] `AssimpImporter` (and all other importers) remove internal `UUID::Generate()` calls and read `meta.UUID` instead
 - [ ] `AssetRegistry::SetStatus(uuid, AssetStatus::Failed)` called on import failure; `DiagnosticMessage` stored and retrievable via `AssetRegistry::GetDiagnosticMessage(uuid)`

--- a/ZEngine/docs/future-plan/memory-budget.md
+++ b/ZEngine/docs/future-plan/memory-budget.md
@@ -10,9 +10,9 @@
 
 ### What MemoryManager.h provides today
 
-`MemoryManager` is a singleton that wraps a single `ArenaAllocator` and exposes it as the engine's global backing store. The entire 2 GB block is allocated in one `malloc` call inside `ArenaAllocator::Initialize(2 * 1024 * 1024 * 1024ULL)`. There is no sub-arena concept at the manager level: callers obtain a region by calling `arena->CreateSubArena(size, &out)` directly on the global allocator, passing whatever size they choose. The manager records neither the names of sub-arenas nor their high-water marks, making it impossible to detect which subsystem is consuming unexpected memory.
+`MemoryManager` is a singleton that wraps a single `ArenaAllocator` and exposes it as the engine's global backing store. The entire 3 GB block is allocated in one `malloc` call inside `ArenaAllocator::Initialize(3 * 1024 * 1024 * 1024ULL)`. There is no sub-arena concept at the manager level: callers obtain a region by calling `arena->CreateSubArena(size, &out)` directly on the global allocator, passing whatever size they choose. The manager records neither the names of sub-arenas nor their high-water marks, making it impossible to detect which subsystem is consuming unexpected memory.
 
-The method name `MemoryManager::Shutdowm` contains a typo — it is spelled `Shutdowm` not `Shutdown`. This means any call site that writes the correct spelling (`Shutdown()`) fails to compile, and the wrong spelling is never called at all. The backing 2 GB `malloc` block leaks at process exit unless the `ArenaAllocator` destructor has been fixed per Bug 4 of the memory-allocator-audit.
+The method name `MemoryManager::Shutdowm` contains a typo — it is spelled `Shutdowm` not `Shutdown`. This means any call site that writes the correct spelling (`Shutdown()`) fails to compile, and the wrong spelling is never called at all. The backing 3 GB `malloc` block leaks at process exit unless the `ArenaAllocator` destructor has been fixed per Bug 4 of the memory-allocator-audit.
 
 ### What existing call sites already allocate
 
@@ -26,13 +26,13 @@ The following sub-arenas are already carved from the global arena in the current
 | Shader cache | 5 MB | Current; increased to 16 MB in budget below |
 | Scene serializer scratch | 150 MB | Scene save/load temporary buffers |
 
-These five allocations total approximately 608 MB. The remaining ~1,416 MB of the 2 GB block is currently unbudgeted and available to any caller that reaches in with `CreateSubArena`. The budget table below assigns this headroom to concrete subsystems and reserves a safety margin.
+These five allocations total approximately 608 MB. The remaining ~2,440 MB of the 3 GB block is currently unbudgeted and available to any caller that reaches in with `CreateSubArena`. The budget table below assigns this headroom to concrete subsystems and reserves a safety margin.
 
 ---
 
 ## 2. Global Arena Budget Table
 
-All sizes are at process startup, allocated once, and never grown. The 2 GB total is a hard ceiling that must not be exceeded. Sub-arenas for optional systems (Network) are only carved when that system is initialized.
+All sizes are at process startup, allocated once, and never grown. The 3 GB total is a hard ceiling that must not be exceeded. Sub-arenas for optional systems (Network) are only carved when that system is initialized.
 
 | Subsystem | Sub-arena size | Notes |
 |---|---|---|
@@ -41,18 +41,17 @@ All sizes are at process startup, allocated once, and never grown. The 2 GB tota
 | Importer | 350 MB | Assimp import scratch; cleared on `AssetManager::ImportComplete()` (matches existing) |
 | ECS::Scene | 128 MB | ComponentStorage dense arrays, EntityRegistry free-list, archetype metadata |
 | Animation::AnimationManager | 64 MB | SkeletonData, AnimationClip arrays, per-frame pose pools (double-buffered) |
-| Physics::PhysicsWorld | 64 MB | Jolt body data, broad-phase cell grid, constraint cache, contact manifold pool |
 | Audio::AudioEngine | 32 MB | miniaudio state, decoded clip pool, stream decode ring buffers |
 | VFS (context + registry) | 32 MB | Path cache, mount table, asset UUID-to-path registry, watcher event queue |
 | Shader cache | 16 MB | SPIR-V bytecode cache; increased from current 5 MB to accommodate compute shaders |
 | UI::UIContext (per-frame) | 8 MB | Widget tree, draw list, retained-mode diff buffers; cleared each frame |
-| MainThreadScheduler | < 1 MB | 512 lock-free MPSC slots (128 B each with cache-line-padded ready flag) = 64 KB |
+| MainThreadScheduler | < 1 MB | 512 MPSC slots (Slot = data + PaddedAtomic seq) = ~64 KB |
 | Network (session + rollback) | 32 MB | Peer state, snapshot ring buffers for rollback; only allocated in multiplayer builds |
 | Serializer scratch | 150 MB | Scene save/load temporary buffers (matches existing) |
 | Swapchain | 3 MB | Swapchain-specific allocations (matches existing) |
 | Logging | 4 MB | Logger ring buffer, event handler list, category filter table |
 | Scratch / general | 48 MB | Engine-internal scratch arenas, temporary string processing, debug overlay |
-| **Total** | **~1,496 MB** | **~552 MB headroom within the 2 GB block** |
+| **Total** | **~1,496 MB** | **~1,576 MB headroom within the 3 GB block** |
 
 ### Sizing rationale
 
@@ -96,15 +95,9 @@ VMA does not enforce per-category budgets automatically. The engine should call 
 `GameApplication::Initialize()` and BEFORE `Engine::Initialize()`. The typical
 call site is in `main()` or the platform entry point:
 
-```cpp
-    Core::Memory::MemoryManager memory_manager;
-    memory_manager.Initialize(Core::Memory::MemoryBudgetConfig::Default());
-    
-    MyGame app;
-    app.Initialize(&memory_manager.Allocator);
-```
+See `Engine::Initialize` for the actual API.
 
-This ensures the 2GB block is allocated and the budget is validated before any
+This ensures the 3 GB block is allocated and the budget is validated before any
 subsystem attempts to carve a sub-arena. If total committed bytes exceed the
 arena size, `Initialize()` asserts and exits before any GPU or window work starts.
 
@@ -152,7 +145,7 @@ struct MemoryBudgetConfig
     //   MemoryManager::Initialize(cfg);
     //
     // All modifications must happen before passing to Initialize().
-    // cfg.Validate() asserts if total committed exceeds 2GB.
+    // cfg.Validate() asserts if total committed exceeds 3GB.
 
     // Returns a reduced budget for dedicated server builds (no GPU, no audio, no UI).
     static MemoryBudgetConfig Server();
@@ -187,7 +180,7 @@ inline MemoryBudgetConfig MemoryBudgetConfig::Default()
     cfg.Logging            = { "Logging",              4ULL * 1024 * 1024 };
     cfg.Input              = { "Input",                1ULL * 1024 * 1024 };
     return cfg;
-    // Total: ~1,496 MB out of 2,048 MB; ~552 MB headroom
+    // Total: ~1,496 MB out of 3,072 MB; ~1,576 MB headroom
 }
 
 } // namespace ZEngine::Memory

--- a/ZEngine/docs/future-plan/render-graph-redesign.md
+++ b/ZEngine/docs/future-plan/render-graph-redesign.md
@@ -48,7 +48,7 @@ outputs changed size.
 4. Execute loop is array-indexed, not hash-keyed — zero string hashing on the hot path.
 5. Barrier batching — collect all barriers needed before a pass into one `vkCmdPipelineBarrier` call.
 6. Keep the existing `IRenderGraphCallbackPass` interface intact. Existing pass implementations
-   (`UploadPass`, `BasePass`, `DepthPrePass`, `SkyboxPass`, `GridPass`) require no changes.
+   (~~UploadPass~~ — removed; SkyboxPass and GridPass now use global VB/IB via RRM::RegisterBuiltinGeometry, `BasePass`, `DepthPrePass`, `SkyboxPass`, `GridPass`) require no changes.
 
 ---
 
@@ -708,7 +708,7 @@ emitted automatically in `Execute()` — the pass implementation never calls
 
 ## 11. Migration from the Current Design
 
-The current pass implementations (`UploadPass`, `BasePass`, `DepthPrePass`, `SkyboxPass`,
+The current pass implementations (~~UploadPass~~ — removed; SkyboxPass and GridPass now use global VB/IB via RRM::RegisterBuiltinGeometry, `BasePass`, `DepthPrePass`, `SkyboxPass`,
 `GridPass`) call `res_builder->CreateBufferSet`, `CreateRenderTarget`, `CreateRenderPassNode`,
 and `res_inspector->GetVertexBufferSet` etc. These APIs are preserved with identical
 signatures on `RGBuilder` and `RGInspector`. Migration is mechanical:
@@ -792,7 +792,7 @@ to query device headroom dynamically at runtime.
 
 ### Migration
 
-- [ ] `UploadPass`, `BasePass`, `DepthPrePass`, `SkyboxPass`, `GridPass` updated to use new `RGBuilder`/`RGInspector` API — builder call sites only; `Execute()` bodies unchanged
+- [ ] ~~UploadPass~~ — removed; SkyboxPass and GridPass now use global VB/IB via RRM::RegisterBuiltinGeometry; `BasePass`, `DepthPrePass`, `SkyboxPass`, `GridPass` updated to use new `RGBuilder`/`RGInspector` API — builder call sites only; `Execute()` bodies unchanged
 - [ ] `GraphicRenderer::Initialize` updated — `RGBuilder::ImportRenderTarget` for `FrameColorRenderTarget` and `FrameDepthRenderTarget`; remove `ResourceBuilder->AttachRenderTarget` calls
 - [ ] `GbufferPass::Setup` and `LightingPass::Setup` updated to use `WriteColorAttachment` and `ReadTexture` — these are currently commented out; enable them as part of this migration
 

--- a/ZEngine/docs/future-plan/render-resource-manager.md
+++ b/ZEngine/docs/future-plan/render-resource-manager.md
@@ -221,8 +221,10 @@ namespace ZEngine::Rendering {
         // Enqueue a Vulkan object for safe deferred deletion.
         // The object is destroyed after N frames (default 3 = max frames in flight)
         // to ensure it is not in use by any in-flight GPU command buffer.
-        // Called from: shader hot-reload (VkShaderModule), pipeline rebuild (VkPipeline),
+        // Called from: shader hot-reload (VkShaderModule),
         // buffer resize (VkBuffer/VmaAllocation), texture eviction (VkImage).
+        // Note: pipeline rebuild is NOT a use case — GraphicPipeline::Dispose() calls
+        // vkDestroyPipeline directly and does not go through EnqueueDeletion.
         void EnqueueDeletion(VkShaderModule module);
         void EnqueueDeletion(VkPipeline pipeline);
         void EnqueueDeletion(VkBuffer buffer, VmaAllocation allocation);
@@ -878,6 +880,8 @@ TEST(RRM, GetBufferOnReleasedHandleReturnsNullptr)
 - [ ] `ZEngine/Rendering/RenderHandle.h` — `RenderHandle<Tag>` generational handle template + four `using` aliases (`BufferHandle`, `ImageHandle`, `SamplerHandle`, `PipelineHandle`)
 - [ ] `ZEngine/Rendering/GPUResource.h` — `GPUBuffer` and `GPUImage` plain aggregates; zero-initialised sentinel values; no RAII
 - [ ] `ZEngine/Rendering/RenderResourceManager.h` — public API (`UploadMesh`, `UploadTexture`, `ScheduleSwap`, `Release`, `BeginFrame`, `EndFrame`, `GetBuffer`, `GetImage` (const), `GetImageMutable`); `FRAMES_IN_FLIGHT = 3` constant
+- [x] `RRM::GetGlobalVertexBuffer()` — returns the shared `GPUBuffer*` holding all builtin geometry vertices registered via `RegisterBuiltinGeometry`; implemented as a live public method on RRM
+- [x] `RRM::GetGlobalIndexBuffer()` — returns the shared `GPUBuffer*` holding all builtin geometry indices registered via `RegisterBuiltinGeometry`; implemented as a live public method on RRM
 - [ ] `ZEngine/Rendering/RenderResourceManager.cpp` — `Init`, `FlushPendingUploads`, upload path with staging buffer, barrier structs, queue-family ownership transfer for transfer-to-graphics handoff
 - [ ] Staging buffer path: `GpuAllocator::Ring.Allocate()` → `memcpy` → `Ring.Submit(signal_val)` → `vkCmdCopyBuffer` → release barrier on transfer queue → acquire barrier on graphics queue
 - [ ] Texture path: `VK_IMAGE_LAYOUT_UNDEFINED` → `VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL` → `vkCmdCopyBufferToImage` → `VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL`; barrier covers all mip levels

--- a/ZEngine/docs/future-plan/rendering-flow.md
+++ b/ZEngine/docs/future-plan/rendering-flow.md
@@ -129,9 +129,9 @@ Frame index `fi` = `SwapchainPtr->CurrentFrame->Index` (0, 1, or 2 in a triple-b
       material_buf->Write(fi, thread, GPUMeshMaterials)  <- full material array
       RenderGraph->Execute(cmd)
 
-        [UploadPass]
-          skybox VB/IB write (write-once per frame-in-flight)
-          grid VB/IB write
+        // UploadPass has been removed. SkyboxPass and GridPass now bind the
+        // global vertex/index buffers registered via RRM::RegisterBuiltinGeometry;
+        // no per-pass VB/IB writes are needed.
 
         // Passes below reflect the current live implementation.
         // Shadow, post-process, and gizmo passes are added by their
@@ -154,12 +154,12 @@ Frame index `fi` = `SwapchainPtr->CurrentFrame->Index` (0, 1, or 2 in a triple-b
           EndRenderPass
 
         [SkyboxPass]
-          BindVertexBuffer / BindIndexBuffer (cube, 36 indices)
+          BindVertexBuffer / BindIndexBuffer (global VB/IB via RRM::RegisterBuiltinGeometry; cube geometry, 36 indices)
           BindDescriptorSets(fi)
           DrawIndexed(36, 1, 0, 0, 0)
 
         [GridPass]
-          BindVertexBuffer / BindIndexBuffer (quad, 6 indices)
+          BindVertexBuffer / BindIndexBuffer (global VB/IB via RRM::RegisterBuiltinGeometry; quad geometry, 6 indices)
           PushConstants(grid_params)
           DrawIndexed(6, 1, 0, 0, 0)
 
@@ -242,7 +242,7 @@ recorded when they were enqueued in `DeferFree`).
 
 ## 5. RRM Upload Path (Current Implementation)
 
-`RenderResourceManager` now owns all buffer uploads. `AsyncResourceLoader` retains only texture uploads.
+`RenderResourceManager (RRM)` now owns all uploads — buffer and texture alike. `AsyncResourceLoader` has been fully replaced by RRM.
 
 ### Buffer domains
 

--- a/ZEngine/docs/future-plan/scene-serialization.md
+++ b/ZEngine/docs/future-plan/scene-serialization.md
@@ -117,6 +117,8 @@ namespace ZEngine::Scene
 }
 ```
 
+**Callback convention note**: The `std::function` fields in `ComponentSerializeFns` and the `ForEach` parameter allocate on capture. The engine's callback convention is a C-style fn-ptr + context — `{ void* Context; void (*Fn)(...); }` — consistent with `ImportCompleteCallback`, `MainThreadScheduler::Post`, and other engine APIs. In the final implementation, `ComponentSerializeFns` fields and `ForEach` should follow this pattern rather than `std::function`.
+
 **Registration example** (in a component's `.cpp`):
 ```cpp
 // TransformComponent.cpp

--- a/ZEngine/docs/future-plan/system-scheduler.md
+++ b/ZEngine/docs/future-plan/system-scheduler.md
@@ -92,7 +92,7 @@ world.RegisterSystem(AnimationSampleSystem, {
 
 world.RegisterSystem(RenderCullSystem, {
     .ReadMask  = MaskBit(ComponentTypeOf<TransformComponent>())
-               | MaskBit(ComponentTypeOf<MeshComponent>()),
+               | MaskBit(ComponentTypeOf<MeshComponent>()), // MeshComponent — pending issue #609
     .WriteMask = 0,  // read-only
 });
 ```
@@ -206,7 +206,7 @@ Example:
 Registered:
   AnimationSampleSystem  writes: AnimatorComponent
   PhysicsSystem          writes: TransformComponent, reads: RigidBodyComponent
-  RenderCullSystem       reads:  TransformComponent, MeshComponent
+  RenderCullSystem       reads:  TransformComponent, MeshComponent  // MeshComponent — pending issue #609
   AudioSystem            reads:  TransformComponent
 
 OrderBefore(PhysicsSystem, RenderCullSystem)
@@ -439,7 +439,7 @@ SystemID physics_id = world.RegisterSystem(PhysicsSystem, {
 
 SystemID cull_id = world.RegisterSystem(RenderCullSystem, {
     .ReadMask  = MaskBit(ComponentTypeOf<TransformComponent>())
-               | MaskBit(ComponentTypeOf<MeshComponent>()),
+               | MaskBit(ComponentTypeOf<MeshComponent>()), // MeshComponent — pending issue #609
     .WriteMask = 0,
 });
 


### PR DESCRIPTION
Fixes all findings from the design doc audit. No code changes — docs only.

| Doc | Fix |
|---|---|
| `game-loop.md` | Add `ImportCoordinator::Tick` + `MainThreadScheduler::Drain()` to `MainThreadRun` pseudocode |
| `memory-budget.md` | Arena 2 GB → 3 GB; remove `PhysicsWorld` entry; fix API examples |
| `rendering-flow.md` | Remove `UploadPass`; replace `AsyncResourceLoader` with RRM; update SkyboxPass/GridPass |
| `render-resource-manager.md` | Fix `EnqueueDeletion` docstring; mark `GetGlobalVertex/IndexBuffer` as done |
| `import-pipeline.md` | `ImportCallback` C-style description; mark completed checklist items `[x]` |
| `scene-serialization.md` | Update callback pattern to C-style |
| `editor-entity-selection.md` | Note that `NameComponent`/`MeshComponent` are pending (#609) |
| `system-scheduler.md` | Note `MeshComponent` examples are pending (#609) |
| `execution-plan.md` | Fix `UploadBuffer` status; fix `ActorTest.cpp` status |
| `render-graph-redesign.md` | Remove `UploadPass` |
| `draw-call-sorting.md` | Remove dead placeholder code |