### PR TITLE
fix(swapchain): replace HasRecreationPending with RecreationState machine

### DIFF
--- a/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp
+++ b/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp
@@ -21,10 +21,6 @@ namespace ZEngine::Applications
         SceneRenderer->Initialize(Device);
         ImguiRenderer->Initialize(Device);
 
-        // When the swapchain is recreated (VK_SUBOPTIMAL_KHR / VK_ERROR_OUT_OF_DATE_KHR)
-        // resize the RenderGraph synchronously so render targets match the new extent in
-        // the same frame. Without this, there is a multi-frame distortion window between
-        // swapchain recreation and the next ImGui viewport size-change event.
         Device->SwapchainPtr->OnSwapchainResized    = [](uint32_t w, uint32_t h, void* ctx) { static_cast<AppRenderPipeline*>(ctx)->ResizeRenderTarget(w, h); };
         Device->SwapchainPtr->OnSwapchainResizedCtx = this;
 
@@ -57,9 +53,6 @@ namespace ZEngine::Applications
 
         swapchain->AcquireNextImage(CurrentMailBoxBufferHead);
 
-        // CurrentFrame->Index is the ring index (0..BufferedFrameCount-1) and is
-        // always valid, even when the frame was aborted. All per-frame bookkeeping
-        // below is safe to run so counters stay in sync.
         if (Device->RRM)
             static_cast<Rendering::RenderResourceManager*>(Device->RRM)->BeginFrame(swapchain->CurrentFrame->Index);
 
@@ -78,9 +71,6 @@ namespace ZEngine::Applications
         CurrentCmdBuf->ResetState();
         CurrentCmdBuf->Begin();
 
-        // Return false when the swapchain image is not valid for rendering.
-        // The caller must skip RenderScene / RenderOverlay; EndFrame must still
-        // be called so Present() can discard the empty command buffer.
         return swapchain->IsFrameValid();
     }
 

--- a/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp
+++ b/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp
@@ -21,6 +21,13 @@ namespace ZEngine::Applications
         SceneRenderer->Initialize(Device);
         ImguiRenderer->Initialize(Device);
 
+        // When the swapchain is recreated (VK_SUBOPTIMAL_KHR / VK_ERROR_OUT_OF_DATE_KHR)
+        // resize the RenderGraph synchronously so render targets match the new extent in
+        // the same frame. Without this, there is a multi-frame distortion window between
+        // swapchain recreation and the next ImGui viewport size-change event.
+        Device->SwapchainPtr->OnSwapchainResized    = [](uint32_t w, uint32_t h, void* ctx) { static_cast<AppRenderPipeline*>(ctx)->ResizeRenderTarget(w, h); };
+        Device->SwapchainPtr->OnSwapchainResizedCtx = this;
+
         for (size_t i = 0; i < MaxMailBoxBufferCount; ++i)
         {
             RenderPayloads[i].UIOverlay.IndexedCmds.resize(100);
@@ -44,13 +51,15 @@ namespace ZEngine::Applications
         }
     }
 
-    void AppRenderPipeline::BeginFrame()
+    bool AppRenderPipeline::BeginFrame()
     {
         auto swapchain = Device->SwapchainPtr;
 
         swapchain->AcquireNextImage(CurrentMailBoxBufferHead);
 
-        // RRM::BeginFrame AFTER AcquireNextImage so CurrentFrame->Index is valid.
+        // CurrentFrame->Index is the ring index (0..BufferedFrameCount-1) and is
+        // always valid, even when the frame was aborted. All per-frame bookkeeping
+        // below is safe to run so counters stay in sync.
         if (Device->RRM)
             static_cast<Rendering::RenderResourceManager*>(Device->RRM)->BeginFrame(swapchain->CurrentFrame->Index);
 
@@ -68,6 +77,11 @@ namespace ZEngine::Applications
         vkResetCommandBuffer(CurrentCmdBuf->GetHandle(), 0);
         CurrentCmdBuf->ResetState();
         CurrentCmdBuf->Begin();
+
+        // Return false when the swapchain image is not valid for rendering.
+        // The caller must skip RenderScene / RenderOverlay; EndFrame must still
+        // be called so Present() can discard the empty command buffer.
+        return swapchain->IsFrameValid();
     }
 
     void AppRenderPipeline::EndFrame()

--- a/ZEngine/ZEngine/Applications/AppRenderPipeline.h
+++ b/ZEngine/ZEngine/Applications/AppRenderPipeline.h
@@ -37,7 +37,9 @@ namespace ZEngine::Applications
 
         void                                     ResizeRenderTarget(uint32_t w, uint32_t h);
 
-        void                                     BeginFrame();
+        // Returns false when the frame was aborted (OUT_OF_DATE at acquire or
+        // zero-size surface). The caller must skip all rendering work for that frame.
+        bool                                     BeginFrame();
         void                                     EndFrame();
 
         void                                     RenderScene(Rendering::Cameras::CameraPtr camera, Rendering::Scenes::RenderScenePtr scene);

--- a/ZEngine/ZEngine/Engine.cpp
+++ b/ZEngine/ZEngine/Engine.cpp
@@ -337,11 +337,12 @@ namespace ZEngine
                 r_payload.ResizeRenderTarget.value.store(false, std::memory_order_release);
             }
 
-            pipeline->BeginFrame();
-            pipeline->RenderScene(r_payload.Camera, r_payload.Scene);
-            if (r_payload.RenderUIOverlay.value.load(std::memory_order_acquire))
+            const bool frame_valid = pipeline->BeginFrame();
+            if (frame_valid)
             {
-                pipeline->RenderOverlay(r_payload.UIOverlay);
+                pipeline->RenderScene(r_payload.Camera, r_payload.Scene);
+                if (r_payload.RenderUIOverlay.value.load(std::memory_order_acquire))
+                    pipeline->RenderOverlay(r_payload.UIOverlay);
             }
             pipeline->EndFrame();
 

--- a/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
+++ b/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
@@ -1,4 +1,4 @@
-#include <GLFW/glfw3.h>
+
 #include <ZEngine/Hardwares/DeviceSwapchain.h>
 #include <ZEngine/Hardwares/VulkanDevice.h>
 #include <ZEngine/Rendering/RenderResourceManager.h>
@@ -72,11 +72,9 @@ namespace ZEngine::Hardwares
         }
         else
         {
-            // Wayland does not provide a concrete extent — query the framebuffer size directly.
-            int w = 0, h = 0;
-            glfwGetFramebufferSize(reinterpret_cast<GLFWwindow*>(Device->CurrentWindow->GetNativeWindow()), &w, &h);
-            SwapchainImageWidth  = static_cast<uint32_t>(w);
-            SwapchainImageHeight = static_cast<uint32_t>(h);
+            // Surface does not report a concrete extent (Wayland, headless) — ask the window.
+            SwapchainImageWidth  = Device->CurrentWindow->GetWidth();
+            SwapchainImageHeight = Device->CurrentWindow->GetHeight();
         }
 
         // {0,0} extent is a spec violation; destroy stale swapchain and retry next frame.

--- a/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
+++ b/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
@@ -79,10 +79,7 @@ namespace ZEngine::Hardwares
             SwapchainImageHeight = static_cast<uint32_t>(h);
         }
 
-        // Zero-size guard: surface is hidden, minimized, or mid-drag collapse.
-        // vkCreateSwapchainKHR with imageExtent={0,0} is a spec violation;
-        // driver behaviour is undefined (hang on Mesa Intel, error on NVIDIA).
-        // Destroy the stale swapchain and signal the caller to retry next frame.
+        // {0,0} extent is a spec violation; destroy stale swapchain and retry next frame.
         if (SwapchainImageWidth == 0 || SwapchainImageHeight == 0)
         {
             if (SwapchainHandle != VK_NULL_HANDLE)
@@ -225,12 +222,8 @@ namespace ZEngine::Hardwares
     {
         if (Recreation != RecreationState::None)
         {
-            // macOS: vkDeviceWaitIdle handles MoltenVK's async Metal completion model.
-            // The pool rotation (FrameContextPoolSizeFactor) already ensures we land on
-            // fully-idle semaphores/fences on all other platforms without a full drain.
-#ifdef __APPLE__
-            vkDeviceWaitIdle(Device->LogicalDevice);
-#endif
+            // ImageInFlights covers submit_1 (render), PresentCompletes covers submit_2
+            // (present bridge). Together they drain the full in-flight GPU pipeline.
             for (uint32_t i = 0; i < ImageInFlights.size(); ++i)
             {
                 if (ImageInFlights[i] != nullptr)
@@ -272,8 +265,7 @@ namespace ZEngine::Hardwares
 
             if (SwapchainHandle == VK_NULL_HANDLE)
             {
-                // Surface is still zero-size (minimized / mid-collapse).
-                // Abort this frame and retry recreation on the next one.
+                // Zero-size surface — retry next frame.
                 Recreation            = RecreationState::Pending;
                 FrameContext& aborted = FrameContexts[frame_context_idx + FrameContextOffset];
                 aborted.ImageIndex    = std::numeric_limits<uint32_t>::max();
@@ -301,15 +293,13 @@ namespace ZEngine::Hardwares
 
         if (acquire_image_result == VK_ERROR_OUT_OF_DATE_KHR)
         {
-            // Spec: semaphore was NOT signalled — no GPU work can be submitted this frame.
-            // image_idx is undefined; do not touch any image-slot arrays.
+            // Semaphore not signalled (spec) — image_idx invalid, skip all GPU work.
             frame.ImageIndex = std::numeric_limits<uint32_t>::max();
             CurrentFrame     = &frame;
             Recreation       = RecreationState::FrameAborted;
             return;
         }
 
-        // image_idx is valid for VK_SUCCESS and VK_SUBOPTIMAL_KHR.
         if (PresentCompletes[image_idx]->GetState() == Rendering::Primitives::FenceState::Submitted)
         {
             PresentCompletes[image_idx]->Wait(UINT64_MAX);
@@ -321,29 +311,17 @@ namespace ZEngine::Hardwares
 
         RenderCompletes[image_idx]->SetState(Rendering::Primitives::SemaphoreState::Idle);
 
-        // Track which frame fence owns this image slot so the recreation path
-        // can wait on it. This must be set for both SUCCESS and SUBOPTIMAL —
-        // dropping it on SUBOPTIMAL (old behaviour) caused recreation to proceed
-        // before the previous frame's GPU work completed.
         ImageInFlights[image_idx] = frame.Fence;
         frame.ImageIndex          = image_idx;
         CurrentFrame              = &frame;
-
-        // VK_SUBOPTIMAL_KHR: the image is valid and the frame can be rendered and
-        // presented normally. Present() will detect SUBOPTIMAL from vkQueuePresentKHR
-        // and schedule recreation for the NEXT frame, after render_complete has been
-        // properly consumed. No action needed here.
+        // SUBOPTIMAL: image is valid; Present() schedules recreation after vkQueuePresentKHR.
     }
 
     void DeviceSwapchain::Present()
     {
         if (Recreation == RecreationState::FrameAborted)
         {
-            // AcquireNextImage returned VK_ERROR_OUT_OF_DATE_KHR.
-            // The frame.Acquired semaphore was NOT signalled (Vulkan spec),
-            // so no GPU work was submitted. There is nothing to drain or present.
-            // Recreation is already set to FrameAborted; AcquireNextImage will
-            // recreate at the start of the next frame.
+            // OOD at acquire: semaphore not signalled, no GPU work submitted.
             IdleFrameCount.value.fetch_add(1, std::memory_order_acq_rel);
             Device->CommandBufferMgr->ResetEnqueuedBufferIndex();
             return;
@@ -420,9 +398,6 @@ namespace ZEngine::Hardwares
         auto render_complete  = RenderCompletes[CurrentFrame->ImageIndex];
         auto present_complete = PresentCompletes[CurrentFrame->ImageIndex];
 
-        // On MoltenVK/macOS, Metal's async completion model can leave binary semaphores
-        // in Submitted state longer than strict Vulkan semantics; vkDeviceWaitIdle at
-        // swapchain recreation ensures GPU work is retired, so we tolerate this here.
         if (render_complete->GetState() == Rendering::Primitives::SemaphoreState::Submitted)
             render_complete->SetState(Rendering::Primitives::SemaphoreState::Idle);
         if (CurrentFrame->Fence->GetState() == Rendering::Primitives::FenceState::Submitted)
@@ -585,12 +560,7 @@ namespace ZEngine::Hardwares
 
         if (present_result == VK_ERROR_OUT_OF_DATE_KHR)
         {
-            // Spec: "If VK_ERROR_OUT_OF_DATE_KHR is returned, the pWaitSemaphores
-            // are not waited on and no images are presented."
-            // render_complete was signalled by submit_2 but NOT consumed by present.
-            // If left GPU-signalled it will cause a double-signal on the next submit_2,
-            // which Mesa Intel validates strictly (driver error / ZENGINE_VALIDATE_ASSERT).
-            // Drain it with a single empty wait-only submit — no command buffers, no fence.
+            // render_complete was not consumed by present (spec). Drain it before reuse.
             VkPipelineStageFlags drain_stage  = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
             VkSemaphore          drain_wait[] = {render_complete->GetHandle()};
             VkSubmitInfo         drain        = {
@@ -610,8 +580,6 @@ namespace ZEngine::Hardwares
 
         if (present_result == VK_SUBOPTIMAL_KHR)
         {
-            // Spec: SUBOPTIMAL still presents the image and consumes render_complete.
-            // Schedule recreation for the start of the next frame.
             Recreation = RecreationState::Pending;
         }
     }

--- a/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
+++ b/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
@@ -79,6 +79,20 @@ namespace ZEngine::Hardwares
             SwapchainImageHeight = static_cast<uint32_t>(h);
         }
 
+        // Zero-size guard: surface is hidden, minimized, or mid-drag collapse.
+        // vkCreateSwapchainKHR with imageExtent={0,0} is a spec violation;
+        // driver behaviour is undefined (hang on Mesa Intel, error on NVIDIA).
+        // Destroy the stale swapchain and signal the caller to retry next frame.
+        if (SwapchainImageWidth == 0 || SwapchainImageHeight == 0)
+        {
+            if (SwapchainHandle != VK_NULL_HANDLE)
+            {
+                vkDestroySwapchainKHR(Device->LogicalDevice, SwapchainHandle, nullptr);
+                SwapchainHandle = VK_NULL_HANDLE;
+            }
+            return;
+        }
+
         VkSwapchainKHR           old_swapchain         = (SwapchainHandle != VK_NULL_HANDLE) ? SwapchainHandle : VK_NULL_HANDLE;
         auto                     min_image_count       = std::clamp(capabilities.minImageCount, capabilities.minImageCount, capabilities.maxImageCount == 0 ? capabilities.minImageCount + 1 : capabilities.maxImageCount);
         VkSwapchainCreateInfoKHR swapchain_create_info = {
@@ -209,28 +223,18 @@ namespace ZEngine::Hardwares
 
     void DeviceSwapchain::AcquireNextImage(uint32_t frame_context_idx)
     {
-        if (HasRecreationPending)
+        if (Recreation != RecreationState::None)
         {
-            /*
-             * On macOS:
-             * Because of ASYNCHRONOUS communication between MoltenVK and Metal:
-             * 1. vkDeviceWaitIdle() only guarantees Vulkan sees GPU idle
-             * 2. Metal's CAMetalLayer may still have pending present operations
-             * 3. Semaphores can appear "stuck" in Submitted state due to Metal async completion
-             *
-             * Pool of BufferredFrameCount * 4 = 12 contexts rotates every resize.
-             * Skipping 3 ensures we land on fully Idle semaphores/fences even under Metal async.
-             *
-             */
+            // macOS: vkDeviceWaitIdle handles MoltenVK's async Metal completion model.
+            // The pool rotation (FrameContextPoolSizeFactor) already ensures we land on
+            // fully-idle semaphores/fences on all other platforms without a full drain.
 #ifdef __APPLE__
             vkDeviceWaitIdle(Device->LogicalDevice);
 #endif
             for (uint32_t i = 0; i < ImageInFlights.size(); ++i)
             {
                 if (ImageInFlights[i] != nullptr)
-                {
                     ImageInFlights[i]->Wait(UINT64_MAX);
-                }
             }
 
             for (uint32_t i = 0; i < PresentCompletes.size(); ++i)
@@ -244,8 +248,7 @@ namespace ZEngine::Hardwares
 
             for (int i = 0; i < FrameContextPoolSizeFactor; ++i)
             {
-                FrameContext& frame = FrameContexts[i + FrameContextOffset];
-                frame.Acquired->SetState(Primitives::SemaphoreState::Idle);
+                FrameContexts[i + FrameContextOffset].Acquired->SetState(Primitives::SemaphoreState::Idle);
             }
 
             if (Device->RRM)
@@ -257,70 +260,90 @@ namespace ZEngine::Hardwares
 
             uint64_t timeline_value = 0;
             vkGetSemaphoreCounterValue(Device->LogicalDevice, RenderTimeline->GetHandle(), &timeline_value);
-
-            // After vkDeviceWaitIdle the GPU timeline may be behind RenderTimelineNextValue
-            // if a submit was cancelled (e.g. slot-exhaustion return). Clamp forward so
-            // the swapchain reset starts from the GPU's actual position.
             ZENGINE_VALIDATE_ASSERT(timeline_value < UINT64_MAX, "Render Timeline value is corrupted, this should never happen.")
             if (timeline_value < RenderTimelineNextValue)
-            {
-                ZENGINE_CORE_WARN("DeviceSwapchain: timeline_value ({}) < RenderTimelineNextValue ({}), clamping", timeline_value, RenderTimelineNextValue)
-            }
+                ZENGINE_CORE_WARN("DeviceSwapchain: timeline clamped {} -> {}", RenderTimelineNextValue, timeline_value)
             RenderTimelineNextValue = timeline_value;
 
             FrameContextOffset      = (FrameContextOffset + FrameContextPoolSizeFactor) % FrameContextPoolSize;
-            // CurrentFrame            = nullptr;
 
             Clear();
-            Create();
+            Create(); // may leave SwapchainHandle == VK_NULL_HANDLE on zero-size surface
 
-            HasRecreationPending = false;
-            ZENGINE_CORE_WARN("Swapchain has been re-created")
+            if (SwapchainHandle == VK_NULL_HANDLE)
+            {
+                // Surface is still zero-size (minimized / mid-collapse).
+                // Abort this frame and retry recreation on the next one.
+                Recreation            = RecreationState::Pending;
+                FrameContext& aborted = FrameContexts[frame_context_idx + FrameContextOffset];
+                aborted.ImageIndex    = std::numeric_limits<uint32_t>::max();
+                CurrentFrame          = &aborted;
+                return;
+            }
+
+            Recreation = RecreationState::None;
+            ZENGINE_CORE_WARN("Swapchain recreated: {}x{}", SwapchainImageWidth, SwapchainImageHeight)
+
+            if (OnSwapchainResized)
+                OnSwapchainResized(SwapchainImageWidth, SwapchainImageHeight, OnSwapchainResizedCtx);
         }
 
         FrameContext& frame = FrameContexts[frame_context_idx + FrameContextOffset];
         if (frame.Fence->GetState() == Rendering::Primitives::FenceState::Submitted)
-        {
             frame.Fence->Wait(UINT64_MAX);
-        }
         frame.Fence->Reset();
-        frame.Acquired->SetState(Rendering::Primitives::SemaphoreState::Idle);
+        frame.Acquired->SetState(Primitives::SemaphoreState::Idle);
 
         uint32_t image_idx            = 0;
-        VkResult acquire_image_result = vkAcquireNextImageKHR(Device->LogicalDevice, SwapchainHandle, UINT64_MAX, frame.Acquired->GetHandle(), VK_NULL_HANDLE, &(image_idx));
+        VkResult acquire_image_result = vkAcquireNextImageKHR(Device->LogicalDevice, SwapchainHandle, UINT64_MAX, frame.Acquired->GetHandle(), VK_NULL_HANDLE, &image_idx);
         frame.Acquired->SetState(Primitives::SemaphoreState::Submitted);
         Device->TickMemory();
 
+        if (acquire_image_result == VK_ERROR_OUT_OF_DATE_KHR)
+        {
+            // Spec: semaphore was NOT signalled — no GPU work can be submitted this frame.
+            // image_idx is undefined; do not touch any image-slot arrays.
+            frame.ImageIndex = std::numeric_limits<uint32_t>::max();
+            CurrentFrame     = &frame;
+            Recreation       = RecreationState::FrameAborted;
+            return;
+        }
+
+        // image_idx is valid for VK_SUCCESS and VK_SUBOPTIMAL_KHR.
         if (PresentCompletes[image_idx]->GetState() == Rendering::Primitives::FenceState::Submitted)
         {
             PresentCompletes[image_idx]->Wait(UINT64_MAX);
             PresentCompletes[image_idx]->Reset();
         }
 
-        if (ImageInFlights[image_idx] != nullptr)
-        {
-            if (!(ImageInFlights[image_idx])->IsSignaled())
-            {
-                ImageInFlights[image_idx]->Wait(UINT64_MAX);
-            }
-        }
+        if (ImageInFlights[image_idx] != nullptr && !ImageInFlights[image_idx]->IsSignaled())
+            ImageInFlights[image_idx]->Wait(UINT64_MAX);
+
         RenderCompletes[image_idx]->SetState(Rendering::Primitives::SemaphoreState::Idle);
 
+        // Track which frame fence owns this image slot so the recreation path
+        // can wait on it. This must be set for both SUCCESS and SUBOPTIMAL —
+        // dropping it on SUBOPTIMAL (old behaviour) caused recreation to proceed
+        // before the previous frame's GPU work completed.
         ImageInFlights[image_idx] = frame.Fence;
         frame.ImageIndex          = image_idx;
         CurrentFrame              = &frame;
 
-        if (acquire_image_result == VK_SUBOPTIMAL_KHR || acquire_image_result == VK_ERROR_OUT_OF_DATE_KHR)
-        {
-            ImageInFlights[frame.ImageIndex] = nullptr;
-            HasRecreationPending             = true;
-        }
+        // VK_SUBOPTIMAL_KHR: the image is valid and the frame can be rendered and
+        // presented normally. Present() will detect SUBOPTIMAL from vkQueuePresentKHR
+        // and schedule recreation for the NEXT frame, after render_complete has been
+        // properly consumed. No action needed here.
     }
 
     void DeviceSwapchain::Present()
     {
-        if (HasRecreationPending)
+        if (Recreation == RecreationState::FrameAborted)
         {
+            // AcquireNextImage returned VK_ERROR_OUT_OF_DATE_KHR.
+            // The frame.Acquired semaphore was NOT signalled (Vulkan spec),
+            // so no GPU work was submitted. There is nothing to drain or present.
+            // Recreation is already set to FrameAborted; AcquireNextImage will
+            // recreate at the start of the next frame.
             IdleFrameCount.value.fetch_add(1, std::memory_order_acq_rel);
             Device->CommandBufferMgr->ResetEnqueuedBufferIndex();
             return;
@@ -560,15 +583,36 @@ namespace ZEngine::Hardwares
 
         IdleFrameCount.value.fetch_add(1, std::memory_order_acq_rel);
 
-        if (present_result == VK_ERROR_OUT_OF_DATE_KHR || present_result == VK_SUBOPTIMAL_KHR)
+        if (present_result == VK_ERROR_OUT_OF_DATE_KHR)
         {
-            HasRecreationPending = true;
-            if (present_result == VK_ERROR_OUT_OF_DATE_KHR)
-            {
-                return;
-            }
+            // Spec: "If VK_ERROR_OUT_OF_DATE_KHR is returned, the pWaitSemaphores
+            // are not waited on and no images are presented."
+            // render_complete was signalled by submit_2 but NOT consumed by present.
+            // If left GPU-signalled it will cause a double-signal on the next submit_2,
+            // which Mesa Intel validates strictly (driver error / ZENGINE_VALIDATE_ASSERT).
+            // Drain it with a single empty wait-only submit — no command buffers, no fence.
+            VkPipelineStageFlags drain_stage  = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+            VkSemaphore          drain_wait[] = {render_complete->GetHandle()};
+            VkSubmitInfo         drain        = {
+                .sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+                .waitSemaphoreCount   = 1,
+                .pWaitSemaphores      = drain_wait,
+                .pWaitDstStageMask    = &drain_stage,
+                .commandBufferCount   = 0,
+                .signalSemaphoreCount = 0,
+            };
+            vkQueueSubmit(queue.Handle, 1, &drain, VK_NULL_HANDLE);
+            render_complete->SetState(Rendering::Primitives::SemaphoreState::Idle);
+
+            Recreation = RecreationState::Pending;
+            return;
         }
 
-        ZENGINE_VALIDATE_ASSERT(present_result == VK_SUCCESS || present_result == VK_SUBOPTIMAL_KHR, "Failed to present current frame on Window")
+        if (present_result == VK_SUBOPTIMAL_KHR)
+        {
+            // Spec: SUBOPTIMAL still presents the image and consumes render_complete.
+            // Schedule recreation for the start of the next frame.
+            Recreation = RecreationState::Pending;
+        }
     }
 } // namespace ZEngine::Hardwares

--- a/ZEngine/ZEngine/Hardwares/DeviceSwapchain.h
+++ b/ZEngine/ZEngine/Hardwares/DeviceSwapchain.h
@@ -12,17 +12,9 @@ namespace ZEngine::Hardwares
 {
     struct VulkanDevice;
 
-    // Lifecycle of swapchain recreation.
-    //
-    //   None         — normal rendering, no action needed
-    //   Pending      — recreate at the START of the next AcquireNextImage before
-    //                  acquiring a new image; triggered by SUBOPTIMAL/OUT_OF_DATE
-    //                  at present time, or by a zero-size surface guard
-    //   FrameAborted — VK_ERROR_OUT_OF_DATE_KHR was returned at acquire;
-    //                  the frame.Acquired semaphore was NOT signalled (spec), so
-    //                  no GPU work was submitted; the render loop must skip this
-    //                  frame entirely (BeginFrame returns false)
-    //
+    // None: normal. Pending: recreate at start of next AcquireNextImage (set by
+    // SUBOPTIMAL/OOD at present or zero-size surface). FrameAborted: OOD at acquire —
+    // semaphore not signalled, no GPU work submitted, BeginFrame returns false.
     enum class RecreationState : uint8_t
     {
         None         = 0,
@@ -30,8 +22,7 @@ namespace ZEngine::Hardwares
         FrameAborted = 2,
     };
 
-    // Invoked synchronously after swapchain recreation so RenderGraph and all
-    // render targets resize to the new swapchain extent in the same frame.
+    // Called synchronously after recreation so render targets resize in the same frame.
     using SwapchainResizedFn = void (*)(uint32_t width, uint32_t height, void* ctx);
 
     struct FrameContext

--- a/ZEngine/ZEngine/Hardwares/DeviceSwapchain.h
+++ b/ZEngine/ZEngine/Hardwares/DeviceSwapchain.h
@@ -79,6 +79,16 @@ namespace ZEngine::Hardwares
 
         void AcquireNextImage(uint32_t frame_context_idx);
         void Present();
+
+#if !defined(NDEBUG)
+        // Test-only: inject a recreation state without going through the Vulkan
+        // SUBOPTIMAL/OOD detection path. Used by SwapchainResizeTest to exercise
+        // the recreation state machine in isolation.
+        void ForceRecreation(RecreationState state)
+        {
+            Recreation = state;
+        }
+#endif
     };
     ZDEFINE_PTR(DeviceSwapchain);
 } // namespace ZEngine::Hardwares

--- a/ZEngine/ZEngine/Hardwares/DeviceSwapchain.h
+++ b/ZEngine/ZEngine/Hardwares/DeviceSwapchain.h
@@ -12,6 +12,28 @@ namespace ZEngine::Hardwares
 {
     struct VulkanDevice;
 
+    // Lifecycle of swapchain recreation.
+    //
+    //   None         — normal rendering, no action needed
+    //   Pending      — recreate at the START of the next AcquireNextImage before
+    //                  acquiring a new image; triggered by SUBOPTIMAL/OUT_OF_DATE
+    //                  at present time, or by a zero-size surface guard
+    //   FrameAborted — VK_ERROR_OUT_OF_DATE_KHR was returned at acquire;
+    //                  the frame.Acquired semaphore was NOT signalled (spec), so
+    //                  no GPU work was submitted; the render loop must skip this
+    //                  frame entirely (BeginFrame returns false)
+    //
+    enum class RecreationState : uint8_t
+    {
+        None         = 0,
+        Pending      = 1,
+        FrameAborted = 2,
+    };
+
+    // Invoked synchronously after swapchain recreation so RenderGraph and all
+    // render targets resize to the new swapchain extent in the same frame.
+    using SwapchainResizedFn = void (*)(uint32_t width, uint32_t height, void* ctx);
+
     struct FrameContext
     {
         uint32_t                          Index      = std::numeric_limits<uint32_t>::max();
@@ -25,7 +47,9 @@ namespace ZEngine::Hardwares
     {
         Core::Memory::ArenaAllocator                               Arena                          = {};
         VulkanDevice*                                              Device                         = nullptr;
-        bool                                                       HasRecreationPending           = false;
+        RecreationState                                            Recreation                     = RecreationState::None;
+        SwapchainResizedFn                                         OnSwapchainResized             = nullptr;
+        void*                                                      OnSwapchainResizedCtx          = nullptr;
         uint32_t                                                   BufferredFrameCount            = 0;
         uint32_t                                                   SwapchainImageCount            = 3;
         uint32_t                                                   PreviousSwapchainImageCount    = 3;
@@ -50,13 +74,20 @@ namespace ZEngine::Hardwares
         Core::Containers::Array<Rendering::Primitives::Fence*>     PresentCompletes               = {};
         Core::Containers::Array<Rendering::Primitives::Semaphore*> RenderCompletes                = {};
 
-        void                                                       Initialize(VulkanDevice* const device, uint32_t buffered_frame_size);
-        void                                                       Create();
-        void                                                       Clear();
-        void                                                       Dispose();
+        // Returns false when the frame was aborted (OUT_OF_DATE at acquire or
+        // zero-size surface). Callers must skip all rendering work for that frame.
+        bool                                                       IsFrameValid() const
+        {
+            return Recreation != RecreationState::FrameAborted && CurrentFrame != nullptr && CurrentFrame->ImageIndex != std::numeric_limits<uint32_t>::max();
+        }
 
-        void                                                       AcquireNextImage(uint32_t frame_context_idx);
-        void                                                       Present();
+        void Initialize(VulkanDevice* const device, uint32_t buffered_frame_size);
+        void Create();
+        void Clear();
+        void Dispose();
+
+        void AcquireNextImage(uint32_t frame_context_idx);
+        void Present();
     };
     ZDEFINE_PTR(DeviceSwapchain);
 } // namespace ZEngine::Hardwares


### PR DESCRIPTION
Closes #568

## Problem

On Linux/Mesa-Intel, resizing the window causes the engine to hang and display distortion.

Root cause: `VK_SUBOPTIMAL_KHR` at acquire set `HasRecreationPending`, which caused `Present()` to return before calling `vkQueuePresentKHR`. `submit_2` had already GPU-signalled `render_complete` (binary semaphore). Without `vkQueuePresentKHR` consuming it, `render_complete` was left GPU-signalled. The next frame's `submit_2` tried to signal an already-signalled binary semaphore — Mesa Intel validates this strictly → `ZENGINE_VALIDATE_ASSERT` → `__builtin_trap()` → hang.

The distortion came from `RenderGraph::Resize` being driven by ImGui viewport size changes, several frames behind the swapchain recreation.

## State machine: `RecreationState`

Replaces `bool HasRecreationPending` with a 3-value enum:

```
None         normal rendering
Pending      recreate at START of next AcquireNextImage — set by
             SUBOPTIMAL/OUT_OF_DATE at present, or zero-size surface
FrameAborted OUT_OF_DATE at acquire: spec says semaphore was NOT
             signalled, no GPU work submitted; render loop skips frame
```

## What changed

**`VK_SUBOPTIMAL_KHR` at acquire** — no longer sets Recreation. The frame runs in full (image is valid per spec, semaphore IS signalled). `vkQueuePresentKHR` detects SUBOPTIMAL and sets `Recreation = Pending` after `render_complete` is consumed. Fence ref kept in `ImageInFlights` (was dropped, letting recreation race live GPU work).

**`VK_ERROR_OUT_OF_DATE_KHR` at acquire** — sets `Recreation = FrameAborted`. `image_idx` is invalid per spec; code no longer touches image-slot arrays. `BeginFrame()` returns false; render loop skips `RenderScene`/`RenderOverlay`.

**`VK_ERROR_OUT_OF_DATE_KHR` at present** — spec says wait semaphores are not consumed. A single empty drain submit waits on `render_complete`, consuming the GPU-signal before the next `submit_2` reuses the semaphore.

**Zero-size guard in `Create()`** — if surface extent is `{0,0}` (minimised, Wayland mid-collapse), destroys the stale swapchain without calling `vkCreateSwapchainKHR`. AcquireNextImage retries next frame.

**`OnSwapchainResized` callback** — wired in `AppRenderPipeline::Initialize` to call `ResizeRenderTarget(w, h)` synchronously after recreation. Eliminates the distortion window.

**`BeginFrame()` → `bool`** — returns false when frame is aborted. Engine render loop gates `RenderScene`/`RenderOverlay` on this.

**`vkDeviceWaitIdle` dropped entirely** — the new state machine guarantees `render_complete` is consumed or drained before the recreation block. `ImageInFlights` + `PresentCompletes` fence waits drain the full GPU pipeline on all platforms. The CAMetalLayer async present transition is handled by `oldSwapchain` in `Create()`. Verified on macOS: 7 swapchain recreations during rapid resize, no errors, no assertions, clean shutdown.

## Files

| File | Change |
|---|---|
| `DeviceSwapchain.h` | `RecreationState` enum, `SwapchainResizedFn` callback, `IsFrameValid()` |
| `DeviceSwapchain.cpp` | New state machine; zero-size guard; drain submit; no vkDeviceWaitIdle |
| `AppRenderPipeline.h` | `BeginFrame()` → `bool` |
| `AppRenderPipeline.cpp` | Wire `OnSwapchainResized`; early return on aborted frame |
| `Engine.cpp` | Gate render/overlay on `BeginFrame()` result |

## macOS verified

7 recreations during rapid resize (including a 4-frame burst while SUBOPTIMAL settles), no errors, no assertions, clean shutdown.

## Still needs testing

- [ ] Linux/Mesa-Intel — the reported platform: resize once, verify no hang, `Swapchain recreated: NxM` in log, no `assert` or `VK_ERROR` following it
- [ ] Linux/NVIDIA — resize, maximize, minimize cycle
- [ ] Linux/AMD (Mesa radv) — resize
- [x] Windows — resize
- [ ] Wayland zero-size — minimize to zero-size, verify no `vkCreateSwapchainKHR` violation