### PR TITLE
fix(crashhandler): guard signal handler + print log on test failure

### DIFF
--- a/ZEngine/ZEngine/CrashHandlers/CrashHandlerLinux.cpp
+++ b/ZEngine/ZEngine/CrashHandlers/CrashHandlerLinux.cpp
@@ -44,6 +44,7 @@ namespace ZEngine::CrashHandlers
     static int                s_crash_pipe[2] = {-1, -1};
     static WorkerThreadParams s_crash_params  = {};
     static pthread_t          s_worker_thread;
+    static std::atomic<bool>  s_in_crash_handler = {false};
 
     static const char*        SignalToString(int sig)
     {
@@ -737,27 +738,27 @@ namespace ZEngine::CrashHandlers
     static void SignalHandler(int sig, siginfo_t* /*info*/, void* ctx)
     {
         s_crash_params.SignalNumber = sig;
-        snprintf(s_crash_params.SignalOrException, sizeof(s_crash_params.SignalOrException), "%s", SignalToString(sig));
-
-        // Capture the crashing thread's backtrace here, in the signal handler,
-        // where the crashing thread's stack is live.  The worker thread's stack
-        // would be meaningless in a crash log.
-        s_crash_params.BacktraceSize       = backtrace(s_crash_params.BacktraceAddrs, kMaxBacktraceFrames);
-        s_crash_params.BacktraceFromSignal = true;
-
-        // If the ucontext is available, overwrite frame 0 with the actual fault
-        // address so the log points at the instruction that faulted, not at the
-        // signal trampoline.
-        if (ctx)
+        // Don't overwrite params already set by OnCrash() — a secondary signal
+        // (e.g. SIGSEGV from backtrace()) must not clobber the original message.
+        // Always write to the pipe so the worker wakes up.
+        if (!s_in_crash_handler.load(std::memory_order_acquire))
         {
-            auto* uc = static_cast<ucontext_t*>(ctx);
+            snprintf(s_crash_params.SignalOrException, sizeof(s_crash_params.SignalOrException), "%s", SignalToString(sig));
+
+            s_crash_params.BacktraceSize       = backtrace(s_crash_params.BacktraceAddrs, kMaxBacktraceFrames);
+            s_crash_params.BacktraceFromSignal = true;
+
+            if (ctx)
+            {
+                auto* uc = static_cast<ucontext_t*>(ctx);
 #if defined(__x86_64__)
-            if (s_crash_params.BacktraceSize > 0)
-                s_crash_params.BacktraceAddrs[0] = reinterpret_cast<void*>(uc->uc_mcontext.gregs[REG_RIP]);
+                if (s_crash_params.BacktraceSize > 0)
+                    s_crash_params.BacktraceAddrs[0] = reinterpret_cast<void*>(uc->uc_mcontext.gregs[REG_RIP]);
 #elif defined(__aarch64__)
-            if (s_crash_params.BacktraceSize > 0)
-                s_crash_params.BacktraceAddrs[0] = reinterpret_cast<void*>(uc->uc_mcontext.pc);
+                if (s_crash_params.BacktraceSize > 0)
+                    s_crash_params.BacktraceAddrs[0] = reinterpret_cast<void*>(uc->uc_mcontext.pc);
 #endif
+            }
         }
 
         uint8_t byte = 1;
@@ -842,20 +843,18 @@ namespace ZEngine::CrashHandlers
 
     [[noreturn]] void CrashHandler::OnCrash(const char* signal_or_exception, void* /*ctx*/)
     {
-        static std::atomic<bool> s_in_crash_handler{false};
         if (s_in_crash_handler.exchange(true, std::memory_order_acq_rel))
         {
             fputs("[CrashHandler] FATAL: crash handler reentered. Aborting.\n", stderr);
             _exit(EXIT_FAILURE);
         }
 
-        // Capture the call-site stack here, on the calling thread, before waking
-        // the worker.  BacktraceFromSignal stays false so the worker skips its own
-        // (meaningless) backtrace and uses these addresses instead.
-        s_crash_params.BacktraceSize = backtrace(s_crash_params.BacktraceAddrs, kMaxBacktraceFrames);
-
+        // Set message BEFORE backtrace: backtrace() can trigger SIGSEGV in Release builds
+        // (no frame pointers). The signal handler guard ensures the message is preserved.
         snprintf(s_crash_params.SignalOrException, sizeof(s_crash_params.SignalOrException), "%s", signal_or_exception ? signal_or_exception : "");
-        uint8_t byte = 1;
+
+        s_crash_params.BacktraceSize = backtrace(s_crash_params.BacktraceAddrs, kMaxBacktraceFrames);
+        uint8_t byte                 = 1;
         write(s_crash_pipe[1], &byte, 1);
         pthread_join(s_worker_thread, nullptr);
         _exit(EXIT_FAILURE);

--- a/ZEngine/ZEngine/CrashHandlers/CrashHandlerMacOS.mm
+++ b/ZEngine/ZEngine/CrashHandlers/CrashHandlerMacOS.mm
@@ -326,12 +326,13 @@ namespace ZEngine::CrashHandlers
         bool        BacktraceFromSignal                 = false;
     };
 
-    static constexpr size_t   kAltStackSize = 32 * 1024;
-    static struct sigaction   s_previous_actions[NSIG] = {};
-    static char               s_alt_stack_mem[kAltStackSize];
-    static int                s_crash_pipe[2] = {-1, -1};
-    static WorkerThreadParams s_crash_params  = {};
-    static pthread_t          s_worker_thread;
+    static constexpr size_t        kAltStackSize       = 32 * 1024;
+    static struct sigaction        s_previous_actions[NSIG] = {};
+    static char                    s_alt_stack_mem[kAltStackSize];
+    static int                     s_crash_pipe[2]     = {-1, -1};
+    static WorkerThreadParams      s_crash_params      = {};
+    static pthread_t               s_worker_thread;
+    static std::atomic<bool>       s_in_crash_handler  = {false};
 
     static const char* SignalToString(int sig)
     {
@@ -603,22 +604,31 @@ namespace ZEngine::CrashHandlers
 
     static void SignalHandler(int sig, siginfo_t* /*info*/, void* ctx)
     {
-        s_crash_params.SignalNumber      = sig;
-        snprintf(s_crash_params.SignalOrException, sizeof(s_crash_params.SignalOrException), "%s", SignalToString(sig));
-
-        s_crash_params.BacktraceSize       = backtrace(s_crash_params.BacktraceAddrs, kMaxBacktraceFrames);
-        s_crash_params.BacktraceFromSignal = true;
-
-        if (ctx)
+        s_crash_params.SignalNumber = sig;
+        // Only overwrite SignalOrException when OnCrash is NOT already running.
+        // If OnCrash set s_in_crash_handler=true first (and already set the message),
+        // a secondary signal (e.g. SIGSEGV from backtrace()) must not clobber it.
+        // If OnCrash() is already running (s_in_crash_handler=true), a secondary signal
+        // (e.g. SIGSEGV from backtrace()) must not overwrite the crash params OnCrash
+        // already set. Still write to the pipe so the worker wakes up.
+        if (!s_in_crash_handler.load(std::memory_order_acquire))
         {
-            auto* uc = static_cast<ucontext_t*>(ctx);
+            snprintf(s_crash_params.SignalOrException, sizeof(s_crash_params.SignalOrException), "%s", SignalToString(sig));
+
+            s_crash_params.BacktraceSize       = backtrace(s_crash_params.BacktraceAddrs, kMaxBacktraceFrames);
+            s_crash_params.BacktraceFromSignal = true;
+
+            if (ctx)
+            {
+                auto* uc = static_cast<ucontext_t*>(ctx);
 #if defined(__x86_64__)
-            if (s_crash_params.BacktraceSize > 0)
-                s_crash_params.BacktraceAddrs[0] = reinterpret_cast<void*>(uc->uc_mcontext->__ss.__rip);
+                if (s_crash_params.BacktraceSize > 0)
+                    s_crash_params.BacktraceAddrs[0] = reinterpret_cast<void*>(uc->uc_mcontext->__ss.__rip);
 #elif defined(__aarch64__)
-            if (s_crash_params.BacktraceSize > 0)
-                s_crash_params.BacktraceAddrs[0] = reinterpret_cast<void*>(uc->uc_mcontext->__ss.__pc);
+                if (s_crash_params.BacktraceSize > 0)
+                    s_crash_params.BacktraceAddrs[0] = reinterpret_cast<void*>(uc->uc_mcontext->__ss.__pc);
 #endif
+            }
         }
 
         uint8_t byte = 1;
@@ -704,19 +714,18 @@ namespace ZEngine::CrashHandlers
 
     [[noreturn]] void CrashHandler::OnCrash(cstring signal_or_exception, void* /*ctx*/)
     {
-        static std::atomic<bool> s_in_crash_handler{false};
         if (s_in_crash_handler.exchange(true, std::memory_order_acq_rel))
         {
             fputs("[CrashHandler] FATAL: crash handler reentered. Aborting.\n", stderr);
             _exit(EXIT_FAILURE);
         }
 
-        // Capture the call-site stack here, on the calling thread, before waking
-        // the worker.  BacktraceFromSignal stays false so the worker skips its own
-        // (meaningless) backtrace and uses these addresses instead.
-        s_crash_params.BacktraceSize = backtrace(s_crash_params.BacktraceAddrs, kMaxBacktraceFrames);
-
+        // Set the message BEFORE backtrace(): in Release builds backtrace() can trigger
+        // SIGSEGV (missing frame pointers). If it does, the signal handler guard above
+        // ensures SignalOrException is not overwritten, so the original message survives.
         snprintf(s_crash_params.SignalOrException, sizeof(s_crash_params.SignalOrException), "%s", signal_or_exception ? signal_or_exception : "");
+
+        s_crash_params.BacktraceSize = backtrace(s_crash_params.BacktraceAddrs, kMaxBacktraceFrames);
         uint8_t byte = 1;
         write(s_crash_pipe[1], &byte, 1);
         // Pump the main run loop so the dispatch_sync block posted by the

--- a/ZEngine/tests/CrashHandlers/CrashHandler_test.cpp
+++ b/ZEngine/tests/CrashHandlers/CrashHandler_test.cpp
@@ -169,12 +169,13 @@ TEST_F(CrashHandlerDeathTest, OnCrashLogContainsAppMetadata)
         "");
 
     std::string log = FindLatestLog();
-    ASSERT_FALSE(log.empty());
+    ASSERT_FALSE(log.empty()) << "No log file found in " << kTestLogDir;
     std::string body = ReadFile(log);
+    ASSERT_FALSE(body.empty()) << "Log file is empty: " << log;
 
-    EXPECT_NE(body.find("ZEngineTest"), std::string::npos) << "App name missing from log";
-    EXPECT_NE(body.find("0.0.1-test"), std::string::npos) << "Version missing from log";
-    EXPECT_NE(body.find("metadata check"), std::string::npos) << "Reason missing from log";
+    EXPECT_NE(body.find("ZEngineTest"), std::string::npos) << "App name missing\n--- log ---\n" << body.substr(0, 1024) << "\n---";
+    EXPECT_NE(body.find("0.0.1-test"), std::string::npos) << "Version missing\n--- log ---\n" << body.substr(0, 1024) << "\n---";
+    EXPECT_NE(body.find("metadata check"), std::string::npos) << "Reason missing\n--- log ---\n" << body.substr(0, 1024) << "\n---";
 }
 
 TEST_F(CrashHandlerDeathTest, OnCrashLogContainsStackTrace)
@@ -213,10 +214,13 @@ TEST_F(CrashHandlerDeathTest, OnAssertionFailureWritesFileAndLine)
         },
         "");
 
-    std::string body = ReadFile(FindLatestLog());
-    EXPECT_NE(body.find("assertion_test.cpp"), std::string::npos) << "File name missing";
-    EXPECT_NE(body.find("42"), std::string::npos) << "Line number missing";
-    EXPECT_NE(body.find("x > 0"), std::string::npos) << "Condition missing";
+    std::string log  = FindLatestLog();
+    std::string body = ReadFile(log);
+    ASSERT_FALSE(body.empty()) << "Log file is empty: " << log;
+
+    EXPECT_NE(body.find("assertion_test.cpp"), std::string::npos) << "File name missing\n--- log ---\n" << body.substr(0, 1024) << "\n---";
+    EXPECT_NE(body.find("42"), std::string::npos) << "Line number missing\n--- log ---\n" << body.substr(0, 1024) << "\n---";
+    EXPECT_NE(body.find("x > 0"), std::string::npos) << "Condition missing\n--- log ---\n" << body.substr(0, 1024) << "\n---";
 }
 
 TEST_F(CrashHandlerDeathTest, OnAssertionFailureHandlesNullArgs)

--- a/ZEngine/tests/CrashHandlers/CrashHandler_test.cpp
+++ b/ZEngine/tests/CrashHandlers/CrashHandler_test.cpp
@@ -173,9 +173,9 @@ TEST_F(CrashHandlerDeathTest, OnCrashLogContainsAppMetadata)
     std::string body = ReadFile(log);
     ASSERT_FALSE(body.empty()) << "Log file is empty: " << log;
 
-    EXPECT_NE(body.find("ZEngineTest"), std::string::npos) << "App name missing\n--- log ---\n" << body.substr(0, 1024) << "\n---";
-    EXPECT_NE(body.find("0.0.1-test"), std::string::npos) << "Version missing\n--- log ---\n" << body.substr(0, 1024) << "\n---";
-    EXPECT_NE(body.find("metadata check"), std::string::npos) << "Reason missing\n--- log ---\n" << body.substr(0, 1024) << "\n---";
+    EXPECT_NE(body.find("ZEngineTest"), std::string::npos) << "App name missing from log";
+    EXPECT_NE(body.find("0.0.1-test"), std::string::npos) << "Version missing from log";
+    EXPECT_NE(body.find("metadata check"), std::string::npos) << "Reason missing from log";
 }
 
 TEST_F(CrashHandlerDeathTest, OnCrashLogContainsStackTrace)
@@ -218,9 +218,9 @@ TEST_F(CrashHandlerDeathTest, OnAssertionFailureWritesFileAndLine)
     std::string body = ReadFile(log);
     ASSERT_FALSE(body.empty()) << "Log file is empty: " << log;
 
-    EXPECT_NE(body.find("assertion_test.cpp"), std::string::npos) << "File name missing\n--- log ---\n" << body.substr(0, 1024) << "\n---";
-    EXPECT_NE(body.find("42"), std::string::npos) << "Line number missing\n--- log ---\n" << body.substr(0, 1024) << "\n---";
-    EXPECT_NE(body.find("x > 0"), std::string::npos) << "Condition missing\n--- log ---\n" << body.substr(0, 1024) << "\n---";
+    EXPECT_NE(body.find("assertion_test.cpp"), std::string::npos) << "File name missing";
+    EXPECT_NE(body.find("42"), std::string::npos) << "Line number missing";
+    EXPECT_NE(body.find("x > 0"), std::string::npos) << "Condition missing";
 }
 
 TEST_F(CrashHandlerDeathTest, OnAssertionFailureHandlesNullArgs)


### PR DESCRIPTION
Fixes `CrashHandlerDeathTest.OnCrashLogContainsAppMetadata` and
`CrashHandlerDeathTest.OnAssertionFailureWritesFileAndLine` on macOS
Release CI. **All 11 `CrashHandlerDeathTest` tests now pass.**

## Root cause

`backtrace()` inside `OnCrash()` triggers SIGSEGV in Release builds on
macOS arm64 — optimised frames, no frame-pointer chain. The signal handler
fires, overwrites `SignalOrException` with the signal name, and wakes the
worker **before `OnCrash`'s own `snprintf` runs**. The log records
"Segmentation Fault (SIGSEGV)" instead of the caller-supplied message.

## Fix

Two changes in `CrashHandlerMacOS.mm` and `CrashHandlerLinux.cpp`:

1. **Promote `s_in_crash_handler` to file scope** so `SignalHandler` can
   read it. When a secondary signal arrives while `s_in_crash_handler` is
   already `true` (OnCrash is running), the signal handler skips all param
   writes but **still writes to the pipe** so the worker always wakes.

2. **Move `snprintf(SignalOrException, ...)` to before `backtrace()`** in
   `OnCrash` — message is stored before the dangerous unwind call.

Windows uses SEH, not POSIX signals — no change needed.

## Test improvement

`ASSERT_FALSE(body.empty())` added to the two log-content tests so an
empty log produces a clear failure message instead of a confusing npos
comparison.

## Verified

All 11 `CrashHandlerDeathTest` pass on macOS arm64 Release CI (manual run
on this branch).