### PR TITLE
fix(rendering): four Bistro rendering blockers

### DIFF
--- a/Resources/Shaders/g_buffer.frag
+++ b/Resources/Shaders/g_buffer.frag
@@ -1,10 +1,12 @@
 #version 460
 #extension GL_GOOGLE_include_directive : require
 #include "material.glsl"
+#include "surface.glsl"
 
 layout(location = 0) in vec2 TexCoord;
 layout(location = 1) in vec3 WorldNormal;
 layout(location = 2) in flat uint MaterialIdx;
+layout(location = 3) in vec3 WorldPos;
 
 layout(location = 0) out vec4 OutAlbedoAO;
 layout(location = 1) out vec4 OutNormalRoughness;
@@ -15,6 +17,7 @@ void main()
     MaterialData material  = FetchMaterial(MaterialIdx);
 
     vec3         albedo    = material.Albedo.rgb;
+    float        alpha     = material.Albedo.a;
     float        ao        = 1.0;
     vec3         normal    = normalize(WorldNormal);
     float        roughness = material.Roughness.y;
@@ -23,8 +26,20 @@ void main()
 
     if (material.AlbedoMap < INVALID_MAP_HANDLE)
     {
-        uint texId = uint(material.AlbedoMap);
-        albedo     = texture(sampler2D(TextureArray[nonuniformEXT(texId)], LinearWrapSampler), TexCoord).rgb;
+        uint texId        = uint(material.AlbedoMap);
+        vec4 albedoSample = texture(sampler2D(TextureArray[nonuniformEXT(texId)], LinearWrapSampler), TexCoord);
+        albedo            = albedoSample.rgb;
+        alpha             = albedoSample.a;
+    }
+
+    // Alpha cutout — discard early before any further sampling
+    runAlphaTest(alpha, material.Factors.z);
+
+    if (material.NormalMap < INVALID_MAP_HANDLE)
+    {
+        uint texId        = uint(material.NormalMap);
+        vec3 normalSample = texture(sampler2D(TextureArray[nonuniformEXT(texId)], LinearWrapSampler), TexCoord).rgb;
+        normal            = perturbNormal(normalize(WorldNormal), WorldPos, normalSample, TexCoord);
     }
 
     if (material.SpecularMap < INVALID_MAP_HANDLE)

--- a/Resources/Shaders/g_buffer.vert
+++ b/Resources/Shaders/g_buffer.vert
@@ -5,6 +5,7 @@
 layout(location = 0) out vec2 TexCoord;
 layout(location = 1) out vec3 WorldNormal;
 layout(location = 2) out flat uint MaterialIdx;
+layout(location = 3) out vec3 WorldPos;
 
 void main()
 {
@@ -13,5 +14,6 @@ void main()
     WorldNormal           = transpose(inverse(mat3(dataView.Transform))) * dataView.Normal;
     TexCoord              = dataView.TexCoord;
     MaterialIdx           = dataView.MaterialId;
+    WorldPos              = worldPos.xyz;
     gl_Position           = Camera.Projection * Camera.View * worldPos;
 }

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.h
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.h
@@ -257,7 +257,7 @@ namespace ZEngine::Hardwares
         uint32_t                                                                                                                     TransferFamilyIndex                         = std::numeric_limits<uint32_t>::max();
 
         uint32_t                                                                                                                     WriteDescriptorSetIndex                     = 0;
-        uint32_t                                                                                                                     MaxGlobalTexture                            = 600;
+        uint32_t                                                                                                                     MaxGlobalTexture                            = 1024;
         VkInstance                                                                                                                   Instance                                    = VK_NULL_HANDLE;
         VkSurfaceKHR                                                                                                                 Surface                                     = VK_NULL_HANDLE;
         VkSurfaceFormatKHR                                                                                                           SurfaceFormat                               = {};

--- a/ZEngine/ZEngine/Importers/AssimpImporter.cpp
+++ b/ZEngine/ZEngine/Importers/AssimpImporter.cpp
@@ -561,8 +561,9 @@ namespace ZEngine::Importers
                 continue;
             }
 
-            auto src_file = (fs::path(config.InputBaseAssetFilePath.c_str()) / tex.Path.c_str()).string();
-            auto dst_file = (fs::path(dst_dir) / tex.Path.c_str()).string();
+            fs::path tex_path(tex.Path.c_str());
+            auto     src_file = (tex_path.is_absolute() ? tex_path : fs::path(config.InputBaseAssetFilePath.c_str()) / tex_path).string();
+            auto     dst_file = (fs::path(dst_dir) / tex_path.filename()).string();
 
             CreateBaseDirectoryFn(dst_file);
 

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.h
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.h
@@ -435,7 +435,7 @@ namespace ZEngine::Rendering
         uint32_t                       m_swap_count                      = 0;
 
         // Pending uploads — written from asset thread, flushed in BeginFrame
-        static constexpr uint32_t      MAX_PENDING                       = 256;
+        static constexpr uint32_t      MAX_PENDING                       = 1024;
         PendingUpload                  m_pending[MAX_PENDING]            = {};
         uint32_t                       m_pending_count                   = 0;
 


### PR DESCRIPTION
## Summary

Four fixes that unblock import and rendering of large scenes like the Amazon Lumberyard Bistro.

### 1. `MAX_PENDING` 256 → 1024

The upload queue is a fixed `m_pending[256]` array. Bistro imports ~100 meshes + ~500 textures = ~600 pending GPU uploads — all above the limit were silently dropped (logged as warnings, assets disappear from the scene).

### 2. Absolute texture paths in `AssimpImporter::CopyTextureFiles`

MTL files from artist machines contain absolute paths (e.g. `C:\art\Bistro\Textures\foo.png`). `fs::path::operator/` discards the left operand when the right side is absolute (C++ standard behavior), causing the source to resolve to a non-existent path. `std::ifstream` failed silently with no error log, writing empty files and falling back to the hot-pink fallback on every surface.

Fix: check `tex_path.is_absolute()` before prepending the base dir. Use `tex_path.filename()` for the destination to avoid replicating the artist's directory structure.

### 3. Normal map sampling in `g_buffer.frag`

`MaterialData.NormalMap` was written by the importer but never read in the shader. All surfaces rendered with raw interpolated vertex normals — no brick relief, no wood grain, no surface detail.

Fix: add `WorldPos` output to `g_buffer.vert`, include `surface.glsl` in `g_buffer.frag`, call `perturbNormal()` when `NormalMap` is set.

### 4. Alpha test in `g_buffer.frag`

`runAlphaTest()` existed in `surface.glsl` and issued `discard` — but was never called. Foliage, wire fences, and plant leaves rendered as fully opaque solid polygons.

Fix: read `.rgba` from the albedo map, call `runAlphaTest(alpha, material.Factors.z)` early to discard before further sampling.

## Test plan

- [x] Debug build clean, shaders recompile without errors
- [ ] Import Bistro exterior OBJ — all meshes and textures appear (no silent drops)
- [ ] Brick walls show normal-mapped surface detail
- [ ] Foliage/fence alpha cutout correctly transparent
- [ ] Textures load from absolute paths on macOS