### PR TITLE
test(swapchain): headless Vulkan resize state machine tests

### DIFF
--- a/.github/workflows/job-test-linux.yml
+++ b/.github/workflows/job-test-linux.yml
@@ -22,10 +22,18 @@ jobs:
         with:
           name: Build-linux-${{ inputs.configuration }}
 
+      - name: Install Mesa software Vulkan (lavapipe)
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y mesa-vulkan-drivers
+
       - name: Update access permission of ZEngineTests
         run: chmod +x ${{github.workspace}}/tests/ZEngineTests
 
       - name: Run Tests
         env:
           LD_LIBRARY_PATH: ${{github.workspace}}/lib
+          # Direct the Vulkan loader at Mesa's lavapipe ICD so the headless
+          # swapchain tests can run without a physical GPU.
+          VK_DRIVER_FILES: /usr/share/vulkan/icd.d/lvp_icd.x86_64.json
         run: ${{github.workspace}}/tests/ZEngineTests

--- a/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
+++ b/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
@@ -1,4 +1,4 @@
-#include <GLFW/glfw3.h>
+
 #include <ZEngine/Hardwares/DeviceSwapchain.h>
 #include <ZEngine/Hardwares/VulkanDevice.h>
 #include <ZEngine/Rendering/RenderResourceManager.h>
@@ -72,11 +72,9 @@ namespace ZEngine::Hardwares
         }
         else
         {
-            // Wayland does not provide a concrete extent — query the framebuffer size directly.
-            int w = 0, h = 0;
-            glfwGetFramebufferSize(reinterpret_cast<GLFWwindow*>(Device->CurrentWindow->GetNativeWindow()), &w, &h);
-            SwapchainImageWidth  = static_cast<uint32_t>(w);
-            SwapchainImageHeight = static_cast<uint32_t>(h);
+            // Surface does not report a concrete extent (Wayland, headless) — ask the window.
+            SwapchainImageWidth  = Device->CurrentWindow->GetWidth();
+            SwapchainImageHeight = Device->CurrentWindow->GetHeight();
         }
 
         // {0,0} extent is a spec violation; destroy stale swapchain and retry next frame.

--- a/ZEngine/ZEngine/Hardwares/DeviceSwapchain.h
+++ b/ZEngine/ZEngine/Hardwares/DeviceSwapchain.h
@@ -79,6 +79,16 @@ namespace ZEngine::Hardwares
 
         void AcquireNextImage(uint32_t frame_context_idx);
         void Present();
+
+#if !defined(NDEBUG)
+        // Test-only: inject a recreation state without going through the Vulkan
+        // SUBOPTIMAL/OOD detection path. Used by SwapchainResizeTest to exercise
+        // the recreation state machine in isolation.
+        void ForceRecreation(RecreationState state)
+        {
+            Recreation = state;
+        }
+#endif
     };
     ZDEFINE_PTR(DeviceSwapchain);
 } // namespace ZEngine::Hardwares

--- a/ZEngine/tests/Rendering/HeadlessWindow.h
+++ b/ZEngine/tests/Rendering/HeadlessWindow.h
@@ -1,0 +1,151 @@
+#pragma once
+#include <ZEngine/Core/Memory/Allocator.h>
+#include <ZEngine/Windows/CoreWindow.h>
+#include <ZEngine/ZEngineDef.h>
+#include <vulkan/vulkan.h>
+#include <cstdint>
+#include <future>
+#include <string>
+
+namespace ZEngine::Tests
+{
+    // CoreWindow backed by VK_EXT_headless_surface — no display, no GPU output.
+    // SetSize() lets tests simulate resize and minimize events.
+    class HeadlessWindow : public Windows::CoreWindow
+    {
+    public:
+        HeadlessWindow(Core::Memory::ArenaAllocator* arena, uint32_t width, uint32_t height) : m_width(width), m_height(height)
+        {
+            RequiredExtensionLayers.init(arena, 2);
+            RequiredExtensionLayers.push(VK_KHR_SURFACE_EXTENSION_NAME);
+            RequiredExtensionLayers.push(VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME);
+        }
+
+        // Returns false on Apple (MoltenVK incomplete headless support) and when
+        // the extension is absent from the loader.
+        static bool IsSupported()
+        {
+#ifdef __APPLE__
+            return false;
+#else
+            uint32_t count = 0;
+            if (vkEnumerateInstanceExtensionProperties(nullptr, &count, nullptr) != VK_SUCCESS || count == 0)
+                return false;
+            auto* props = new VkExtensionProperties[count];
+            vkEnumerateInstanceExtensionProperties(nullptr, &count, props);
+            bool found = false;
+            for (uint32_t i = 0; i < count; ++i)
+            {
+                if (std::string_view(props[i].extensionName) == VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME)
+                {
+                    found = true;
+                    break;
+                }
+            }
+            delete[] props;
+            return found;
+#endif
+        }
+
+        void SetSize(uint32_t w, uint32_t h)
+        {
+            m_width  = w;
+            m_height = h;
+        }
+
+        uint32_t GetWidth() const override
+        {
+            return m_width;
+        }
+        uint32_t GetHeight() const override
+        {
+            return m_height;
+        }
+        Core::Containers::StringView GetTitle() const override
+        {
+            return "headless";
+        }
+        void SetTitle(Core::Containers::StringView) override {}
+        bool IsMinimized() const override
+        {
+            return m_width == 0 || m_height == 0;
+        }
+        bool IsVSyncEnable() const override
+        {
+            return false;
+        }
+        void                           SetVSync(bool) override {}
+        void                           SetCallbackFunction(const EventCallbackFn&) override {}
+        const Windows::WindowProperty& GetWindowProperty() const override
+        {
+            return m_prop;
+        }
+        void* GetNativeWindow() const override
+        {
+            return nullptr;
+        }
+
+        bool CreateSurface(void* instance, void** out_surface) override
+        {
+            VkHeadlessSurfaceCreateInfoEXT ci = {
+                .sType = VK_STRUCTURE_TYPE_HEADLESS_SURFACE_CREATE_INFO_EXT,
+                .pNext = nullptr,
+                .flags = 0,
+            };
+            auto fn = reinterpret_cast<PFN_vkCreateHeadlessSurfaceEXT>(vkGetInstanceProcAddr(static_cast<VkInstance>(instance), "vkCreateHeadlessSurfaceEXT"));
+            if (!fn)
+                return false;
+            VkSurfaceKHR surface = VK_NULL_HANDLE;
+            if (fn(static_cast<VkInstance>(instance), &ci, nullptr, &surface) != VK_SUCCESS)
+                return false;
+            *out_surface = surface;
+            return true;
+        }
+
+        std::future<std::string> OpenFileDialogAsync(std::span<std::string_view>) override
+        {
+            return std::async(std::launch::deferred, [] { return std::string{}; });
+        }
+
+        void  PollEvent() override {}
+        float GetTime() override
+        {
+            return 0.f;
+        }
+        float GetDeltaTime() override
+        {
+            return 0.f;
+        }
+
+        bool OnWindowClosed(Windows::Events::WindowClosedEvent&) override
+        {
+            return false;
+        }
+        bool OnWindowResized(Windows::Events::WindowResizedEvent&) override
+        {
+            return false;
+        }
+        bool OnWindowMinimized(Windows::Events::WindowMinimizedEvent&) override
+        {
+            return false;
+        }
+        bool OnWindowMaximized(Windows::Events::WindowMaximizedEvent&) override
+        {
+            return false;
+        }
+        bool OnWindowRestored(Windows::Events::WindowRestoredEvent&) override
+        {
+            return false;
+        }
+        bool OnEvent(Core::CoreEvent&) override
+        {
+            return false;
+        }
+
+    private:
+        uint32_t                m_width  = 0;
+        uint32_t                m_height = 0;
+        Windows::WindowProperty m_prop   = {};
+    };
+
+} // namespace ZEngine::Tests

--- a/ZEngine/tests/Rendering/SwapchainResizeTest.cpp
+++ b/ZEngine/tests/Rendering/SwapchainResizeTest.cpp
@@ -1,0 +1,251 @@
+#include <ZEngine/Core/Memory/MemoryManager.h>
+#include <ZEngine/Hardwares/DeviceSwapchain.h>
+#include <ZEngine/Hardwares/VulkanDevice.h>
+#include <gtest/gtest.h>
+#include <chrono>
+#include <thread>
+#include "HeadlessWindow.h"
+
+using namespace ZEngine;
+using namespace ZEngine::Core::Memory;
+using namespace ZEngine::Hardwares;
+
+class SwapchainResizeFixture : public ::testing::Test
+{
+protected:
+    static constexpr uint32_t kWidth  = 320;
+    static constexpr uint32_t kHeight = 240;
+
+    MemoryManager             m_mem;
+    Tests::HeadlessWindow*    m_window = nullptr;
+    VulkanDevice*             m_device = nullptr;
+    bool                      m_ok     = false;
+
+    void                      SetUp() override
+    {
+        if (!Tests::HeadlessWindow::IsSupported())
+            GTEST_SKIP() << "VK_EXT_headless_surface not supported on this system";
+
+        m_mem.Initialize(ZMega(128), {});
+        m_window = ZPushStructCtorArgs(&m_mem.MainArena, Tests::HeadlessWindow, &m_mem.MainArena, kWidth, kHeight);
+        m_device = ZPushStructCtor(&m_mem.MainArena, VulkanDevice);
+        m_device->Initialize(&m_mem.MainArena, m_window, 1);
+        m_ok = true;
+    }
+
+    void TearDown() override
+    {
+        if (m_ok && m_device)
+            m_device->Deinitialize();
+        m_mem.Shutdown();
+    }
+
+    DeviceSwapchain* Swapchain() const
+    {
+        return m_device->SwapchainPtr;
+    }
+
+    bool RunMinimalFrame(uint32_t frame_idx = 0)
+    {
+        auto* sc = Swapchain();
+        sc->AcquireNextImage(frame_idx % sc->BufferredFrameCount);
+        if (!sc->IsFrameValid())
+        {
+            sc->Present();
+            return false;
+        }
+        sc->Present();
+        return true;
+    }
+};
+
+TEST_F(SwapchainResizeFixture, NormalFrame_Succeeds)
+{
+    EXPECT_TRUE(RunMinimalFrame());
+    EXPECT_EQ(Swapchain()->Recreation, RecreationState::None);
+    EXPECT_TRUE(Swapchain()->IsFrameValid());
+}
+
+TEST_F(SwapchainResizeFixture, PendingRecreation_CompletesOnNextAcquire)
+{
+    ASSERT_TRUE(RunMinimalFrame(0));
+
+    Swapchain()->ForceRecreation(RecreationState::Pending);
+    RunMinimalFrame(1);
+
+    EXPECT_EQ(Swapchain()->Recreation, RecreationState::None);
+    EXPECT_TRUE(Swapchain()->IsFrameValid());
+}
+
+TEST_F(SwapchainResizeFixture, FrameAborted_PresentSkipsGPUWork)
+{
+    ASSERT_TRUE(RunMinimalFrame(0));
+
+    Swapchain()->ForceRecreation(RecreationState::FrameAborted);
+    EXPECT_FALSE(Swapchain()->IsFrameValid());
+
+    Swapchain()->Present();
+    EXPECT_EQ(Swapchain()->Recreation, RecreationState::FrameAborted);
+
+    RunMinimalFrame(1);
+    EXPECT_EQ(Swapchain()->Recreation, RecreationState::None);
+    EXPECT_TRUE(Swapchain()->IsFrameValid());
+}
+
+TEST_F(SwapchainResizeFixture, RecreationFiresOnSwapchainResizedCallback)
+{
+    uint32_t cb_w = 0, cb_h = 0;
+    bool     fired                  = false;
+
+    Swapchain()->OnSwapchainResized = [](uint32_t w, uint32_t h, void* ctx) {
+        auto* p          = static_cast<std::tuple<uint32_t*, uint32_t*, bool*>*>(ctx);
+        *std::get<0>(*p) = w;
+        *std::get<1>(*p) = h;
+        *std::get<2>(*p) = true;
+    };
+    auto ctx                           = std::make_tuple(&cb_w, &cb_h, &fired);
+    Swapchain()->OnSwapchainResizedCtx = &ctx;
+
+    ASSERT_TRUE(RunMinimalFrame(0));
+    Swapchain()->ForceRecreation(RecreationState::Pending);
+    RunMinimalFrame(1);
+
+    EXPECT_TRUE(fired);
+    EXPECT_GT(cb_w, 0u);
+    EXPECT_GT(cb_h, 0u);
+}
+
+TEST_F(SwapchainResizeFixture, RapidRecreation_TenCycles_NoHang)
+{
+    for (int i = 0; i < 10; ++i)
+    {
+        ASSERT_TRUE(RunMinimalFrame(static_cast<uint32_t>(i * 2))) << "cycle " << i;
+        Swapchain()->ForceRecreation(RecreationState::Pending);
+        RunMinimalFrame(static_cast<uint32_t>(i * 2 + 1));
+        ASSERT_EQ(Swapchain()->Recreation, RecreationState::None) << "cycle " << i;
+    }
+}
+
+// 100 cycles crosses 3 full pool rotations — needed to surface latent
+// fence-tracking bugs that only appear after several rotations.
+TEST_F(SwapchainResizeFixture, AggressiveRecreation_HundredCycles_NoHang)
+{
+    for (int i = 0; i < 100; ++i)
+    {
+        ASSERT_TRUE(RunMinimalFrame(static_cast<uint32_t>(i * 2))) << "cycle " << i;
+        Swapchain()->ForceRecreation(RecreationState::Pending);
+        RunMinimalFrame(static_cast<uint32_t>(i * 2 + 1));
+        ASSERT_EQ(Swapchain()->Recreation, RecreationState::None) << "cycle " << i;
+    }
+}
+
+// Mirrors the Intel/Ubuntu hang: OOD at acquire (FrameAborted) immediately
+// followed by OOD at present (Pending) in the next frame boundary.
+TEST_F(SwapchainResizeFixture, AlternatingAbortAndPending_NoHang)
+{
+    for (int i = 0; i < 20; ++i)
+    {
+        ASSERT_TRUE(RunMinimalFrame(static_cast<uint32_t>(i * 3))) << "cycle " << i;
+
+        Swapchain()->ForceRecreation(RecreationState::FrameAborted);
+        Swapchain()->Present();
+
+        Swapchain()->AcquireNextImage(static_cast<uint32_t>((i * 3 + 1) % Swapchain()->BufferredFrameCount));
+
+        if (Swapchain()->IsFrameValid())
+        {
+            Swapchain()->ForceRecreation(RecreationState::Pending);
+            RunMinimalFrame(static_cast<uint32_t>(i * 3 + 2));
+        }
+
+        ASSERT_EQ(Swapchain()->Recreation, RecreationState::None) << "cycle " << i;
+        ASSERT_TRUE(Swapchain()->IsFrameValid()) << "cycle " << i;
+    }
+}
+
+// All ImageInFlights are null after consecutive aborts — tests fence drain
+// when no GPU work was ever submitted before recreation.
+TEST_F(SwapchainResizeFixture, ConsecutiveFrameAborts_ThenRecovery)
+{
+    ASSERT_TRUE(RunMinimalFrame(0));
+
+    for (int i = 0; i < 5; ++i)
+    {
+        Swapchain()->ForceRecreation(RecreationState::FrameAborted);
+        Swapchain()->Present();
+    }
+
+    RunMinimalFrame(1);
+    EXPECT_EQ(Swapchain()->Recreation, RecreationState::None);
+    EXPECT_TRUE(Swapchain()->IsFrameValid());
+
+    for (int i = 0; i < 5; ++i)
+        ASSERT_TRUE(RunMinimalFrame(static_cast<uint32_t>(i + 2))) << "recovery frame " << i;
+}
+
+TEST_F(SwapchainResizeFixture, SizeChangingRecreations_NoHang)
+{
+    static constexpr uint32_t kSizes[][2] = {
+        { 160, 120},
+        { 320, 240},
+        { 640, 480},
+        {1280, 720},
+        { 640, 480},
+        { 320, 240},
+        { 160, 120},
+        { 320, 240},
+    };
+
+    for (int i = 0; i < 8; ++i)
+    {
+        ASSERT_TRUE(RunMinimalFrame(static_cast<uint32_t>(i * 2))) << "cycle " << i;
+
+        m_window->SetSize(kSizes[i][0], kSizes[i][1]);
+        Swapchain()->ForceRecreation(RecreationState::Pending);
+        RunMinimalFrame(static_cast<uint32_t>(i * 2 + 1));
+
+        ASSERT_EQ(Swapchain()->Recreation, RecreationState::None) << "cycle " << i;
+        EXPECT_EQ(Swapchain()->SwapchainImageWidth, kSizes[i][0]) << "cycle " << i;
+        EXPECT_EQ(Swapchain()->SwapchainImageHeight, kSizes[i][1]) << "cycle " << i;
+    }
+}
+
+TEST_F(SwapchainResizeFixture, MultipleMinimizeRestore_NoHang)
+{
+    for (int i = 0; i < 10; ++i)
+    {
+        ASSERT_TRUE(RunMinimalFrame(static_cast<uint32_t>(i * 2))) << "cycle " << i;
+
+        m_window->SetSize(0, 0);
+        Swapchain()->ForceRecreation(RecreationState::Pending);
+        Swapchain()->AcquireNextImage(static_cast<uint32_t>((i * 2) % Swapchain()->BufferredFrameCount));
+
+        ASSERT_EQ(Swapchain()->Recreation, RecreationState::Pending) << "cycle " << i;
+        ASSERT_EQ(Swapchain()->SwapchainHandle, VK_NULL_HANDLE) << "cycle " << i;
+
+        m_window->SetSize(kWidth, kHeight);
+        RunMinimalFrame(static_cast<uint32_t>(i * 2 + 1));
+
+        ASSERT_EQ(Swapchain()->Recreation, RecreationState::None) << "cycle " << i;
+        ASSERT_NE(Swapchain()->SwapchainHandle, VK_NULL_HANDLE) << "cycle " << i;
+    }
+}
+
+TEST_F(SwapchainResizeFixture, ZeroSizeGuard_SkipsRecreationUntilNonZero)
+{
+    ASSERT_TRUE(RunMinimalFrame(0));
+
+    m_window->SetSize(0, 0);
+    Swapchain()->ForceRecreation(RecreationState::Pending);
+    Swapchain()->AcquireNextImage(0);
+
+    EXPECT_EQ(Swapchain()->Recreation, RecreationState::Pending);
+    EXPECT_EQ(Swapchain()->SwapchainHandle, VK_NULL_HANDLE);
+
+    m_window->SetSize(kWidth, kHeight);
+    RunMinimalFrame(0);
+
+    EXPECT_EQ(Swapchain()->Recreation, RecreationState::None);
+    EXPECT_NE(Swapchain()->SwapchainHandle, VK_NULL_HANDLE);
+    EXPECT_TRUE(Swapchain()->IsFrameValid());
+}


### PR DESCRIPTION
Adds a headless Vulkan test suite for the `RecreationState` machine in PR #623.

## 11 tests across two tiers

### Baseline (6 tests)

| Test | Scenario |
|---|---|
| `NormalFrame_Succeeds` | Warm-up: baseline frame |
| `PendingRecreation_CompletesOnNextAcquire` | Pending → recreation → None |
| `FrameAborted_PresentSkipsGPUWork` | FrameAborted → Present early-returns → next acquire recreates |
| `RecreationFiresOnSwapchainResizedCallback` | `OnSwapchainResized` called with correct dims |
| `RapidRecreation_TenCycles_NoHang` | 10 forced recreations, no hang |
| `ZeroSizeGuard_SkipsRecreationUntilNonZero` | Zero-size defers recreation |

### Aggressive stress (5 tests)

These directly target the Intel/Ubuntu hang patterns:

| Test | Scenario |
|---|---|
| `AggressiveRecreation_HundredCycles_NoHang` | 100 recreation cycles — surfaces pool rotation bugs and fence leaks |
| `AlternatingAbortAndPending_NoHang` | OOD-at-acquire then OOD-at-present in the same frame boundary — the exact observed hang pattern |
| `ConsecutiveFrameAborts_ThenRecovery` | 5 aborted frames with no GPU work before recovery — tests fence drain with all-null ImageInFlights |
| `SizeChangingRecreations_NoHang` | 8 recreations with different extents — exercises descriptor set and image view teardown per pool rotation |
| `MultipleMinimizeRestore_NoHang` | 10 minimize/restore cycles — zero-size guard must never call `vkCreateSwapchainKHR({0,0})` |

## Infrastructure

**`HeadlessWindow`** — `CoreWindow` via `VK_EXT_headless_surface`. `SetSize()` simulates resize/minimize.

**`ForceRecreation(RecreationState)`** — debug-only injection API on `DeviceSwapchain`.

**`DeviceSwapchain::Create()`** — replaced direct `glfwGetFramebufferSize` call with `CurrentWindow->GetWidth/Height()`.

## CI

`job-test-linux.yml` installs `mesa-vulkan-drivers` and sets `VK_DRIVER_FILES` to Mesa lavapipe. Tests run on the same Ubuntu 24.04 runners where Intel hangs were reported — no GPU needed.

macOS/Windows: all 11 tests `SKIP` cleanly. Linux: all 11 run against software Vulkan.