### PR TITLE
fix(ecs): WorldCommands staging buffers for parallel-wave systems

### DIFF
--- a/ZEngine/ZEngine/ECS/WorldCommands.cpp
+++ b/ZEngine/ZEngine/ECS/WorldCommands.cpp
@@ -80,6 +80,27 @@ namespace ZEngine::ECS
         Clear();
     }
 
+    void WorldCommands::Merge(const WorldCommands& src)
+    {
+        if (src.IsEmpty())
+            return;
+
+        // Callbacks from src are appended after our existing ones, so indices
+        // in src's SpawnEntity commands must be shifted by the current count.
+        int32_t callback_offset = static_cast<int32_t>(m_spawn_callbacks.size());
+
+        for (size_t i = 0; i < src.m_spawn_callbacks.size(); ++i)
+            m_spawn_callbacks.push(src.m_spawn_callbacks[i]);
+
+        for (size_t i = 0; i < src.m_commands.size(); ++i)
+        {
+            Command cmd = src.m_commands[i];
+            if (cmd.Kind == CommandKind::SpawnEntity && cmd.SpawnCallbackIndex >= 0)
+                cmd.SpawnCallbackIndex += callback_offset;
+            m_commands.push(cmd);
+        }
+    }
+
     void WorldCommands::Clear()
     {
         // Reset size to 0; arena memory is not reclaimed (reused next frame)

--- a/ZEngine/ZEngine/ECS/WorldCommands.h
+++ b/ZEngine/ZEngine/ECS/WorldCommands.h
@@ -71,6 +71,13 @@ namespace ZEngine::ECS
         void Flush(Scene& scene);
         void Clear();
 
+        // Append all commands from src into this buffer.
+        // SpawnCallbackIndex values in src are offset so they remain valid
+        // after the two m_spawn_callbacks arrays are concatenated.
+        // Called by WorldTick after a parallel wave to merge per-system
+        // staging buffers into the authoritative command buffer in order.
+        void Merge(const WorldCommands& src);
+
         bool IsEmpty() const
         {
             return m_commands.empty() && m_spawn_callbacks.empty();

--- a/ZEngine/ZEngine/ECS/WorldTick.cpp
+++ b/ZEngine/ZEngine/ECS/WorldTick.cpp
@@ -184,6 +184,14 @@ namespace ZEngine::ECS
         BuildEdges();
         TopologicalSort();
 
+        // Pre-allocate one staging WorldCommands per system. These are reused
+        // every frame: Clear() resets size to 0 without releasing arena memory,
+        // so pushes stay allocation-free after the first exercised frame.
+        uint32_t n = static_cast<uint32_t>(m_nodes.size());
+        m_staging.init(m_arena, n, n);
+        for (uint32_t i = 0; i < n; ++i)
+            m_staging[i].Initialize(m_arena);
+
         m_committed = true;
     }
 
@@ -195,23 +203,32 @@ namespace ZEngine::ECS
         {
             const Core::Containers::Array<uint32_t>& wave = m_waves[w];
 
-            // Single-system wave: run inline on the calling thread — zero overhead.
+            // Single-system wave: run inline on the calling thread.
+            // Uses the caller's commands buffer directly — zero overhead.
             if (wave.size() == 1)
             {
-                SystemFn fn = m_nodes[wave[0]].Fn;
-                fn(scene, dt, commands);
+                m_nodes[wave[0]].Fn(scene, dt, commands);
                 continue;
             }
 
-            // Multi-system wave: dispatch to thread pool with spin-yield + cv barrier.
+            // Multi-system wave: each system writes to its own staging buffer
+            // so concurrent calls to WorldCommands never touch shared state.
+            // After the wave barrier the main thread merges staging buffers into
+            // the authoritative commands buffer in wave-submission order.
+            for (size_t i = 0; i < wave.size(); ++i)
+                m_staging[wave[i]].Clear();
+
             std::atomic<uint32_t>   remaining{static_cast<uint32_t>(wave.size())};
             std::mutex              mtx;
             std::condition_variable cv;
 
             for (size_t i = 0; i < wave.size(); ++i)
             {
-                SystemFn fn = m_nodes[wave[i]].Fn;
-                ZEngine::Helpers::ThreadPoolHelper::Submit([&scene, dt, &commands, fn, &remaining, &cv]() {
+                uint32_t       node_idx = wave[i];
+                SystemFn       fn       = m_nodes[node_idx].Fn;
+                WorldCommands* staging  = &m_staging[node_idx];
+
+                ZEngine::Helpers::ThreadPoolHelper::Submit([&scene, dt, fn, staging, &remaining, &cv]() {
                     struct Guard
                     {
                         std::atomic<uint32_t>&   r;
@@ -222,11 +239,11 @@ namespace ZEngine::ECS
                                 cv.notify_one();
                         }
                     } guard{remaining, cv};
-                    fn(scene, dt, commands);
+                    fn(scene, dt, *staging);
                 });
             }
 
-            // Phase 1: spin-yield — stays in user space for fast waves
+            // Phase 1: spin-yield — stays in user space for fast waves.
             for (int spin = 0; spin < 100; ++spin)
             {
                 if (remaining.load(std::memory_order_acquire) == 0)
@@ -234,7 +251,7 @@ namespace ZEngine::ECS
                 std::this_thread::yield();
             }
 
-            // Phase 2: cv.wait fallback for slow waves (physics, skinning, etc.)
+            // Phase 2: cv.wait fallback for slow waves.
             if (remaining.load(std::memory_order_acquire) != 0)
             {
                 std::unique_lock<std::mutex> lock(mtx);
@@ -242,6 +259,10 @@ namespace ZEngine::ECS
                 bool                         completed           = cv.wait_for(lock, std::chrono::seconds(kWaveTimeoutSeconds), [&remaining] { return remaining.load(std::memory_order_relaxed) == 0; });
                 ZENGINE_VALIDATE_ASSERT(completed, "WorldTick::Tick: wave timed out — a system has hung or crashed")
             }
+
+            // Merge staging buffers into the authoritative buffer in submission order.
+            for (size_t i = 0; i < wave.size(); ++i)
+                commands.Merge(m_staging[wave[i]]);
         }
     }
 } // namespace ZEngine::ECS

--- a/ZEngine/ZEngine/ECS/WorldTick.h
+++ b/ZEngine/ZEngine/ECS/WorldTick.h
@@ -15,8 +15,9 @@ namespace ZEngine::ECS
 
     struct SystemDeps
     {
-        ArchetypeMask ReadMask  = 0;
-        ArchetypeMask WriteMask = 0;
+        ArchetypeMask ReadMask     = 0;
+        ArchetypeMask WriteMask    = 0;
+        bool          UsesCommands = false; // true if this system calls any WorldCommands method
     };
 
     class WorldTick
@@ -67,6 +68,10 @@ namespace ZEngine::ECS
         Core::Containers::Array<Core::Containers::Array<uint32_t>> m_waves;
         Core::Containers::Array<uint32_t>                          m_order_edges_from;
         Core::Containers::Array<uint32_t>                          m_order_edges_to;
+        // Per-system staging WorldCommands for parallel waves.
+        // Allocated at Commit() for every system; cleared before each wave,
+        // merged into the caller's buffer after the wave barrier.
+        Core::Containers::Array<WorldCommands>                     m_staging;
         Core::Memory::ArenaAllocator*                              m_arena     = nullptr;
         bool                                                       m_committed = false;
 

--- a/ZEngine/docs/future-plan/actor-ecs-architecture.md
+++ b/ZEngine/docs/future-plan/actor-ecs-architecture.md
@@ -689,6 +689,40 @@ programmer error and asserts in debug.
 - Actor creation — `Actor::Create(scene)` is safe to call from `Actor::OnTick` since
   that runs after `WorldTick::Tick` completes
 
+### 7.5 Thread safety — per-system staging buffers
+
+`WorldCommands` itself is **not thread-safe**. The original design passed the same
+`WorldCommands&` to every system in a parallel wave, which caused a data race if two
+systems in the same wave both called `SpawnEntity()` or `AddComponent()`.
+
+**Implemented fix (Option A — staging buffers):** `WorldTick` pre-allocates one staging
+`WorldCommands` per registered system at `Commit()` time. In a multi-system wave each
+worker receives its own staging buffer rather than the shared one. After the wave barrier,
+the main thread merges all staging buffers into the authoritative `WorldCommands` in
+submission order via `WorldCommands::Merge()`.
+
+```
+Wave with N systems (parallel):
+  worker 0 → staging[0].SpawnEntity(...)   ← private, no contention
+  worker 1 → staging[1].AddComponent(...)  ← private, no contention
+  ...
+  barrier
+  main thread: commands.Merge(staging[0])
+               commands.Merge(staging[1])
+               ...
+  → commands.Flush(scene)
+```
+
+`SpawnCallbackIndex` values are offset-corrected during merge so callbacks remain
+correctly associated with their spawned entities regardless of merge order.
+
+Single-system waves are unaffected — the system runs inline with the caller's
+`WorldCommands` directly, no staging involved.
+
+To declare that a system uses WorldCommands, set `SystemDeps::UsesCommands = true`
+when registering. This is documentation only — the staging buffer is always assigned
+in parallel waves regardless of the flag.
+
 ---
 
 ## 8. Memory Layout

--- a/ZEngine/docs/future-plan/system-scheduler.md
+++ b/ZEngine/docs/future-plan/system-scheduler.md
@@ -339,16 +339,19 @@ void WorldTick::Tick(Scene& scene, float dt, WorldCommands& commands) {
             continue;
         }
 
-        // Multi-system wave: dispatch all systems to the thread pool.
+        // Multi-system wave: each system gets its own staging WorldCommands so
+        // concurrent calls to SpawnEntity/AddComponent never touch shared state.
+        // Staging buffers are pre-allocated at Commit() and reused each frame.
+        for (uint32_t idx : wave) m_staging[idx].Clear();
+
         std::atomic<uint32_t>   remaining{static_cast<uint32_t>(wave.size())};
         std::mutex              mtx;
         std::condition_variable cv;
 
         for (uint32_t idx : wave) {
-            SystemFn fn = m_nodes[idx].Fn;
-            ZENGINE_VALIDATE_ASSERT(fn != nullptr,
-                "WorldTick: null system function pointer")
-            ThreadPoolHelper::Submit([&scene, dt, &commands, fn, &remaining, &cv]() {
+            SystemFn       fn      = m_nodes[idx].Fn;
+            WorldCommands* staging = &m_staging[idx];
+            ThreadPoolHelper::Submit([&scene, dt, fn, staging, &remaining, &cv]() {
                 struct Guard {
                     std::atomic<uint32_t>&   r;
                     std::condition_variable& cv;
@@ -357,20 +360,17 @@ void WorldTick::Tick(Scene& scene, float dt, WorldCommands& commands) {
                             cv.notify_one();
                     }
                 } guard{remaining, cv};
-                fn(scene, dt, commands);
+                fn(scene, dt, *staging);   // ← private staging buffer, no contention
             });
         }
 
         // Phase 1: spin-yield — stays in user space for fast waves (< ~100 μs).
-        // Avoids the syscall cost of mutex lock when workers finish quickly.
         for (int spin = 0; spin < 100; ++spin) {
             if (remaining.load(std::memory_order_acquire) == 0) break;
             std::this_thread::yield();
         }
 
         // Phase 2: fall back to cv.wait for slow waves (physics, skinning, etc.).
-        // LIFETIME GUARANTEE: Tick() blocks here until all worker tasks complete.
-        // Stack-local variables remain valid for the entire duration of the wait.
         if (remaining.load(std::memory_order_acquire) != 0) {
             std::unique_lock<std::mutex> lock(mtx);
             static constexpr int kWaveTimeoutSeconds = 30;
@@ -380,6 +380,9 @@ void WorldTick::Tick(Scene& scene, float dt, WorldCommands& commands) {
             ZENGINE_VALIDATE_ASSERT(completed,
                 "WorldTick::Tick: wave timed out — a system has hung or crashed")
         }
+
+        // Merge staging buffers into the authoritative commands in submission order.
+        for (uint32_t idx : wave) commands.Merge(m_staging[idx]);
     }
 }
 ```
@@ -389,6 +392,13 @@ void WorldTick::Tick(Scene& scene, float dt, WorldCommands& commands) {
 are partitioned by type and workers never share a storage. `EntityRegistry::ForEachAlive`
 is read-only during `Tick`; mutations must go through `WorldCommands`, not called
 directly from within a system.
+
+**`WorldCommands` in parallel waves**: `WorldCommands` itself is not thread-safe.
+In multi-system waves, each worker receives a private staging `WorldCommands` instead
+of the shared one. After the wave barrier, the main thread merges all staging buffers
+into the authoritative buffer in submission order. `SpawnCallbackIndex` values are
+offset-corrected during merge. Single-system waves use the caller's buffer directly
+with no staging overhead. See `actor-ecs-architecture.md` §7.5 for the full design.
 
 ---
 

--- a/ZEngine/tests/ECS/SchedulerTest.cpp
+++ b/ZEngine/tests/ECS/SchedulerTest.cpp
@@ -155,3 +155,57 @@ TEST_F(SchedulerFixture, ThreeSystemChainProducesThreeWaves)
     EXPECT_EQ(m_tick.WaveCount(), 3u);
     m_tick.Tick(m_scene, 0.016f, m_commands);
 }
+
+// Test 6 — Two parallel systems both calling SpawnEntity produce two valid
+// entities with no corruption. This is the core regression test for the
+// staging-buffer fix: without it, concurrent push() calls on the shared
+// WorldCommands would race and lose one or both spawns.
+TEST_F(SchedulerFixture, ParallelSystemsBothSpawn_BothEntitiesCreated)
+{
+    static std::atomic<int> s_spawn_count{0};
+
+    auto                    SpawnerA = [](Scene&, float, WorldCommands& cmds) { cmds.SpawnEntity({nullptr, [](void*, EntityID) { s_spawn_count.fetch_add(1, std::memory_order_relaxed); }}); };
+    auto                    SpawnerB = [](Scene&, float, WorldCommands& cmds) { cmds.SpawnEntity({nullptr, [](void*, EntityID) { s_spawn_count.fetch_add(1, std::memory_order_relaxed); }}); };
+
+    // Disjoint masks → same wave (no conflict, no OrderBefore required).
+    m_tick.RegisterSystem(SpawnerA, {.UsesCommands = true});
+    m_tick.RegisterSystem(SpawnerB, {.UsesCommands = true});
+    m_tick.Commit();
+
+    EXPECT_EQ(m_tick.WaveCount(), 1u);
+
+    s_spawn_count.store(0);
+    m_tick.Tick(m_scene, 0.016f, m_commands);
+    m_commands.Flush(m_scene);
+
+    EXPECT_EQ(s_spawn_count.load(), 2) << "both spawn callbacks must fire";
+    EXPECT_EQ(m_scene.AliveCount(), 2u) << "both entities must be created";
+}
+
+// Test 7 — SpawnCallbackIndex is correctly remapped when staging buffers are
+// merged. Each spawner attaches a distinct callback; verify the correct callback
+// fires for the correct entity (index fixup correctness).
+TEST_F(SchedulerFixture, ParallelSpawnCallbacks_IndicesRemappedCorrectly)
+{
+    static EntityID s_from_a = INVALID_ENTITY;
+    static EntityID s_from_b = INVALID_ENTITY;
+
+    auto            SpawnerA = [](Scene&, float, WorldCommands& cmds) { cmds.SpawnEntity({&s_from_a, [](void* ctx, EntityID id) { *static_cast<EntityID*>(ctx) = id; }}); };
+    auto            SpawnerB = [](Scene&, float, WorldCommands& cmds) { cmds.SpawnEntity({&s_from_b, [](void* ctx, EntityID id) { *static_cast<EntityID*>(ctx) = id; }}); };
+
+    m_tick.RegisterSystem(SpawnerA, {.UsesCommands = true});
+    m_tick.RegisterSystem(SpawnerB, {.UsesCommands = true});
+    m_tick.Commit();
+
+    s_from_a = INVALID_ENTITY;
+    s_from_b = INVALID_ENTITY;
+
+    m_tick.Tick(m_scene, 0.016f, m_commands);
+    m_commands.Flush(m_scene);
+
+    EXPECT_TRUE(s_from_a.IsValid()) << "SpawnerA callback must have fired";
+    EXPECT_TRUE(s_from_b.IsValid()) << "SpawnerB callback must have fired";
+    EXPECT_NE(s_from_a, s_from_b) << "each spawn must produce a distinct entity";
+    EXPECT_TRUE(m_scene.IsAlive(s_from_a));
+    EXPECT_TRUE(m_scene.IsAlive(s_from_b));
+}


### PR DESCRIPTION
Closes #606

## Root cause

`WorldTick::Tick` dispatched all systems in a parallel wave with the same
`WorldCommands&` reference. Concurrent calls to `SpawnEntity()`, `AddComponent()`,
etc. raced on `Array::push()` inside `WorldCommands` — no locks, no atomics.

## Fix — Option A: per-system staging buffers

**`SystemDeps::UsesCommands`** — documentation flag marking systems that call WorldCommands methods.

**`WorldCommands::Merge(src)`** — appends all commands from `src` with `SpawnCallbackIndex`
offset-fixup so indices remain valid after the two `m_spawn_callbacks` arrays are concatenated.

**`WorldTick::Commit()`** — pre-allocates one staging `WorldCommands` per registered system
(arena-backed, reused each frame via `Clear()` — no heap allocation after the first exercised frame).

**`WorldTick::Tick()` — multi-system waves:**
1. Clear each system's staging buffer
2. Submit every worker with its own staging buffer (no shared state on hot path)
3. After wave barrier, main thread merges staging buffers into the authoritative `commands` in submission order

**Single-system waves** unchanged: run inline on the calling thread with the caller's
`WorldCommands` buffer directly — zero overhead.

## Tests

`ParallelSystemsBothSpawn_BothEntitiesCreated` — two parallel spawners produce two valid
entities; no commands lost under concurrent execution.

`ParallelSpawnCallbacks_IndicesRemappedCorrectly` — `SpawnCallbackIndex` correctly remapped
after merge; each callback fires on its own distinct entity.

All 7 scheduler tests pass.

## Docs

- `actor-ecs-architecture.md` §7.5 — new subsection documenting the staging buffer
  approach, the merge protocol, and the `UsesCommands` flag
- `system-scheduler.md` §8 — updated multi-system wave code block + thread safety note