### PR TITLE
fix(crashhandler): copy SignalOrException into struct buffer

### DIFF
--- a/ZEngine/ZEngine/CrashHandlers/CrashHandlerLinux.cpp
+++ b/ZEngine/ZEngine/CrashHandlers/CrashHandlerLinux.cpp
@@ -30,12 +30,12 @@ namespace ZEngine::CrashHandlers
 
     struct WorkerThreadParams
     {
-        int     SignalNumber                        = 0;
-        cstring SignalOrException                   = nullptr;
-        void*   BacktraceAddrs[kMaxBacktraceFrames] = {};
-        int     BacktraceSize                       = 0;
-        char    LogPath[kMaxPathLen]                = {};
-        bool    BacktraceFromSignal                 = false;
+        int   SignalNumber                        = 0;
+        char  SignalOrException[512]              = {};
+        void* BacktraceAddrs[kMaxBacktraceFrames] = {};
+        int   BacktraceSize                       = 0;
+        char  LogPath[kMaxPathLen]                = {};
+        bool  BacktraceFromSignal                 = false;
     };
 
     static constexpr size_t   kAltStackSize            = 32 * 1024;
@@ -736,8 +736,8 @@ namespace ZEngine::CrashHandlers
 
     static void SignalHandler(int sig, siginfo_t* /*info*/, void* ctx)
     {
-        s_crash_params.SignalNumber        = sig;
-        s_crash_params.SignalOrException   = SignalToString(sig);
+        s_crash_params.SignalNumber = sig;
+        snprintf(s_crash_params.SignalOrException, sizeof(s_crash_params.SignalOrException), "%s", SignalToString(sig));
 
         // Capture the crashing thread's backtrace here, in the signal handler,
         // where the crashing thread's stack is live.  The worker thread's stack
@@ -852,10 +852,10 @@ namespace ZEngine::CrashHandlers
         // Capture the call-site stack here, on the calling thread, before waking
         // the worker.  BacktraceFromSignal stays false so the worker skips its own
         // (meaningless) backtrace and uses these addresses instead.
-        s_crash_params.BacktraceSize     = backtrace(s_crash_params.BacktraceAddrs, kMaxBacktraceFrames);
+        s_crash_params.BacktraceSize = backtrace(s_crash_params.BacktraceAddrs, kMaxBacktraceFrames);
 
-        s_crash_params.SignalOrException = signal_or_exception;
-        uint8_t byte                     = 1;
+        snprintf(s_crash_params.SignalOrException, sizeof(s_crash_params.SignalOrException), "%s", signal_or_exception ? signal_or_exception : "");
+        uint8_t byte = 1;
         write(s_crash_pipe[1], &byte, 1);
         pthread_join(s_worker_thread, nullptr);
         _exit(EXIT_FAILURE);

--- a/ZEngine/ZEngine/CrashHandlers/CrashHandlerMacOS.mm
+++ b/ZEngine/ZEngine/CrashHandlers/CrashHandlerMacOS.mm
@@ -319,7 +319,7 @@ namespace ZEngine::CrashHandlers
     struct WorkerThreadParams
     {
         int         SignalNumber                        = 0;
-        cstring     SignalOrException                   = nullptr;
+        char        SignalOrException[512]              = {};
         void*       BacktraceAddrs[kMaxBacktraceFrames] = {};
         int         BacktraceSize                       = 0;
         char        LogPath[kMaxPathLen]                = {};
@@ -604,7 +604,7 @@ namespace ZEngine::CrashHandlers
     static void SignalHandler(int sig, siginfo_t* /*info*/, void* ctx)
     {
         s_crash_params.SignalNumber      = sig;
-        s_crash_params.SignalOrException = SignalToString(sig);
+        snprintf(s_crash_params.SignalOrException, sizeof(s_crash_params.SignalOrException), "%s", SignalToString(sig));
 
         s_crash_params.BacktraceSize       = backtrace(s_crash_params.BacktraceAddrs, kMaxBacktraceFrames);
         s_crash_params.BacktraceFromSignal = true;
@@ -716,8 +716,8 @@ namespace ZEngine::CrashHandlers
         // (meaningless) backtrace and uses these addresses instead.
         s_crash_params.BacktraceSize = backtrace(s_crash_params.BacktraceAddrs, kMaxBacktraceFrames);
 
-        s_crash_params.SignalOrException = signal_or_exception;
-        uint8_t byte                     = 1;
+        snprintf(s_crash_params.SignalOrException, sizeof(s_crash_params.SignalOrException), "%s", signal_or_exception ? signal_or_exception : "");
+        uint8_t byte = 1;
         write(s_crash_pipe[1], &byte, 1);
         // Pump the main run loop so the dispatch_sync block posted by the
         // worker thread (which shows the Cocoa dialog) can execute here on

--- a/ZEngine/ZEngine/CrashHandlers/CrashHandlerWindows.cpp
+++ b/ZEngine/ZEngine/CrashHandlers/CrashHandlerWindows.cpp
@@ -22,12 +22,12 @@ namespace ZEngine::CrashHandlers
 
     struct WorkerThreadParams
     {
-        DWORD               FaultedThreadId       = 0;
-        HANDLE              FaultedThreadHandle   = nullptr;
-        cstring             SignalOrException     = nullptr;
-        EXCEPTION_POINTERS* ExceptionInfo         = nullptr;
-        char                LogPath[kMaxPathLen]  = {0};
-        char                DumpPath[kMaxPathLen] = {0};
+        DWORD               FaultedThreadId        = 0;
+        HANDLE              FaultedThreadHandle    = nullptr;
+        char                SignalOrException[512] = {};
+        EXCEPTION_POINTERS* ExceptionInfo          = nullptr;
+        char                LogPath[kMaxPathLen]   = {0};
+        char                DumpPath[kMaxPathLen]  = {0};
     };
 
     enum : int
@@ -848,9 +848,9 @@ namespace ZEngine::CrashHandlers
         }
 
         WorkerThreadParams params;
-        params.SignalOrException = signal_or_exception;
-        params.ExceptionInfo     = exception_info;
-        params.FaultedThreadId   = GetCurrentThreadId();
+        snprintf(params.SignalOrException, sizeof(params.SignalOrException), "%s", signal_or_exception ? signal_or_exception : "");
+        params.ExceptionInfo   = exception_info;
+        params.FaultedThreadId = GetCurrentThreadId();
         if (!DuplicateHandle(GetCurrentProcess(), GetCurrentThread(), GetCurrentProcess(), &params.FaultedThreadHandle, THREAD_SUSPEND_RESUME | THREAD_GET_CONTEXT | THREAD_QUERY_INFORMATION, FALSE, 0))
             params.FaultedThreadHandle = GetCurrentThread();
 


### PR DESCRIPTION
Fixes `CrashHandlerDeathTest.OnCrashLogContainsAppMetadata` and
`CrashHandlerDeathTest.OnAssertionFailureWritesFileAndLine` on macOS
Release CI (broken since #616 was merged).

## Root cause

`WorkerThreadParams::SignalOrException` was a raw `cstring` pointer set in
`OnCrash` / `SignalHandler` and read later by the worker thread. Two
failure paths:

1. **Stack variable lifetime**: `OnAssertionFailure` builds `assertion_message`
   on its stack and passes its address to `[[noreturn]] OnCrash`. In Release
   builds, Clang/LLVM may elide the stack allocation because the caller can
   never observe it after the `[[noreturn]]` call — the compiler treats the
   buffer as dead. The worker thread reads a dangling pointer and writes an
   empty Signal line to the log.

2. **Store/pipe ordering**: the `SignalOrException = ptr` store and the
   `write(pipe)` are plain memory operations with no explicit fence. In
   Release with `-O2`, the compiler is permitted to sink the pointer store
   past the pipe write. The worker unblocks before the store is visible.

Both paths produce a log with the App line present but the Signal line blank
or absent — exactly what the CI failure shows.

## Fix

Change `SignalOrException` from `cstring` to `char[512]` in
`WorkerThreadParams` across all three platform handlers and copy with
`snprintf` at every assignment site. The struct is self-contained; no
caller lifetime or ordering dependency.

## Files

| File | Change |
|---|---|
| `CrashHandlerMacOS.mm` | struct field + `SignalHandler` + `OnCrash` |
| `CrashHandlerLinux.cpp` | struct field + `SignalHandler` + `OnCrash` |
| `CrashHandlerWindows.cpp` | struct field + `OnCrash` |