### PR TITLE
test(ecs): add ActorTest.cpp — Actor lifecycle and component tests

### DIFF
--- a/ZEngine/ZEngine/ECS/ActorManager.cpp
+++ b/ZEngine/ZEngine/ECS/ActorManager.cpp
@@ -65,6 +65,35 @@ namespace ZEngine::ECS
         }
     }
 
+    void ActorManager::AssertUniqueEntityID(EntityID id) const
+    {
+        uint32_t head = m_handles.Head();
+        for (uint32_t i = 0; i < head; ++i)
+        {
+            ActorHandle slot = const_cast<Helpers::HandleManager<Actor*>&>(m_handles).ToHandle(i);
+            if (!m_handles.IsLive(slot))
+                continue;
+            Actor** ptr = const_cast<Helpers::HandleManager<Actor*>&>(m_handles).Access(slot);
+            if (ptr && *ptr && (*ptr)->m_entity_id == id)
+            {
+                ZENGINE_VALIDATE_ASSERT(false, "ActorManager: EntityID already wrapped by another Actor")
+            }
+        }
+    }
+
+#if !defined(NDEBUG)
+    ActorHandle ActorManager::CreateWithExistingEntityID(EntityID id)
+    {
+        ZENGINE_VALIDATE_ASSERT(m_arena != nullptr, "ActorManager::CreateWithExistingEntityID: not initialized")
+        Actor* actor       = ZPushStructCtor(m_arena, Actor);
+        actor->m_entity_id = id;
+        actor->m_scene     = m_scene;
+        AssertUniqueEntityID(actor->m_entity_id);
+        ActorHandle handle = m_handles.Add(static_cast<Actor*>(actor));
+        return handle;
+    }
+#endif
+
     void ActorManager::Shutdown()
     {
         // Destroy all live Actors in reverse creation order (head-1 down to 0)

--- a/ZEngine/ZEngine/ECS/ActorManager.h
+++ b/ZEngine/ZEngine/ECS/ActorManager.h
@@ -28,21 +28,27 @@ namespace ZEngine::ECS
 
             ZENGINE_VALIDATE_ASSERT(m_arena != nullptr, "ActorManager::Create: not initialized")
 
-            // Allocate T from arena
             T* actor           = ZPushStructCtor(m_arena, T);
-
-            // Wire entity
             actor->m_entity_id = m_scene->CreateEntity();
             actor->m_scene     = m_scene;
 
-            // Store pointer in handle array
-            Actor**     slot   = nullptr;
+#if !defined(NDEBUG)
+            AssertUniqueEntityID(actor->m_entity_id);
+#endif
+
             ActorHandle handle = m_handles.Add(static_cast<Actor*>(actor));
             ZENGINE_VALIDATE_ASSERT(handle.Valid(), "ActorManager::Create: MAX_ACTORS capacity reached")
 
             actor->OnCreate();
             return handle;
         }
+
+#if !defined(NDEBUG)
+        // Test-only: creates an Actor wrapping an existing EntityID without calling
+        // Scene::CreateEntity(). Immediately triggers the duplicate-EntityID guard
+        // if `id` is already owned by a live Actor — useful for EXPECT_DEATH tests.
+        ActorHandle CreateWithExistingEntityID(EntityID id);
+#endif
 
         // Calls OnDestroy(), destroys the EntityID, frees the handle slot.
         // Stale handles are silently ignored.
@@ -66,6 +72,8 @@ namespace ZEngine::ECS
         }
 
     private:
+        void                           AssertUniqueEntityID(EntityID id) const;
+
         Helpers::HandleManager<Actor*> m_handles;
         Core::Memory::ArenaAllocator*  m_arena = nullptr;
         Scene*                         m_scene = nullptr;

--- a/ZEngine/tests/ECS/ActorTest.cpp
+++ b/ZEngine/tests/ECS/ActorTest.cpp
@@ -1,0 +1,150 @@
+#include <ZEngine/Core/Memory/MemoryManager.h>
+#include <ZEngine/ECS/ActorManager.h>
+#include <ZEngine/ECS/Components/TransformComponent.h>
+#include <ZEngine/ECS/Scene.h>
+#include <gtest/gtest.h>
+
+using namespace ZEngine;
+using namespace ZEngine::ECS;
+using namespace ZEngine::ECS::Components;
+using namespace ZEngine::Core::Memory;
+
+class ActorFixture : public ::testing::Test
+{
+protected:
+    MemoryManager m_manager;
+    Scene         m_scene;
+    ActorManager  m_actors;
+
+    void          SetUp() override
+    {
+        m_manager.Initialize(ZMega(64), {});
+        m_scene.Initialize(&m_manager.MainArena);
+        m_actors.Initialize(&m_manager.MainArena, m_scene);
+    }
+
+    void TearDown() override
+    {
+        m_actors.Shutdown();
+        m_scene.Shutdown();
+    }
+};
+
+// 1. Create returns a valid, live handle.
+TEST_F(ActorFixture, CreateReturnsValidHandle)
+{
+    ActorHandle h = m_actors.Create();
+    EXPECT_TRUE(h.Valid());
+    EXPECT_TRUE(m_actors.IsLive(h));
+    ASSERT_NE(m_actors.Access(h), nullptr);
+    EXPECT_TRUE(m_actors.Access(h)->IsAlive());
+}
+
+class LifecycleActor : public Actor
+{
+public:
+    bool  CreateFired  = false;
+    bool  DestroyFired = false;
+    float Accumulated  = 0.f;
+
+    void  OnCreate() override
+    {
+        CreateFired = true;
+    }
+    void OnDestroy() override
+    {
+        DestroyFired = true;
+    }
+    void OnTick(float dt) override
+    {
+        Accumulated += dt;
+    }
+};
+
+// 2. OnCreate fires immediately after Create().
+TEST_F(ActorFixture, OnCreateFiresOnCreate)
+{
+    ActorHandle     h = m_actors.Create<LifecycleActor>();
+    LifecycleActor* a = static_cast<LifecycleActor*>(m_actors.Access(h));
+    ASSERT_NE(a, nullptr);
+    EXPECT_TRUE(a->CreateFired);
+}
+
+// 3. Component added through Actor is retrievable with correct values.
+TEST_F(ActorFixture, ComponentAddGetRoundtrip)
+{
+    ActorHandle h     = m_actors.Create();
+    Actor*      actor = m_actors.Access(h);
+    ASSERT_NE(actor, nullptr);
+
+    actor->AddComponent<TransformComponent>({
+        {7.f, 8.f, 9.f}
+    });
+
+    TransformComponent* t = actor->GetComponent<TransformComponent>();
+    ASSERT_NE(t, nullptr);
+    EXPECT_FLOAT_EQ(t->Position.x, 7.f);
+    EXPECT_FLOAT_EQ(t->Position.y, 8.f);
+    EXPECT_FLOAT_EQ(t->Position.z, 9.f);
+    EXPECT_TRUE(actor->HasComponent<TransformComponent>());
+}
+
+// 4. Destroy makes the handle stale and Access returns nullptr.
+TEST_F(ActorFixture, DestroyMakesHandleStale)
+{
+    ActorHandle h  = m_actors.Create();
+    EntityID    id = m_actors.Access(h)->GetEntityID();
+
+    m_actors.Destroy(h);
+
+    EXPECT_FALSE(m_actors.IsLive(h));
+    EXPECT_EQ(m_actors.Access(h), nullptr);
+    EXPECT_FALSE(m_scene.IsAlive(id));
+}
+
+// 5. OnDestroy fires when Destroy() is called.
+TEST_F(ActorFixture, OnDestroyFiresOnDestroy)
+{
+    ActorHandle     h = m_actors.Create<LifecycleActor>();
+    LifecycleActor* a = static_cast<LifecycleActor*>(m_actors.Access(h));
+    ASSERT_NE(a, nullptr);
+    EXPECT_FALSE(a->DestroyFired);
+
+    m_actors.Destroy(h);
+    EXPECT_TRUE(a->DestroyFired);
+}
+
+// 6. Scene::ForEach visits components attached to Actor-backed entities.
+TEST_F(ActorFixture, ForEachVisitsActorEntity)
+{
+    ActorHandle h = m_actors.Create();
+    m_actors.Access(h)->AddComponent<TransformComponent>({
+        {1.f, 2.f, 3.f}
+    });
+
+    uint32_t count = 0;
+    m_scene.ForEach<TransformComponent>([&](EntityID, TransformComponent& t) {
+        EXPECT_FLOAT_EQ(t.Position.x, 1.f);
+        ++count;
+    });
+    EXPECT_EQ(count, 1u);
+}
+
+// 7. Tick dispatches OnTick to all live Actors with the correct dt.
+TEST_F(ActorFixture, TickDispatchesOnTick)
+{
+    ActorHandle     h = m_actors.Create<LifecycleActor>();
+    LifecycleActor* a = static_cast<LifecycleActor*>(m_actors.Access(h));
+    ASSERT_NE(a, nullptr);
+
+    m_actors.Tick(1.f);
+    m_actors.Tick(1.f);
+
+    EXPECT_FLOAT_EQ(a->Accumulated, 2.f);
+}
+
+// 8. Duplicate EntityID wrapping should trigger a debug assert.
+// DISABLED: ActorManager::Create<T>() has no duplicate-EntityID guard yet.
+// When the guard is added, re-enable this test and supply a path that
+// injects the same EntityID into two Actors.
+TEST_F(ActorFixture, DISABLED_DuplicateEntityIDAsserts) {}

--- a/ZEngine/tests/ECS/ActorTest.cpp
+++ b/ZEngine/tests/ECS/ActorTest.cpp
@@ -143,8 +143,16 @@ TEST_F(ActorFixture, TickDispatchesOnTick)
     EXPECT_FLOAT_EQ(a->Accumulated, 2.f);
 }
 
-// 8. Duplicate EntityID wrapping should trigger a debug assert.
-// DISABLED: ActorManager::Create<T>() has no duplicate-EntityID guard yet.
-// When the guard is added, re-enable this test and supply a path that
-// injects the same EntityID into two Actors.
+// 8. Wrapping an EntityID already owned by a live Actor fires the debug guard.
+// Only meaningful in debug builds where NDEBUG is not defined.
+#if !defined(NDEBUG)
+TEST_F(ActorFixture, DuplicateEntityIDAsserts)
+{
+    ActorHandle h  = m_actors.Create();
+    EntityID    id = m_actors.Access(h)->GetEntityID();
+
+    EXPECT_DEATH({ m_actors.CreateWithExistingEntityID(id); }, ".*");
+}
+#else
 TEST_F(ActorFixture, DISABLED_DuplicateEntityIDAsserts) {}
+#endif


### PR DESCRIPTION
Closes #608

## What's added

`ZEngine/tests/ECS/ActorTest.cpp` — 8 tests under `ActorFixture`.

| # | Test | What it verifies |
|---|---|---|
| 1 | `CreateReturnsValidHandle` | `Create()` returns a valid, live handle; entity is alive |
| 2 | `OnCreateFiresOnCreate` | `OnCreate()` fires immediately inside `Create()` |
| 3 | `ComponentAddGetRoundtrip` | `AddComponent` / `GetComponent` / `HasComponent` delegate to `Scene` |
| 4 | `DestroyMakesHandleStale` | After `Destroy()`, handle is stale, `Access` returns `nullptr`, entity is dead |
| 5 | `OnDestroyFiresOnDestroy` | `OnDestroy()` fires during `Destroy()`; not before |
| 6 | `ForEachVisitsActorEntity` | `Scene::ForEach` visits components on Actor-backed entities |
| 7 | `TickDispatchesOnTick` | `Tick(dt)` accumulates correctly across two calls |
| 8 | `DuplicateEntityIDAsserts` | Death test — `EXPECT_DEATH` on a duplicate-EntityID injection; `DISABLED_` in release |

`LifecycleActor` (OnCreate / OnDestroy / OnTick) covers tests 2, 5, and 7 in one subclass.

## Guard added to `ActorManager`

- `AssertUniqueEntityID(EntityID)` — debug-only O(n) walk; fires `ZENGINE_VALIDATE_ASSERT` if any live Actor already owns the given EntityID. Called from `Create<T>()` under `#if !defined(NDEBUG)` — zero overhead in release.
- `CreateWithExistingEntityID(EntityID)` — debug-only test-only method that bypasses `CreateEntity()` to inject an existing EntityID, triggering the guard. Compiled out when `NDEBUG` is defined.

## CMake

No change needed — `ZEngine/tests/CMakeLists.txt` already globs `ECS/*.cpp`.