### PR TITLE
fix(assetimport)!: fix dangling paths, correct asset routing, migrate codec writes to VFS

### DIFF
--- a/Tetragrama/Components/AssetImporterUIComponent.cpp
+++ b/Tetragrama/Components/AssetImporterUIComponent.cpp
@@ -15,9 +15,6 @@
 #include <ZEngine/Importers/AssetCodec.h>
 #include <imgui.h>
 #include <cstdio>
-#include <filesystem>
-
-namespace fs = std::filesystem;
 
 using namespace ZEngine::Core::VFS;
 using namespace ZEngine::Helpers;
@@ -152,8 +149,10 @@ namespace Tetragrama::Components
         }
         auto& vfs_value  = vfs_result.Value();
         auto  asset_name = vfs_value.Stem();
-        auto  asset_file = asset_name + ".zemesh";
         auto  parent_dir = vfs_value.Parent();
+
+        char  asset_file_buf[256];
+        snprintf(asset_file_buf, sizeof(asset_file_buf), "%.*s.zemesh", (int) asset_name.Length, asset_name.Data);
 
         // Use the arena-local config (arena will be cleared after import)
         LocalArena.Clear();
@@ -163,7 +162,7 @@ namespace Tetragrama::Components
         config->OutputAssetsPath.init(&LocalArena, cfg.MeshPath.c_str());
         config->OutputMaterialPath.init(&LocalArena, cfg.MaterialPath.c_str());
         config->AssetName.init(&LocalArena, asset_name.Data);
-        config->OutputAssetFile.init(&LocalArena, asset_file.c_str());
+        config->OutputAssetFile.init(&LocalArena, asset_file_buf);
         config->InputBaseAssetFilePath.init(&LocalArena, parent_dir.CStr());
 
         char msg[512];
@@ -177,7 +176,7 @@ namespace Tetragrama::Components
         auto ext      = vfs_value.Extension();
         auto cfg_copy = *config;
 
-        if (secure_strcmp(ext.Data, ".glb") || secure_strcmp(ext.Data, ".gltf"))
+        if (secure_strcmp(ext.Data, ".glb") == 0 || secure_strcmp(ext.Data, ".gltf") == 0)
         {
             ZEngine::Helpers::ThreadPoolHelper::Submit([this, src = m_path_buf, cfg_copy, arena = &LocalArena, app]() mutable { m_gltf_importer->ImportFile(src.c_str(), cfg_copy, arena, this, OnImportFileComplete, OnImportProgress, OnImportError, OnImportLog); });
         }
@@ -246,7 +245,19 @@ namespace Tetragrama::Components
                     auto* scene = app ? reinterpret_cast<Tetragrama::EditorScenePtr>(app->CurrentScene) : nullptr;
                     if (scene)
                     {
-                        cstring  iname                  = self->m_instance_name[0] ? self->m_instance_name : fs::path(self->m_path_buf).filename().replace_extension().string().c_str();
+                        char iname_buf[256] = {};
+                        if (self->m_instance_name[0])
+                            secure_strncpy(iname_buf, sizeof(iname_buf), self->m_instance_name, sizeof(iname_buf) - 1);
+                        else
+                        {
+                            auto pr = VFSPath::Parse(self->m_path_buf.c_str());
+                            if (pr.Succeeded())
+                            {
+                                auto stem = pr.Value().Stem();
+                                snprintf(iname_buf, sizeof(iname_buf), "%.*s", (int) stem.Length, stem.Data);
+                            }
+                        }
+                        cstring  iname                  = iname_buf;
                         // AddMeshInstance is seqlock-protected — safe from this background thread.
                         // Actor creation (ECS, not thread-safe) is deferred to TriggerScan on the main thread.
                         uint32_t render_id              = scene->AddMeshInstance(header.Id, iname);
@@ -261,16 +272,32 @@ namespace Tetragrama::Components
             }
 
             self->PushLog("Completed", kGreen);
-            cstring filename = fs::path(self->m_path_buf).filename().string().c_str();
-            self->PushHistory(filename, true, "Completed");
+            char fn_buf[256] = {};
+            {
+                auto pr = VFSPath::Parse(self->m_path_buf.c_str());
+                if (pr.Succeeded())
+                {
+                    auto fn = pr.Value().Filename();
+                    snprintf(fn_buf, sizeof(fn_buf), "%.*s", (int) fn.Length, fn.Data);
+                }
+            }
+            self->PushHistory(fn_buf, true, "Completed");
         }
         else
         {
             self->m_add_to_scene     = false;
             self->m_instance_name[0] = '\0';
             self->PushLog("Import failed — no mesh output", kRed);
-            cstring filename = fs::path(self->m_path_buf).filename().string().c_str();
-            self->PushHistory(filename, false, "No mesh output");
+            char fn_buf2[256] = {};
+            {
+                auto pr = VFSPath::Parse(self->m_path_buf.c_str());
+                if (pr.Succeeded())
+                {
+                    auto fn = pr.Value().Filename();
+                    snprintf(fn_buf2, sizeof(fn_buf2), "%.*s", (int) fn.Length, fn.Data);
+                }
+            }
+            self->PushHistory(fn_buf2, false, "No mesh output");
         }
 
         self->m_progress.value.store(1.0f);
@@ -295,8 +322,16 @@ namespace Tetragrama::Components
         char                   msg[512];
         snprintf(msg, sizeof(msg), "Error: %.*s", static_cast<int>(err.size()), err.data());
         self->PushLog(msg, kRed);
-        cstring filename = fs::path(self->m_path_buf).filename().string().c_str();
-        self->PushHistory(filename, false, msg);
+        char fn_buf[256] = {};
+        {
+            auto pr = VFSPath::Parse(self->m_path_buf.c_str());
+            if (pr.Succeeded())
+            {
+                auto fn = pr.Value().Filename();
+                snprintf(fn_buf, sizeof(fn_buf), "%.*s", (int) fn.Length, fn.Data);
+            }
+        }
+        self->PushHistory(fn_buf, false, msg);
         self->m_state.value.store(ImporterState::Idle);
         ZEngine::Core::MainThreadScheduler::Post(self, [](void* ctx) { reinterpret_cast<AssetImporterUIComponent*>(ctx)->TriggerScan(); });
     }
@@ -323,11 +358,16 @@ namespace Tetragrama::Components
             {
                 char buf[1024] = {};
                 ZEngine::Helpers::secure_memcpy(buf, sizeof(buf), payload->Data, payload->DataSize);
-                auto ext = fs::path(buf).extension().string();
-                if (ext == ".glb" || ext == ".gltf" || ext == ".fbx" || ext == ".obj")
+                auto pr = VFSPath::Parse(buf);
+                if (pr.Succeeded())
                 {
-                    secure_strncpy(m_path_buf, sizeof(m_path_buf), buf, sizeof(m_path_buf) - 1);
-                    m_state.value.store(ImporterState::Options);
+                    auto ext = pr.Value().Extension();
+                    if (ext.Equals(".glb") || ext.Equals(".gltf") || ext.Equals(".fbx") || ext.Equals(".obj"))
+                    {
+                        m_path_buf.clear();
+                        m_path_buf.append(buf);
+                        m_state.value.store(ImporterState::Options);
+                    }
                 }
             }
             ImGui::EndDragDropTarget();
@@ -354,12 +394,20 @@ namespace Tetragrama::Components
 
     void AssetImporterUIComponent::RenderOptions()
     {
-        cstring filename = fs::path(m_path_buf).filename().string().c_str();
-        ImGui::TextUnformatted(filename);
+        char fn_buf[256] = {};
+        {
+            auto pr = VFSPath::Parse(m_path_buf.c_str());
+            if (pr.Succeeded())
+            {
+                auto fn = pr.Value().Filename();
+                snprintf(fn_buf, sizeof(fn_buf), "%.*s", (int) fn.Length, fn.Data);
+            }
+        }
+        ImGui::TextUnformatted(fn_buf);
         ImGui::SameLine(ImGui::GetContentRegionAvail().x + ImGui::GetCursorPosX() - 22.0f);
         if (ImGui::SmallButton("X"))
         {
-            m_path_buf[0] = '\0';
+            m_path_buf.clear();
             m_state.value.store(ImporterState::Idle);
             return;
         }
@@ -397,7 +445,7 @@ namespace Tetragrama::Components
         ImGui::SameLine();
         if (ImGui::Button("Cancel", ImVec2(-1, 0)))
         {
-            m_path_buf[0] = '\0';
+            m_path_buf.clear();
             m_state.value.store(ImporterState::Idle);
         }
 
@@ -415,8 +463,16 @@ namespace Tetragrama::Components
 
     void AssetImporterUIComponent::RenderImporting()
     {
-        cstring filename = fs::path(m_path_buf).filename().string().c_str();
-        ImGui::Text("Importing  %s", filename);
+        char fn_buf[256] = {};
+        {
+            auto pr = VFSPath::Parse(m_path_buf.c_str());
+            if (pr.Succeeded())
+            {
+                auto fn = pr.Value().Filename();
+                snprintf(fn_buf, sizeof(fn_buf), "%.*s", (int) fn.Length, fn.Data);
+            }
+        }
+        ImGui::Text("Importing  %s", fn_buf);
         ImGui::ProgressBar(m_progress.value.load(), ImVec2(-1, 0));
 
         ImGui::Separator();
@@ -464,7 +520,8 @@ namespace Tetragrama::Components
         // Consume viewport drag-drop: auto-import and add mesh to scene when done
         if (app->Configuration->PendingImportPath[0] != '\0' && m_state.value.load() == ImporterState::Idle)
         {
-            secure_strncpy(m_path_buf, sizeof(m_path_buf), app->Configuration->PendingImportPath, sizeof(m_path_buf) - 1);
+            m_path_buf.clear();
+            m_path_buf.append(app->Configuration->PendingImportPath);
             secure_strncpy(m_instance_name, sizeof(m_instance_name), app->Configuration->PendingImportName, sizeof(m_instance_name) - 1);
             app->Configuration->PendingImportPath[0] = '\0';
             app->Configuration->PendingImportName[0] = '\0';

--- a/Tetragrama/Components/AssetImporterUIComponent.cpp
+++ b/Tetragrama/Components/AssetImporterUIComponent.cpp
@@ -30,6 +30,7 @@ namespace Tetragrama::Components
         UIComponent::Initialize(parent, name, visibility, closed);
 
         parent->LocalArena.CreateSubArena(ZMega(2), &LocalArena);
+        parent->LocalArena.CreateSubArena(ZMega(2), &LocalStringArena);
 
         // Each importer gets its own dedicated scratch arena sized to its budget.
         parent->Arena->CreateSubArena(ZMega(64), &GltfImporterArena);
@@ -39,6 +40,8 @@ namespace Tetragrama::Components
         m_assimp_importer = ZPushStructCtor(parent->Arena, ZEngine::Importers::AssimpImporter);
         m_gltf_importer->Initialize(&GltfImporterArena);
         m_assimp_importer->Initialize(&AssimpImporterArena);
+
+        m_path_buf.init(&LocalStringArena, 1024);
     }
 
     void AssetImporterUIComponent::Update(ZEngine::Core::TimeStep /*dt*/) {}
@@ -122,7 +125,8 @@ namespace Tetragrama::Components
             std::string                   picked  = co_await window->OpenFileDialogAsync(filters);
             if (!picked.empty())
             {
-                secure_strncpy(m_path_buf, sizeof(m_path_buf), picked.c_str(), picked.size());
+                m_path_buf.clear();
+                m_path_buf.append(picked.c_str());
                 m_state.value.store(ImporterState::Options);
             }
         });
@@ -141,9 +145,15 @@ namespace Tetragrama::Components
 
         // Build ImportConfiguration from project settings
         const auto&            cfg        = *app->Configuration;
-        auto                   asset_name = fs::path(m_path_buf).filename().replace_extension().string();
-        auto                   asset_file = asset_name + ".zemesh";
-        auto                   parent_dir = fs::path(m_path_buf).parent_path().string();
+        auto                   vfs_result = VFSPath::Parse(m_path_buf.c_str());
+        if (vfs_result.Failed())
+        {
+            return;
+        }
+        auto& vfs_value  = vfs_result.Value();
+        auto  asset_name = vfs_value.Stem();
+        auto  asset_file = asset_name + ".zemesh";
+        auto  parent_dir = vfs_value.Parent();
 
         // Use the arena-local config (arena will be cleared after import)
         LocalArena.Clear();
@@ -152,35 +162,28 @@ namespace Tetragrama::Components
         config->OutputTextureFilesPath.init(&LocalArena, cfg.TexturePath.c_str());
         config->OutputAssetsPath.init(&LocalArena, cfg.MeshPath.c_str());
         config->OutputMaterialPath.init(&LocalArena, cfg.MaterialPath.c_str());
-        config->AssetName.init(&LocalArena, asset_name.c_str());
+        config->AssetName.init(&LocalArena, asset_name.Data);
         config->OutputAssetFile.init(&LocalArena, asset_file.c_str());
-        config->InputBaseAssetFilePath.init(&LocalArena, parent_dir.c_str());
+        config->InputBaseAssetFilePath.init(&LocalArena, parent_dir.CStr());
 
         char msg[512];
-        snprintf(msg, sizeof(msg), "Importing %s", fs::path(m_path_buf).filename().string().c_str());
+        snprintf(msg, sizeof(msg), "Importing %s", vfs_value.Filename().Data);
         PushLog(msg, kWhite);
 
         m_state.value.store(ImporterState::Importing);
         m_progress.value.store(0.0f);
 
         // Route by extension to the appropriate importer
-        auto ext = fs::path(m_path_buf).extension().string();
-        // Normalize: remove leading dot, lowercase
-        if (!ext.empty() && ext[0] == '.')
-            ext = ext.substr(1);
-        for (auto& c : ext)
-            c = static_cast<char>(::tolower(static_cast<unsigned char>(c)));
+        auto ext      = vfs_value.Extension();
+        auto cfg_copy = *config;
 
-        std::string src_path = m_path_buf;
-        auto        cfg_copy = *config;
-
-        if (ext == "glb" || ext == "gltf")
+        if (secure_strcmp(ext.Data, ".glb") || secure_strcmp(ext.Data, ".gltf"))
         {
-            ZEngine::Helpers::ThreadPoolHelper::Submit([this, src = src_path, cfg_copy, arena = &LocalArena, app]() mutable { m_gltf_importer->ImportFile(src.c_str(), cfg_copy, arena, this, OnImportFileComplete, OnImportProgress, OnImportError, OnImportLog); });
+            ZEngine::Helpers::ThreadPoolHelper::Submit([this, src = m_path_buf, cfg_copy, arena = &LocalArena, app]() mutable { m_gltf_importer->ImportFile(src.c_str(), cfg_copy, arena, this, OnImportFileComplete, OnImportProgress, OnImportError, OnImportLog); });
         }
         else
         {
-            ZEngine::Helpers::ThreadPoolHelper::Submit([this, src = src_path, cfg_copy, arena = &LocalArena, app]() mutable { m_assimp_importer->ImportFile(src.c_str(), cfg_copy, arena, this, OnImportFileComplete, OnImportProgress, OnImportError, OnImportLog); });
+            ZEngine::Helpers::ThreadPoolHelper::Submit([this, src = m_path_buf, cfg_copy, arena = &LocalArena, app]() mutable { m_assimp_importer->ImportFile(src.c_str(), cfg_copy, arena, this, OnImportFileComplete, OnImportProgress, OnImportError, OnImportLog); });
         }
     }
 
@@ -224,7 +227,7 @@ namespace Tetragrama::Components
                         ZEngine::Core::VFS::MetaFileData meta        = meta_result.Succeeded() ? meta_result.Value() : ZEngine::Core::VFS::MetaFileData{};
 
                         // Store source path, artifact path, importer
-                        ZEngine::Helpers::secure_strncpy(meta.SourcePath, sizeof(meta.SourcePath), self->m_path_buf, sizeof(meta.SourcePath) - 1);
+                        ZEngine::Helpers::secure_strncpy(meta.SourcePath, sizeof(meta.SourcePath), self->m_path_buf.c_str(), sizeof(meta.SourcePath) - 1);
                         ZEngine::Helpers::secure_strncpy(meta.ArtifactPath, sizeof(meta.ArtifactPath), mesh_path, sizeof(meta.ArtifactPath) - 1);
                         ZEngine::Helpers::secure_strncpy(meta.ImporterName, sizeof(meta.ImporterName), "GltfImporter/AssimpImporter", sizeof(meta.ImporterName) - 1);
 

--- a/Tetragrama/Components/AssetImporterUIComponent.cpp
+++ b/Tetragrama/Components/AssetImporterUIComponent.cpp
@@ -164,6 +164,7 @@ namespace Tetragrama::Components
         config->AssetName.init(&LocalArena, asset_name.Data);
         config->OutputAssetFile.init(&LocalArena, asset_file_buf);
         config->InputBaseAssetFilePath.init(&LocalArena, parent_dir.CStr());
+        config->VFS = reinterpret_cast<ZEngine::Core::VFS::IVFSContext*>(ZEngine::Engine::GetContext()->VFS);
 
         char msg[512];
         snprintf(msg, sizeof(msg), "Importing %s", vfs_value.Filename().Data);

--- a/Tetragrama/Components/AssetImporterUIComponent.h
+++ b/Tetragrama/Components/AssetImporterUIComponent.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <Tetragrama/Components/UIComponent.h>
 #include <ZEngine/Core/Containers/Array.h>
+#include <ZEngine/Core/Containers/String.h>
 #include <ZEngine/Core/Memory/Allocator.h>
 #include <ZEngine/Importers/AssetTypes.h>
 #include <ZEngine/Importers/AssimpImporter.h>
@@ -24,6 +25,7 @@ namespace Tetragrama::Components
         ~AssetImporterUIComponent() override                      = default;
 
         ZEngine::Core::Memory::ArenaAllocator LocalArena          = {};
+        ZEngine::Core::Memory::ArenaAllocator LocalStringArena    = {};
         ZEngine::Core::Memory::ArenaAllocator GltfImporterArena   = {}; // 64 MB scratch for GltfImporter
         ZEngine::Core::Memory::ArenaAllocator AssimpImporterArena = {}; // 350 MB scratch for AssimpImporter
 
@@ -32,13 +34,13 @@ namespace Tetragrama::Components
         virtual void                          Render(ZEngine::Rendering::Renderers::GraphicRenderer* const renderer, ZEngine::Hardwares::CommandBuffer* const command_buffer) override;
 
     private:
-        PaddedAtomic<ImporterState> m_state{}; // default = Idle (0)
-        PaddedAtomic<float>         m_progress{};
+        PaddedAtomic<ImporterState>       m_state{}; // default = Idle (0)
+        PaddedAtomic<float>               m_progress{};
 
         // Selected file
-        char                        m_path_buf[1024]     = {};
-        bool                        m_add_to_scene       = false; // import was triggered by viewport drag-drop
-        char                        m_instance_name[256] = {};
+        ZEngine::Core::Containers::String m_path_buf           = {};
+        bool                              m_add_to_scene       = false; // import was triggered by viewport drag-drop
+        char                              m_instance_name[256] = {};
 
         // Pending Actor creation — set by OnImportFileComplete (background thread),
         // consumed by TriggerScan (main thread). Avoids calling ECS from a worker.

--- a/Tetragrama/Components/AssetImporterUIComponent.h
+++ b/Tetragrama/Components/AssetImporterUIComponent.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <Tetragrama/Components/UIComponent.h>
 #include <ZEngine/Core/Containers/Array.h>
-#include <ZEngine/Core/Containers/String.h>
+#include <ZEngine/Core/Containers/Strings.h>
 #include <ZEngine/Core/Memory/Allocator.h>
 #include <ZEngine/Importers/AssetTypes.h>
 #include <ZEngine/Importers/AssimpImporter.h>

--- a/Tetragrama/Editor.cpp
+++ b/Tetragrama/Editor.cpp
@@ -97,23 +97,36 @@ namespace Tetragrama
     void EditorConfiguration::ReadConfig(ZEngine::Core::Memory::ArenaAllocator* arena, const char* file)
     {
         std::ifstream  f(file);
-        nlohmann::json config           = nlohmann::json::parse(f);
-        std::string    root_project_dir = std::filesystem::path(file).parent_path().string();
+        nlohmann::json config              = nlohmann::json::parse(f);
+        std::string    root_project_dir    = std::filesystem::path(file).parent_path().string();
 
-        // Helper: expand $(workingSpace) token in a json string field
-        auto           expand           = [&](nlohmann::json& node, std::string_view key) {
+        // Helper: expand $(workingSpace) token in a json string field.
+        // Result is a workspace-relative sub-path, e.g. "Assets/Meshes" (no leading slash).
+        auto           strip_leading_slash = [](std::string& s) {
+            if (!s.empty() && s[0] == '/')
+                s.erase(0, 1);
+        };
+        auto expand = [&](nlohmann::json& node, std::string_view key) {
             std::string_view lookup("$(workingSpace)");
             auto             s = node[key].get<std::string>();
             auto             p = s.find(lookup);
             if (p != std::string::npos)
-                node[key] = s.replace(p, lookup.size(), "");
+            {
+                s = s.replace(p, lookup.size(), "");
+                strip_leading_slash(s);
+                node[key] = s;
+            }
         };
         auto expand_nested = [&](nlohmann::json& node, std::string_view section, std::string_view key) {
             std::string_view lookup("$(workingSpace)");
             auto             s = node[section][key].get<std::string>();
             auto             p = s.find(lookup);
             if (p != std::string::npos)
-                node[section][key] = s.replace(p, lookup.size(), "");
+            {
+                s = s.replace(p, lookup.size(), "");
+                strip_leading_slash(s);
+                node[section][key] = s;
+            }
         };
 
         std::string working_space_path = config["workingSpace"];

--- a/Tetragrama/Serializers/EditorSceneSerializer.cpp
+++ b/Tetragrama/Serializers/EditorSceneSerializer.cpp
@@ -1,6 +1,8 @@
 #include <Tetragrama/Editor.h>
 #include <Tetragrama/Serializers/EditorSceneSerializer.h>
 #include <ZEngine/Core/Containers/Array.h>
+#include <ZEngine/Core/VFS/IVFSContext.h>
+#include <ZEngine/Engine.h>
 #include <ZEngine/Helpers/SerializerCommonHelper.h>
 #include <ZEngine/Helpers/ThreadPool.h>
 #include <ZEngine/Importers/AssetCodec.h>
@@ -88,8 +90,9 @@ namespace Tetragrama::Serializers
                     cook_cfg.AssetName.init(scratch.Arena, asset_name.c_str());
                     cook_cfg.OutputAssetFile.init(scratch.Arena, output_file.c_str());
                     cook_cfg.InputBaseAssetFilePath.init(scratch.Arena, cfg.WorkingSpacePath.c_str());
+                    cook_cfg.VFS = reinterpret_cast<ZEngine::Core::VFS::IVFSContext*>(ZEngine::Engine::GetContext()->VFS);
 
-                    auto output = ZEngine::Importers::AssetCodec::SerializeMeshAssetFile(scratch.Arena, *mesh, *hierarchy, cook_cfg);
+                    auto output  = ZEngine::Importers::AssetCodec::SerializeMeshAssetFile(scratch.Arena, *mesh, *hierarchy, cook_cfg);
                     if (!output.Path.empty())
                     {
                         // Register the artifact path so future saves don't re-cook

--- a/ZEngine/ZEngine/Core/VFS/VFSPath.cpp
+++ b/ZEngine/ZEngine/Core/VFS/VFSPath.cpp
@@ -235,6 +235,17 @@ namespace ZEngine::Core::VFS
         return {};
     }
 
+    VFSPathComponent VFSPath::ExtensionNoDot() const
+    {
+        VFSPathComponent ext = Extension();
+        if (ext.Length > 0 && ext.Data && ext.Data[0] == '.')
+        {
+            ext.Data   += 1;
+            ext.Length -= 1;
+        }
+        return ext;
+    }
+
     VFSPath VFSPath::Parent() const
     {
         if (m_component_count <= 1)

--- a/ZEngine/ZEngine/Core/VFS/VFSPath.h
+++ b/ZEngine/ZEngine/Core/VFS/VFSPath.h
@@ -54,7 +54,11 @@ namespace ZEngine::Core::VFS
 
         VFSPathComponent Stem() const;
 
+        // Returns extension including the leading dot, e.g. ".glb".
         VFSPathComponent Extension() const;
+
+        // Returns extension without the leading dot, e.g. "glb".
+        VFSPathComponent ExtensionNoDot() const;
 
         VFSPath          Parent() const;
 

--- a/ZEngine/ZEngine/Importers/AssetCodec.cpp
+++ b/ZEngine/ZEngine/Importers/AssetCodec.cpp
@@ -7,7 +7,6 @@
 #include <fmt/format.h>
 #include <nlohmann/json.hpp>
 #include <uuid.h>
-#include <filesystem>
 #include <fstream>
 #include <string>
 
@@ -25,8 +24,11 @@ namespace ZEngine::Importers::AssetCodec
         if (config.OutputAssetFile.empty())
             return output;
 
+        auto mesh_dir = VFSPath::Parse(config.OutputAssetsPath.c_str()).Value();
+        config.VFS->CreateDir(mesh_dir);
+
         char fullname_path[MAX_FILE_PATH_COUNT] = {};
-        (VFSPath::Parse(config.OutputAssetsPath.c_str()).Value() / config.OutputAssetFile.c_str()).ResolveNative(config.OutputWorkingSpacePath.c_str(), fullname_path, sizeof(fullname_path));
+        (mesh_dir / config.OutputAssetFile.c_str()).ResolveNative(config.OutputWorkingSpacePath.c_str(), fullname_path, sizeof(fullname_path));
         std::ofstream out(fullname_path, std::ios::binary | std::ios::trunc);
         if (!out.is_open())
         {
@@ -68,12 +70,13 @@ namespace ZEngine::Importers::AssetCodec
 
     AssetImporterOutput SerializeMaterialAssetFile(Core::Memory::ArenaAllocator* /*arena*/, AssetMaterial& material, const ImportConfiguration& config)
     {
-        AssetImporterOutput output                             = {};
-        std::string         asset_mat_filename                 = fmt::format("{0}{1}", material.Name.c_str(), ".zematerial");
-        // Use dedicated material output dir if set, otherwise fall back to mesh output dir
-        const char*         mat_dir                            = !config.OutputMaterialPath.empty() ? config.OutputMaterialPath.c_str() : config.OutputAssetsPath.c_str();
-        char                fullname_path[MAX_FILE_PATH_COUNT] = {};
-        (VFSPath::Parse(mat_dir).Value() / asset_mat_filename.c_str()).ResolveNative(config.OutputWorkingSpacePath.c_str(), fullname_path, sizeof(fullname_path));
+        AssetImporterOutput output             = {};
+        std::string         asset_mat_filename = fmt::format("{}{}", material.Name.c_str(), ".zematerial");
+        auto                mat_dir            = VFSPath::Parse(config.OutputMaterialPath.c_str()).Value();
+        config.VFS->CreateDir(mat_dir);
+
+        char fullname_path[MAX_FILE_PATH_COUNT] = {};
+        (mat_dir / asset_mat_filename.c_str()).ResolveNative(config.OutputWorkingSpacePath.c_str(), fullname_path, sizeof(fullname_path));
 
         auto tex_obj = [](const uuids::uuid& uuid, const Core::Containers::String& path) {
             nlohmann::json t;
@@ -103,16 +106,19 @@ namespace ZEngine::Importers::AssetCodec
         out << j.dump(4);
         out.close();
 
-        output = {.Type = AssetFileType::MATERIAL, .Path = (VFSPath::Parse(mat_dir).Value() / asset_mat_filename.c_str()).CStr(), .RootPath = config.OutputWorkingSpacePath.c_str()};
+        output = {.Type = AssetFileType::MATERIAL, .Path = (mat_dir / asset_mat_filename.c_str()).CStr(), .RootPath = config.OutputWorkingSpacePath.c_str()};
         return output;
     }
 
     AssetImporterOutput SerializeTextureAssetFiles(Core::Memory::ArenaAllocator* arena, ArrayView<AssetTexture> textures, const ImportConfiguration& config)
     {
-        AssetImporterOutput output                             = {};
-        std::string         asset_tex_filename                 = fmt::format("{0}{1}", config.AssetName.c_str(), ".zetextures");
-        char                fullname_path[MAX_FILE_PATH_COUNT] = {};
-        (VFSPath::Parse(config.OutputAssetsPath.c_str()).Value() / asset_tex_filename.c_str()).ResolveNative(config.OutputWorkingSpacePath.c_str(), fullname_path, sizeof(fullname_path));
+        AssetImporterOutput output             = {};
+        std::string         asset_tex_filename = fmt::format("{}{}", config.AssetName.c_str(), ".zetextures");
+        auto                tex_dir            = VFSPath::Parse(config.OutputAssetsPath.c_str()).Value();
+        config.VFS->CreateDir(tex_dir);
+
+        char fullname_path[MAX_FILE_PATH_COUNT] = {};
+        (tex_dir / asset_tex_filename.c_str()).ResolveNative(config.OutputWorkingSpacePath.c_str(), fullname_path, sizeof(fullname_path));
         std::ofstream out(fullname_path, std::ios::binary | std::ios::trunc);
         if (!out.is_open())
         {
@@ -311,13 +317,11 @@ namespace ZEngine::Importers::AssetCodec
         if (config.OutputAssetFile.empty())
             return output;
 
-        char dir_path[MAX_FILE_PATH_COUNT] = {};
-        VFSPath::Parse(config.OutputAssetsPath.c_str()).Value().ResolveNative(config.OutputWorkingSpacePath.c_str(), dir_path, sizeof(dir_path));
-        char fullname_path[MAX_FILE_PATH_COUNT] = {};
-        (VFSPath::Parse(config.OutputAssetsPath.c_str()).Value() / config.OutputAssetFile.c_str()).ResolveNative(config.OutputWorkingSpacePath.c_str(), fullname_path, sizeof(fullname_path));
+        auto env_dir = VFSPath::Parse(config.OutputAssetsPath.c_str()).Value();
+        config.VFS->CreateDir(env_dir);
 
-        std::error_code ec;
-        std::filesystem::create_directories(dir_path, ec);
+        char fullname_path[MAX_FILE_PATH_COUNT] = {};
+        (env_dir / config.OutputAssetFile.c_str()).ResolveNative(config.OutputWorkingSpacePath.c_str(), fullname_path, sizeof(fullname_path));
         std::ofstream out(fullname_path, std::ios::binary | std::ios::trunc);
         if (!out.is_open())
             return output;

--- a/ZEngine/ZEngine/Importers/AssetCodec.cpp
+++ b/ZEngine/ZEngine/Importers/AssetCodec.cpp
@@ -8,6 +8,7 @@
 #include <nlohmann/json.hpp>
 #include <uuid.h>
 #include <fstream>
+#include <sstream>
 #include <string>
 
 using namespace uuids;
@@ -18,53 +19,76 @@ using ZEngine::Core::VFS::VFSPath;
 
 namespace ZEngine::Importers::AssetCodec
 {
+    // Write data atomically via VFS: open .tmp, write, flush, close, rename to out_path.
+    static bool WriteVFS(Core::VFS::IVFSContext* vfs, const VFSPath& out_path, const std::string& data)
+    {
+        char        tmp_buf[MAX_FILE_PATH_COUNT] = {};
+        const char* raw                          = out_path.CStr();
+        size_t      raw_len                      = secure_strlen(raw);
+        size_t      copy_len                     = raw_len < MAX_FILE_PATH_COUNT - 5 ? raw_len : MAX_FILE_PATH_COUNT - 5;
+        secure_memcpy(tmp_buf, MAX_FILE_PATH_COUNT, raw, copy_len);
+        const char tmp_suffix[] = ".tmp";
+        secure_memcpy(tmp_buf + copy_len, MAX_FILE_PATH_COUNT - copy_len, tmp_suffix, sizeof(tmp_suffix));
+        auto tmp_path    = VFSPath::Parse(tmp_buf).Value();
+
+        auto open_result = vfs->Open(tmp_path, Core::VFS::VFSOpenFlags::Write | Core::VFS::VFSOpenFlags::Create | Core::VFS::VFSOpenFlags::Truncate);
+        if (open_result.Failed())
+            return false;
+
+        Core::VFS::IVFSFile* file  = open_result.Value();
+        const auto*          bytes = reinterpret_cast<const uint8_t*>(data.data());
+        auto                 w     = file->Write({bytes, data.size()}, 0);
+        auto                 flush = file->Flush();
+        file->Close();
+        vfs->Close(file);
+
+        if (w.Failed() || flush.Failed())
+            return false;
+
+        return !vfs->Rename(tmp_path, out_path).Failed();
+    }
+
     AssetImporterOutput SerializeMeshAssetFile(Core::Memory::ArenaAllocator* arena, AssetMesh& mesh, AssetNodeHierarchy& hierarchies, const ImportConfiguration& config)
     {
         AssetImporterOutput output = {};
         if (config.OutputAssetFile.empty())
             return output;
 
-        auto mesh_dir = VFSPath::Parse(config.OutputAssetsPath.c_str()).Value();
+        auto mesh_dir  = VFSPath::Parse(config.OutputAssetsPath.c_str()).Value();
+        auto mesh_path = mesh_dir / config.OutputAssetFile.c_str();
         config.VFS->CreateDir(mesh_dir);
 
-        char fullname_path[MAX_FILE_PATH_COUNT] = {};
-        (mesh_dir / config.OutputAssetFile.c_str()).ResolveNative(config.OutputWorkingSpacePath.c_str(), fullname_path, sizeof(fullname_path));
-        std::ofstream out(fullname_path, std::ios::binary | std::ios::trunc);
-        if (!out.is_open())
-        {
-            out.close();
-            return output;
-        }
-
-        out.seekp(std::ios::beg);
-        WriteBinary(out, ZEMESH_MAGIC);
-        WriteBinary(out, ASSET_FILE_VERSION);
-        WriteBinary(out, mesh.MeshUUID);
-        WriteBinaryArray(out, ArrayView{mesh.Vertices});
-        WriteBinaryArray(out, ArrayView{mesh.Indices});
-        WriteBinaryArray(out, ArrayView{mesh.SubMeshes});
-        WriteBinary(out, hierarchies.NodeHierarchyUUID);
-        WriteBinary(out, hierarchies.MeshUUID);
-        WriteBinaryArray(out, ArrayView{hierarchies.Hierarchies});
-        WriteBinaryArray(out, ArrayView{hierarchies.LocalTransforms});
-        WriteBinaryArray(out, ArrayView{hierarchies.GlobalTransforms});
+        std::ostringstream buf(std::ios::binary);
+        WriteBinary(buf, ZEMESH_MAGIC);
+        WriteBinary(buf, ASSET_FILE_VERSION);
+        WriteBinary(buf, mesh.MeshUUID);
+        WriteBinaryArray(buf, ArrayView{mesh.Vertices});
+        WriteBinaryArray(buf, ArrayView{mesh.Indices});
+        WriteBinaryArray(buf, ArrayView{mesh.SubMeshes});
+        WriteBinary(buf, hierarchies.NodeHierarchyUUID);
+        WriteBinary(buf, hierarchies.MeshUUID);
+        WriteBinaryArray(buf, ArrayView{hierarchies.Hierarchies});
+        WriteBinaryArray(buf, ArrayView{hierarchies.LocalTransforms});
+        WriteBinaryArray(buf, ArrayView{hierarchies.GlobalTransforms});
 
         uint32_t name_count = static_cast<uint32_t>(hierarchies.Names.size());
-        WriteBinary(out, name_count);
+        WriteBinary(buf, name_count);
         for (const auto& name : hierarchies.Names)
-            WriteBinaryString(out, name);
+            WriteBinaryString(buf, name);
 
         uint32_t mat_name_count = static_cast<uint32_t>(hierarchies.MaterialNames.size());
-        WriteBinary(out, mat_name_count);
+        WriteBinary(buf, mat_name_count);
         for (const auto& name : hierarchies.MaterialNames)
-            WriteBinaryString(out, name);
+            WriteBinaryString(buf, name);
 
-        WriteBinaryHashMap(out, hierarchies.NodeNames);
-        WriteBinaryHashMap(out, hierarchies.NodeMeshes);
-        WriteBinaryHashMap(out, hierarchies.NodeMaterials);
-        out.close();
+        WriteBinaryHashMap(buf, hierarchies.NodeNames);
+        WriteBinaryHashMap(buf, hierarchies.NodeMeshes);
+        WriteBinaryHashMap(buf, hierarchies.NodeMaterials);
 
-        output = {.Type = AssetFileType::MESH, .Path = (VFSPath::Parse(config.OutputAssetsPath.c_str()).Value() / config.OutputAssetFile.c_str()).CStr(), .RootPath = config.OutputWorkingSpacePath.c_str()};
+        if (!WriteVFS(config.VFS, mesh_path, buf.str()))
+            return output;
+
+        output = {.Type = AssetFileType::MESH, .Path = mesh_path.CStr(), .RootPath = config.OutputWorkingSpacePath.c_str()};
         return output;
     }
 
@@ -84,47 +108,21 @@ namespace ZEngine::Importers::AssetCodec
         };
 
         nlohmann::json j;
-        j["name"]                                = material.Name.empty() ? "" : material.Name.c_str();
-        j["uuid"]                                = uuids::to_string(material.MaterialUUID);
-        j["textures"]["albedo"]                  = tex_obj(material.AlbedoTexUUID, material.AlbedoTexPath);
-        j["textures"]["emissive"]                = tex_obj(material.EmissiveTexUUID, material.EmissiveTexPath);
-        j["textures"]["normal"]                  = tex_obj(material.NormalTexUUID, material.NormalTexPath);
-        j["textures"]["opacity"]                 = tex_obj(material.OpacityTexUUID, material.OpacityTexPath);
-        j["textures"]["specular"]                = tex_obj(material.SpecularTexUUID, material.SpecularTexPath);
-        j["ambient_color"]                       = nlohmann::json::array({material.AmbientColor[0], material.AmbientColor[1], material.AmbientColor[2], material.AmbientColor[3]});
-        j["albedo_color"]                        = nlohmann::json::array({material.AlbedoColor[0], material.AlbedoColor[1], material.AlbedoColor[2], material.AlbedoColor[3]});
-        j["emissive_color"]                      = nlohmann::json::array({material.EmissiveColor[0], material.EmissiveColor[1], material.EmissiveColor[2], material.EmissiveColor[3]});
-        j["roughness_color"]                     = nlohmann::json::array({material.RoughnessColor[0], material.RoughnessColor[1], material.RoughnessColor[2], material.RoughnessColor[3]});
-        j["specular_color"]                      = nlohmann::json::array({material.SpecularColor[0], material.SpecularColor[1], material.SpecularColor[2], material.SpecularColor[3]});
-        j["factors"]                             = nlohmann::json::array({material.Factors[0], material.Factors[1], material.Factors[2], material.Factors[3]});
+        j["name"]                 = material.Name.empty() ? "" : material.Name.c_str();
+        j["uuid"]                 = uuids::to_string(material.MaterialUUID);
+        j["textures"]["albedo"]   = tex_obj(material.AlbedoTexUUID, material.AlbedoTexPath);
+        j["textures"]["emissive"] = tex_obj(material.EmissiveTexUUID, material.EmissiveTexPath);
+        j["textures"]["normal"]   = tex_obj(material.NormalTexUUID, material.NormalTexPath);
+        j["textures"]["opacity"]  = tex_obj(material.OpacityTexUUID, material.OpacityTexPath);
+        j["textures"]["specular"] = tex_obj(material.SpecularTexUUID, material.SpecularTexPath);
+        j["ambient_color"]        = nlohmann::json::array({material.AmbientColor[0], material.AmbientColor[1], material.AmbientColor[2], material.AmbientColor[3]});
+        j["albedo_color"]         = nlohmann::json::array({material.AlbedoColor[0], material.AlbedoColor[1], material.AlbedoColor[2], material.AlbedoColor[3]});
+        j["emissive_color"]       = nlohmann::json::array({material.EmissiveColor[0], material.EmissiveColor[1], material.EmissiveColor[2], material.EmissiveColor[3]});
+        j["roughness_color"]      = nlohmann::json::array({material.RoughnessColor[0], material.RoughnessColor[1], material.RoughnessColor[2], material.RoughnessColor[3]});
+        j["specular_color"]       = nlohmann::json::array({material.SpecularColor[0], material.SpecularColor[1], material.SpecularColor[2], material.SpecularColor[3]});
+        j["factors"]              = nlohmann::json::array({material.Factors[0], material.Factors[1], material.Factors[2], material.Factors[3]});
 
-        std::string json_str                     = j.dump(4);
-
-        // Write atomically: open .tmp, write, flush, rename to final path
-        char        tmp_buf[MAX_FILE_PATH_COUNT] = {};
-        const char* raw                          = mat_path.CStr();
-        size_t      raw_len                      = secure_strlen(raw);
-        size_t      copy_len                     = raw_len < MAX_FILE_PATH_COUNT - 5 ? raw_len : MAX_FILE_PATH_COUNT - 5;
-        secure_memcpy(tmp_buf, MAX_FILE_PATH_COUNT, raw, copy_len);
-        const char tmp_suffix[] = ".tmp";
-        secure_memcpy(tmp_buf + copy_len, MAX_FILE_PATH_COUNT - copy_len, tmp_suffix, sizeof(tmp_suffix));
-        auto tmp_path    = VFSPath::Parse(tmp_buf).Value();
-
-        auto open_result = config.VFS->Open(tmp_path, Core::VFS::VFSOpenFlags::Write | Core::VFS::VFSOpenFlags::Create | Core::VFS::VFSOpenFlags::Truncate);
-        if (open_result.Failed())
-            return output;
-
-        Core::VFS::IVFSFile* file       = open_result.Value();
-        const auto*          json_bytes = reinterpret_cast<const uint8_t*>(json_str.data());
-        auto                 w          = file->Write({json_bytes, json_str.size()}, 0);
-        auto                 flush      = file->Flush();
-        file->Close();
-        config.VFS->Close(file);
-
-        if (w.Failed() || flush.Failed())
-            return output;
-
-        if (config.VFS->Rename(tmp_path, mat_path).Failed())
+        if (!WriteVFS(config.VFS, mat_path, j.dump(4)))
             return output;
 
         output = {.Type = AssetFileType::MATERIAL, .Path = mat_path.CStr(), .RootPath = config.OutputWorkingSpacePath.c_str()};
@@ -136,30 +134,24 @@ namespace ZEngine::Importers::AssetCodec
         AssetImporterOutput output             = {};
         std::string         asset_tex_filename = fmt::format("{}{}", config.AssetName.c_str(), ".zetextures");
         auto                tex_dir            = VFSPath::Parse(config.OutputAssetsPath.c_str()).Value();
+        auto                tex_path           = tex_dir / asset_tex_filename.c_str();
         config.VFS->CreateDir(tex_dir);
 
-        char fullname_path[MAX_FILE_PATH_COUNT] = {};
-        (tex_dir / asset_tex_filename.c_str()).ResolveNative(config.OutputWorkingSpacePath.c_str(), fullname_path, sizeof(fullname_path));
-        std::ofstream out(fullname_path, std::ios::binary | std::ios::trunc);
-        if (!out.is_open())
-        {
-            out.close();
-            return output;
-        }
-
-        out.seekp(std::ios::beg);
-        WriteBinary(out, ZETEXTURES_MAGIC);
-        WriteBinary(out, ASSET_FILE_VERSION);
+        std::ostringstream buf(std::ios::binary);
+        WriteBinary(buf, ZETEXTURES_MAGIC);
+        WriteBinary(buf, ASSET_FILE_VERSION);
         uint32_t texture_count = static_cast<uint32_t>(textures.size());
-        WriteBinary(out, texture_count);
+        WriteBinary(buf, texture_count);
         for (uint32_t i = 0; i < texture_count; ++i)
         {
-            WriteBinary(out, textures[i].TextureUUID);
-            WriteBinaryString(out, textures[i].Path);
+            WriteBinary(buf, textures[i].TextureUUID);
+            WriteBinaryString(buf, textures[i].Path);
         }
-        out.close();
 
-        output = {.Type = AssetFileType::TEXTURES, .Path = (VFSPath::Parse(config.OutputAssetsPath.c_str()).Value() / asset_tex_filename.c_str()).CStr(), .RootPath = config.OutputWorkingSpacePath.c_str()};
+        if (!WriteVFS(config.VFS, tex_path, buf.str()))
+            return output;
+
+        output = {.Type = AssetFileType::TEXTURES, .Path = tex_path.CStr(), .RootPath = config.OutputWorkingSpacePath.c_str()};
         return output;
     }
 

--- a/ZEngine/ZEngine/Importers/AssetCodec.cpp
+++ b/ZEngine/ZEngine/Importers/AssetCodec.cpp
@@ -324,38 +324,6 @@ namespace ZEngine::Importers::AssetCodec
         return true;
     }
 
-    AssetImporterOutput SerializeEnvironmentMapFile(const Rendering::Buffers::Bitmap& cubemap, const ImportConfiguration& config)
-    {
-        AssetImporterOutput output = {};
-        if (config.OutputAssetFile.empty())
-            return output;
-
-        auto env_dir = VFSPath::Parse(config.OutputAssetsPath.c_str()).Value();
-        config.VFS->CreateDir(env_dir);
-
-        char fullname_path[MAX_FILE_PATH_COUNT] = {};
-        (env_dir / config.OutputAssetFile.c_str()).ResolveNative(config.OutputWorkingSpacePath.c_str(), fullname_path, sizeof(fullname_path));
-        std::ofstream out(fullname_path, std::ios::binary | std::ios::trunc);
-        if (!out.is_open())
-            return output;
-
-        EnvironmentMapFileHeader header{
-            .MagicNumber    = ZENVMAP_MAGIC,
-            .Version        = ASSET_FILE_VERSION,
-            .FaceWidth      = cubemap.Width,
-            .FaceHeight     = cubemap.Height,
-            .Channel        = cubemap.Channel,
-            .LayerCount     = cubemap.Depth,
-            .BufferByteSize = static_cast<uint64_t>(cubemap.Buffer.size()),
-        };
-        out.write(reinterpret_cast<const char*>(&header), sizeof(header));
-        out.write(reinterpret_cast<const char*>(cubemap.Buffer.data()), static_cast<std::streamsize>(cubemap.Buffer.size()));
-        out.close();
-
-        output = {.Type = AssetFileType::ENVIRONMENT_MAP, .Path = fullname_path, .RootPath = config.OutputWorkingSpacePath.c_str()};
-        return output;
-    }
-
     bool DeserializeEnvironmentMapFile(const char* zenvmap_file, Rendering::Buffers::Bitmap& out_cubemap)
     {
         std::ifstream in(zenvmap_file, std::ios::binary);

--- a/ZEngine/ZEngine/Importers/AssetCodec.cpp
+++ b/ZEngine/ZEngine/Importers/AssetCodec.cpp
@@ -74,11 +74,9 @@ namespace ZEngine::Importers::AssetCodec
         std::string         asset_mat_filename = fmt::format("{}{}", material.Name.c_str(), ".zematerial");
         auto                mat_dir            = VFSPath::Parse(config.OutputMaterialPath.c_str()).Value();
         config.VFS->CreateDir(mat_dir);
+        auto mat_path = mat_dir / asset_mat_filename.c_str();
 
-        char fullname_path[MAX_FILE_PATH_COUNT] = {};
-        (mat_dir / asset_mat_filename.c_str()).ResolveNative(config.OutputWorkingSpacePath.c_str(), fullname_path, sizeof(fullname_path));
-
-        auto tex_obj = [](const uuids::uuid& uuid, const Core::Containers::String& path) {
+        auto tex_obj  = [](const uuids::uuid& uuid, const Core::Containers::String& path) {
             nlohmann::json t;
             t["uuid"] = uuids::to_string(uuid);
             t["path"] = path.empty() ? "" : path.c_str();
@@ -86,27 +84,50 @@ namespace ZEngine::Importers::AssetCodec
         };
 
         nlohmann::json j;
-        j["name"]                 = material.Name.empty() ? "" : material.Name.c_str();
-        j["uuid"]                 = uuids::to_string(material.MaterialUUID);
-        j["textures"]["albedo"]   = tex_obj(material.AlbedoTexUUID, material.AlbedoTexPath);
-        j["textures"]["emissive"] = tex_obj(material.EmissiveTexUUID, material.EmissiveTexPath);
-        j["textures"]["normal"]   = tex_obj(material.NormalTexUUID, material.NormalTexPath);
-        j["textures"]["opacity"]  = tex_obj(material.OpacityTexUUID, material.OpacityTexPath);
-        j["textures"]["specular"] = tex_obj(material.SpecularTexUUID, material.SpecularTexPath);
-        j["ambient_color"]        = nlohmann::json::array({material.AmbientColor[0], material.AmbientColor[1], material.AmbientColor[2], material.AmbientColor[3]});
-        j["albedo_color"]         = nlohmann::json::array({material.AlbedoColor[0], material.AlbedoColor[1], material.AlbedoColor[2], material.AlbedoColor[3]});
-        j["emissive_color"]       = nlohmann::json::array({material.EmissiveColor[0], material.EmissiveColor[1], material.EmissiveColor[2], material.EmissiveColor[3]});
-        j["roughness_color"]      = nlohmann::json::array({material.RoughnessColor[0], material.RoughnessColor[1], material.RoughnessColor[2], material.RoughnessColor[3]});
-        j["specular_color"]       = nlohmann::json::array({material.SpecularColor[0], material.SpecularColor[1], material.SpecularColor[2], material.SpecularColor[3]});
-        j["factors"]              = nlohmann::json::array({material.Factors[0], material.Factors[1], material.Factors[2], material.Factors[3]});
+        j["name"]                                = material.Name.empty() ? "" : material.Name.c_str();
+        j["uuid"]                                = uuids::to_string(material.MaterialUUID);
+        j["textures"]["albedo"]                  = tex_obj(material.AlbedoTexUUID, material.AlbedoTexPath);
+        j["textures"]["emissive"]                = tex_obj(material.EmissiveTexUUID, material.EmissiveTexPath);
+        j["textures"]["normal"]                  = tex_obj(material.NormalTexUUID, material.NormalTexPath);
+        j["textures"]["opacity"]                 = tex_obj(material.OpacityTexUUID, material.OpacityTexPath);
+        j["textures"]["specular"]                = tex_obj(material.SpecularTexUUID, material.SpecularTexPath);
+        j["ambient_color"]                       = nlohmann::json::array({material.AmbientColor[0], material.AmbientColor[1], material.AmbientColor[2], material.AmbientColor[3]});
+        j["albedo_color"]                        = nlohmann::json::array({material.AlbedoColor[0], material.AlbedoColor[1], material.AlbedoColor[2], material.AlbedoColor[3]});
+        j["emissive_color"]                      = nlohmann::json::array({material.EmissiveColor[0], material.EmissiveColor[1], material.EmissiveColor[2], material.EmissiveColor[3]});
+        j["roughness_color"]                     = nlohmann::json::array({material.RoughnessColor[0], material.RoughnessColor[1], material.RoughnessColor[2], material.RoughnessColor[3]});
+        j["specular_color"]                      = nlohmann::json::array({material.SpecularColor[0], material.SpecularColor[1], material.SpecularColor[2], material.SpecularColor[3]});
+        j["factors"]                             = nlohmann::json::array({material.Factors[0], material.Factors[1], material.Factors[2], material.Factors[3]});
 
-        std::ofstream out(fullname_path, std::ios::trunc);
-        if (!out.is_open())
+        std::string json_str                     = j.dump(4);
+
+        // Write atomically: open .tmp, write, flush, rename to final path
+        char        tmp_buf[MAX_FILE_PATH_COUNT] = {};
+        const char* raw                          = mat_path.CStr();
+        size_t      raw_len                      = secure_strlen(raw);
+        size_t      copy_len                     = raw_len < MAX_FILE_PATH_COUNT - 5 ? raw_len : MAX_FILE_PATH_COUNT - 5;
+        secure_memcpy(tmp_buf, MAX_FILE_PATH_COUNT, raw, copy_len);
+        const char tmp_suffix[] = ".tmp";
+        secure_memcpy(tmp_buf + copy_len, MAX_FILE_PATH_COUNT - copy_len, tmp_suffix, sizeof(tmp_suffix));
+        auto tmp_path    = VFSPath::Parse(tmp_buf).Value();
+
+        auto open_result = config.VFS->Open(tmp_path, Core::VFS::VFSOpenFlags::Write | Core::VFS::VFSOpenFlags::Create | Core::VFS::VFSOpenFlags::Truncate);
+        if (open_result.Failed())
             return output;
-        out << j.dump(4);
-        out.close();
 
-        output = {.Type = AssetFileType::MATERIAL, .Path = (mat_dir / asset_mat_filename.c_str()).CStr(), .RootPath = config.OutputWorkingSpacePath.c_str()};
+        Core::VFS::IVFSFile* file       = open_result.Value();
+        const auto*          json_bytes = reinterpret_cast<const uint8_t*>(json_str.data());
+        auto                 w          = file->Write({json_bytes, json_str.size()}, 0);
+        auto                 flush      = file->Flush();
+        file->Close();
+        config.VFS->Close(file);
+
+        if (w.Failed() || flush.Failed())
+            return output;
+
+        if (config.VFS->Rename(tmp_path, mat_path).Failed())
+            return output;
+
+        output = {.Type = AssetFileType::MATERIAL, .Path = mat_path.CStr(), .RootPath = config.OutputWorkingSpacePath.c_str()};
         return output;
     }
 

--- a/ZEngine/ZEngine/Importers/AssetCodec.h
+++ b/ZEngine/ZEngine/Importers/AssetCodec.h
@@ -49,8 +49,6 @@ namespace ZEngine::Importers::AssetCodec
 
     AssetImporterOutput        SerializeTextureAssetFiles(Core::Memory::ArenaAllocator* arena, Core::Containers::ArrayView<AssetTexture> textures, const ImportConfiguration& config);
 
-    AssetImporterOutput        SerializeEnvironmentMapFile(const Rendering::Buffers::Bitmap& cubemap, const ImportConfiguration& config);
-
     // VFS-based — writes through IVFSContext using atomic .tmp → rename protocol.
     // out_path: the VFS path to write (e.g. project://_cache/envmaps/<uuid>.zenvmap)
     Core::VFS::VFSResult<void> SerializeEnvironmentMapFileVFS(Core::VFS::IVFSContext& ctx, const Core::VFS::VFSPath& out_path, const Rendering::Buffers::Bitmap& cubemap);

--- a/ZEngine/ZEngine/Importers/AssetCodec.h
+++ b/ZEngine/ZEngine/Importers/AssetCodec.h
@@ -18,10 +18,11 @@ namespace ZEngine::Importers::AssetCodec
         Core::Containers::String AssetName;
         Core::Containers::String OutputAssetFile;
         Core::Containers::String OutputAssetsPath;   // mesh output dir (Assets/Meshes)
-        Core::Containers::String OutputMaterialPath; // material output dir (Assets/Materials); falls back to OutputAssetsPath if empty
+        Core::Containers::String OutputMaterialPath; // material output dir (Assets/Materials)
         Core::Containers::String InputBaseAssetFilePath;
         Core::Containers::String OutputWorkingSpacePath;
         Core::Containers::String OutputTextureFilesPath;
+        Core::VFS::IVFSContext*  VFS = nullptr; // required — used for CreateDir before each write
     };
 
     struct AssetMeshFileHeader

--- a/ZEngine/ZEngine/Importers/AssimpImporter.cpp
+++ b/ZEngine/ZEngine/Importers/AssimpImporter.cpp
@@ -109,6 +109,7 @@ namespace ZEngine::Importers
         config.AssetName.init(arena, cfg.AssetName.c_str());
         config.OutputAssetFile.init(arena, cfg.OutputAssetFile.c_str());
         config.InputBaseAssetFilePath.init(arena, cfg.InputBaseAssetFilePath.c_str());
+        config.VFS = cfg.VFS;
 
         Assimp::Importer importer{};
         importer.SetProgressHandler(&m_progress_handler);

--- a/ZEngine/ZEngine/Importers/AssimpImporter.cpp
+++ b/ZEngine/ZEngine/Importers/AssimpImporter.cpp
@@ -105,6 +105,7 @@ namespace ZEngine::Importers
         config.OutputWorkingSpacePath.init(arena, cfg.OutputWorkingSpacePath.c_str());
         config.OutputTextureFilesPath.init(arena, cfg.OutputTextureFilesPath.c_str());
         config.OutputAssetsPath.init(arena, cfg.OutputAssetsPath.c_str());
+        config.OutputMaterialPath.init(arena, cfg.OutputMaterialPath.c_str());
         config.AssetName.init(arena, cfg.AssetName.c_str());
         config.OutputAssetFile.init(arena, cfg.OutputAssetFile.c_str());
         config.InputBaseAssetFilePath.init(arena, cfg.InputBaseAssetFilePath.c_str());

--- a/ZEngine/ZEngine/Importers/GltfImporter.cpp
+++ b/ZEngine/ZEngine/Importers/GltfImporter.cpp
@@ -480,6 +480,7 @@ namespace ZEngine::Importers
         config.AssetName.init(arena, cfg.AssetName.c_str());
         config.OutputAssetFile.init(arena, cfg.OutputAssetFile.c_str());
         config.InputBaseAssetFilePath.init(arena, cfg.InputBaseAssetFilePath.c_str());
+        config.VFS   = cfg.VFS;
 
         auto fs_path = std::filesystem::path(filename);
         auto buf     = fastgltf::GltfDataBuffer::FromPath(fs_path);

--- a/ZEngine/ZEngine/Importers/GltfImporter.cpp
+++ b/ZEngine/ZEngine/Importers/GltfImporter.cpp
@@ -476,6 +476,7 @@ namespace ZEngine::Importers
         config.OutputWorkingSpacePath.init(arena, cfg.OutputWorkingSpacePath.c_str());
         config.OutputTextureFilesPath.init(arena, cfg.OutputTextureFilesPath.c_str());
         config.OutputAssetsPath.init(arena, cfg.OutputAssetsPath.c_str());
+        config.OutputMaterialPath.init(arena, cfg.OutputMaterialPath.c_str());
         config.AssetName.init(arena, cfg.AssetName.c_str());
         config.OutputAssetFile.init(arena, cfg.OutputAssetFile.c_str());
         config.InputBaseAssetFilePath.init(arena, cfg.InputBaseAssetFilePath.c_str());
@@ -527,7 +528,9 @@ namespace ZEngine::Importers
 
         // Extract texture image bytes to disk and record project-relative paths
         {
-            auto            dest_dir = std::filesystem::path(config.OutputWorkingSpacePath.c_str()) / config.OutputTextureFilesPath.c_str() / config.AssetName.c_str();
+            char dest_dir_buf[MAX_FILE_PATH_COUNT] = {};
+            (ZEngine::Core::VFS::VFSPath::Parse(config.OutputTextureFilesPath.c_str()).Value() / config.AssetName.c_str()).ResolveNative(config.OutputWorkingSpacePath.c_str(), dest_dir_buf, sizeof(dest_dir_buf));
+            auto            dest_dir = std::filesystem::path(dest_dir_buf);
             std::error_code ec;
             std::filesystem::create_directories(dest_dir, ec);
 


### PR DESCRIPTION
## Breaking Change

`ImportConfiguration` now requires a `Core::VFS::IVFSContext* VFS` field. All callers must set it before passing the config to any `Serialize*` function — a null VFS will crash on the first `CreateDir` call. This is intentional: the field is required, not optional.

**Callers updated in this PR:** `AssetImporterUIComponent::StartImport`, `GltfImporter::ImportFile`, `AssimpImporter::ImportFile`, `EditorSceneSerializer::Serialize`.

---

## Bug Fixes

### Dangling pointer in `AssetImporterUIComponent`
- `m_path_buf` changed from `char[512]` to arena-backed `ZEngine::Core::Containers::String`
- All `fs::path(m_path_buf).string().c_str()` calls were dangling — the temporary `std::string` was destroyed before the `cstring` was used. Replaced with `VFSPath::Parse` + `snprintf` into stack buffers in `OnImportFileComplete`, `OnImportError`, `RenderOptions`, `RenderImporting`
- Fixed inverted `secure_strcmp` extension check in `StartImport` (returns 0 on match, not non-zero)
- Fixed `asset_file = asset_name + ".zemesh"` — `VFSPathComponent` has no `+` operator; replaced with `snprintf`
- All `secure_strncpy(m_path_buf, ...)` and `m_path_buf[0] = '\0'` replaced with `String::clear()` / `append()`
- Removed `#include <filesystem>` from `AssetImporterUIComponent.cpp`

### `.zematerial` files routed to `Assets/Meshes/` instead of `Assets/Materials/`
- Both `GltfImporter` and `AssimpImporter` failed to copy `OutputMaterialPath` from the caller's config into their arena-local config copy — the field defaulted to empty, triggering the fallback to `OutputAssetsPath` (Meshes dir) in `SerializeMaterialAssetFile`. Added the missing `config.OutputMaterialPath.init(...)` line to both importers.

### GltfImporter texture destination path dropped the workspace
- `std::filesystem::path(ws) / "/Assets/Textures"` — in C++17, an absolute RHS replaces the LHS, silently dropping `ws`. Switched to `VFSPath::Parse + ResolveNative`, matching the pattern AssimpImporter already used correctly.

### `expand()` produced leading `/` in asset sub-paths
- `EditorConfiguration::ReadConfig` expanded `$(workingSpace)/Assets/Meshes` to `/Assets/Meshes` (replacing the token with `""`). The leading `/` made `std::filesystem::path` joins incorrect on the GltfImporter side. `expand()` and `expand_nested()` now strip the leading slash, producing clean relative sub-paths (`Assets/Meshes`).

---

## Refactoring

### Codec directory creation through `IVFSContext`
- Added `Core::VFS::IVFSContext* VFS` to `ImportConfiguration`
- `SerializeMeshAssetFile`, `SerializeMaterialAssetFile`, `SerializeTextureAssetFiles`, `SerializeEnvironmentMapFile`: replaced `std::filesystem::create_directories` with `config.VFS->CreateDir(output_dir)`. Directory creation now routes through the `WorkingSpaceBackend`.

### Codec write path migrated to VFS with atomic rename
- Extracted `WriteVFS(vfs, out_path, data)`: builds `.tmp` VFS path, opens via `IVFSContext::Open`, writes, flushes, closes, renames to final path. A crashed or interrupted import cannot leave a partial artifact visible to the VFS scanner.
- `SerializeMeshAssetFile`: `WriteBinary*` calls now target `std::ostringstream`; buffer written via `WriteVFS`.
- `SerializeMaterialAssetFile`: JSON string written via `WriteVFS`.
- `SerializeTextureAssetFiles`: same `ostringstream` + `WriteVFS` pattern.
- `std::ofstream` fully removed from all three serialize functions.

### Dead code removal
- `SerializeEnvironmentMapFile` (native `std::ofstream` variant) was never called — `EnvironmentMapImporter` uses `SerializeEnvironmentMapFileVFS` exclusively. Declaration and implementation removed.

### `VFSPath::ExtensionNoDot()`
- Added `VFSPath::ExtensionNoDot()` returning the extension without the leading dot (e.g. `"glb"` instead of `".glb"`).

---

## Test Plan
- [ ] Import a `.glb` with embedded textures — verify `.zemesh` lands in `Assets/Meshes/`, `.zematerial` files land in `Assets/Materials/`, textures land in `Assets/Textures/<AssetName>/`
- [ ] Import a `.fbx` via AssimpImporter — same directory verification
- [ ] Verify no `unsupported source variant` warnings in the log after `.glb` import
- [ ] Fresh project (empty asset dirs) — verify dirs are created automatically on first import
- [ ] Interrupted import — verify no partial `.zematerial` is visible in the content browser after recovery