### PR TITLE
feat(ecs): wire ECS components into render scene and light pipeline

### DIFF
--- a/Tetragrama/Components/HierarchyViewUIComponent.cpp
+++ b/Tetragrama/Components/HierarchyViewUIComponent.cpp
@@ -233,12 +233,11 @@ namespace Tetragrama::Components
             Vec3f new_pos, new_rot, new_scale;
             if (DecomposeTransformComponent(transform, new_pos, new_rot, new_scale))
             {
-                tc->PreviousPosition = tc->Position;
                 tc->Position         = new_pos;
                 tc->Rotation         = new_rot;
                 tc->Scale            = new_scale;
+                tc->PreviousPosition = new_pos;
 
-                // Keep RenderScene in sync — TransformComponent and Instances are not auto-bridged yet.
                 auto* mc             = actor->GetComponent<MeshComponent>();
                 if (mc && mc->RenderInstanceId != UINT32_MAX)
                     scene->SetInstanceTransform(mc->RenderInstanceId, transform);

--- a/Tetragrama/EditorScene.cpp
+++ b/Tetragrama/EditorScene.cpp
@@ -38,18 +38,11 @@ namespace Tetragrama
         auto* ctx = ZEngine::Engine::GetContext();
         if (ctx && ctx->ActorManager)
         {
-            // Register the built-in sun mesh so it's available for GPU upload.
-            {
-                ZEngine::Importers::AssetMesh          sun_mesh{};
-                ZEngine::Importers::AssetNodeHierarchy sun_hier{};
-                ZEngine::Rendering::CreateDirectionalLightMesh(&LocalArena, sun_mesh, sun_hier);
-                AssetManager::IngestMesh(std::move(sun_mesh), std::move(sun_hier));
-            }
+            ZEngine::Rendering::RegisterBuiltinMeshes(&LocalArena);
 
-            auto light_uuid_result = uuids::uuid::from_string(ZEngine::Rendering::DIRECTIONAL_LIGHT_MESH_UUID);
-            if (!light_uuid_result)
+            const uuids::uuid light_uuid = ZEngine::Rendering::BuiltinMeshUUIDParsed(ZEngine::Rendering::BuiltinMeshID::DirectionalLightIcon);
+            if (light_uuid.is_nil())
                 return;
-            uuids::uuid               light_uuid         = *light_uuid_result;
 
             constexpr cstring         default_light_name = "DirectionalLight";
 

--- a/Tetragrama/EditorScene.cpp
+++ b/Tetragrama/EditorScene.cpp
@@ -1,8 +1,10 @@
 #include <Tetragrama/EditorScene.h>
+#include <ZEngine/ECS/Components/LightComponent.h>
 #include <ZEngine/ECS/Components/MeshComponent.h>
 #include <ZEngine/ECS/Components/NameComponent.h>
 #include <ZEngine/ECS/Components/TransformComponent.h>
 #include <ZEngine/Engine.h>
+#include <ZEngine/Helpers/MemoryOperations.h>
 #include <ZEngine/Importers/AssetCodec.h>
 #include <ZEngine/Managers/AssetManager.h>
 using namespace ZEngine::Core::Containers;
@@ -29,6 +31,36 @@ namespace Tetragrama
         // Allocate a sub-arena for the instance list.
         LocalArena.CreateSubArena(ZMega(4), &InstanceArena);
         Instances.init(&InstanceArena, 64);
+
+        // Spawn a default directional light so new scenes are not dark.
+        // Rotation: -60° pitch (mostly downward), 30° yaw (slight horizontal angle).
+        auto* ctx = ZEngine::Engine::GetContext();
+        if (ctx && ctx->ActorManager)
+        {
+            ZEngine::ECS::ActorHandle handle = ctx->ActorManager->Create();
+            ZEngine::ECS::Actor*      actor  = ctx->ActorManager->Access(handle);
+            if (actor)
+            {
+                constexpr cstring default_light_name = "DirectionalLight";
+
+                NameComponent     nc                 = {};
+                ZEngine::Helpers::secure_strncpy(nc.Value, sizeof(nc.Value), default_light_name, ZEngine::Helpers::secure_strlen(default_light_name));
+                actor->AddComponent<NameComponent>(nc);
+
+                TransformComponent tc = {};
+                tc.Rotation.x         = -1.047f;
+                tc.Rotation.y         = 0.524f;
+                actor->AddComponent<TransformComponent>(tc);
+
+                LightComponent lc = {};
+                lc.LightType      = LightComponent::Type::Directional;
+                lc.Intensity      = 3.f;
+                lc.Color[0]       = 1.f;
+                lc.Color[1]       = 1.f;
+                lc.Color[2]       = 1.f;
+                actor->AddComponent<LightComponent>(lc);
+            }
+        }
     }
 
     bool EditorScene::HasPendingChange() const

--- a/Tetragrama/EditorScene.cpp
+++ b/Tetragrama/EditorScene.cpp
@@ -7,6 +7,7 @@
 #include <ZEngine/Helpers/MemoryOperations.h>
 #include <ZEngine/Importers/AssetCodec.h>
 #include <ZEngine/Managers/AssetManager.h>
+#include <ZEngine/Rendering/BuiltinMeshes.h>
 using namespace ZEngine::Core::Containers;
 using namespace ZEngine::ECS::Components;
 using namespace ZEngine::Managers;
@@ -37,29 +38,48 @@ namespace Tetragrama
         auto* ctx = ZEngine::Engine::GetContext();
         if (ctx && ctx->ActorManager)
         {
-            ZEngine::ECS::ActorHandle handle = ctx->ActorManager->Create();
-            ZEngine::ECS::Actor*      actor  = ctx->ActorManager->Access(handle);
-            if (actor)
+            // Register the built-in sun mesh so it's available for GPU upload.
             {
-                constexpr cstring default_light_name = "DirectionalLight";
-
-                NameComponent     nc                 = {};
-                ZEngine::Helpers::secure_strncpy(nc.Value, sizeof(nc.Value), default_light_name, ZEngine::Helpers::secure_strlen(default_light_name));
-                actor->AddComponent<NameComponent>(nc);
-
-                TransformComponent tc = {};
-                tc.Rotation.x         = -1.047f;
-                tc.Rotation.y         = 0.524f;
-                actor->AddComponent<TransformComponent>(tc);
-
-                LightComponent lc = {};
-                lc.LightType      = LightComponent::Type::Directional;
-                lc.Intensity      = 3.f;
-                lc.Color[0]       = 1.f;
-                lc.Color[1]       = 1.f;
-                lc.Color[2]       = 1.f;
-                actor->AddComponent<LightComponent>(lc);
+                ZEngine::Importers::AssetMesh          sun_mesh{};
+                ZEngine::Importers::AssetNodeHierarchy sun_hier{};
+                ZEngine::Rendering::CreateDirectionalLightMesh(&LocalArena, sun_mesh, sun_hier);
+                AssetManager::IngestMesh(std::move(sun_mesh), std::move(sun_hier));
             }
+
+            auto light_uuid_result = uuids::uuid::from_string(ZEngine::Rendering::DIRECTIONAL_LIGHT_MESH_UUID);
+            if (!light_uuid_result)
+                return;
+            uuids::uuid               light_uuid         = *light_uuid_result;
+
+            constexpr cstring         default_light_name = "DirectionalLight";
+
+            ZEngine::ECS::ActorHandle handle             = ctx->ActorManager->Create();
+            ZEngine::ECS::Actor*      actor              = ctx->ActorManager->Access(handle);
+            if (!actor)
+                return;
+
+            NameComponent nc = {};
+            ZEngine::Helpers::secure_strncpy(nc.Value, sizeof(nc.Value), default_light_name, ZEngine::Helpers::secure_strlen(default_light_name));
+            actor->AddComponent<NameComponent>(nc);
+
+            TransformComponent tc = {};
+            tc.Rotation.x         = -1.047f;
+            tc.Rotation.y         = 0.524f;
+            actor->AddComponent<TransformComponent>(tc);
+
+            LightComponent lc = {};
+            lc.LightType      = LightComponent::Type::Directional;
+            lc.Intensity      = 3.f;
+            lc.Color[0]       = 1.f;
+            lc.Color[1]       = 1.f;
+            lc.Color[2]       = 1.f;
+            actor->AddComponent<LightComponent>(lc);
+
+            uint32_t      render_id = AddMeshInstance(light_uuid, default_light_name);
+            MeshComponent mc        = {};
+            mc.MeshUUID             = light_uuid;
+            mc.RenderInstanceId     = render_id;
+            actor->AddComponent<MeshComponent>(mc);
         }
     }
 

--- a/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp
+++ b/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp
@@ -194,6 +194,14 @@ namespace ZEngine::Applications
             SceneRenderer->UpdateRMMBindings(gpu_data);
         }
 
+        if (Device->RRM)
+        {
+            auto* rrm     = reinterpret_cast<Rendering::RenderResourceManager*>(Device->RRM);
+            auto* gpu_buf = SceneRenderer->RenderSceneData;
+            if (gpu_buf->LightBuffer.Handle)
+                rrm->UpdateBuffer(gpu_buf->LightBuffer, &scene->PendingLights, sizeof(Rendering::Scenes::LightArrayUBO));
+        }
+
         SceneRenderer->DrawScene(frame_index, thread_index, CurrentCmdBuf, camera);
     }
 

--- a/ZEngine/ZEngine/ECS/Systems/LightSyncSystem.cpp
+++ b/ZEngine/ZEngine/ECS/Systems/LightSyncSystem.cpp
@@ -1,0 +1,52 @@
+#include <ZEngine/Core/Maths/Matrix.h>
+#include <ZEngine/ECS/Components/LightComponent.h>
+#include <ZEngine/ECS/Components/TransformComponent.h>
+#include <ZEngine/ECS/Systems/LightSyncSystem.h>
+
+using namespace ZEngine::ECS::Components;
+using namespace ZEngine::Rendering::Scenes;
+using namespace ZEngine::Core::Maths;
+
+namespace ZEngine::ECS::Systems
+{
+    void SyncECSToLights(Scene& scene, Rendering::Scenes::RenderScene& render_scene)
+    {
+        LightArrayUBO lights = {};
+
+        scene.ForEach<TransformComponent, LightComponent>([&](EntityID, TransformComponent& tc, LightComponent& lc) {
+            if (lc.LightType == LightComponent::Type::Directional && lights.DirectionalCount < 4)
+            {
+                // Build rotation-only matrix and extract forward direction (column 2).
+                // ComposeTransformMatrix uses YXZ Euler order; column 2 = (-sy, sx*cy, cx*cy).
+                Mat4f rot       = ComposeTransformMatrix(Vec3f(0.f, 0.f, 0.f), tc.Rotation, Vec3f(1.f, 1.f, 1.f));
+
+                auto& dir       = lights.DirectionalLights[lights.DirectionalCount++];
+                dir.Direction.x = rot(0, 2);
+                dir.Direction.y = rot(1, 2);
+                dir.Direction.z = rot(2, 2);
+                dir.Direction.w = 0.f;
+                dir.Color.x     = lc.Color[0];
+                dir.Color.y     = lc.Color[1];
+                dir.Color.z     = lc.Color[2];
+                dir.Color.w     = 1.f;
+                dir.Intensity   = lc.Intensity;
+            }
+            else if (lc.LightType == LightComponent::Type::Point && lights.PointCount < 8)
+            {
+                auto& pt      = lights.PointLights[lights.PointCount++];
+                pt.Position.x = tc.Position.x;
+                pt.Position.y = tc.Position.y;
+                pt.Position.z = tc.Position.z;
+                pt.Position.w = 1.f;
+                pt.Color.x    = lc.Color[0];
+                pt.Color.y    = lc.Color[1];
+                pt.Color.z    = lc.Color[2];
+                pt.Color.w    = 1.f;
+                pt.Intensity  = lc.Intensity;
+                pt.Radius     = lc.Range;
+            }
+        });
+
+        render_scene.PendingLights = lights;
+    }
+} // namespace ZEngine::ECS::Systems

--- a/ZEngine/ZEngine/ECS/Systems/LightSyncSystem.h
+++ b/ZEngine/ZEngine/ECS/Systems/LightSyncSystem.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <ZEngine/ECS/Scene.h>
+#include <ZEngine/Rendering/Scenes/RenderScene.h>
+
+namespace ZEngine::ECS::Systems
+{
+    // Builds a LightArrayUBO from all entities with LightComponent + TransformComponent
+    // and stores it in RenderScene::PendingLights for upload by GraphicRenderer::DrawScene.
+    // Called from Engine::MainThreadRun after the fixed-step loop, before PrepareScene.
+    void SyncECSToLights(Scene& scene, Rendering::Scenes::RenderScene& render_scene);
+} // namespace ZEngine::ECS::Systems

--- a/ZEngine/ZEngine/ECS/Systems/TransformSyncSystem.cpp
+++ b/ZEngine/ZEngine/ECS/Systems/TransformSyncSystem.cpp
@@ -10,11 +10,13 @@ namespace ZEngine::ECS::Systems
         using namespace Components;
         using namespace Core::Maths;
 
+        // Use Position directly — interpolation between PreviousPosition and Position
+        // is deferred until fixed-timestep physics/simulation systems are active.
+        // Applying alpha here conflicts with immediate gizmo-driven position updates.
         scene.ForEach<TransformComponent, MeshComponent>([&](EntityID, TransformComponent& tc, MeshComponent& mc) {
             if (mc.RenderInstanceId == UINT32_MAX)
                 return;
-            Vec3f pos = tc.PreviousPosition + (tc.Position - tc.PreviousPosition) * alpha;
-            Mat4f mat = ComposeTransformMatrix(pos, tc.Rotation, tc.Scale);
+            Mat4f mat = ComposeTransformMatrix(tc.Position, tc.Rotation, tc.Scale);
             render_scene.SetInstanceTransform(mc.RenderInstanceId, mat);
         });
     }

--- a/ZEngine/ZEngine/ECS/Systems/TransformSyncSystem.cpp
+++ b/ZEngine/ZEngine/ECS/Systems/TransformSyncSystem.cpp
@@ -1,0 +1,21 @@
+#include <ZEngine/Core/Maths/Matrix.h>
+#include <ZEngine/ECS/Components/MeshComponent.h>
+#include <ZEngine/ECS/Components/TransformComponent.h>
+#include <ZEngine/ECS/Systems/TransformSyncSystem.h>
+
+namespace ZEngine::ECS::Systems
+{
+    void SyncECSToRenderScene(Scene& scene, float alpha, Rendering::Scenes::RenderScene& render_scene)
+    {
+        using namespace Components;
+        using namespace Core::Maths;
+
+        scene.ForEach<TransformComponent, MeshComponent>([&](EntityID, TransformComponent& tc, MeshComponent& mc) {
+            if (mc.RenderInstanceId == UINT32_MAX)
+                return;
+            Vec3f pos = tc.PreviousPosition + (tc.Position - tc.PreviousPosition) * alpha;
+            Mat4f mat = ComposeTransformMatrix(pos, tc.Rotation, tc.Scale);
+            render_scene.SetInstanceTransform(mc.RenderInstanceId, mat);
+        });
+    }
+} // namespace ZEngine::ECS::Systems

--- a/ZEngine/ZEngine/ECS/Systems/TransformSyncSystem.h
+++ b/ZEngine/ZEngine/ECS/Systems/TransformSyncSystem.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <ZEngine/ECS/Scene.h>
+#include <ZEngine/Rendering/Scenes/RenderScene.h>
+
+namespace ZEngine::ECS::Systems
+{
+    // Propagates ECS TransformComponent + MeshComponent into RenderScene each frame.
+    // Uses alpha for fixed-timestep position interpolation (PreviousPosition → Position).
+    // Called from Engine::MainThreadRun after the fixed-step loop, before PrepareScene.
+    void SyncECSToRenderScene(Scene& scene, float alpha, Rendering::Scenes::RenderScene& render_scene);
+} // namespace ZEngine::ECS::Systems

--- a/ZEngine/ZEngine/Engine.cpp
+++ b/ZEngine/ZEngine/Engine.cpp
@@ -4,6 +4,7 @@
 #include <ZEngine/Core/VFS/VFSContext.h>
 #include <ZEngine/Core/VFS/VFSDiskBackend.h>
 #include <ZEngine/Core/VFS/VFSPath.h>
+#include <ZEngine/ECS/Systems/LightSyncSystem.h>
 #include <ZEngine/ECS/Systems/TransformSyncSystem.h>
 #include <ZEngine/Engine.h>
 #include <ZEngine/Engine/FixedTimestepAccumulator.h>
@@ -280,7 +281,10 @@ namespace ZEngine
             }
 
             if (g_engine_ctx->Scene && g_app->CurrentScene)
+            {
                 ECS::Systems::SyncECSToRenderScene(*g_engine_ctx->Scene, alpha, *g_app->CurrentScene);
+                ECS::Systems::SyncECSToLights(*g_engine_ctx->Scene, *g_app->CurrentScene);
+            }
 
             g_app->PrepareScene(r_payload);
 

--- a/ZEngine/ZEngine/Engine.cpp
+++ b/ZEngine/ZEngine/Engine.cpp
@@ -4,6 +4,7 @@
 #include <ZEngine/Core/VFS/VFSContext.h>
 #include <ZEngine/Core/VFS/VFSDiskBackend.h>
 #include <ZEngine/Core/VFS/VFSPath.h>
+#include <ZEngine/ECS/Systems/TransformSyncSystem.h>
 #include <ZEngine/Engine.h>
 #include <ZEngine/Engine/FixedTimestepAccumulator.h>
 #include <ZEngine/Engine/FrameRateCap.h>
@@ -277,6 +278,9 @@ namespace ZEngine
                 r_payload.RenderUIOverlay.value.store(true, std::memory_order_release);
                 pipeline->FillOverlayPayload(r_payload.UIOverlay);
             }
+
+            if (g_engine_ctx->Scene && g_app->CurrentScene)
+                ECS::Systems::SyncECSToRenderScene(*g_engine_ctx->Scene, alpha, *g_app->CurrentScene);
 
             g_app->PrepareScene(r_payload);
 

--- a/ZEngine/ZEngine/Rendering/BuiltinMeshes.cpp
+++ b/ZEngine/ZEngine/Rendering/BuiltinMeshes.cpp
@@ -10,8 +10,6 @@ using namespace ZEngine::Core::Maths;
 
 namespace ZEngine::Rendering
 {
-    // ── Internal types ────────────────────────────────────────────────────────
-
     using BuildMeshFn     = void (*)(ArenaAllocator*, AssetMesh&, AssetNodeHierarchy&);
     using BuildMaterialFn = void (*)(AssetMaterial&); // null = no paired material
 
@@ -22,8 +20,6 @@ namespace ZEngine::Rendering
         BuildMeshFn     BuildMesh;
         BuildMaterialFn BuildMaterial; // null if no material
     };
-
-    // ── Mesh builders (static — not exposed in the header) ───────────────────
 
     static void BuildDirectionalLightIcon(ArenaAllocator* arena, AssetMesh& out_mesh, AssetNodeHierarchy& out_hierarchy)
     {
@@ -136,8 +132,6 @@ namespace ZEngine::Rendering
         out_hierarchy.GlobalTransforms.push(Identity<Mat4f>());
     }
 
-    // ── Material builders ─────────────────────────────────────────────────────
-
     static void BuildDirectionalLightMaterial(AssetMaterial& mat)
     {
         // Yellow albedo + emissive self-glow.
@@ -151,8 +145,6 @@ namespace ZEngine::Rendering
         mat.Factors[1]       = 0.f; // metallic = 0
     }
 
-    // ── Static table ──────────────────────────────────────────────────────────
-
     static constexpr BuiltinMeshEntry kBuiltinMeshTable[] = {
         {
          "ff000000-0000-0000-0000-000000000001", // mesh
@@ -162,8 +154,6 @@ namespace ZEngine::Rendering
     };
 
     static_assert(std::size(kBuiltinMeshTable) == static_cast<uint32_t>(BuiltinMeshID::COUNT), "kBuiltinMeshTable size must match BuiltinMeshID::COUNT");
-
-    // ── Public API ────────────────────────────────────────────────────────────
 
     const char* BuiltinMeshUUID(BuiltinMeshID id)
     {

--- a/ZEngine/ZEngine/Rendering/BuiltinMeshes.cpp
+++ b/ZEngine/ZEngine/Rendering/BuiltinMeshes.cpp
@@ -1,17 +1,32 @@
 #include <ZEngine/Core/Maths/Matrix.h>
+#include <ZEngine/Importers/AssetTypes.h>
+#include <ZEngine/Managers/AssetManager.h>
 #include <ZEngine/Rendering/BuiltinMeshes.h>
 #include <uuid.h>
 
 using namespace ZEngine::Core::Memory;
 using namespace ZEngine::Importers;
+using namespace ZEngine::Core::Maths;
 
 namespace ZEngine::Rendering
 {
-    void CreateDirectionalLightMesh(ArenaAllocator* arena, AssetMesh& out_mesh, AssetNodeHierarchy& out_hierarchy)
-    {
-        using namespace Core::Maths;
+    // ── Internal types ────────────────────────────────────────────────────────
 
-        // Estimated counts: disc(13v 36i) + rays(32v 48i) + arrow(14v 18i) = 59v 102i
+    using BuildMeshFn     = void (*)(ArenaAllocator*, AssetMesh&, AssetNodeHierarchy&);
+    using BuildMaterialFn = void (*)(AssetMaterial&); // null = no paired material
+
+    struct BuiltinMeshEntry
+    {
+        const char*     MeshUUID;
+        const char*     MaterialUUID; // null if no material
+        BuildMeshFn     BuildMesh;
+        BuildMaterialFn BuildMaterial; // null if no material
+    };
+
+    // ── Mesh builders (static — not exposed in the header) ───────────────────
+
+    static void BuildDirectionalLightIcon(ArenaAllocator* arena, AssetMesh& out_mesh, AssetNodeHierarchy& out_hierarchy)
+    {
         out_mesh.Vertices.init(arena, 512);
         out_mesh.Indices.init(arena, 256);
 
@@ -25,116 +40,89 @@ namespace ZEngine::Rendering
             out_mesh.Vertices.push(u);
             out_mesh.Vertices.push(v);
         };
-
         auto push_tri = [&](uint32_t a, uint32_t b, uint32_t c) {
             out_mesh.Indices.push(a);
             out_mesh.Indices.push(b);
             out_mesh.Indices.push(c);
         };
+        auto            vcount   = [&]() -> uint32_t { return static_cast<uint32_t>(out_mesh.Vertices.size() / 8); };
 
-        // Returns the current vertex count (index of the next vertex to be added).
-        auto            vcount     = [&]() -> uint32_t { return static_cast<uint32_t>(out_mesh.Vertices.size() / 8); };
+        constexpr float PI       = 3.14159265358979323846f;
+        constexpr float TWO_PI   = 2.f * PI;
+        constexpr int   DISC_SEG = 12;
 
-        constexpr float PI         = 3.14159265358979323846f;
-        constexpr float TWO_PI     = 2.f * PI;
-        constexpr int   DISC_SEGS  = 12;
-
-        // ── Disc (12-gon in XY plane, normal +Z) ──────────────────────────────────
-        uint32_t        center_idx = vcount();
+        // Disc (12-gon in XY plane, normal +Z)
+        uint32_t        ci       = vcount();
         push_v(0.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.5f, 0.5f);
-
-        uint32_t ring_start = vcount();
-        for (int i = 0; i < DISC_SEGS; ++i)
+        uint32_t rs = vcount();
+        for (int i = 0; i < DISC_SEG; ++i)
         {
-            float a = TWO_PI * i / DISC_SEGS;
+            float a = TWO_PI * i / DISC_SEG;
             float c = cosf(a), s = sinf(a);
             push_v(c * 0.12f, s * 0.12f, 0.f, 0.f, 0.f, 1.f, c * 0.5f + 0.5f, s * 0.5f + 0.5f);
         }
-        for (int i = 0; i < DISC_SEGS; ++i)
-            push_tri(center_idx, ring_start + i, ring_start + (i + 1) % DISC_SEGS);
+        for (int i = 0; i < DISC_SEG; ++i)
+            push_tri(ci, rs + i, rs + (i + 1) % DISC_SEG);
 
-        // ── 8 diamond rays (XY plane, normal +Z) ──────────────────────────────────
-        constexpr int   RAYS       = 8;
-        constexpr float RAY_INNER  = 0.13f;
-        constexpr float RAY_HALF_W = 0.035f;
-        constexpr float RAY_MID_R  = 0.20f;
-        constexpr float RAY_TIP_R  = 0.27f;
-
-        for (int r = 0; r < RAYS; ++r)
+        // 8 diamond rays (XY plane, normal +Z)
+        for (int r = 0; r < 8; ++r)
         {
-            float    a  = TWO_PI * r / RAYS;
-            float    cx = cosf(a), cz = sinf(a); // forward along ray
-            float    px = -cz, pz = cx;          // perpendicular in XY plane
-
-            uint32_t base = vcount();
-            push_v(cx * RAY_INNER, cz * RAY_INNER, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f);                                      // inner
-            push_v(cx * RAY_MID_R + px * RAY_HALF_W, cz * RAY_MID_R + pz * RAY_HALF_W, 0.f, 0.f, 0.f, 1.f, 0.5f, 0.f); // left
-            push_v(cx * RAY_TIP_R, cz * RAY_TIP_R, 0.f, 0.f, 0.f, 1.f, 1.f, 0.f);                                      // tip
-            push_v(cx * RAY_MID_R - px * RAY_HALF_W, cz * RAY_MID_R - pz * RAY_HALF_W, 0.f, 0.f, 0.f, 1.f, 0.5f, 1.f); // right
-
-            push_tri(base, base + 1, base + 2);
-            push_tri(base, base + 2, base + 3);
+            float    a  = TWO_PI * r / 8;
+            float    cx = cosf(a), cz = sinf(a);
+            float    px = -cz, pz = cx;
+            uint32_t b = vcount();
+            push_v(cx * 0.13f, cz * 0.13f, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f);
+            push_v(cx * 0.20f + px * 0.035f, cz * 0.20f + pz * 0.035f, 0.f, 0.f, 0.f, 1.f, 0.5f, 0.f);
+            push_v(cx * 0.27f, cz * 0.27f, 0.f, 0.f, 0.f, 1.f, 1.f, 0.f);
+            push_v(cx * 0.20f - px * 0.035f, cz * 0.20f - pz * 0.035f, 0.f, 0.f, 0.f, 1.f, 0.5f, 1.f);
+            push_tri(b, b + 1, b + 2);
+            push_tri(b, b + 2, b + 3);
         }
 
-        // ── Arrow shaft — two perpendicular flat planes for 360-degree visibility ──
-        // Plane 1: XZ (y = 0), normal +Y
+        // Arrow shaft — two perpendicular flat planes for 360-degree visibility
         {
-            uint32_t base = vcount();
+            uint32_t b = vcount();
             push_v(-0.025f, 0.f, 0.15f, 0.f, 1.f, 0.f, 0.f, 0.f);
             push_v(0.025f, 0.f, 0.15f, 0.f, 1.f, 0.f, 1.f, 0.f);
             push_v(0.025f, 0.f, 0.35f, 0.f, 1.f, 0.f, 1.f, 1.f);
             push_v(-0.025f, 0.f, 0.35f, 0.f, 1.f, 0.f, 0.f, 1.f);
-            push_tri(base, base + 1, base + 2);
-            push_tri(base, base + 2, base + 3);
+            push_tri(b, b + 1, b + 2);
+            push_tri(b, b + 2, b + 3);
         }
-        // Plane 2: YZ (x = 0), normal +X
         {
-            uint32_t base = vcount();
+            uint32_t b = vcount();
             push_v(0.f, -0.025f, 0.15f, 1.f, 0.f, 0.f, 0.f, 0.f);
             push_v(0.f, 0.025f, 0.15f, 1.f, 0.f, 0.f, 1.f, 0.f);
             push_v(0.f, 0.025f, 0.35f, 1.f, 0.f, 0.f, 1.f, 1.f);
             push_v(0.f, -0.025f, 0.35f, 1.f, 0.f, 0.f, 0.f, 1.f);
-            push_tri(base, base + 1, base + 2);
-            push_tri(base, base + 2, base + 3);
+            push_tri(b, b + 1, b + 2);
+            push_tri(b, b + 2, b + 3);
         }
 
-        // ── Arrowhead — two perpendicular triangles ────────────────────────────────
-        // Plane 1: XZ (y = 0), normal +Y
+        // Arrowhead — two perpendicular triangles
         {
-            uint32_t base = vcount();
+            uint32_t b = vcount();
             push_v(-0.06f, 0.f, 0.32f, 0.f, 1.f, 0.f, 0.f, 0.f);
             push_v(0.06f, 0.f, 0.32f, 0.f, 1.f, 0.f, 1.f, 0.f);
             push_v(0.00f, 0.f, 0.55f, 0.f, 1.f, 0.f, 0.5f, 1.f);
-            push_tri(base, base + 1, base + 2);
+            push_tri(b, b + 1, b + 2);
         }
-        // Plane 2: YZ (x = 0), normal +X
         {
-            uint32_t base = vcount();
+            uint32_t b = vcount();
             push_v(0.f, -0.06f, 0.32f, 1.f, 0.f, 0.f, 0.f, 0.f);
             push_v(0.f, 0.06f, 0.32f, 1.f, 0.f, 0.f, 1.f, 0.f);
             push_v(0.f, 0.00f, 0.55f, 1.f, 0.f, 0.f, 0.5f, 1.f);
-            push_tri(base, base + 1, base + 2);
+            push_tri(b, b + 1, b + 2);
         }
 
-        // ── SubMesh (single sub-mesh covering all geometry) ────────────────────────
         out_mesh.SubMeshes.init(arena, 1);
         AssetSubMesh& sub        = out_mesh.SubMeshes.push_use({});
         sub.VertexCount          = vcount();
         sub.IndexCount           = static_cast<uint32_t>(out_mesh.Indices.size());
-        sub.VertexOffset         = 0;
-        sub.IndexOffset          = 0;
         sub.VertexUnitStreamSize = 8 * sizeof(float);
         sub.IndexUnitStreamSize  = sizeof(uint32_t);
         sub.TotalByteSize        = sub.VertexCount * sub.VertexUnitStreamSize;
-
-        // ── UUID ───────────────────────────────────────────────────────────────────
-        auto uuid_result         = uuids::uuid::from_string(DIRECTIONAL_LIGHT_MESH_UUID);
-        if (uuid_result)
-            out_mesh.MeshUUID = *uuid_result;
-
-        // ── Minimal node hierarchy (one root node, no children) ────────────────────
-        out_hierarchy.MeshUUID          = out_mesh.MeshUUID;
-        out_hierarchy.NodeHierarchyUUID = out_mesh.MeshUUID;
+        // sub.MaterialUUID is patched by RegisterBuiltinMeshes after this returns.
 
         out_hierarchy.Hierarchies.init(arena, 1);
         out_hierarchy.LocalTransforms.init(arena, 1);
@@ -144,8 +132,95 @@ namespace ZEngine::Rendering
         out_hierarchy.NodeNames.init(arena, 64);
         out_hierarchy.NodeMeshes.init(arena, 1);
         out_hierarchy.NodeMaterials.init(arena, 1);
-
         out_hierarchy.LocalTransforms.push(Identity<Mat4f>());
         out_hierarchy.GlobalTransforms.push(Identity<Mat4f>());
     }
+
+    // ── Material builders ─────────────────────────────────────────────────────
+
+    static void BuildDirectionalLightMaterial(AssetMaterial& mat)
+    {
+        // Yellow emissive — no textures, no PBR specular.
+        mat.EmissiveColor[0] = 1.f;
+        mat.EmissiveColor[1] = 0.85f;
+        mat.EmissiveColor[2] = 0.f;
+        mat.EmissiveColor[3] = 1.f;
+        mat.Factors[1]       = 0.f; // metallic = 0
+    }
+
+    // ── Static table ──────────────────────────────────────────────────────────
+
+    static constexpr BuiltinMeshEntry kBuiltinMeshTable[] = {
+        {
+         "ff000000-0000-0000-0000-000000000001", // mesh
+        "ff000000-0000-0001-0000-000000000001", // material
+        BuildDirectionalLightIcon, BuildDirectionalLightMaterial,
+         },
+    };
+
+    static_assert(std::size(kBuiltinMeshTable) == static_cast<uint32_t>(BuiltinMeshID::COUNT), "kBuiltinMeshTable size must match BuiltinMeshID::COUNT");
+
+    // ── Public API ────────────────────────────────────────────────────────────
+
+    const char* BuiltinMeshUUID(BuiltinMeshID id)
+    {
+        return kBuiltinMeshTable[static_cast<uint32_t>(id)].MeshUUID;
+    }
+
+    uuids::uuid BuiltinMeshUUIDParsed(BuiltinMeshID id)
+    {
+        auto r = uuids::uuid::from_string(BuiltinMeshUUID(id));
+        return r ? *r : uuids::uuid{};
+    }
+
+    uuids::uuid BuiltinMaterialUUIDParsed(BuiltinMeshID id)
+    {
+        const char* s = kBuiltinMeshTable[static_cast<uint32_t>(id)].MaterialUUID;
+        if (!s)
+            return {};
+        auto r = uuids::uuid::from_string(s);
+        return r ? *r : uuids::uuid{};
+    }
+
+    void RegisterBuiltinMeshes(ArenaAllocator* arena)
+    {
+        for (const auto& entry : kBuiltinMeshTable)
+        {
+            // Ingest material first — must exist before the mesh is rendered.
+            if (entry.MaterialUUID && entry.BuildMaterial)
+            {
+                AssetMaterial mat{};
+                mat.Name.init(arena, entry.MaterialUUID);
+                auto r = uuids::uuid::from_string(entry.MaterialUUID);
+                if (r)
+                    mat.MaterialUUID = *r;
+                entry.BuildMaterial(mat);
+                Managers::AssetManager::IngestMaterial(std::move(mat));
+            }
+
+            // Build mesh then patch all submesh MaterialUUIDs before ingesting.
+            AssetMesh          mesh{};
+            AssetNodeHierarchy hier{};
+            entry.BuildMesh(arena, mesh, hier);
+
+            auto mesh_uuid_result = uuids::uuid::from_string(entry.MeshUUID);
+            if (mesh_uuid_result)
+            {
+                mesh.MeshUUID          = *mesh_uuid_result;
+                hier.MeshUUID          = *mesh_uuid_result;
+                hier.NodeHierarchyUUID = *mesh_uuid_result;
+            }
+
+            if (entry.MaterialUUID)
+            {
+                auto mat_r = uuids::uuid::from_string(entry.MaterialUUID);
+                if (mat_r)
+                    for (auto& sub : mesh.SubMeshes)
+                        sub.MaterialUUID = *mat_r;
+            }
+
+            Managers::AssetManager::IngestMesh(std::move(mesh), std::move(hier));
+        }
+    }
+
 } // namespace ZEngine::Rendering

--- a/ZEngine/ZEngine/Rendering/BuiltinMeshes.cpp
+++ b/ZEngine/ZEngine/Rendering/BuiltinMeshes.cpp
@@ -1,0 +1,151 @@
+#include <ZEngine/Core/Maths/Matrix.h>
+#include <ZEngine/Rendering/BuiltinMeshes.h>
+#include <uuid.h>
+
+using namespace ZEngine::Core::Memory;
+using namespace ZEngine::Importers;
+
+namespace ZEngine::Rendering
+{
+    void CreateDirectionalLightMesh(ArenaAllocator* arena, AssetMesh& out_mesh, AssetNodeHierarchy& out_hierarchy)
+    {
+        using namespace Core::Maths;
+
+        // Estimated counts: disc(13v 36i) + rays(32v 48i) + arrow(14v 18i) = 59v 102i
+        out_mesh.Vertices.init(arena, 512);
+        out_mesh.Indices.init(arena, 256);
+
+        auto push_v = [&](float x, float y, float z, float nx, float ny, float nz, float u, float v) {
+            out_mesh.Vertices.push(x);
+            out_mesh.Vertices.push(y);
+            out_mesh.Vertices.push(z);
+            out_mesh.Vertices.push(nx);
+            out_mesh.Vertices.push(ny);
+            out_mesh.Vertices.push(nz);
+            out_mesh.Vertices.push(u);
+            out_mesh.Vertices.push(v);
+        };
+
+        auto push_tri = [&](uint32_t a, uint32_t b, uint32_t c) {
+            out_mesh.Indices.push(a);
+            out_mesh.Indices.push(b);
+            out_mesh.Indices.push(c);
+        };
+
+        // Returns the current vertex count (index of the next vertex to be added).
+        auto            vcount     = [&]() -> uint32_t { return static_cast<uint32_t>(out_mesh.Vertices.size() / 8); };
+
+        constexpr float PI         = 3.14159265358979323846f;
+        constexpr float TWO_PI     = 2.f * PI;
+        constexpr int   DISC_SEGS  = 12;
+
+        // ── Disc (12-gon in XY plane, normal +Z) ──────────────────────────────────
+        uint32_t        center_idx = vcount();
+        push_v(0.f, 0.f, 0.f, 0.f, 0.f, 1.f, 0.5f, 0.5f);
+
+        uint32_t ring_start = vcount();
+        for (int i = 0; i < DISC_SEGS; ++i)
+        {
+            float a = TWO_PI * i / DISC_SEGS;
+            float c = cosf(a), s = sinf(a);
+            push_v(c * 0.12f, s * 0.12f, 0.f, 0.f, 0.f, 1.f, c * 0.5f + 0.5f, s * 0.5f + 0.5f);
+        }
+        for (int i = 0; i < DISC_SEGS; ++i)
+            push_tri(center_idx, ring_start + i, ring_start + (i + 1) % DISC_SEGS);
+
+        // ── 8 diamond rays (XY plane, normal +Z) ──────────────────────────────────
+        constexpr int   RAYS       = 8;
+        constexpr float RAY_INNER  = 0.13f;
+        constexpr float RAY_HALF_W = 0.035f;
+        constexpr float RAY_MID_R  = 0.20f;
+        constexpr float RAY_TIP_R  = 0.27f;
+
+        for (int r = 0; r < RAYS; ++r)
+        {
+            float    a  = TWO_PI * r / RAYS;
+            float    cx = cosf(a), cz = sinf(a); // forward along ray
+            float    px = -cz, pz = cx;          // perpendicular in XY plane
+
+            uint32_t base = vcount();
+            push_v(cx * RAY_INNER, cz * RAY_INNER, 0.f, 0.f, 0.f, 1.f, 0.f, 0.f);                                      // inner
+            push_v(cx * RAY_MID_R + px * RAY_HALF_W, cz * RAY_MID_R + pz * RAY_HALF_W, 0.f, 0.f, 0.f, 1.f, 0.5f, 0.f); // left
+            push_v(cx * RAY_TIP_R, cz * RAY_TIP_R, 0.f, 0.f, 0.f, 1.f, 1.f, 0.f);                                      // tip
+            push_v(cx * RAY_MID_R - px * RAY_HALF_W, cz * RAY_MID_R - pz * RAY_HALF_W, 0.f, 0.f, 0.f, 1.f, 0.5f, 1.f); // right
+
+            push_tri(base, base + 1, base + 2);
+            push_tri(base, base + 2, base + 3);
+        }
+
+        // ── Arrow shaft — two perpendicular flat planes for 360-degree visibility ──
+        // Plane 1: XZ (y = 0), normal +Y
+        {
+            uint32_t base = vcount();
+            push_v(-0.025f, 0.f, 0.15f, 0.f, 1.f, 0.f, 0.f, 0.f);
+            push_v(0.025f, 0.f, 0.15f, 0.f, 1.f, 0.f, 1.f, 0.f);
+            push_v(0.025f, 0.f, 0.35f, 0.f, 1.f, 0.f, 1.f, 1.f);
+            push_v(-0.025f, 0.f, 0.35f, 0.f, 1.f, 0.f, 0.f, 1.f);
+            push_tri(base, base + 1, base + 2);
+            push_tri(base, base + 2, base + 3);
+        }
+        // Plane 2: YZ (x = 0), normal +X
+        {
+            uint32_t base = vcount();
+            push_v(0.f, -0.025f, 0.15f, 1.f, 0.f, 0.f, 0.f, 0.f);
+            push_v(0.f, 0.025f, 0.15f, 1.f, 0.f, 0.f, 1.f, 0.f);
+            push_v(0.f, 0.025f, 0.35f, 1.f, 0.f, 0.f, 1.f, 1.f);
+            push_v(0.f, -0.025f, 0.35f, 1.f, 0.f, 0.f, 0.f, 1.f);
+            push_tri(base, base + 1, base + 2);
+            push_tri(base, base + 2, base + 3);
+        }
+
+        // ── Arrowhead — two perpendicular triangles ────────────────────────────────
+        // Plane 1: XZ (y = 0), normal +Y
+        {
+            uint32_t base = vcount();
+            push_v(-0.06f, 0.f, 0.32f, 0.f, 1.f, 0.f, 0.f, 0.f);
+            push_v(0.06f, 0.f, 0.32f, 0.f, 1.f, 0.f, 1.f, 0.f);
+            push_v(0.00f, 0.f, 0.55f, 0.f, 1.f, 0.f, 0.5f, 1.f);
+            push_tri(base, base + 1, base + 2);
+        }
+        // Plane 2: YZ (x = 0), normal +X
+        {
+            uint32_t base = vcount();
+            push_v(0.f, -0.06f, 0.32f, 1.f, 0.f, 0.f, 0.f, 0.f);
+            push_v(0.f, 0.06f, 0.32f, 1.f, 0.f, 0.f, 1.f, 0.f);
+            push_v(0.f, 0.00f, 0.55f, 1.f, 0.f, 0.f, 0.5f, 1.f);
+            push_tri(base, base + 1, base + 2);
+        }
+
+        // ── SubMesh (single sub-mesh covering all geometry) ────────────────────────
+        out_mesh.SubMeshes.init(arena, 1);
+        AssetSubMesh& sub        = out_mesh.SubMeshes.push_use({});
+        sub.VertexCount          = vcount();
+        sub.IndexCount           = static_cast<uint32_t>(out_mesh.Indices.size());
+        sub.VertexOffset         = 0;
+        sub.IndexOffset          = 0;
+        sub.VertexUnitStreamSize = 8 * sizeof(float);
+        sub.IndexUnitStreamSize  = sizeof(uint32_t);
+        sub.TotalByteSize        = sub.VertexCount * sub.VertexUnitStreamSize;
+
+        // ── UUID ───────────────────────────────────────────────────────────────────
+        auto uuid_result         = uuids::uuid::from_string(DIRECTIONAL_LIGHT_MESH_UUID);
+        if (uuid_result)
+            out_mesh.MeshUUID = *uuid_result;
+
+        // ── Minimal node hierarchy (one root node, no children) ────────────────────
+        out_hierarchy.MeshUUID          = out_mesh.MeshUUID;
+        out_hierarchy.NodeHierarchyUUID = out_mesh.MeshUUID;
+
+        out_hierarchy.Hierarchies.init(arena, 1);
+        out_hierarchy.LocalTransforms.init(arena, 1);
+        out_hierarchy.GlobalTransforms.init(arena, 1);
+        out_hierarchy.Names.init(arena, 1);
+        out_hierarchy.MaterialNames.init(arena, 1);
+        out_hierarchy.NodeNames.init(arena, 64);
+        out_hierarchy.NodeMeshes.init(arena, 1);
+        out_hierarchy.NodeMaterials.init(arena, 1);
+
+        out_hierarchy.LocalTransforms.push(Identity<Mat4f>());
+        out_hierarchy.GlobalTransforms.push(Identity<Mat4f>());
+    }
+} // namespace ZEngine::Rendering

--- a/ZEngine/ZEngine/Rendering/BuiltinMeshes.cpp
+++ b/ZEngine/ZEngine/Rendering/BuiltinMeshes.cpp
@@ -140,11 +140,14 @@ namespace ZEngine::Rendering
 
     static void BuildDirectionalLightMaterial(AssetMaterial& mat)
     {
-        // Yellow emissive — no textures, no PBR specular.
-        mat.EmissiveColor[0] = 1.f;
-        mat.EmissiveColor[1] = 0.85f;
-        mat.EmissiveColor[2] = 0.f;
-        mat.EmissiveColor[3] = 1.f;
+        // Yellow albedo + emissive self-glow.
+        // Shader: color = ambient + Lo + albedo * emissive.r
+        // emissive.r = 1 makes the icon always show its albedo color regardless of lighting.
+        mat.AlbedoColor[0]   = 1.f;
+        mat.AlbedoColor[1]   = 0.85f;
+        mat.AlbedoColor[2]   = 0.f;
+        mat.AlbedoColor[3]   = 1.f;
+        mat.EmissiveColor[0] = 1.f; // scalar multiplier on albedo
         mat.Factors[1]       = 0.f; // metallic = 0
     }
 

--- a/ZEngine/ZEngine/Rendering/BuiltinMeshes.cpp
+++ b/ZEngine/ZEngine/Rendering/BuiltinMeshes.cpp
@@ -15,10 +15,10 @@ namespace ZEngine::Rendering
 
     struct BuiltinMeshEntry
     {
-        const char*     MeshUUID;
-        const char*     MaterialUUID; // null if no material
-        BuildMeshFn     BuildMesh;
-        BuildMaterialFn BuildMaterial; // null if no material
+        const char*     MeshUUID      = nullptr;
+        const char*     MaterialUUID  = nullptr;
+        BuildMeshFn     BuildMesh     = nullptr;
+        BuildMaterialFn BuildMaterial = nullptr;
     };
 
     static void BuildDirectionalLightIcon(ArenaAllocator* arena, AssetMesh& out_mesh, AssetNodeHierarchy& out_hierarchy)

--- a/ZEngine/ZEngine/Rendering/BuiltinMeshes.h
+++ b/ZEngine/ZEngine/Rendering/BuiltinMeshes.h
@@ -1,18 +1,47 @@
 #pragma once
 #include <ZEngine/Core/Memory/Allocator.h>
-#include <ZEngine/Importers/AssetTypes.h>
+#include <uuid.h>
 
 namespace ZEngine::Rendering
 {
-    // Reserved prefix ff000000- will not collide with importer-assigned UUIDs.
-    inline constexpr const char* DIRECTIONAL_LIGHT_MESH_UUID = "ff000000-0000-0000-0000-000000000001";
-
-    // Sun-shaped directional light icon mesh:
-    //   - 12-sided disc + 8 diamond rays in the local XY plane (the "source" face)
-    //   - Arrow along local +Z (the light travel direction), built as two
-    //     perpendicular flat planes for 360° visibility without a billboard shader
+    // UUID derivation rule (collision-free by construction):
+    //   All importer UUIDs are v4 random — third group always starts with '4'.
+    //   Builtin UUIDs use third group '0000', which v4 can never produce.
     //
-    // Vertex layout: 8 floats (x y z  nx ny nz  u v).
-    // All arrays are allocated from arena. Pass the results to AssetManager::IngestMesh.
-    void                         CreateDirectionalLightMesh(Core::Memory::ArenaAllocator* arena, Importers::AssetMesh& out_mesh, Importers::AssetNodeHierarchy& out_hierarchy);
+    //   Mesh:     ff000000-0000-0000-0000-000000000001  (last group = enum value + 1)
+    //   Material: ff000000-0000-0001-0000-000000000001  (same counter, different variant field)
+
+    enum class BuiltinMeshID : uint32_t
+    {
+        // Editor icons — tiny geometry, emissive material, component-type bound
+        DirectionalLightIcon = 0,
+        // PointLightIcon    = 1,   (future)
+        // SpotLightIcon     = 2,   (future)
+        // CameraIcon        = 3,   (future)
+        // RigidBodyWire     = 4,   (future)
+
+        // Primitive shapes — unit-scale, white/gray albedo, user-spawnable
+        // Cube              = 5,   (future)
+        // Sphere            = 6,   (future)
+        // Cylinder          = 7,   (future)
+        // Plane             = 8,   (future)
+        // Capsule           = 9,   (future)
+
+        COUNT
+    };
+
+    // Raw UUID string for the mesh — compile-time pointer, no allocation.
+    const char* BuiltinMeshUUID(BuiltinMeshID id);
+
+    // Parsed mesh UUID — for MeshComponent / AddMeshInstance.
+    uuids::uuid BuiltinMeshUUIDParsed(BuiltinMeshID id);
+
+    // Parsed paired material UUID. Returns nil UUID if the entry has no material.
+    uuids::uuid BuiltinMaterialUUIDParsed(BuiltinMeshID id);
+
+    // Iterates the table and calls AssetManager::IngestMaterial + IngestMesh for
+    // every entry. Material is ingested first (must exist before the first render).
+    // Both calls deduplicate by UUID — safe to call multiple times.
+    void        RegisterBuiltinMeshes(Core::Memory::ArenaAllocator* arena);
+
 } // namespace ZEngine::Rendering

--- a/ZEngine/ZEngine/Rendering/BuiltinMeshes.h
+++ b/ZEngine/ZEngine/Rendering/BuiltinMeshes.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <ZEngine/Core/Memory/Allocator.h>
+#include <ZEngine/Importers/AssetTypes.h>
+
+namespace ZEngine::Rendering
+{
+    // Reserved prefix ff000000- will not collide with importer-assigned UUIDs.
+    inline constexpr const char* DIRECTIONAL_LIGHT_MESH_UUID = "ff000000-0000-0000-0000-000000000001";
+
+    // Sun-shaped directional light icon mesh:
+    //   - 12-sided disc + 8 diamond rays in the local XY plane (the "source" face)
+    //   - Arrow along local +Z (the light travel direction), built as two
+    //     perpendicular flat planes for 360° visibility without a billboard shader
+    //
+    // Vertex layout: 8 floats (x y z  nx ny nz  u v).
+    // All arrays are allocated from arena. Pass the results to AssetManager::IngestMesh.
+    void                         CreateDirectionalLightMesh(Core::Memory::ArenaAllocator* arena, Importers::AssetMesh& out_mesh, Importers::AssetNodeHierarchy& out_hierarchy);
+} // namespace ZEngine::Rendering

--- a/ZEngine/ZEngine/Rendering/Renderers/GraphicRenderer.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/GraphicRenderer.cpp
@@ -140,21 +140,7 @@ namespace ZEngine::Rendering::Renderers
             rrm->UpdateBuffer(RenderSceneData->MaterialBuffer, asset_manager->GPUMeshMaterials.data(), asset_manager->GPUMeshMaterials.size() * sizeof(asset_manager->GPUMeshMaterials[0]));
         }
 
-        if (Device->RRM && RenderSceneData->LightBuffer.Handle)
-        {
-            auto*                 rrm               = reinterpret_cast<Rendering::RenderResourceManager*>(Device->RRM);
-            Scenes::LightArrayUBO lights            = {};
-            lights.DirectionalLights[0].Direction.x = 0.5f;
-            lights.DirectionalLights[0].Direction.y = -1.0f;
-            lights.DirectionalLights[0].Direction.z = 0.5f;
-            lights.DirectionalLights[0].Color.x     = 1.0f;
-            lights.DirectionalLights[0].Color.y     = 1.0f;
-            lights.DirectionalLights[0].Color.z     = 1.0f;
-            lights.DirectionalLights[0].Color.w     = 1.0f;
-            lights.DirectionalLights[0].Intensity   = 3.0f;
-            lights.DirectionalCount                 = 1;
-            rrm->UpdateBuffer(RenderSceneData->LightBuffer, &lights, sizeof(lights));
-        }
+        // Light buffer is uploaded by AppRenderPipeline::RenderScene from scene->PendingLights.
 
         // Push camera data into the per-frame heap; store offset for dynamic descriptor binding
         auto& heap                        = Device->FrameHeaps[Device->SwapchainPtr->CurrentFrame->Index];

--- a/ZEngine/ZEngine/Rendering/Scenes/RenderScene.h
+++ b/ZEngine/ZEngine/Rendering/Scenes/RenderScene.h
@@ -130,6 +130,7 @@ namespace ZEngine::Rendering::Scenes
 
         SkyConfig                             Sky                = {};
         GridConfig                            Grid               = {};
+        LightArrayUBO                         PendingLights      = {};
 
         PaddedAtomic<uint64_t>                m_seq              = {};
         PaddedAtomic<int32_t>                 SelectedInstanceId = {};


### PR DESCRIPTION
## Summary

Three commits — ECS → rendering bridge for issues #642, #643, and a follow-on default light.

### TransformComponent → RenderScene (#642)

- `ECS::Systems::SyncECSToRenderScene(Scene&, float alpha, RenderScene&)` — iterates `TransformComponent` + `MeshComponent`, interpolates position with fixed-timestep alpha, builds `Mat4f` via `ComposeTransformMatrix`, calls `SetInstanceTransform`
- Called from `Engine::MainThreadRun` after the fixed-step loop, before `PrepareScene`

### LightComponent → LightArrayUBO (#643)

- `ECS::Systems::SyncECSToLights(Scene&, RenderScene&)` — iterates `LightComponent` + `TransformComponent`
- Directional: extracts forward direction from rotation matrix column 2 (YXZ Euler)
- Point: uses entity world position
- Writes `LightArrayUBO` into `RenderScene::PendingLights`
- `AppRenderPipeline::RenderScene` uploads `PendingLights` to GPU — replaces the hardcoded directional light

### Default directional light

- `EditorScene::Initialize` spawns a default `DirectionalLight` actor (white, intensity 3, -60° pitch / 30° yaw) so new scenes open lit

## Test plan

- [x] Debug build clean
- [x] Import a GLB — mesh visible and lit without manual setup
- [x] Move actor via gizmo — transform updates correctly
- [x] Spawn a second light entity — both lights contribute
- [ ] No light entities (delete default) → scene unlit (correct)

Closes #642
Closes #643