### PR TITLE
fix(importer): handle sources::Vector in GLB texture extraction

### DIFF
--- a/ZEngine/ZEngine/Importers/GltfImporter.cpp
+++ b/ZEngine/ZEngine/Importers/GltfImporter.cpp
@@ -554,6 +554,12 @@ namespace ZEngine::Importers
                         nbytes = arr.bytes.size();
                         set_mime(arr.mimeType);
                     },
+                    [&](const fastgltf::sources::Vector& vec) {
+                        // GLB binary chunk is loaded as sources::Vector by fastgltf
+                        bytes  = reinterpret_cast<const uint8_t*>(vec.bytes.data());
+                        nbytes = vec.bytes.size();
+                        set_mime(vec.mimeType);
+                    },
                     [&](const fastgltf::sources::ByteView& bv_data) {
                         bytes  = reinterpret_cast<const uint8_t*>(bv_data.bytes.data());
                         nbytes = bv_data.bytes.size();
@@ -565,6 +571,11 @@ namespace ZEngine::Importers
                             fastgltf::visitor{
                             [&](const fastgltf::sources::Array& arr) {
                                 bytes  = reinterpret_cast<const uint8_t*>(arr.bytes.data()) + bv.byteOffset;
+                                nbytes = bv.byteLength;
+                                set_mime(bv_src.mimeType);
+                            },
+                            [&](const fastgltf::sources::Vector& vec) {
+                                bytes  = reinterpret_cast<const uint8_t*>(vec.bytes.data()) + bv.byteOffset;
                                 nbytes = bv.byteLength;
                                 set_mime(bv_src.mimeType);
                             },


### PR DESCRIPTION
## Root cause

fastgltf loads GLB binary chunk buffers as `sources::Vector` (a `std::vector<std::byte>`). The texture extraction visitor only handled `sources::Array` and `sources::ByteView`, so `sources::Vector` fell through to the `[](auto&&) {}` no-op, leaving `bytes = nullptr` and triggering:

```
GltfImporter: tex N image data not accessible (unsupported source variant)
```

All embedded textures in GLB files were silently skipped, leaving materials without albedo textures and meshes rendering as uniformly dark.

## Fix

Added `sources::Vector` handlers in two places:
1. **Outer visitor** on `img.data` — for images stored directly as Vector
2. **Inner visitor** on `asset.buffers[bv.bufferIndex].data` — for images in a BufferView whose backing buffer is a Vector (the common GLB case)