### PR TITLE
fix(importer): fire on_progress callbacks in AssimpImporter::ImportFile

### DIFF
--- a/ZEngine/ZEngine/Importers/AssimpImporter.cpp
+++ b/ZEngine/ZEngine/Importers/AssimpImporter.cpp
@@ -123,6 +123,9 @@ namespace ZEngine::Importers
         }
         else
         {
+            if (on_progress)
+                on_progress(context, 0.2f);
+
             std::random_device    rd;
             std::mt19937          generator(rd());
             uuid_random_generator gen(&generator);
@@ -133,10 +136,15 @@ namespace ZEngine::Importers
             Array<AssetTexture>   textures    = {};
 
             ExtractMeshes(arena, scene, gen, mesh);
+            if (on_progress)
+                on_progress(context, 0.4f);
+
             ExtractMaterials(arena, scene, gen, materials, hierarchies);
             ExtractTextures(arena, scene, gen, materials, textures);
             CreateHierachy(arena, scene, gen, hierarchies, mesh, materials);
             CopyTextureFiles(arena, textures, config);
+            if (on_progress)
+                on_progress(context, 0.7f);
 
             // Propagate tex.Path (set by CopyTextureFiles) → material.*TexPath
             for (size_t m = 0; m < materials.size(); ++m)
@@ -158,13 +166,14 @@ namespace ZEngine::Importers
                 set_path(materials[m].SpecularTexUUID, materials[m].SpecularTexPath);
             }
 
-            // Serialize .zemesh + .zematerial — no .zetextures (paths are inline in material)
             Array<AssetImporterOutput> outputs = {};
             outputs.init(arena, 100);
             outputs.push(AssetCodec::SerializeMeshAssetFile(arena, mesh, hierarchies, config));
             for (size_t i = 0; i < materials.size(); ++i)
                 outputs.push(AssetCodec::SerializeMaterialAssetFile(arena, materials[i], config));
 
+            if (on_progress)
+                on_progress(context, 1.0f);
             if (on_complete)
                 on_complete(context, ArrayView{outputs});
         }


### PR DESCRIPTION
## Problem

`AssimpImporter::ImportFile` accepted `on_progress` as a parameter but never called it. The progress bar in `AssetImporterUIComponent` stayed at 0% for all Assimp-handled formats (.fbx, .obj, .dae, etc.). `GltfImporter::ImportFile` already called `on_progress` correctly at discrete stages.

`AssimpProgressHandler::Update` was wired to receive Assimp's internal progress but forwarded nothing to the caller.

## Fix

Add discrete `on_progress` calls at each major stage in `AssimpImporter::ImportFile`:

| Progress | Stage |
|---|---|
| 0.2 | File parsed by Assimp (`ReadFile` returned) |
| 0.4 | Meshes extracted |
| 0.7 | Materials, textures, hierarchy extracted; texture files copied |
| 1.0 | Serialized to disk; fires before `on_complete` |

Matches the existing pattern in `GltfImporter::ImportFile`.

## Test plan

- [x] Debug build clean
- [x] Import an `.fbx` or `.obj` file — progress bar advances through 20% → 40% → 70% → 100%
- [x] Log panel shows "Processing… 20%", "Processing… 40%", "Processing… 70%", "Processing… 100%"
- [x] `.glb`/`.gltf` import progress unaffected

Closes #601