### PR TITLE
feat(importer): tab bar import UI + wire options to GltfImporter and AssimpImporter

### DIFF
--- a/Tetragrama/Components/AssetImporterUIComponent.cpp
+++ b/Tetragrama/Components/AssetImporterUIComponent.cpp
@@ -124,7 +124,10 @@ namespace Tetragrama::Components
         {
             m_path_buf.clear();
             m_path_buf.append(picked.c_str());
-            m_state.value.store(ImporterState::Options);
+            if (m_same_settings)
+                StartImport();
+            else
+                m_state.value.store(ImporterState::Options);
         }
     }
 
@@ -165,10 +168,20 @@ namespace Tetragrama::Components
         config->OutputTextureFilesPath.init(&LocalArena, cfg.TexturePath.c_str());
         config->OutputAssetsPath.init(&LocalArena, cfg.MeshPath.c_str());
         config->OutputMaterialPath.init(&LocalArena, cfg.MaterialPath.c_str());
-        config->AssetName.init(&LocalArena, asset_name.Data);
+        if (!m_use_source_name && m_instance_name[0] != '\0')
+            config->AssetName.init(&LocalArena, m_instance_name);
+        else
+            config->AssetName.init(&LocalArena, asset_name.Data);
         config->OutputAssetFile.init(&LocalArena, asset_file_buf);
         config->InputBaseAssetFilePath.init(&LocalArena, parent_dir.CStr());
-        config->VFS = reinterpret_cast<ZEngine::Core::VFS::IVFSContext*>(ZEngine::Engine::GetContext()->VFS);
+        config->VFS                     = reinterpret_cast<ZEngine::Core::VFS::IVFSContext*>(ZEngine::Engine::GetContext()->VFS);
+        config->Options.UniformScale    = m_scale;
+        config->Options.AxisUpIsZ       = m_axis_index == 1;
+        config->Options.NormalsMode     = static_cast<uint8_t>(m_normals_mode);
+        config->Options.MergeVertices   = m_merge_vertices;
+        config->Options.ImportMaterials = m_import_materials;
+        config->Options.ImportTextures  = m_import_textures;
+        config->Options.FlipUVs         = m_flip_uvs;
 
         char msg[512];
         snprintf(msg, sizeof(msg), "Importing %s", vfs_value.Filename().Data);
@@ -371,7 +384,10 @@ namespace Tetragrama::Components
                     {
                         m_path_buf.clear();
                         m_path_buf.append(buf);
-                        m_state.value.store(ImporterState::Options);
+                        if (m_same_settings)
+                            StartImport();
+                        else
+                            m_state.value.store(ImporterState::Options);
                     }
                 }
             }
@@ -419,50 +435,107 @@ namespace Tetragrama::Components
 
         ImGui::Separator();
 
-        static constexpr cstring kAxes[] = {"Y-Up", "Z-Up"};
-
-        if (ImGui::CollapsingHeader("Transform", ImGuiTreeNodeFlags_DefaultOpen))
+        if (ImGui::BeginTabBar("##import_tabs"))
         {
-            ImGui::SetNextItemWidth(80.0f);
-            ImGui::DragFloat("Scale", &m_scale, 0.01f, 0.001f, 100.0f, "%.3f");
-            ImGui::SameLine(0.0f, 16.0f);
-            ImGui::SetNextItemWidth(80.0f);
-            ImGui::Combo("Axis", &m_axis_index, kAxes, 2);
-        }
+            // General tab
+            if (ImGui::BeginTabItem("General"))
+            {
+                ImGui::Checkbox("Use Source Name", &m_use_source_name);
+                if (!m_use_source_name)
+                {
+                    ImGui::SetNextItemWidth(-1.f);
+                    ImGui::InputText("Asset Name", m_instance_name, sizeof(m_instance_name));
+                }
+                else
+                {
+                    ImGui::BeginDisabled(true);
+                    ImGui::SetNextItemWidth(-1.f);
+                    ImGui::InputText("Asset Name", fn_buf, sizeof(fn_buf));
+                    ImGui::EndDisabled();
+                }
+                ImGui::Spacing();
+                ImGui::SetNextItemWidth(100.f);
+                ImGui::DragFloat("Uniform Scale", &m_scale, 0.01f, 0.001f, 100.f, "%.3f");
+                ImGui::SetNextItemWidth(100.f);
+                static constexpr cstring kAxes[] = {"Y-Up", "Z-Up"};
+                ImGui::Combo("Axis Up", &m_axis_index, kAxes, 2);
+                ImGui::EndTabItem();
+            }
 
-        if (ImGui::CollapsingHeader("Mesh", ImGuiTreeNodeFlags_DefaultOpen))
-        {
-            ImGui::Checkbox("Generate Normals", &m_gen_normals);
-            ImGui::Checkbox("Merge Identical Vertices", &m_merge_vertices);
-        }
+            // Mesh tab
+            if (ImGui::BeginTabItem("Mesh"))
+            {
+                static constexpr cstring kNormals[] = {"Off", "Flat", "Smooth"};
+                ImGui::SetNextItemWidth(120.f);
+                ImGui::Combo("Normals", &m_normals_mode, kNormals, 3);
+                ImGui::Checkbox("Merge Identical Vertices", &m_merge_vertices);
+                ImGui::Checkbox("Flip UVs", &m_flip_uvs);
+                ImGui::BeginDisabled(true);
+                static bool s_keep_sections = false;
+                ImGui::Checkbox("Keep Sections Separate", &s_keep_sections);
+                if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+                    ImGui::SetTooltip("Not yet supported");
+                ImGui::EndDisabled();
+                ImGui::EndTabItem();
+            }
 
-        if (ImGui::CollapsingHeader("Material", ImGuiTreeNodeFlags_DefaultOpen))
-        {
-            ImGui::Checkbox("Import Materials", &m_import_materials);
-            ImGui::SameLine(0.0f, 16.0f);
-            ImGui::Checkbox("Import Textures", &m_import_textures);
+            // Material tab
+            if (ImGui::BeginTabItem("Material"))
+            {
+                ImGui::Checkbox("Import Materials", &m_import_materials);
+                ImGui::Checkbox("Import Textures", &m_import_textures);
+                ImGui::EndTabItem();
+            }
+
+            // Animation tab — placeholder, all disabled
+            if (ImGui::BeginTabItem("Animation"))
+            {
+                ImGui::BeginDisabled(true);
+                static bool s_import_anims = true, s_only_anims = false, s_bone_tracks = true;
+                ImGui::Checkbox("Import Animations", &s_import_anims);
+                ImGui::Checkbox("Import Only Animations", &s_only_anims);
+                ImGui::Checkbox("Import Bone Tracks", &s_bone_tracks);
+                ImGui::EndDisabled();
+                ImGui::Spacing();
+                ImGui::TextDisabled("Animation import requires skeletal mesh support.");
+                ImGui::EndTabItem();
+            }
+
+            // LOD tab — placeholder, all disabled
+            if (ImGui::BeginTabItem("LOD"))
+            {
+                ImGui::BeginDisabled(true);
+                static bool s_import_lods = false;
+                static int  s_max_lods    = 4;
+                ImGui::Checkbox("Import LODs", &s_import_lods);
+                ImGui::SetNextItemWidth(120.f);
+                ImGui::SliderInt("Max LOD Count", &s_max_lods, 1, 8);
+                ImGui::EndDisabled();
+                ImGui::Spacing();
+                ImGui::TextDisabled("LOD support requires virtual geometry streaming.");
+                ImGui::EndTabItem();
+            }
+
+            ImGui::EndTabBar();
         }
 
         ImGui::Separator();
+        ImGui::Checkbox("Use same settings for subsequent files", &m_same_settings);
+        ImGui::Spacing();
 
-        if (ImGui::Button("Import All", ImVec2(-108.0f, 0)))
+        if (ImGui::Button("Import All", ImVec2(-168.f, 0)))
             StartImport();
+        ImGui::SameLine();
+        ImGui::BeginDisabled(true);
+        ImGui::Button("Preview...", ImVec2(-88.f, 0));
+        if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+            ImGui::SetTooltip("Not yet supported");
+        ImGui::EndDisabled();
         ImGui::SameLine();
         if (ImGui::Button("Cancel", ImVec2(-1, 0)))
         {
             m_path_buf.clear();
             m_state.value.store(ImporterState::Idle);
-        }
-
-        // Show last log entry for immediate error feedback
-        {
-            std::lock_guard<std::mutex> lk(m_log_mutex);
-            if (m_log_count > 0)
-            {
-                const auto& last = m_log[(m_log_head - 1 + kLogMax) % kLogMax];
-                ImGui::Spacing();
-                ImGui::TextColored({last.Color[0], last.Color[1], last.Color[2], last.Color[3]}, "%s", last.Text);
-            }
         }
     }
 

--- a/Tetragrama/Components/AssetImporterUIComponent.h
+++ b/Tetragrama/Components/AssetImporterUIComponent.h
@@ -57,10 +57,14 @@ namespace Tetragrama::Components
         // Import settings (shown in Options state)
         float m_scale            = 1.0f;
         int   m_axis_index       = 0; // 0 = Y-Up, 1 = Z-Up
-        bool  m_gen_normals      = true;
+        int   m_normals_mode     = 1; // 0 = Off, 1 = Flat, 2 = Smooth
+        bool  m_flip_uvs         = false;
         bool  m_merge_vertices   = true;
         bool  m_import_materials = true;
         bool  m_import_textures  = true;
+        bool  m_use_source_name  = true;
+        bool  m_same_settings    = false;
+        int   m_active_tab       = 0;
 
         // Compact import log (Importing state — ring buffer)
         struct LogEntry

--- a/ZEngine/ZEngine/Importers/AssetCodec.h
+++ b/ZEngine/ZEngine/Importers/AssetCodec.h
@@ -13,16 +13,28 @@ namespace ZEngine::Importers::AssetCodec
     // These are the cook-time serialization helpers used by format importers to produce
     // the cooked binary artifacts that AssetManager loads at runtime.
 
+    struct ImportOptions
+    {
+        float   UniformScale    = 1.0f;
+        bool    AxisUpIsZ       = false;
+        bool    FlipUVs         = false;
+        uint8_t NormalsMode     = 1; // 0 = off, 1 = flat, 2 = smooth
+        bool    MergeVertices   = true;
+        bool    ImportMaterials = true;
+        bool    ImportTextures  = true;
+    };
+
     struct ImportConfiguration
     {
         Core::Containers::String AssetName;
         Core::Containers::String OutputAssetFile;
-        Core::Containers::String OutputAssetsPath;   // mesh output dir (Assets/Meshes)
-        Core::Containers::String OutputMaterialPath; // material output dir (Assets/Materials)
+        Core::Containers::String OutputAssetsPath;
+        Core::Containers::String OutputMaterialPath;
         Core::Containers::String InputBaseAssetFilePath;
         Core::Containers::String OutputWorkingSpacePath;
         Core::Containers::String OutputTextureFilesPath;
-        Core::VFS::IVFSContext*  VFS = nullptr; // required — used for CreateDir before each write
+        Core::VFS::IVFSContext*  VFS     = nullptr;
+        ImportOptions            Options = {};
     };
 
     struct AssetMeshFileHeader

--- a/ZEngine/ZEngine/Importers/AssimpImporter.cpp
+++ b/ZEngine/ZEngine/Importers/AssimpImporter.cpp
@@ -23,7 +23,9 @@ namespace fs = std::filesystem;
 
 namespace ZEngine::Importers
 {
-    AssimpImporter::AssimpImporter() : m_progress_handler{}, m_flags{aiProcess_JoinIdenticalVertices | aiProcess_Triangulate | aiProcess_GenNormals | aiProcess_SortByPType}
+    static constexpr uint32_t kDefaultFlags = aiProcess_JoinIdenticalVertices | aiProcess_Triangulate | aiProcess_GenNormals | aiProcess_SortByPType;
+
+    AssimpImporter::AssimpImporter() : m_progress_handler{}
     {
         m_progress_handler.SetImporter(this);
     }
@@ -54,7 +56,7 @@ namespace ZEngine::Importers
             path.ToNative(native, sizeof(native));
 
         Assimp::Importer importer{};
-        const aiScene*   scene = importer.ReadFile(native, m_flags);
+        const aiScene*   scene = importer.ReadFile(native, kDefaultFlags);
 
         if (!scene || (scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE) || !scene->mRootNode)
         {
@@ -109,12 +111,23 @@ namespace ZEngine::Importers
         config.AssetName.init(arena, cfg.AssetName.c_str());
         config.OutputAssetFile.init(arena, cfg.OutputAssetFile.c_str());
         config.InputBaseAssetFilePath.init(arena, cfg.InputBaseAssetFilePath.c_str());
-        config.VFS = cfg.VFS;
+        config.VFS     = cfg.VFS;
+        config.Options = cfg.Options;
+
+        uint32_t flags = aiProcess_Triangulate | aiProcess_SortByPType;
+        if (config.Options.MergeVertices)
+            flags |= aiProcess_JoinIdenticalVertices;
+        if (config.Options.FlipUVs)
+            flags |= aiProcess_FlipUVs;
+        if (config.Options.NormalsMode == 1)
+            flags |= aiProcess_GenNormals;
+        else if (config.Options.NormalsMode == 2)
+            flags |= aiProcess_GenSmoothNormals;
 
         Assimp::Importer importer{};
         importer.SetProgressHandler(&m_progress_handler);
 
-        const aiScene* scene = importer.ReadFile(filename, m_flags);
+        const aiScene* scene = importer.ReadFile(filename, flags);
 
         if (!scene || (scene->mFlags & AI_SCENE_FLAGS_INCOMPLETE) || !scene->mRootNode)
         {
@@ -139,38 +152,55 @@ namespace ZEngine::Importers
             if (on_progress)
                 on_progress(context, 0.4f);
 
-            ExtractMaterials(arena, scene, gen, materials, hierarchies);
-            ExtractTextures(arena, scene, gen, materials, textures);
+            // Apply scale
+            if (config.Options.UniformScale != 1.0f)
+            {
+                const float s = config.Options.UniformScale;
+                for (size_t vi = 0; vi < mesh.Vertices.size(); vi += 8)
+                {
+                    mesh.Vertices[vi + 0] *= s;
+                    mesh.Vertices[vi + 1] *= s;
+                    mesh.Vertices[vi + 2] *= s;
+                }
+            }
+
+            if (config.Options.ImportMaterials)
+            {
+                ExtractMaterials(arena, scene, gen, materials, hierarchies);
+                if (config.Options.ImportTextures)
+                {
+                    ExtractTextures(arena, scene, gen, materials, textures);
+                    CopyTextureFiles(arena, textures, config);
+                    for (size_t m = 0; m < materials.size(); ++m)
+                    {
+                        auto set_path = [&](const uuids::uuid& uuid, Core::Containers::String& path_out) {
+                            for (size_t t = 0; t < textures.size(); ++t)
+                            {
+                                if (textures[t].TextureUUID == uuid && !textures[t].Path.empty())
+                                {
+                                    path_out.init(arena, textures[t].Path.c_str());
+                                    return;
+                                }
+                            }
+                        };
+                        set_path(materials[m].AlbedoTexUUID, materials[m].AlbedoTexPath);
+                        set_path(materials[m].EmissiveTexUUID, materials[m].EmissiveTexPath);
+                        set_path(materials[m].NormalTexUUID, materials[m].NormalTexPath);
+                        set_path(materials[m].OpacityTexUUID, materials[m].OpacityTexPath);
+                        set_path(materials[m].SpecularTexUUID, materials[m].SpecularTexPath);
+                    }
+                }
+            }
             CreateHierachy(arena, scene, gen, hierarchies, mesh, materials);
-            CopyTextureFiles(arena, textures, config);
             if (on_progress)
                 on_progress(context, 0.7f);
-
-            // Propagate tex.Path (set by CopyTextureFiles) → material.*TexPath
-            for (size_t m = 0; m < materials.size(); ++m)
-            {
-                auto set_path = [&](const uuids::uuid& uuid, Core::Containers::String& path_out) {
-                    for (size_t t = 0; t < textures.size(); ++t)
-                    {
-                        if (textures[t].TextureUUID == uuid && !textures[t].Path.empty())
-                        {
-                            path_out.init(arena, textures[t].Path.c_str());
-                            return;
-                        }
-                    }
-                };
-                set_path(materials[m].AlbedoTexUUID, materials[m].AlbedoTexPath);
-                set_path(materials[m].EmissiveTexUUID, materials[m].EmissiveTexPath);
-                set_path(materials[m].NormalTexUUID, materials[m].NormalTexPath);
-                set_path(materials[m].OpacityTexUUID, materials[m].OpacityTexPath);
-                set_path(materials[m].SpecularTexUUID, materials[m].SpecularTexPath);
-            }
 
             Array<AssetImporterOutput> outputs = {};
             outputs.init(arena, 100);
             outputs.push(AssetCodec::SerializeMeshAssetFile(arena, mesh, hierarchies, config));
-            for (size_t i = 0; i < materials.size(); ++i)
-                outputs.push(AssetCodec::SerializeMaterialAssetFile(arena, materials[i], config));
+            if (config.Options.ImportMaterials)
+                for (size_t i = 0; i < materials.size(); ++i)
+                    outputs.push(AssetCodec::SerializeMaterialAssetFile(arena, materials[i], config));
 
             if (on_progress)
                 on_progress(context, 1.0f);

--- a/ZEngine/ZEngine/Importers/AssimpImporter.h
+++ b/ZEngine/ZEngine/Importers/AssimpImporter.h
@@ -42,7 +42,6 @@ namespace ZEngine::Importers
         void                         CopyTextureFiles(Core::Memory::ArenaAllocator*, Core::Containers::Array<AssetTexture>&, const AssetCodec::ImportConfiguration&);
 
     private:
-        uint32_t              m_flags;
         AssimpProgressHandler m_progress_handler;
 
         friend struct AssimpProgressHandler;

--- a/ZEngine/ZEngine/Importers/GltfImporter.cpp
+++ b/ZEngine/ZEngine/Importers/GltfImporter.cpp
@@ -473,10 +473,11 @@ namespace ZEngine::Importers
         config.AssetName.init(arena, cfg.AssetName.c_str());
         config.OutputAssetFile.init(arena, cfg.OutputAssetFile.c_str());
         config.InputBaseAssetFilePath.init(arena, cfg.InputBaseAssetFilePath.c_str());
-        config.VFS   = cfg.VFS;
+        config.VFS     = cfg.VFS;
+        config.Options = cfg.Options;
 
-        auto fs_path = std::filesystem::path(filename);
-        auto buf     = fastgltf::GltfDataBuffer::FromPath(fs_path);
+        auto fs_path   = std::filesystem::path(filename);
+        auto buf       = fastgltf::GltfDataBuffer::FromPath(fs_path);
         if (buf.error() != fastgltf::Error::None)
         {
             if (on_error)
@@ -516,11 +517,49 @@ namespace ZEngine::Importers
 
         ExtractMeshes(&scratch, asset, mesh);
         mesh.MeshUUID = gen();
-        ExtractMaterials(&scratch, asset, gen, materials);
-        ExtractTextures(&scratch, asset, gen, textures, materials);
+
+        // Apply per-vertex transform options
+        {
+            const float scale   = config.Options.UniformScale;
+            const bool  axis_z  = config.Options.AxisUpIsZ;
+            const bool  flip_uv = config.Options.FlipUVs;
+            if (scale != 1.0f || axis_z || flip_uv)
+            {
+                for (size_t vi = 0; vi < mesh.Vertices.size(); vi += 8)
+                {
+                    if (scale != 1.0f)
+                    {
+                        mesh.Vertices[vi + 0] *= scale;
+                        mesh.Vertices[vi + 1] *= scale;
+                        mesh.Vertices[vi + 2] *= scale;
+                    }
+                    if (axis_z)
+                    {
+                        float py              = mesh.Vertices[vi + 1];
+                        float pz              = mesh.Vertices[vi + 2];
+                        mesh.Vertices[vi + 1] = pz;
+                        mesh.Vertices[vi + 2] = -py;
+                        float ny              = mesh.Vertices[vi + 4];
+                        float nz              = mesh.Vertices[vi + 5];
+                        mesh.Vertices[vi + 4] = nz;
+                        mesh.Vertices[vi + 5] = -ny;
+                    }
+                    if (flip_uv)
+                        mesh.Vertices[vi + 7] = 1.0f - mesh.Vertices[vi + 7];
+                }
+            }
+        }
+
+        if (config.Options.ImportMaterials)
+        {
+            ExtractMaterials(&scratch, asset, gen, materials);
+            if (config.Options.ImportTextures)
+                ExtractTextures(&scratch, asset, gen, textures, materials);
+        }
         BuildHierarchy(&scratch, asset, gen, hierarchy, mesh, materials);
 
         // Extract texture image bytes to disk and record project-relative paths
+        if (config.Options.ImportTextures && config.Options.ImportMaterials)
         {
             char dest_dir_buf[MAX_FILE_PATH_COUNT] = {};
             (ZEngine::Core::VFS::VFSPath::Parse(config.OutputTextureFilesPath.c_str()).Value() / config.AssetName.c_str()).ResolveNative(config.OutputWorkingSpacePath.c_str(), dest_dir_buf, sizeof(dest_dir_buf));
@@ -709,16 +748,18 @@ namespace ZEngine::Importers
         Array<AssetImporterOutput> outputs = {};
         outputs.init(arena, 16);
         outputs.push(AssetCodec::SerializeMeshAssetFile(arena, mesh, hierarchy, config));
-        for (size_t i = 0; i < materials.size(); ++i)
-            outputs.push(AssetCodec::SerializeMaterialAssetFile(arena, materials[i], config));
+        if (config.Options.ImportMaterials)
+            for (size_t i = 0; i < materials.size(); ++i)
+                outputs.push(AssetCodec::SerializeMaterialAssetFile(arena, materials[i], config));
 
-        // Also ingest into AssetManager so the asset is usable this session without a reload
         auto* mgr = Managers::AssetManager::Instance();
         if (mgr)
         {
-            Managers::AssetManager::IngestTextures(std::move(textures));
-            for (size_t i = 0; i < materials.size(); ++i)
-                Managers::AssetManager::IngestMaterial(std::move(materials[i]));
+            if (config.Options.ImportTextures && config.Options.ImportMaterials)
+                Managers::AssetManager::IngestTextures(std::move(textures));
+            if (config.Options.ImportMaterials)
+                for (size_t i = 0; i < materials.size(); ++i)
+                    Managers::AssetManager::IngestMaterial(std::move(materials[i]));
             Managers::AssetManager::IngestMesh(std::move(mesh), std::move(hierarchy));
         }
 


### PR DESCRIPTION
## Summary

Closes #599 — import options (scale, axis, normals, merge vertices, materials, textures) were shown in the UI but never wired to the importers.

### New `ImportOptions` struct (`AssetCodec.h`)

Added `ImportOptions` to `ImportConfiguration`:
- `UniformScale` — applied to vertex positions post-extraction
- `AxisUpIsZ` — swaps Y/Z on positions and normals (Z-up → Y-up)
- `FlipUVs` — flips V channel (`1.0 - v`)
- `NormalsMode` — 0=Off, 1=Flat (`aiProcess_GenNormals`), 2=Smooth (`aiProcess_GenSmoothNormals`)
- `MergeVertices` — toggles `aiProcess_JoinIdenticalVertices`
- `ImportMaterials` / `ImportTextures` — gate extraction and serialization

### UI — tab bar replaces collapsing headers

Five tabs matching the UE Interchange Pipeline layout:
- **General**: Use Source Name, custom Asset Name input, Uniform Scale, Axis Up
- **Mesh**: Normals combo (Off/Flat/Smooth), Merge Identical Vertices, Flip UVs, Keep Sections Separate (disabled)
- **Material**: Import Materials, Import Textures
- **Animation**: all controls disabled — "Animation import requires skeletal mesh support"
- **LOD**: all controls disabled — "LOD support requires virtual geometry streaming"

Bottom row: "Use same settings for subsequent files" checkbox (skips Options dialog on next import), disabled Preview button.

### GltfImporter
- Copy `Options` from `cfg`
- Post-`ExtractMeshes` vertex pass: scale, axis swap, UV flip
- Gate `ExtractMaterials`/`ExtractTextures` and their serialization/ingest paths

### AssimpImporter
- Build Assimp `flags` dynamically from `Options` (was hardcoded)
- Remove `m_flags` member; `Import()` uses `kDefaultFlags` constant
- Apply scale to vertex positions after `ExtractMeshes`
- Gate material/texture extraction and serialization

## Test plan

- [x] Debug build clean
- [x] Import `.glb` with Scale=2.0 — mesh twice as large
- [x] Import `.fbx` with Normals=Off — no `aiProcess_GenNormals`
- [x] Import `.fbx` with Import Materials=false — no `.zematerial` files
- [x] Import `.fbx` with Flip UVs=true — V channel flipped
- [x] Animation and LOD tabs visible, all controls grayed with tooltips
- [x] "Use same settings" skips Options on the next drag-drop