### PR TITLE
fix(#603): bind material texture handles to mesh submeshes at draw time

### DIFF
--- a/Obelisk/EntryPoint.cpp
+++ b/Obelisk/EntryPoint.cpp
@@ -30,7 +30,7 @@ int applicationEntryPoint(int argc, char* argv[])
     CLI11_PARSE(cli, argc, argv);
 
     MemoryManager manager = {};
-    manager.Initialize(ZGiga(8u), launch_editor ? MemoryBudgetConfig::Editor() : MemoryBudgetConfig::Default());
+    manager.Initialize(ZGiga(8ULL), launch_editor ? MemoryBudgetConfig::Editor() : MemoryBudgetConfig::Default());
 #if ZENGINE_PROFILING
     ZEngine::Profiling::MemoryProfiler::Initialize(&manager.MainArena);
     ZEngine::Profiling::MemoryProfiler::TrackArena("MainArena", &manager.MainArena);

--- a/Obelisk/EntryPoint.cpp
+++ b/Obelisk/EntryPoint.cpp
@@ -30,7 +30,7 @@ int applicationEntryPoint(int argc, char* argv[])
     CLI11_PARSE(cli, argc, argv);
 
     MemoryManager manager = {};
-    manager.Initialize(ZGiga(3u), launch_editor ? MemoryBudgetConfig::Editor() : MemoryBudgetConfig::Default());
+    manager.Initialize(ZGiga(8u), launch_editor ? MemoryBudgetConfig::Editor() : MemoryBudgetConfig::Default());
 #if ZENGINE_PROFILING
     ZEngine::Profiling::MemoryProfiler::Initialize(&manager.MainArena);
     ZEngine::Profiling::MemoryProfiler::TrackArena("MainArena", &manager.MainArena);
@@ -73,7 +73,7 @@ int applicationEntryPoint(int argc, char* argv[])
     Logger::Flush();
     Logger::Dispose();
 
-    // Step 17 — free the 3 GB arena block
+    // Step 17 — free the 8 GB arena block
     manager.Shutdown();
 
     // OnClosed fires after memory is freed — may only use stack/OS resources

--- a/Tetragrama/Components/AssetImporterUIComponent.cpp
+++ b/Tetragrama/Components/AssetImporterUIComponent.cpp
@@ -26,8 +26,8 @@ namespace Tetragrama::Components
     {
         UIComponent::Initialize(parent, name, visibility, closed);
 
-        parent->LocalArena.CreateSubArena(ZMega(2), &LocalArena);
-        parent->LocalArena.CreateSubArena(ZMega(2), &LocalStringArena);
+        parent->LocalArena.CreateSubArena(ZMega(8), &LocalArena);
+        parent->LocalArena.CreateSubArena(ZMega(4), &LocalStringArena);
 
         // Each importer gets its own dedicated scratch arena sized to its budget.
         parent->Arena->CreateSubArena(ZMega(64), &GltfImporterArena);

--- a/Tetragrama/Components/DockspaceUIComponent.cpp
+++ b/Tetragrama/Components/DockspaceUIComponent.cpp
@@ -1205,12 +1205,44 @@ namespace Tetragrama::Components
         // so both the CPU asset registry and the RRM GPU buffers are populated.
         if (!ZEngine::Managers::AssetManager::GetAsset<ZEngine::Importers::AssetMesh>(header.Id))
         {
-            auto                                   scratch = ZGetScratch(&LocalArena);
-            ZEngine::Importers::AssetMesh          mesh{};
-            ZEngine::Importers::AssetNodeHierarchy hier{};
-            ZEngine::Importers::AssetCodec::DeserializeMeshAssetFile(scratch.Arena, filename, mesh, hier);
-            ZEngine::Managers::AssetManager::IngestMesh(std::move(mesh), std::move(hier));
-            ZReleaseScratch(scratch);
+            // Phase 1: deserialize mesh. Copy material names to stack before releasing
+            // the scratch — material names live in scratch.Arena and are invalidated on release.
+            static constexpr size_t kMaxMaterials                 = 64;
+            char                    mat_names[kMaxMaterials][256] = {};
+            size_t                  mat_count                     = 0;
+
+            {
+                auto                                   scratch = ZGetScratch(&LocalArena);
+                ZEngine::Importers::AssetMesh          mesh{};
+                ZEngine::Importers::AssetNodeHierarchy hier{};
+                ZEngine::Importers::AssetCodec::DeserializeMeshAssetFile(scratch.Arena, filename, mesh, hier);
+
+                mat_count = hier.MaterialNames.size() < kMaxMaterials ? hier.MaterialNames.size() : kMaxMaterials;
+                for (size_t i = 0; i < mat_count; ++i)
+                    ZEngine::Helpers::secure_strncpy(mat_names[i], sizeof(mat_names[i]), hier.MaterialNames[i].c_str(), sizeof(mat_names[i]) - 1);
+
+                ZEngine::Managers::AssetManager::IngestMesh(std::move(mesh), std::move(hier));
+                ZReleaseScratch(scratch);
+            }
+
+            // Phase 2: load associated .zematerial files in a fresh scratch so mesh and
+            // material deserializations never compete for the same 1 MB LocalArena.
+            auto* app_cfg = ParentLayer && ParentLayer->CurrentApp ? reinterpret_cast<EditorPtr>(ParentLayer->CurrentApp)->Configuration : nullptr;
+            if (app_cfg)
+            {
+                for (size_t i = 0; i < mat_count; ++i)
+                {
+                    char mat_path[MAX_FILE_PATH_COUNT] = {};
+                    snprintf(mat_path, sizeof(mat_path), "%s/%s/%s.zematerial", app_cfg->WorkingSpacePath.c_str(), app_cfg->MaterialPath.c_str(), mat_names[i]);
+
+                    auto                              scratch = ZGetScratch(&LocalArena);
+                    ZEngine::Importers::AssetMaterial mat{};
+                    ZEngine::Importers::AssetCodec::DeserializeMaterialAssetFile(scratch.Arena, mat_path, mat);
+                    if (!mat.MaterialUUID.is_nil())
+                        ZEngine::Managers::AssetManager::IngestMaterial(std::move(mat));
+                    ZReleaseScratch(scratch);
+                }
+            }
         }
 
         auto        app           = reinterpret_cast<EditorPtr>(ParentLayer->CurrentApp);

--- a/Tetragrama/Components/DockspaceUIComponent.cpp
+++ b/Tetragrama/Components/DockspaceUIComponent.cpp
@@ -298,7 +298,7 @@ namespace Tetragrama::Components
     {
         UIComponent::Initialize(parent, name, visibility, closed);
 
-        parent->LocalArena.CreateSubArena(ZMega(1), &LocalArena);
+        parent->LocalArena.CreateSubArena(ZMega(32), &LocalArena);
 
         m_editor_serializer = ZPushStructCtor(parent->Arena, Serializers::EditorSceneSerializer);
 

--- a/Tetragrama/Components/ProjectViewUIComponent.cpp
+++ b/Tetragrama/Components/ProjectViewUIComponent.cpp
@@ -21,7 +21,7 @@ namespace Tetragrama::Components
     void ProjectViewUIComponent::Initialize(Layers::ImguiLayer* parent, const char* name, bool visibility, bool closed)
     {
         UIComponent::Initialize(parent, name, visibility, closed);
-        parent->LocalArena.CreateSubArena(ZMega(1), &m_local_arena);
+        parent->LocalArena.CreateSubArena(ZMega(4), &m_local_arena);
 
         m_vfs_context     = ZEngine::Engine::GetContext()->VFS;
         m_directory_cache = &ParentLayer->Cache;

--- a/Tetragrama/Layers/ImguiLayer.cpp
+++ b/Tetragrama/Layers/ImguiLayer.cpp
@@ -30,7 +30,7 @@ namespace Tetragrama::Layers
     {
         Arena      = arena;
         CurrentApp = app;
-        arena->CreateSubArena(ZMega(10), &LocalArena);
+        arena->CreateSubArena(ZMega(64), &LocalArena);
 
         Scanner.Initialize(arena);
         Cache.Initialize(arena);

--- a/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp
+++ b/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp
@@ -146,8 +146,8 @@ namespace ZEngine::Applications
                 for (uint32_t sub_i = 0; sub_i < static_cast<uint32_t>(mesh->SubMeshes.size()); ++sub_i)
                 {
                     const auto&                          sub      = mesh->SubMeshes[sub_i];
-                    auto                                 mat_h    = mgr->GetMaterialHandleFromUUID(sub.MaterialUUID);
-                    uint32_t                             mat_idx  = Managers::AssetManager::ReadAssetHandleIndex(mat_h);
+                    auto*                                mat      = Managers::AssetManager::GetAsset<Importers::AssetMaterial>(sub.MaterialUUID);
+                    uint32_t                             mat_idx  = mat ? static_cast<uint32_t>(mat - mgr->Materials.data()) : 0;
                     uint32_t                             draw_idx = static_cast<uint32_t>(allocs.size());
 
                     Rendering::Meshes::SubMeshAllocation alloc    = {};

--- a/ZEngine/ZEngine/Core/Memory/MemoryManager.h
+++ b/ZEngine/ZEngine/Core/Memory/MemoryManager.h
@@ -55,20 +55,20 @@ namespace ZEngine::Core::Memory
         inline static MemoryBudgetConfig Default()
         {
             MemoryBudgetConfig cfg = {};
-            cfg.AudioEngine        = {"AudioEngine", ZMega(32ULL)};
-            cfg.AnimationManager   = {"AnimationManager", ZMega(64ULL)};
-            cfg.AssetManager       = {"AssetManager", ZMega(100ULL)};
-            cfg.ECSScene           = {"ECSScene", ZMega(128ULL)};
-            cfg.Logging            = {"Logging", ZMega(4ULL)};
-            cfg.VirtualFS          = {"VirtualFS", ZMega(32ULL)};
-            cfg.VulkanDevice       = {"VulkanDevice", ZMega(512ULL)};
-            cfg.Importer           = {"Importer", ZMega(350ULL)};
-            cfg.UIContext          = {"UIContext", ZMega(8ULL)};
-            cfg.Swapchain          = {"Swapchain", ZMega(3ULL)};
-            cfg.ShaderCache        = {"ShaderCache", ZMega(16ULL)};
-            cfg.Serializer         = {"Serializer", ZMega(150ULL)};
-            cfg.Network            = {"Network", ZMega(32ULL)};
-            cfg.Input              = {"Input", ZMega(1ULL)};
+            cfg.AudioEngine        = {"AudioEngine", ZMega(128ULL)};
+            cfg.AnimationManager   = {"AnimationManager", ZMega(256ULL)};
+            cfg.AssetManager       = {"AssetManager", ZMega(512ULL)};
+            cfg.ECSScene           = {"ECSScene", ZMega(512ULL)};
+            cfg.Logging            = {"Logging", ZMega(8ULL)};
+            cfg.VirtualFS          = {"VirtualFS", ZMega(64ULL)};
+            cfg.VulkanDevice       = {"VulkanDevice", ZGiga(1ULL)};
+            cfg.Importer           = {"Importer", ZMega(512ULL)};
+            cfg.UIContext          = {"UIContext", ZMega(64ULL)};
+            cfg.Swapchain          = {"Swapchain", ZMega(8ULL)};
+            cfg.ShaderCache        = {"ShaderCache", ZMega(64ULL)};
+            cfg.Serializer         = {"Serializer", ZMega(256ULL)};
+            cfg.Network            = {"Network", ZMega(64ULL)};
+            cfg.Input              = {"Input", ZMega(4ULL)};
 
             return cfg;
         }
@@ -91,7 +91,7 @@ namespace ZEngine::Core::Memory
             auto cfg                  = Default();
             cfg.AudioEngine.SizeBytes = 0ull;
             cfg.Network.SizeBytes     = 0ull;
-            cfg.UIContext.SizeBytes   = ZMega(32ULL);
+            cfg.UIContext.SizeBytes   = ZMega(128ULL);
 
             return cfg;
         }

--- a/ZEngine/ZEngine/Managers/AssetManager.cpp
+++ b/ZEngine/ZEngine/Managers/AssetManager.cpp
@@ -48,6 +48,7 @@ namespace ZEngine::Managers
         s_Instance->GPUMeshMaterials.init(&s_Instance->Arena, 5000);
         s_Instance->Textures.init(&s_Instance->Arena, 5000);
         s_Instance->UUIDToTextureHandle.init(&s_Instance->Arena, 5000);
+        s_Instance->MeshToHierarchySlot.init(&s_Instance->Arena, 5000);
 
         static Core::VFS::AssetRegistry s_registry;
         s_registry.Initialize(&s_Instance->Arena);
@@ -79,16 +80,23 @@ namespace ZEngine::Managers
 
     // ── Direct ingest methods — called from ImportCoordinator thread ─────────────
 
+    bool AssetManager::IsRegistered(const uuids::uuid& id)
+    {
+        return s_Instance && s_Instance->Registry && s_Instance->Registry->FindByUUID(id) != nullptr;
+    }
+
     void AssetManager::IngestMesh(AssetMesh&& mesh, AssetNodeHierarchy&& hierarchy)
     {
         if (!s_Instance)
             return;
         std::lock_guard lock(s_Instance->IngestMutex);
+        if (IsRegistered(mesh.MeshUUID))
+            return;
 
         // Mesh
-        auto            mesh_slot = static_cast<uint32_t>(s_Instance->Meshes.size());
-        auto&           m         = s_Instance->Meshes.push_use({});
-        m.MeshUUID                = mesh.MeshUUID;
+        auto  mesh_slot = static_cast<uint32_t>(s_Instance->Meshes.size());
+        auto& m         = s_Instance->Meshes.push_use({});
+        m.MeshUUID      = mesh.MeshUUID;
         m.SubMeshes.init(&s_Instance->Arena, mesh.SubMeshes.size());
         m.Vertices.init(&s_Instance->Arena, mesh.Vertices.size(), mesh.Vertices.size());
         m.Indices.init(&s_Instance->Arena, mesh.Indices.size(), mesh.Indices.size());
@@ -135,6 +143,7 @@ namespace ZEngine::Managers
             h.NodeMaterials.insert(k, v);
 
         RegisterAsset(AssetType::MESH_HIERARCHY, h.NodeHierarchyUUID, hier_slot);
+        s_Instance->MeshToHierarchySlot.insert(h.MeshUUID, hier_slot);
 
         // Notify the registry that both assets are now loaded so hot-reload callbacks fire.
         if (s_Instance->Registry)
@@ -144,44 +153,55 @@ namespace ZEngine::Managers
         }
     }
 
+    Rendering::Textures::TextureHandle AssetManager::IngestTexture(const uuids::uuid& uuid, const Core::Containers::String& path)
+    {
+        if (!s_Instance)
+            return {};
+        std::lock_guard lock(s_Instance->IngestMutex);
+
+        // Dedup — return existing handle if already registered.
+        if (IsRegistered(uuid))
+        {
+            auto* h = s_Instance->UUIDToTextureHandle.find(uuid);
+            return h ? *h : s_Instance->FallbackTextureHandle;
+        }
+
+        auto  slot          = static_cast<uint32_t>(s_Instance->Textures.size());
+        auto& new_tex       = s_Instance->Textures.push_use({});
+        new_tex.TextureUUID = uuid;
+        new_tex.Path.init(&s_Instance->Arena, path.c_str());
+
+        if (!new_tex.Path.empty() && s_Instance->Device && s_Instance->Device->RRM)
+        {
+            char full_path[MAX_FILE_PATH_COUNT] = {};
+            snprintf(full_path, sizeof(full_path), "%s%c%s", s_Instance->CurrentWorkingSpacePath, PLATFORM_OS_BACKSLASH, new_tex.Path.c_str());
+            auto* rrm      = static_cast<Rendering::RenderResourceManager*>(s_Instance->Device->RRM);
+            new_tex.Handle = rrm->SubmitTextureFile(0, 0, full_path);
+            if (!new_tex.Handle.Valid())
+            {
+                ZENGINE_VALIDATE_ASSERT(s_Instance->FallbackTextureHandle.Valid(), "FallbackTextureHandle not initialized — InitFallbackTexture must be called before ingesting assets")
+                ZENGINE_LOG_ASSET_WARN("Texture not found: '{}' — using fallback", full_path)
+                new_tex.Handle = s_Instance->FallbackTextureHandle;
+            }
+        }
+        else
+        {
+            ZENGINE_VALIDATE_ASSERT(s_Instance->FallbackTextureHandle.Valid(), "FallbackTextureHandle not initialized — InitFallbackTexture must be called before ingesting assets")
+            ZENGINE_LOG_ASSET_WARN("Texture {} has no path — extraction may have failed, using fallback", uuids::to_string(uuid))
+            new_tex.Handle = s_Instance->FallbackTextureHandle;
+        }
+
+        RegisterAsset(AssetType::TEXTURE, new_tex.TextureUUID, slot);
+        s_Instance->UUIDToTextureHandle.insert(new_tex.TextureUUID, new_tex.Handle);
+        return new_tex.Handle;
+    }
+
     void AssetManager::IngestTextures(Core::Containers::Array<AssetTexture>&& textures)
     {
         if (!s_Instance)
             return;
-        std::lock_guard lock(s_Instance->IngestMutex);
-
         for (size_t i = 0; i < textures.size(); ++i)
-        {
-            auto& tex           = textures[i];
-            auto  slot          = static_cast<uint32_t>(s_Instance->Textures.size());
-            auto& new_tex       = s_Instance->Textures.push_use({});
-            new_tex.TextureUUID = tex.TextureUUID;
-
-            // Store the path in the arena first so the pointer is stable
-            // for the async GPU upload that outlives this stack frame.
-            new_tex.Path.init(&s_Instance->Arena, tex.Path.c_str());
-            if (!new_tex.Path.empty() && s_Instance->Device->RRM)
-            {
-                const auto               path = fmt::format("{0}{1}{2}", s_Instance->CurrentWorkingSpacePath, PLATFORM_OS_BACKSLASH, new_tex.Path.c_str());
-                Core::Containers::String stable_path;
-                stable_path.init(&s_Instance->Arena, path.c_str());
-                auto* rrm      = static_cast<Rendering::RenderResourceManager*>(s_Instance->Device->RRM);
-                new_tex.Handle = rrm->SubmitTextureFile(0, 0, stable_path.c_str());
-                if (!new_tex.Handle.Valid())
-                {
-                    ZENGINE_LOG_ASSET_WARN("Texture not found: '{}' — using fallback", stable_path.c_str())
-                    new_tex.Handle = s_Instance->FallbackTextureHandle;
-                }
-            }
-            else if (new_tex.Path.empty())
-            {
-                // No path at all — use fallback so the slot is never null
-                new_tex.Handle = s_Instance->FallbackTextureHandle;
-            }
-
-            RegisterAsset(AssetType::TEXTURE, new_tex.TextureUUID, slot);
-            s_Instance->UUIDToTextureHandle.insert(new_tex.TextureUUID, new_tex.Handle);
-        }
+            IngestTexture(textures[i].TextureUUID, textures[i].Path);
     }
 
     void AssetManager::IngestMaterial(AssetMaterial&& mat)
@@ -189,8 +209,10 @@ namespace ZEngine::Managers
         if (!s_Instance)
             return;
         std::lock_guard lock(s_Instance->IngestMutex);
+        if (IsRegistered(mat.MaterialUUID))
+            return;
 
-        auto            slot = static_cast<uint32_t>(s_Instance->Materials.size());
+        auto slot = static_cast<uint32_t>(s_Instance->Materials.size());
         s_Instance->Materials.push(mat);
         RegisterAsset(AssetType::MATERIAL, mat.MaterialUUID, slot);
 
@@ -202,17 +224,24 @@ namespace ZEngine::Managers
         gpu_mat.AmbientColor                     = mat.AmbientColor;
         gpu_mat.Factors                          = mat.Factors;
 
-        auto tex_handle                          = [&](const uuids::uuid& id) -> uint32_t {
+        // Resolve handle for a texture slot: UUID lookup first, then fall back to uploading
+        // from the stored path — handles scene-reload and dragged-.zmesh cases where
+        // IngestTextures may not have run yet for this material's textures.
+        auto tex_handle                          = [&](const uuids::uuid& id, const Core::Containers::String& path) -> uint32_t {
             if (id.is_nil())
-                return 0;
+                return INVALID_MAP_HANDLE;
             auto* h = s_Instance->UUIDToTextureHandle.find(id);
-            return h ? h->Index : 0;
+            if (h)
+                return h->Index;
+            if (!path.empty())
+                return IngestTexture(id, path).Index;
+            return INVALID_MAP_HANDLE;
         };
-        gpu_mat.AlbedoMap   = tex_handle(mat.AlbedoTexUUID);
-        gpu_mat.EmissiveMap = tex_handle(mat.EmissiveTexUUID);
-        gpu_mat.NormalMap   = tex_handle(mat.NormalTexUUID);
-        gpu_mat.OpacityMap  = tex_handle(mat.OpacityTexUUID);
-        gpu_mat.SpecularMap = tex_handle(mat.SpecularTexUUID);
+        gpu_mat.AlbedoMap   = tex_handle(mat.AlbedoTexUUID, mat.AlbedoTexPath);
+        gpu_mat.EmissiveMap = tex_handle(mat.EmissiveTexUUID, mat.EmissiveTexPath);
+        gpu_mat.NormalMap   = tex_handle(mat.NormalTexUUID, mat.NormalTexPath);
+        gpu_mat.OpacityMap  = tex_handle(mat.OpacityTexUUID, mat.OpacityTexPath);
+        gpu_mat.SpecularMap = tex_handle(mat.SpecularTexUUID, mat.SpecularTexPath);
     }
 
     // ── CPU buffer accessors ──────────────────────────────────────────────────────
@@ -228,14 +257,12 @@ namespace ZEngine::Managers
         return index < Meshes.size() ? &Meshes[index] : nullptr;
     }
 
-    Importers::AssetNodeHierarchy* AssetManager::GetMeshNodeHierarchy(const uuids::uuid& id)
+    Importers::AssetNodeHierarchy* AssetManager::GetMeshNodeHierarchy(const uuids::uuid& mesh_id)
     {
-        if (!Registry)
+        if (!s_Instance)
             return nullptr;
-        for (size_t i = 0; i < NodeHierarchies.size(); ++i)
-            if (NodeHierarchies[i].MeshUUID == id)
-                return &NodeHierarchies[i];
-        return nullptr;
+        const uint32_t* slot = s_Instance->MeshToHierarchySlot.find(mesh_id);
+        return (slot && *slot < s_Instance->NodeHierarchies.size()) ? &s_Instance->NodeHierarchies[*slot] : nullptr;
     }
 
     AssetHandle AssetManager::GetMeshNodeHierarchyHandle(const uuids::uuid& id)
@@ -244,49 +271,6 @@ namespace ZEngine::Managers
             return 0;
         const Core::VFS::AssetRecord* rec = Registry->FindByUUID(id);
         return rec ? rec->SlotHandle : 0;
-    }
-
-    AssetHandle AssetManager::GetMaterialHandleFromUUID(const uuids::uuid& material_uuid)
-    {
-        if (!Registry)
-            return 0;
-        const Core::VFS::AssetRecord* rec = Registry->FindByUUID(material_uuid);
-        return rec ? rec->SlotHandle : 0;
-    }
-
-    Importers::AssetTexture* AssetManager::LoadTextureFileAsAsset(cstring file, bool absolute)
-    {
-        if (!Helpers::secure_strlen(file))
-            return nullptr;
-
-        auto                         asset_id = static_cast<uint32_t>(Textures.size());
-        auto&                        new_tex  = Textures.push_use({});
-
-        std::random_device           rd;
-        std::mt19937                 generator(rd());
-        uuids::uuid_random_generator gen{generator};
-        new_tex.TextureUUID = gen();
-
-        new_tex.Path.init(&s_Instance->Arena, file);
-        {
-            const auto               tex_path_str = absolute ? std::string(file) : fmt::format("{0}{1}{2}", s_Instance->CurrentWorkingSpacePath, PLATFORM_OS_BACKSLASH, file);
-            Core::Containers::String stable_path;
-            stable_path.init(&s_Instance->Arena, tex_path_str.c_str());
-            if (s_Instance->Device->RRM)
-            {
-                auto* rrm      = static_cast<Rendering::RenderResourceManager*>(s_Instance->Device->RRM);
-                new_tex.Handle = rrm->SubmitTextureFile(0, 0, stable_path.c_str());
-                if (!new_tex.Handle.Valid())
-                {
-                    ZENGINE_LOG_ASSET_WARN("Texture not found: '{}' — using fallback", stable_path.c_str())
-                    new_tex.Handle = s_Instance->FallbackTextureHandle;
-                }
-            }
-        }
-
-        RegisterAsset(AssetType::TEXTURE, new_tex.TextureUUID, asset_id);
-        UUIDToTextureHandle.insert(new_tex.TextureUUID, new_tex.Handle);
-        return &new_tex;
     }
 
     uuids::uuid AssetManager::GetOrCreateUUID(Core::VFS::IVFSContext& ctx, const Core::VFS::VFSPath& asset_path, const char* importer_name)

--- a/ZEngine/ZEngine/Managers/AssetManager.h
+++ b/ZEngine/ZEngine/Managers/AssetManager.h
@@ -32,21 +32,22 @@ namespace ZEngine::Managers
         // GPU texture handle map — needed to resolve material → texture handles at upload time.
         Core::Containers::UnorderedHashMap<uuids::uuid, Rendering::Textures::TextureHandle> UUIDToTextureHandle     = {};
 
+        // Mesh UUID → NodeHierarchy slot — O(1) lookup replacing the old linear scan.
+        Core::Containers::UnorderedHashMap<uuids::uuid, uint32_t>                           MeshToHierarchySlot     = {};
+
         // (255, 20, 147) fallback handle used when a texture file cannot be resolved.
         Rendering::Textures::TextureHandle                                                  FallbackTextureHandle   = {};
 
-        // Mutex guards direct-ingest methods called from import threads.
-        mutable std::mutex                                                                  IngestMutex;
+        // Recursive so IngestMaterial can call IngestTexture while holding the lock.
+        mutable std::recursive_mutex                                                        IngestMutex;
 
         Hardwares::VulkanDevice*                                                            Device   = nullptr;
         ::ZEngine::Core::VFS::AssetRegistry*                                                Registry = nullptr;
 
         // CPU buffer accessors
         Importers::AssetMesh*                                                               GetMeshAsset(const uuids::uuid& id);
-        Importers::AssetNodeHierarchy*                                                      GetMeshNodeHierarchy(const uuids::uuid& id);
+        Importers::AssetNodeHierarchy*                                                      GetMeshNodeHierarchy(const uuids::uuid& mesh_id);
         AssetHandle                                                                         GetMeshNodeHierarchyHandle(const uuids::uuid& id);
-        AssetHandle                                                                         GetMaterialHandleFromUUID(const uuids::uuid& material_uuid);
-        Importers::AssetTexture*                                                            LoadTextureFileAsAsset(cstring file, bool absolute);
 
         static AssetManager*                                                                Instance();
         static AssetHandle                                                                  CreateHandle(uint32_t index, AssetType type);
@@ -59,10 +60,14 @@ namespace ZEngine::Managers
 
         static AssetHandle                                                                  RegisterAsset(AssetType type, const uuids::uuid& uuid, uint32_t slot_index, const Core::VFS::VFSPath& path = {}, const Core::VFS::MetaFileData& meta = {});
 
+        // Returns true if uuid is already registered — used by Ingest* for deduplication.
+        static bool                                                                         IsRegistered(const uuids::uuid& id);
+
         // Direct ingest — called from ImportCoordinator thread after AssetCodec cooks the file.
-        // Each method copies the data into the arena-backed flat buffers and calls RegisterAsset.
-        // Thread-safe via IngestMutex.
+        // Each method deduplicates (no-ops if uuid is already registered), copies data into
+        // arena-backed flat buffers, and calls RegisterAsset. Thread-safe via IngestMutex.
         static void                                                                         IngestMesh(Importers::AssetMesh&& mesh, Importers::AssetNodeHierarchy&& hierarchy);
+        static Rendering::Textures::TextureHandle                                           IngestTexture(const uuids::uuid& uuid, const Core::Containers::String& path);
         static void                                                                         IngestTextures(Core::Containers::Array<Importers::AssetTexture>&& textures);
         static void                                                                         IngestMaterial(Importers::AssetMaterial&& material);
 

--- a/ZEngine/ZEngine/ZEngineDef.h
+++ b/ZEngine/ZEngine/ZEngineDef.h
@@ -86,9 +86,9 @@
 #define DEFAULT_ALIGNMENT (2 * sizeof(void*))
 #endif // !DEFAULT_ALIGNMENT
 
-#define ZKilo(size)                    (size * 1024)
-#define ZMega(size)                    (ZKilo(size) * 1024)
-#define ZGiga(size)                    (ZMega(size) * 1024)
+#define ZKilo(size)                    (static_cast<uint64_t>(size) * 1024ULL)
+#define ZMega(size)                    (static_cast<uint64_t>(size) * 1024ULL * 1024ULL)
+#define ZGiga(size)                    (static_cast<uint64_t>(size) * 1024ULL * 1024ULL * 1024ULL)
 
 #define ZPush(allocator, type, size)   ((type*) (allocator)->Allocate(size, DEFAULT_ALIGNMENT, __FILE__, __LINE__))
 

--- a/ZEngine/docs/asset-manager.md
+++ b/ZEngine/docs/asset-manager.md
@@ -1,0 +1,356 @@
+# Asset Manager
+
+**Status:** Implemented  
+**Location:** `ZEngine/ZEngine/Managers/AssetManager.h/.cpp`  
+**Depends on:** `import-pipeline.md`, `render-resource-manager.md`, `vfs-ticket6-asset-registry.md`  
+**Related issues:** #603, #635
+
+---
+
+## Overview
+
+`AssetManager` is the single authority over all CPU-side asset data at runtime. It owns every
+`AssetMesh`, `AssetMaterial`, `AssetTexture`, and `AssetNodeHierarchy` that has been cooked
+by the import pipeline. It also owns the GPU-side material data mirror (`GPUMeshMaterials`)
+that is uploaded to the `MatSB` storage buffer every frame.
+
+**It is not** a streaming system and does not evict assets. All ingested data lives for the
+lifetime of the engine session in a fixed arena. A future `StreamingManager` will sit above it.
+
+---
+
+## Position in the Pipeline
+
+```mermaid
+flowchart LR
+    disk[(Disk\n.zemesh / .zematerial\n.png textures)]
+    importers["Importers\nGltfImporter\nAssimpImporter"]
+    codec["AssetCodec\nSerialize*\nDeserialize*"]
+    AM["AssetManager\nIngestMesh\nIngestTexture\nIngestMaterial"]
+    RRM["RenderResourceManager\nSubmitTextureFile\nUpdateBuffer"]
+    GPU[("GPU\nTextureArray\nMatSB\nVertexSB")]
+    renderer["GraphicRenderer\nDrawScene"]
+
+    disk -->|"cook-time"| importers
+    disk -->|"load-time"| codec
+    importers --> codec
+    codec --> AM
+    AM -->|"TextureHandle"| RRM
+    RRM -->|"GPU upload"| GPU
+    AM -->|"GPUMeshMaterials[]"| renderer
+    renderer -->|"UpdateBuffer"| GPU
+```
+
+---
+
+## Memory Layout
+
+Everything is allocated from a single 512 MB sub-arena carved from the `AssetManager`
+budget slot during `Initialize()`. All flat arrays grow inside this arena — no heap.
+
+```mermaid
+graph TD
+    MainArena["MainArena (8 GB root)"]
+    AssetArena["AssetManager::Arena (512 MB)"]
+    Meshes["Meshes: Array&lt;AssetMesh&gt;\nmax ~5000 entries"]
+    Hierarchies["NodeHierarchies: Array&lt;AssetNodeHierarchy&gt;\nmax ~5000 entries"]
+    Materials["Materials: Array&lt;AssetMaterial&gt;\nmax ~5000 entries"]
+    Textures["Textures: Array&lt;AssetTexture&gt;\nmax ~5000 entries"]
+    GPU["GPUMeshMaterials: Array&lt;MeshMaterial&gt;\nmirrors Materials 1:1 as GPU structs"]
+    UUIDMap["UUIDToTextureHandle\nHashMap&lt;uuid → TextureHandle&gt;"]
+    HierMap["MeshToHierarchySlot\nHashMap&lt;MeshUUID → slot&gt;"]
+    Registry["AssetRegistry\n(uuid → SlotHandle + state)"]
+
+    MainArena --> AssetArena
+    AssetArena --> Meshes
+    AssetArena --> Hierarchies
+    AssetArena --> Materials
+    AssetArena --> Textures
+    AssetArena --> GPU
+    AssetArena --> UUIDMap
+    AssetArena --> HierMap
+    AssetArena --> Registry
+```
+
+---
+
+## Data Structures
+
+### CPU-side flat arrays
+
+All arrays are pre-allocated at `Initialize()` with capacity 5000. Access is by slot index,
+not by UUID — UUIDs are resolved through `AssetRegistry` to a `SlotHandle`, then the slot
+index is extracted from the handle.
+
+| Array | Element type | Index key |
+|---|---|---|
+| `Meshes` | `AssetMesh` | `ReadAssetHandleIndex(rec->SlotHandle)` |
+| `NodeHierarchies` | `AssetNodeHierarchy` | `MeshToHierarchySlot[MeshUUID]` |
+| `Materials` | `AssetMaterial` | `ReadAssetHandleIndex(rec->SlotHandle)` |
+| `Textures` | `AssetTexture` | `ReadAssetHandleIndex(rec->SlotHandle)` |
+| `GPUMeshMaterials` | `MeshMaterial` | same slot as `Materials` |
+
+### `MeshMaterial` (GPU struct)
+
+`MeshMaterial` is uploaded verbatim to `MatSB` (set 0, binding 5) every frame. It mirrors
+`AssetMaterial` but replaces texture UUID references with bindless array indices.
+
+```
+struct MeshMaterial {            // std140 layout, 96 bytes
+    gpuvec4  AmbientColor;
+    gpuvec4  EmissiveColor;
+    gpuvec4  AlbedoColor;
+    gpuvec4  SpecularColor;
+    gpuvec4  RoughnessColor;
+    gpuvec4  Factors;
+    uint64_t EmissiveMap;        // bindless TextureArray index or INVALID_MAP_HANDLE (0xFFFFFFFF)
+    uint64_t AlbedoMap;
+    uint64_t SpecularMap;
+    uint64_t NormalMap;
+    uint64_t OpacityMap;
+    uint64_t _padding;
+};
+```
+
+The fragment shader gate: `if (material.AlbedoMap < INVALID_MAP_HANDLE)` — valid textures
+have small indices; unset slots hold `0xFFFFFFFF` and are skipped.
+
+### `AssetHandle` encoding
+
+```
+31      28 27                              0
+┌──────────┬─────────────────────────────────┐
+│  type(4) │         slot index (28)          │
+└──────────┴─────────────────────────────────┘
+```
+
+`CreateHandle(slot, type)` and `ReadAssetHandleIndex(handle)` encode/decode this.
+
+---
+
+## Ingest Pipeline
+
+### Deduplication
+
+Every `Ingest*` method calls `IsRegistered(uuid)` first. If the UUID is already in
+`AssetRegistry`, the call is a no-op — the asset is already in the flat arrays.
+
+### `IngestMesh`
+
+```mermaid
+flowchart TD
+    A["IngestMesh(mesh, hierarchy)"]
+    B{IsRegistered\nmesh.MeshUUID?}
+    C[return — already loaded]
+    D["Copy mesh data into Arena\nMeshes[slot] = mesh\nRegisterAsset MESH"]
+    E["Copy hierarchy data into Arena\nNodeHierarchies[hier_slot] = hierarchy\nRegisterAsset MESH_HIERARCHY"]
+    F["MeshToHierarchySlot[MeshUUID] = hier_slot\n→ O(1) lookup replaces linear scan"]
+    G["Registry.SetState → Loaded"]
+
+    A --> B
+    B -->|yes| C
+    B -->|no| D
+    D --> E
+    E --> F
+    F --> G
+```
+
+### `IngestTexture` (single canonical upload)
+
+```mermaid
+flowchart TD
+    A["IngestTexture(uuid, path)"]
+    B{IsRegistered\nuuid?}
+    C["return existing handle\nfrom UUIDToTextureHandle"]
+    D["Textures.push_use() — allocate slot"]
+    E{path empty?}
+    F["Build absolute path:\nWorkingSpacePath + '/' + path\nRRM.SubmitTextureFile → TextureHandle"]
+    G{Handle valid?}
+    H["ASSERT FallbackHandle.Valid()\nLog 'not found'\nnew_tex.Handle = FallbackHandle"]
+    I["ASSERT FallbackHandle.Valid()\nLog 'no path — extraction failed'\nnew_tex.Handle = FallbackHandle"]
+    J["RegisterAsset TEXTURE\nUUIDToTextureHandle[uuid] = Handle\nreturn Handle"]
+
+    A --> B
+    B -->|yes| C
+    B -->|no| D
+    D --> E
+    E -->|no| F
+    F --> G
+    G -->|valid| J
+    G -->|invalid| H
+    H --> J
+    E -->|yes| I
+    I --> J
+```
+
+> The assert on `FallbackHandle.Valid()` enforces the initialization contract:
+> `AssetManager::InitFallbackTexture()` must be called before any ingest can use the fallback.
+> A crash here means the engine startup sequence is broken, not a recoverable error.
+
+### `IngestTextures` (batch)
+
+Iterates the array and calls `IngestTexture` per element. The `IngestMutex` is acquired once
+per element (inside `IngestTexture`) since the mutex is `std::recursive_mutex`.
+
+### `IngestMaterial`
+
+```mermaid
+flowchart TD
+    A["IngestMaterial(mat)"]
+    B{IsRegistered\nmat.MaterialUUID?}
+    C[return — already loaded]
+    D["Materials.push(mat)\nRegisterAsset MATERIAL\nGPUMeshMaterials.push_use()"]
+    E["Copy color fields to gpu_mat\n(AlbedoColor, EmissiveColor, ...)"]
+    F["tex_handle(AlbedoTexUUID, AlbedoTexPath)"]
+    G{UUID in\nUUIDToTextureHandle?}
+    H["return Handle.Index"]
+    I{path empty?}
+    J["IngestTexture(uuid, path)\nreturn new Handle.Index"]
+    K["return INVALID_MAP_HANDLE"]
+    L["gpu_mat.AlbedoMap = result\n(repeat for Emissive, Normal, Opacity, Specular)"]
+
+    A --> B
+    B -->|yes| C
+    B -->|no| D
+    D --> E
+    E --> F
+    F --> G
+    G -->|yes| H --> L
+    G -->|no| I
+    I -->|no| J --> L
+    I -->|yes| K --> L
+```
+
+The `tex_handle` fallback path — calling `IngestTexture` from inside `IngestMaterial` — is
+what makes scene reload and dragged-`.zmesh` work: the material knows its own texture paths
+and can trigger GPU upload without a prior `IngestTextures` call.
+
+---
+
+## GPU Material Binding — End to End
+
+```mermaid
+sequenceDiagram
+    participant Import as GltfImporter (background thread)
+    participant AM as AssetManager
+    participant RRM as RenderResourceManager
+    participant GPU as GPU (TextureArray + MatSB)
+    participant Render as GraphicRenderer (main thread)
+    participant Shader as g_buffer.frag
+
+    Import->>AM: IngestTextures([tex_0..tex_N])
+    AM->>RRM: SubmitTextureFile(abs_path) per texture
+    RRM-->>AM: TextureHandle{Index=K}
+    AM->>AM: UUIDToTextureHandle[uuid] = {Index=K}
+
+    Import->>AM: IngestMaterial(mat)
+    AM->>AM: tex_handle(AlbedoTexUUID) → K
+    AM->>AM: GPUMeshMaterials[slot].AlbedoMap = K
+
+    Import->>AM: IngestMesh(mesh, hier)
+    AM->>AM: Meshes[slot] = mesh
+
+    Note over Render: Next frame — InstancesDirty
+
+    Render->>AM: GetMeshAsset(MeshUUID)
+    AM-->>Render: &Meshes[slot]
+    Render->>AM: GetAsset&lt;AssetMaterial&gt;(sub.MaterialUUID)
+    AM-->>Render: &Materials[mat_slot]
+    Render->>Render: alloc.MaterialId = mat_slot
+
+    Render->>RRM: UpdateBuffer(MaterialBuffer, GPUMeshMaterials)
+    RRM->>GPU: vmaMemcpy → MatSB[mat_slot].AlbedoMap = K
+
+    Shader->>GPU: FetchMaterial(MaterialIdx) → mat
+    Shader->>GPU: texture(TextureArray[mat.AlbedoMap], uv) if AlbedoMap < INVALID
+```
+
+---
+
+## Lookup API
+
+`GetAsset<T>(key)` is a template with two key types:
+
+```mermaid
+graph LR
+    GetAssetUUID["GetAsset&lt;T&gt;(uuid)"]
+    GetAssetHandle["GetAsset&lt;T&gt;(AssetHandle)"]
+    Registry["AssetRegistry\nFindByUUID(uuid)"]
+    SlotHandle["rec->SlotHandle"]
+    Index["ReadAssetHandleIndex(h)"]
+    Array["Flat array\ne.g. Meshes[index]"]
+
+    GetAssetUUID --> Registry
+    Registry --> SlotHandle
+    SlotHandle --> GetAssetHandle
+    GetAssetHandle --> Index
+    Index --> Array
+```
+
+Specializations exist for `AssetMesh`, `AssetMaterial`, `AssetTexture`, `AssetNodeHierarchy`
+with both `uuid` and `AssetHandle` key types — 8 specializations total.
+
+---
+
+## Thread Safety
+
+| Method | Thread-safe | Notes |
+|---|---|---|
+| `IngestMesh` | Yes | Acquires `IngestMutex` (recursive) |
+| `IngestTexture` | Yes | Acquires `IngestMutex` |
+| `IngestTextures` | Yes | Calls `IngestTexture` per element |
+| `IngestMaterial` | Yes | Acquires `IngestMutex`; may call `IngestTexture` (recursive lock) |
+| `IsRegistered` | Yes | Read-only registry lookup |
+| `GetAsset<T>(uuid)` | Yes | Read-only after ingest completes |
+| `GetMeshAsset` | Yes | Read-only |
+| `GetMeshNodeHierarchy` | Yes | O(1) via `MeshToHierarchySlot` |
+| `InitFallbackTexture` | Main thread only | Called once during engine init |
+
+`IngestMutex` is `std::recursive_mutex` — `IngestMaterial` can safely call `IngestTexture`
+without deadlock.
+
+---
+
+## Initialization Order Contract
+
+```mermaid
+sequenceDiagram
+    participant EP as EntryPoint
+    participant MM as MemoryManager
+    participant Log as Logger
+    participant Eng as Engine
+    participant AM as AssetManager
+    participant RRM as RenderResourceManager
+
+    EP->>MM: Initialize(8 GB, Editor())
+    EP->>Log: Logger::Initialize(LoggingArena)
+    EP->>Eng: Engine::Initialize()
+    Eng->>AM: AssetManager::Initialize(AssetArena, device, ws_path)
+    Note over AM: FallbackTextureHandle is NOT set yet
+    Eng->>RRM: RenderResourceManager::Initialize()
+    Eng->>AM: AssetManager::InitFallbackTexture()
+    Note over AM: FallbackTextureHandle = RRM.GetOrCreateFallbackTexture()
+    Note over AM: ASSERT fires in IngestTexture if called before this point
+```
+
+Any `IngestTexture` call before `InitFallbackTexture` will hit:
+```
+ZENGINE_VALIDATE_ASSERT(s_Instance->FallbackTextureHandle.Valid(),
+    "FallbackTextureHandle not initialized — InitFallbackTexture must be called before ingesting assets")
+```
+
+---
+
+## Known Gaps and Future Work
+
+See issue [#635](https://github.com/JeanPhilippeKernel/RendererEngine/issues/635) for the
+full memory budget redesign tracking. Key items relevant to AssetManager:
+
+- **No eviction** — all ingested assets live until shutdown. A `StreamingManager` (2 GB budget,
+  tracked in #635) will sit above AssetManager and manage which assets are resident.
+- **AssetManager carved size** — currently carves 512 MB from its budget slot into
+  `s_Instance->Arena`. The remaining budget headroom is used for `ImportCoordinator` and
+  `RenderResourceManager` objects placed via `ZPushStructCtor`.
+- **Duplicate importer instances** — `AssetImporterUIComponent` allocates its own `GltfImporter`
+  (64 MB) and `AssimpImporter` (350 MB) in addition to the engine's importers. Consolidation
+  tracked in #635.


### PR DESCRIPTION
Closes #603.

## What was broken

Textures extracted during import were never reaching the GPU material buffer used at draw time. Three independent failure points:

1. `IngestMaterial::tex_handle` returned `0` for nil/missing UUIDs instead of `INVALID_MAP_HANDLE (0xFFFFFFFF)` — the shader gate `if (AlbedoMap < INVALID_MAP_HANDLE)` let slot 0 through, sampling `TextureArray[0]` for every nil texture slot
2. `IngestMaterial` ignored texture path fields — if a UUID was not yet in `UUIDToTextureHandle` (scene reload, dragged `.zmesh`) it returned `INVALID_MAP_HANDLE` and never tried to load from path
3. `OnOpenMeshRequestAsync` (drag `.zmesh` to viewport) only ingested the mesh — never loaded the matching `.zematerial` files, so all submeshes rendered with `MaterialId = 0`

## AssetManager API cleanup

| Before | After |
|---|---|
| `std::mutex` | `std::recursive_mutex` — allows `IngestMaterial` to call `IngestTexture` while holding the lock |
| No dedup | `IsRegistered(uuid)` guard at the top of all `Ingest*` methods |
| Texture upload duplicated in `IngestTextures` and `LoadTextureFileAsAsset` | Single `IngestTexture(uuid, path)` — deduplicates, builds absolute path, submits to RRM |
| `IngestMaterial` ignored path fields | `tex_handle` lambda calls `IngestTexture(uuid, path)` as fallback when UUID has no handle |
| `GetMeshNodeHierarchy` O(n) linear scan | O(1) via `MeshToHierarchySlot` map populated during `IngestMesh` |
| `GetMaterialHandleFromUUID` — returns `0` for both not-found and slot-0 | Removed — callers use `GetAsset<AssetMaterial, uuid>` + pointer arithmetic |
| `LoadTextureFileAsAsset` — bypassed mutex, created orphan UUIDs | Removed — no callers |

## DockspaceUIComponent

`OnOpenMeshRequestAsync` now iterates `hier.MaterialNames` and loads each matching `.zematerial` from `Assets/Materials/<name>.zematerial` **before** calling `IngestMesh`, so texture handles are ready when the render pipeline builds the first draw call.

## Test Plan
- [x] Import a `.glb` with textures — verify textures visible on mesh in viewport
- [x] Close and reopen engine, drag the `.zmesh` to viewport — verify textures still visible (scene-reload path)
- [x] Import a second mesh with different materials — verify no cross-contamination between materials
- [ ] Import same mesh twice — verify no duplicate entries in GPUMeshMaterials