### PR TITLE
fix(deps): pin simdjson as explicit FetchContent dep before fastgltf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -424,3 +424,7 @@ CMakeSettings.json
 # MacOS files
 .DS_Store
 SampleProject/
+
+# Presentation exports
+*.pdf
+*.pptx

--- a/Scripts/ClangFormat.ps1
+++ b/Scripts/ClangFormat.ps1
@@ -34,7 +34,7 @@ $ErrorActionPreference = "Stop"
 
 . (Join-Path $PSScriptRoot Shared.ps1)
 
-$srcFiles = Get-ChildItem -Path $SourceDirectory -Recurse -File | Where-Object { $_.Name -notlike "CMakeLists*" -and $_.Name -notlike "*.json" -and $_.Name -notlike "*.spv" -and $_.Name -notlike "*.md" -and $_.Name -notlike "*.mm"}
+$srcFiles = Get-ChildItem -Path $SourceDirectory -Recurse -File | Where-Object { $_.Name -notlike "CMakeLists*" -and $_.Name -notlike "*.json" -and $_.Name -notlike "*.spv" -and $_.Name -notlike "*.md" -and $_.Name -notlike "*.mm" -and $_.Name -notlike "*.pdf" -and $_.Name -notlike "*.pptx"}
 
 if ($srcFiles.Count -eq 0) {
     Write-Host "No source files found in the specified directory."

--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -162,6 +162,14 @@ FetchContent_Declare(miniz
     GIT_SHALLOW TRUE
 )
 
+FetchContent_Declare(simdjson
+    GIT_REPOSITORY https://github.com/simdjson/simdjson.git
+    GIT_SHALLOW    TRUE
+    GIT_TAG        v3.12.3
+    SOURCE_DIR     ${FETCHCONTENT_BASE_DIR}/simdjson
+)
+set(SIMDJSON_DEVELOPER_MODE OFF CACHE BOOL "" FORCE)
+
 FetchContent_Declare(fastgltf
     GIT_REPOSITORY https://github.com/spnda/fastgltf.git
     GIT_SHALLOW    TRUE
@@ -203,6 +211,7 @@ FetchContent_MakeAvailable(
   GTest
   miniz
   TracyClient
+  simdjson
   fastgltf
   )
 


### PR DESCRIPTION
## Problem

The latest RC fails to launch on macOS machines that do not have simdjson installed via Homebrew.

`fastgltf`'s CMake calls `find_package(simdjson CONFIG)` before falling back to its bundled copy. On a developer machine with Homebrew's simdjson installed, it resolves to the system shared library (`/opt/homebrew/lib/libsimdjson.dylib`) and links dynamically. The resulting binary carries a runtime dylib dependency that end users without Homebrew's simdjson cannot resolve → crash at startup.

`BUILD_SHARED_LIBS=OFF` is set globally but does not prevent `find_package` from resolving a pre-installed shared config.

## Fix

Declare `simdjson v3.12.3` (the version fastgltf vendors) as an explicit `FetchContent` dependency **before** fastgltf in `FetchContent_MakeAvailable`. When fastgltf's CMake runs and checks `if (NOT TARGET simdjson::simdjson)`, the target already exists as a static library — it skips `find_package` entirely.

Also excludes `*.pdf` and `*.pptx` from the clang-format pre-push hook (binary files caused the hook to crash).

## Verification

- `otool -L` on the Debug binary shows no `libsimdjson` dylib dependency
- Debug build clean, no errors