### PR TITLE
fix(#635): structural memory budget cleanups

### DIFF
--- a/Tetragrama/Components/AssetImporterUIComponent.cpp
+++ b/Tetragrama/Components/AssetImporterUIComponent.cpp
@@ -29,12 +29,14 @@ namespace Tetragrama::Components
         parent->LocalArena.CreateSubArena(ZMega(8), &LocalArena);
         parent->LocalArena.CreateSubArena(ZMega(4), &LocalStringArena);
 
-        // Each importer gets its own dedicated scratch arena sized to its budget.
-        parent->Arena->CreateSubArena(ZMega(64), &GltfImporterArena);
-        parent->Arena->CreateSubArena(ZMega(350), &AssimpImporterArena);
+        // Importer arenas carved from the engine's ImportPipeline budget so all
+        // import memory — engine importers and editor importers — is budget-tracked.
+        auto* import_arena = &ZEngine::Engine::GetContext()->ImportPipelineArena;
+        import_arena->CreateSubArena(ZMega(64), &GltfImporterArena);
+        import_arena->CreateSubArena(ZMega(350), &AssimpImporterArena);
 
-        m_gltf_importer   = ZPushStructCtor(parent->Arena, ZEngine::Importers::GltfImporter);
-        m_assimp_importer = ZPushStructCtor(parent->Arena, ZEngine::Importers::AssimpImporter);
+        m_gltf_importer   = ZPushStructCtor(import_arena, ZEngine::Importers::GltfImporter);
+        m_assimp_importer = ZPushStructCtor(import_arena, ZEngine::Importers::AssimpImporter);
         m_gltf_importer->Initialize(&GltfImporterArena);
         m_assimp_importer->Initialize(&AssimpImporterArena);
 

--- a/Tetragrama/EditorScene.cpp
+++ b/Tetragrama/EditorScene.cpp
@@ -14,6 +14,10 @@ namespace Tetragrama
 {
     void EditorScene::Initialize(ZEngine::Core::Memory::ArenaAllocator* arena, cstring name)
     {
+        // 200 MB carved directly from MainArena — not part of UIContext budget.
+        // Covers: AssetFiles list (500 entries), scene graph data, seqlock instance buffers,
+        // material/texture path strings on reload, and sub-arenas (InstanceArena 4 MB).
+        // No budget config entry: EditorScene is a scene-level system, not a UI component.
         arena->CreateSubArena(ZMega(200), &LocalArena);
 
         Name = name;

--- a/ZEngine/ZEngine/Core/Memory/MemoryManager.h
+++ b/ZEngine/ZEngine/Core/Memory/MemoryManager.h
@@ -29,7 +29,7 @@ namespace ZEngine::Core::Memory
         SubArenaConfig  Logging          = {};
         SubArenaConfig  VirtualFS        = {};
         SubArenaConfig  VulkanDevice     = {};
-        SubArenaConfig  Importer         = {};
+        SubArenaConfig  ImportPipeline   = {}; // engine importers + editor importers
         SubArenaConfig  UIContext        = {};
         SubArenaConfig  Swapchain        = {};
         SubArenaConfig  ShaderCache      = {};
@@ -40,7 +40,7 @@ namespace ZEngine::Core::Memory
         // Returns the total bytes committed by all SubArenaConfig entries.
         inline uint64_t TotalCommitted() const
         {
-            return AudioEngine.SizeBytes + AnimationManager.SizeBytes + AssetManager.SizeBytes + ECSScene.SizeBytes + Logging.SizeBytes + VirtualFS.SizeBytes + VulkanDevice.SizeBytes + Importer.SizeBytes + UIContext.SizeBytes + Swapchain.SizeBytes + ShaderCache.SizeBytes + Serializer.SizeBytes + Network.SizeBytes + Input.SizeBytes;
+            return AudioEngine.SizeBytes + AnimationManager.SizeBytes + AssetManager.SizeBytes + ECSScene.SizeBytes + Logging.SizeBytes + VirtualFS.SizeBytes + VulkanDevice.SizeBytes + ImportPipeline.SizeBytes + UIContext.SizeBytes + Swapchain.SizeBytes + ShaderCache.SizeBytes + Serializer.SizeBytes + Network.SizeBytes + Input.SizeBytes;
         }
 
         // Validates that the sum of all SizeBytes fields does not exceed total_available_bytes.
@@ -62,7 +62,7 @@ namespace ZEngine::Core::Memory
             cfg.Logging            = {"Logging", ZMega(8ULL)};
             cfg.VirtualFS          = {"VirtualFS", ZMega(64ULL)};
             cfg.VulkanDevice       = {"VulkanDevice", ZGiga(1ULL)};
-            cfg.Importer           = {"Importer", ZMega(512ULL)};
+            cfg.ImportPipeline     = {"ImportPipeline", ZGiga(1ULL)}; // engine importers (414 MB) + editor importers (414 MB) + coordinator
             cfg.UIContext          = {"UIContext", ZMega(64ULL)};
             cfg.Swapchain          = {"Swapchain", ZMega(8ULL)};
             cfg.ShaderCache        = {"ShaderCache", ZMega(64ULL)};

--- a/ZEngine/ZEngine/Engine.cpp
+++ b/ZEngine/ZEngine/Engine.cpp
@@ -85,25 +85,25 @@ namespace ZEngine
         g_engine_ctx->WorldTick = ZPushStructCtor(&g_engine_ctx->ECSArena, ECS::WorldTick);
         g_engine_ctx->WorldTick->Initialize(&g_engine_ctx->ECSArena);
 
+        // ImportPipeline arena: covers engine importers (414 MB) + editor importers (414 MB) + coordinator overhead.
+        // Editor's AssetImporterUIComponent carves its own importer arenas from this same budget
+        // via Engine::GetContext()->ImportPipelineArena so all import memory is budget-tracked.
+        memory->CreateBudgetedArena(memory->Budget.ImportPipeline, &g_engine_ctx->ImportPipelineArena);
         g_engine_ctx->ImportCoordinator = ZPushStructCtor(&g_engine_ctx->AssetArena, Importers::ImportCoordinator);
         g_engine_ctx->ImportCoordinator->Initialize(&g_engine_ctx->AssetArena, g_engine_ctx->VFS, Managers::AssetManager::Instance()->Registry);
 
-        // Register format importers
-        // All importers get their own arenas carved from MainArena (3 GB).
-        // AssetArena is only 78 MB — not enough for intermediate geometry data.
         static Importers::GltfImporter           s_gltf_importer;
         static Importers::AssimpImporter         s_assimp_importer;
         static Importers::EnvironmentMapImporter s_env_map_importer;
         static Core::Memory::ArenaAllocator      s_gltf_arena;
         static Core::Memory::ArenaAllocator      s_assimp_arena;
         static Core::Memory::ArenaAllocator      s_envmap_arena;
-        arena.CreateSubArena(ZMega(64), &s_gltf_arena);
-        arena.CreateSubArena(ZMega(350), &s_assimp_arena);
-        arena.CreateSubArena(ZMega(32), &s_envmap_arena);
+        g_engine_ctx->ImportPipelineArena.CreateSubArena(ZMega(64), &s_gltf_arena);
+        g_engine_ctx->ImportPipelineArena.CreateSubArena(ZMega(350), &s_assimp_arena);
+        g_engine_ctx->ImportPipelineArena.CreateSubArena(ZMega(32), &s_envmap_arena);
         s_gltf_importer.Initialize(&s_gltf_arena);
         s_assimp_importer.Initialize(&s_assimp_arena);
         s_env_map_importer.Initialize(&s_envmap_arena);
-        // GLB/GLTF handled by GltfImporter; FBX/OBJ by AssimpImporter.
         g_engine_ctx->ImportCoordinator->RegisterImporter(&s_gltf_importer);
         g_engine_ctx->ImportCoordinator->RegisterImporter(&s_assimp_importer);
         g_engine_ctx->ImportCoordinator->RegisterImporter(&s_env_map_importer);

--- a/ZEngine/ZEngine/Engine.h
+++ b/ZEngine/ZEngine/Engine.h
@@ -29,6 +29,7 @@ namespace ZEngine
         Core::Memory::ArenaAllocator      AssetArena            = {};
         Core::Memory::ArenaAllocator      InputArena            = {};
         Core::Memory::ArenaAllocator      ECSArena              = {};
+        Core::Memory::ArenaAllocator      ImportPipelineArena   = {};
 
         // Pointers (8 bytes each — grouped to pack cleanly)
         Hardwares::VulkanDevicePtr        Device                = nullptr;

--- a/ZEngine/ZEngine/Managers/AssetManager.cpp
+++ b/ZEngine/ZEngine/Managers/AssetManager.cpp
@@ -37,7 +37,7 @@ namespace ZEngine::Managers
     void AssetManager::Initialize(Core::Memory::ArenaAllocator* arena, Hardwares::VulkanDevice* device, cstring working_space_path)
     {
         s_Instance = ZPushStructCtor(arena, AssetManager);
-        arena->CreateSubArena(ZMega(78), &s_Instance->Arena);
+        arena->CreateSubArena(ZMega(400), &s_Instance->Arena);
 
         s_Instance->Device                  = device;
         s_Instance->CurrentWorkingSpacePath = working_space_path;

--- a/ZEngine/docs/memory-budget.md
+++ b/ZEngine/docs/memory-budget.md
@@ -1,0 +1,105 @@
+# Memory Budget
+
+Documents the full arena hierarchy, each slot's purpose, sizing rationale, and growth headroom.
+
+**Root arena:** `ZGiga(8ULL)` = 8 GB (virtual reservation via `mmap` / `VirtualAlloc`; physical pages committed on first write — RSS is much lower than the virtual reservation).
+
+---
+
+## MemoryBudgetConfig slots
+
+Defined in `ZEngine/ZEngine/Core/Memory/MemoryManager.h`. `Default()` is the game runtime profile; `Editor()` overrides UIContext and zeroes Audio/Network.
+
+| Slot | Default | Editor | What lives here |
+|---|---|---|---|
+| `VulkanDevice` | 1 GB | 1 GB | VMA metadata, descriptor pool backing, command pools, swapchain objects |
+| `ImportPipeline` | 1 GB | 1 GB | Engine importers: GltfImporter (64 MB) + AssimpImporter (350 MB) + EnvironmentMapImporter (32 MB) + ImportCoordinator. **Also** editor's duplicate GltfImporter (64 MB) + AssimpImporter (350 MB) in AssetImporterUIComponent — see [Editor import duplication](#editor-import-duplication) |
+| `AssetManager` | 512 MB | 512 MB | Flat arrays: Meshes, NodeHierarchies, Materials, Textures, GPUMeshMaterials (all capped at 5000 entries). UUID hash maps (UUIDToTextureHandle, MeshToHierarchySlot). AssetRegistry. RenderResourceManager and ImportCoordinator structs placed in the budget parent arena |
+| `ECSScene` | 512 MB | 512 MB | ComponentStorage dense arrays, EntityRegistry, ActorManager, WorldCommands staging buffers, WorldTick DAG |
+| `Serializer` | 256 MB | 256 MB | EditorSceneSerializer scratch (150 MB sub-arena), scene file temporaries |
+| `AnimationManager` | 256 MB | 256 MB | Skeleton data, clip arrays, pose pools (system not yet implemented) |
+| `AudioEngine` | 128 MB | **0** | miniaudio state, decoded clip pool (disabled in editor) |
+| `UIContext` | 64 MB | **128 MB** | ImguiLayer (64 MB) → all UI components (Dockspace 32 MB, AssetImporter 12 MB, ProjectView 4 MB, others) |
+| `VirtualFS` | 64 MB | 64 MB | VFSContext mount table, VFSScanner cache, FileWatcher event queue, AssetRegistry scratch |
+| `ShaderCache` | 64 MB | 64 MB | SPIR-V bytecode, shader reflection data |
+| `Network` | 64 MB | **0** | Peer state, rollback ring buffers (disabled in editor) |
+| `Logging` | 8 MB | 8 MB | Logger ring buffer (spdlog), category filter arrays |
+| `Swapchain` | 8 MB | 8 MB | Swapchain-specific metadata |
+| `Input` | 4 MB | 4 MB | InputManager state, key/axis binding tables |
+| **Total committed** | ~3.95 GB | ~3.82 GB | **Headroom: ~4 GB** reserved for future systems |
+
+---
+
+## Arenas NOT in the budget config
+
+These are carved directly from `MainArena` and are intentionally outside `MemoryBudgetConfig`.
+
+| Who | Size | Why outside budget |
+|---|---|---|
+| `EditorScene::LocalArena` | 200 MB | Scene-level system, not a UI component. Covers AssetFiles list, scene graph data, seqlock instance buffers, material/texture path strings. |
+| `AppRenderPipeline::LocalArena` | 30 MB | Render-pipeline-level scratch, carved from VulkanDevice arena |
+
+---
+
+## ImportPipeline breakdown
+
+```
+ImportPipeline (1 GB)
+├── ImportCoordinator struct + queue    ~1 MB
+├── Engine importers
+│   ├── s_gltf_arena   (GltfImporter)   64 MB
+│   ├── s_assimp_arena (AssimpImporter) 350 MB
+│   └── s_envmap_arena (EnvMapImporter)  32 MB
+└── Editor importers (AssetImporterUIComponent)
+    ├── GltfImporterArena               64 MB
+    └── AssimpImporterArena            350 MB
+                                ─────────────
+                    Total used:        861 MB
+                    Headroom:          163 MB
+```
+
+### Editor import duplication
+
+`AssetImporterUIComponent` maintains its own `GltfImporter` + `AssimpImporter` instances because:
+1. The editor import UI requires granular callbacks (per-file output, per-log-message, progress percentage) that `ImportCoordinator`'s `ImportCallback` (`void(*)(void*, bool success)`) does not support.
+2. Imports triggered from the editor panel run concurrently with background ImportCoordinator jobs — sharing importer instances would require an additional mutex and could stall the background pipeline.
+
+**Design debt:** when `ImportCoordinator` is extended to support full progress/log/output callbacks (tracked in `import-pipeline.md`), the editor importers should be removed and `AssetImporterUIComponent::StartImport` should call `ImportCoordinator::Enqueue` instead.
+
+---
+
+## UIContext component chain (Editor)
+
+```
+UIContext (128 MB, Editor)
+└── ImguiLayer::LocalArena (64 MB)
+    ├── DockspaceUIComponent::LocalArena     32 MB
+    │   └── (mesh deserialization scratch — large meshes need up to ~20 MB)
+    ├── AssetImporterUIComponent::LocalArena  8 MB
+    ├── AssetImporterUIComponent::LocalStringArena  4 MB
+    ├── ProjectViewUIComponent::m_local_arena 4 MB
+    └── remaining for other components       ~16 MB
+```
+
+---
+
+## Headroom for future systems
+
+The ~4 GB headroom in the 8 GB root is reserved for systems not yet built:
+
+| System | Planned budget | Notes |
+|---|---|---|
+| `StreamingManager` | 2 GB | Open world chunk geometry + texture page streaming; arena cleared per-region-transition |
+| `PhysicsEngine` | 512 MB | Rigid bodies, terrain collision, broad-phase structures |
+| `NavigationEngine` | 256 MB | NavMesh, pathfinding graph, agent state |
+
+These will be added as new `SubArenaConfig` fields in `MemoryBudgetConfig` when the systems are implemented.
+
+---
+
+## How to update this document
+
+1. When a budget slot changes size, update the table above.
+2. When a new slot is added, add it to the table and to `TotalCommitted()`.
+3. When `EditorScene::LocalArena` or other unbudgeted arenas change, update the "Arenas NOT in the budget config" table.
+4. Recalculate the total and verify headroom is positive with at least 1 GB margin.


### PR DESCRIPTION
Closes #635 (structural items — new system slots deferred to when those systems are built).

## Changes

### Rename `Importer` → `ImportPipeline`
`MemoryBudgetConfig::Importer` was misleading — the actual importer arenas were carved from `MainArena` directly, not from this slot. Renamed to `ImportPipeline` and increased from 512 MB to **1 GB** to properly account for both engine importers (414 MB) and editor importers (414 MB).

### Expose `ImportPipelineArena` on `EngineContext`
`Engine::Initialize` now carves a budgeted `ImportPipelineArena` and stores a reference on `g_engine_ctx`. Engine importer arenas (`s_gltf_arena`, `s_assimp_arena`, `s_envmap_arena`) are now carved from this arena instead of raw `MainArena`.

### Route editor importer arenas through the budget
`AssetImporterUIComponent` was carving `GltfImporterArena` (64 MB) and `AssimpImporterArena` (350 MB) from `parent->Arena` which resolves to `MainArena` — completely outside the budget system. Now carved from `Engine::GetContext()->ImportPipelineArena`.

Note: the editor still maintains its own importer instances (not shared with the engine's) because `ImportCoordinator`'s `ImportCallback` doesn't support the granular progress/log/output callbacks the editor UI needs. Documented in `memory-budget.md` as design debt to resolve when `ImportCoordinator` is extended.

### Align AssetManager carved size
`AssetManager::Initialize` was carving only **78 MB** from the **512 MB** budget slot. Increased to **400 MB** to match the open-world asset volume the budget was sized for. Remaining ~112 MB left for `ImportCoordinator` + `RenderResourceManager` struct placement in the same budget parent arena.

### Document `EditorScene::LocalArena` (200 MB)
Added comment explaining why it's 200 MB and why it's intentionally outside the budget config.

### Create `ZEngine/docs/memory-budget.md`
New doc covering: full slot table with Default/Editor sizes, arenas outside the budget config, ImportPipeline breakdown, editor import duplication rationale, UIContext component chain, and headroom table for future systems (StreamingManager 2 GB, PhysicsEngine 512 MB, NavigationEngine 256 MB).