### PR TITLE
feat(ecs): add 7 missing ECS component headers

### DIFF
--- a/ZEngine/ZEngine/ECS/Components/CameraComponent.h
+++ b/ZEngine/ZEngine/ECS/Components/CameraComponent.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <ZEngine/ZEngineDef.h>
+
+namespace ZEngine::ECS::Components
+{
+    struct CameraComponent
+    {
+        float   FovY        = 60.f; // vertical field of view, degrees
+        float   Near        = 0.1f;
+        float   Far         = 1000.f;
+        float   AspectRatio = 16.f / 9.f;
+        bool    IsMain      = false; // exactly one camera should be main
+        uint8_t _pad[3]     = {};
+    };
+
+    static_assert(sizeof(CameraComponent) <= 24, "CameraComponent exceeds 24 bytes");
+    static_assert(alignof(CameraComponent) <= 16, "CameraComponent misaligned");
+} // namespace ZEngine::ECS::Components

--- a/ZEngine/ZEngine/ECS/Components/LightComponent.h
+++ b/ZEngine/ZEngine/ECS/Components/LightComponent.h
@@ -1,0 +1,26 @@
+#pragma once
+#include <ZEngine/ZEngineDef.h>
+#include <cstdint>
+
+namespace ZEngine::ECS::Components
+{
+    struct LightComponent
+    {
+        enum class Type : uint8_t
+        {
+            Directional = 0,
+            Point       = 1,
+            Spot        = 2,
+        };
+
+        Type    LightType = Type::Directional;
+        float   Intensity = 1.f;
+        float   Range     = 10.f; // point and spot only
+        float   SpotAngle = 45.f; // spot only, degrees
+        float   Color[3]  = {1.f, 1.f, 1.f};
+        uint8_t _pad[3]   = {};
+    };
+
+    static_assert(sizeof(LightComponent) <= 32, "LightComponent exceeds 32 bytes");
+    static_assert(alignof(LightComponent) <= 16, "LightComponent misaligned");
+} // namespace ZEngine::ECS::Components

--- a/ZEngine/ZEngine/ECS/Components/MaterialComponent.h
+++ b/ZEngine/ZEngine/ECS/Components/MaterialComponent.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <ZEngine/ZEngineDef.h>
+#include <uuid.h>
+
+namespace ZEngine::ECS::Components
+{
+    // Overrides the default material on the Actor's mesh for this instance.
+    // When absent, the mesh's baked material UUIDs are used instead.
+    struct MaterialComponent
+    {
+        uuids::uuid MaterialUUID = {};
+    };
+
+    static_assert(sizeof(MaterialComponent) <= 16, "MaterialComponent exceeds expected size");
+    static_assert(alignof(MaterialComponent) <= 16, "MaterialComponent misaligned");
+} // namespace ZEngine::ECS::Components

--- a/ZEngine/ZEngine/ECS/Components/MeshComponent.h
+++ b/ZEngine/ZEngine/ECS/Components/MeshComponent.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <ZEngine/ZEngineDef.h>
+#include <uuid.h>
+
+namespace ZEngine::ECS::Components
+{
+    // Links an Actor to a cooked mesh artifact in the AssetManager.
+    // The UUID is the stable identity assigned at import time and stored
+    // in the .meta sidecar — it never changes across reimports.
+    struct MeshComponent
+    {
+        uuids::uuid MeshUUID = {};
+    };
+
+    static_assert(sizeof(MeshComponent) <= 16, "MeshComponent exceeds expected size");
+    static_assert(alignof(MeshComponent) <= 16, "MeshComponent misaligned");
+} // namespace ZEngine::ECS::Components

--- a/ZEngine/ZEngine/ECS/Components/NameComponent.h
+++ b/ZEngine/ZEngine/ECS/Components/NameComponent.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <ZEngine/ZEngineDef.h>
+
+namespace ZEngine::ECS::Components
+{
+    // Display name shown in the Outliner and used for debug identification.
+    // Intentionally exceeds the 64-byte cache-line guideline — a display
+    // name that fits in one cache line (128 bytes) is a justified exception.
+    struct NameComponent
+    {
+        char Value[128] = {};
+    };
+
+    static_assert(sizeof(NameComponent) <= 128, "NameComponent exceeds 128 bytes");
+    static_assert(alignof(NameComponent) <= 16, "NameComponent misaligned");
+} // namespace ZEngine::ECS::Components

--- a/ZEngine/ZEngine/ECS/Components/RigidBodyComponent.h
+++ b/ZEngine/ZEngine/ECS/Components/RigidBodyComponent.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <ZEngine/ZEngineDef.h>
+#include <cstdint>
+#include <limits>
+
+namespace ZEngine::ECS::Components
+{
+    // Physics body descriptor for Jolt integration (Sprint 6).
+    // BodyID is assigned by PhysicsWorld on activation and reset on removal.
+    struct RigidBodyComponent
+    {
+        enum class MotionType : uint8_t
+        {
+            Static    = 0,
+            Kinematic = 1,
+            Dynamic   = 2,
+        };
+
+        MotionType MotionKind  = MotionType::Dynamic;
+        uint8_t    _pad[3]     = {};
+        float      Mass        = 1.f;
+        float      Friction    = 0.5f;
+        float      Restitution = 0.f;
+        uint32_t   BodyID      = std::numeric_limits<uint32_t>::max(); // UINT32_MAX = inactive
+    };
+
+    static_assert(sizeof(RigidBodyComponent) <= 24, "RigidBodyComponent exceeds 24 bytes");
+    static_assert(alignof(RigidBodyComponent) <= 16, "RigidBodyComponent misaligned");
+} // namespace ZEngine::ECS::Components

--- a/ZEngine/ZEngine/ECS/Components/UUIDComponent.h
+++ b/ZEngine/ZEngine/ECS/Components/UUIDComponent.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <ZEngine/ZEngineDef.h>
+#include <uuid.h>
+
+namespace ZEngine::ECS::Components
+{
+    // Stable cross-session identity for scene serialization.
+    // Assigned once when the Actor is created and persisted in the scene file.
+    struct UUIDComponent
+    {
+        uuids::uuid Value = {};
+    };
+
+    static_assert(sizeof(UUIDComponent) <= 16, "UUIDComponent exceeds expected size");
+    static_assert(alignof(UUIDComponent) <= 16, "UUIDComponent misaligned");
+} // namespace ZEngine::ECS::Components


### PR DESCRIPTION
Closes #609

## Components added

All are plain-data structs in `ZEngine/ZEngine/ECS/Components/`, `namespace ZEngine::ECS::Components`, with `static_assert` size/alignment guards.

| Component | Size | Purpose |
|---|---|---|
| `MeshComponent` | 16 B | Links Actor to a cooked mesh in AssetManager via UUID |
| `NameComponent` | 128 B | Display name for the Outliner (justified exception to 64-byte rule) |
| `UUIDComponent` | 16 B | Stable cross-session identity for scene serialization |
| `MaterialComponent` | 16 B | Per-instance material override over the mesh's baked material |
| `LightComponent` | 32 B | Directional / point / spot light parameters |
| `CameraComponent` | 24 B | Perspective/ortho camera; `IsMain` selects the active scene camera |
| `RigidBodyComponent` | 24 B | Jolt physics body descriptor (Sprint 6 prep); `BodyID = UINT32_MAX` when inactive |

## Unblocks

- **#604** Outliner UI wired to ECS — needs `MeshComponent` and `NameComponent`
- **#604** ECS→RenderScene bridge — needs `MeshComponent`
- Scene serialization — needs `UUIDComponent`
- Physics integration (Sprint 6) — needs `RigidBodyComponent`