### PR TITLE
fix(vfs): add VFSOpenFlags::Create and Truncate

### DIFF
--- a/Tetragrama/Components/ProjectViewUIComponent.cpp
+++ b/Tetragrama/Components/ProjectViewUIComponent.cpp
@@ -549,7 +549,7 @@ namespace Tetragrama::Components
                         auto exists = m_vfs_context->Exists(vfs_res.Value());
                         if (!exists.Succeeded() || !exists.Value())
                         {
-                            auto file_res = m_vfs_context->Open(vfs_res.Value(), VFSOpenFlags::Write);
+                            auto file_res = m_vfs_context->Open(vfs_res.Value(), VFSOpenFlags::Write | VFSOpenFlags::Create);
                             if (file_res.Succeeded())
                             {
                                 m_vfs_context->Close(file_res.Value());

--- a/ZEngine/ZEngine/Core/VFS/IVFSFile.h
+++ b/ZEngine/ZEngine/Core/VFS/IVFSFile.h
@@ -11,10 +11,12 @@ namespace ZEngine::Core::VFS
 
     enum class VFSOpenFlags : uint32_t
     {
-        None   = 0,
-        Read   = BIT(0),
-        Write  = BIT(1),
-        Append = BIT(2),
+        None     = 0,
+        Read     = BIT(0),
+        Write    = BIT(1),
+        Append   = BIT(2),
+        Create   = BIT(3), // create file if it does not exist (requires Write)
+        Truncate = BIT(4), // truncate to zero length on open  (requires Write)
     };
 
     inline VFSOpenFlags operator|(VFSOpenFlags a, VFSOpenFlags b)

--- a/ZEngine/ZEngine/Core/VFS/Meta/MetaFileIO.cpp
+++ b/ZEngine/ZEngine/Core/VFS/Meta/MetaFileIO.cpp
@@ -160,7 +160,7 @@ namespace ZEngine::Core::VFS
             Helpers::secure_memcpy(tmp_buf + copy, MAX_FILE_PATH_COUNT - copy, tmp_suffix, suf_len + 1);
         VFSPath tmp_path    = VFSPath::Parse(tmp_buf).Value();
 
-        auto    open_result = ctx.Open(tmp_path, VFSOpenFlags::Write);
+        auto    open_result = ctx.Open(tmp_path, VFSOpenFlags::Write | VFSOpenFlags::Create | VFSOpenFlags::Truncate);
         if (open_result.Failed())
             return VFSResult<void>::Fail(open_result.Error());
 

--- a/ZEngine/ZEngine/Core/VFS/VFSDiskBackend.cpp
+++ b/ZEngine/ZEngine/Core/VFS/VFSDiskBackend.cpp
@@ -279,7 +279,7 @@ namespace ZEngine::Core::VFS
             return VFSResult<IVFSFile*>::Fail(VFSError::PermissionDenied);
         }
 
-        const bool wants_write = HasFlag(flags, VFSOpenFlags::Write) || HasFlag(flags, VFSOpenFlags::Append);
+        const bool wants_write = HasFlag(flags, VFSOpenFlags::Write) || HasFlag(flags, VFSOpenFlags::Append) || HasFlag(flags, VFSOpenFlags::Create) || HasFlag(flags, VFSOpenFlags::Truncate);
         if (wants_write && !HasCap(m_caps, VFSBackendCaps::Write))
         {
             return VFSResult<IVFSFile*>::Fail(VFSError::PermissionDenied);
@@ -296,9 +296,17 @@ namespace ZEngine::Core::VFS
         file->m_writable  = wants_write;
 
 #if defined(_WIN32)
-        const DWORD access   = GENERIC_READ | (wants_write ? GENERIC_WRITE : 0);
-        const DWORD creation = wants_write ? OPEN_ALWAYS : OPEN_EXISTING;
-        file->m_handle       = CreateFileA(native, access, FILE_SHARE_READ, nullptr, creation, FILE_ATTRIBUTE_NORMAL, nullptr);
+        const DWORD access = GENERIC_READ | (wants_write ? GENERIC_WRITE : 0);
+        DWORD       creation;
+        if (HasFlag(flags, VFSOpenFlags::Create) && HasFlag(flags, VFSOpenFlags::Truncate))
+            creation = CREATE_ALWAYS; // create or truncate
+        else if (HasFlag(flags, VFSOpenFlags::Truncate))
+            creation = TRUNCATE_EXISTING; // truncate must-exist file
+        else if (wants_write || HasFlag(flags, VFSOpenFlags::Create))
+            creation = OPEN_ALWAYS; // create if absent, open if present
+        else
+            creation = OPEN_EXISTING;
+        file->m_handle = CreateFileA(native, access, FILE_SHARE_READ, nullptr, creation, FILE_ATTRIBUTE_NORMAL, nullptr);
         if (file->m_handle == INVALID_HANDLE_VALUE)
         {
             file->~VFSDiskFile();
@@ -312,14 +320,12 @@ namespace ZEngine::Core::VFS
         }
 #else
         int oflags = wants_write ? O_RDWR : O_RDONLY;
-        if (HasFlag(flags, VFSOpenFlags::Write))
-        {
+        if (HasFlag(flags, VFSOpenFlags::Write) || HasFlag(flags, VFSOpenFlags::Create))
             oflags |= O_CREAT;
-        }
+        if (HasFlag(flags, VFSOpenFlags::Truncate))
+            oflags |= O_TRUNC;
         if (HasFlag(flags, VFSOpenFlags::Append))
-        {
             oflags |= O_CREAT | O_APPEND;
-        }
         file->m_fd = ::open(native, oflags, 0644);
         if (file->m_fd < 0)
         {

--- a/ZEngine/ZEngine/Importers/AssetCodec.cpp
+++ b/ZEngine/ZEngine/Importers/AssetCodec.cpp
@@ -377,7 +377,7 @@ namespace ZEngine::Importers::AssetCodec
         secure_memcpy(tmp_buf + copy, MAX_FILE_PATH_COUNT - copy, tmp_suffix, sizeof(tmp_suffix));
         Core::VFS::VFSPath tmp_path    = Core::VFS::VFSPath::Parse(tmp_buf).Value();
 
-        auto               open_result = ctx.Open(tmp_path, Core::VFS::VFSOpenFlags::Write);
+        auto               open_result = ctx.Open(tmp_path, Core::VFS::VFSOpenFlags::Write | Core::VFS::VFSOpenFlags::Create | Core::VFS::VFSOpenFlags::Truncate);
         if (open_result.Failed())
             return Core::VFS::VFSResult<void>::Fail(open_result.Error());
 

--- a/ZEngine/tests/VFS/vfs_disk_test.cpp
+++ b/ZEngine/tests/VFS/vfs_disk_test.cpp
@@ -287,6 +287,48 @@ TEST_F(VFSDiskBackendTest, CapabilitiesAndType)
     EXPECT_STREQ(m_backend.BackendType(), "disk");
 }
 
+TEST_F(VFSDiskBackendTest, OpenWithCreateAndTruncate)
+{
+    const VFSPath path = VFSPath::Parse("/atomic.tmp").Value();
+    ASSERT_FALSE(m_backend.Exists(path));
+
+    // Write | Create — creates a non-existent file and writes content.
+    {
+        VFSResult<IVFSFile*> r = m_backend.Open(path, VFSOpenFlags::Write | VFSOpenFlags::Create);
+        ASSERT_TRUE(r.Succeeded());
+        IVFSFile*         file    = r.Value();
+        cstring           payload = "hello create";
+        const size_t      n       = secure_strlen(payload);
+        VFSResult<size_t> wrote   = file->Write(ArrayView<const uint8_t>(reinterpret_cast<const uint8_t*>(payload), n), 0);
+        EXPECT_TRUE(wrote.Succeeded());
+        EXPECT_EQ(wrote.Value(), n);
+        m_backend.Close(file);
+    }
+
+    // Read back and verify content.
+    {
+        VFSResult<IVFSFile*> r = m_backend.Open(path, VFSOpenFlags::Read);
+        ASSERT_TRUE(r.Succeeded());
+        IVFSFile*         file   = r.Value();
+        Array<uint8_t>    buffer = ReadBuffer(64);
+        VFSResult<size_t> read   = file->Read(ArrayView<uint8_t>(buffer.data(), buffer.size()), 0);
+        ASSERT_TRUE(read.Succeeded());
+        EXPECT_TRUE(BytesEqual(buffer.data(), read.Value(), "hello create"));
+        m_backend.Close(file);
+    }
+
+    // Write | Create | Truncate — reopens and clears the existing file.
+    {
+        VFSResult<IVFSFile*> r = m_backend.Open(path, VFSOpenFlags::Write | VFSOpenFlags::Create | VFSOpenFlags::Truncate);
+        ASSERT_TRUE(r.Succeeded());
+        IVFSFile*           file = r.Value();
+        VFSResult<uint64_t> sz   = file->Size();
+        ASSERT_TRUE(sz.Succeeded());
+        EXPECT_EQ(sz.Value(), 0u);
+        m_backend.Close(file);
+    }
+}
+
 TEST_F(VFSDiskBackendTest, ReadOnlyBackendRejectsWrite)
 {
     VFSDiskBackend read_only;


### PR DESCRIPTION
Closes #607

## What changed

### `IVFSFile.h`
Two new flags added to `VFSOpenFlags`:
```cpp
Create   = BIT(3),  // create file if it does not exist (requires Write)
Truncate = BIT(4),  // truncate to zero length on open  (requires Write)
```

### `VFSDiskBackend::Open()`

**POSIX**
- `Create` → `O_CREAT`; `Truncate` → `O_TRUNC`
- `Write` still implies `O_CREAT` for backward compatibility with existing callers
- `Append` still implies `O_CREAT | O_APPEND` (unchanged)

**Windows**
| Flags | `CreateFileA` disposition |
|---|---|
| `Create \| Truncate` | `CREATE_ALWAYS` |
| `Truncate` only | `TRUNCATE_EXISTING` |
| `Write` or `Create` | `OPEN_ALWAYS` |
| read-only | `OPEN_EXISTING` |

`Create` and `Truncate` are added to the `wants_write` check so they trigger the read-only backend guard and set `m_writable = true`.

### Call sites updated to atomic-write protocol

| File | Old | New |
|---|---|---|
| `MetaFileIO::Write` | `Write` | `Write \| Create \| Truncate` |
| `AssetCodec::SerializeEnvironmentMapFileVFS` | `Write` | `Write \| Create \| Truncate` |
| `ProjectViewUIComponent` | `Write` | `Write \| Create` |

`ProjectViewUIComponent` only needs `Create` — the code guards behind `!Exists()`, so truncation is never needed there.

### New test

`VFSDiskBackendTest.OpenWithCreateAndTruncate`:
1. Opens a non-existent path with `Write | Create` — succeeds, writes "hello create"
2. Reads back and verifies content
3. Reopens with `Write | Create | Truncate` — succeeds; `Size()` returns 0

All 18 `VFSDiskBackendTest` tests pass.