### PR TITLE
feat(ecs/editor): scene graph — local transforms, HierarchySystem, UE5-style outliner

### DIFF
--- a/Tetragrama/Components/HierarchyViewUIComponent.cpp
+++ b/Tetragrama/Components/HierarchyViewUIComponent.cpp
@@ -60,9 +60,9 @@ namespace Tetragrama::Components
 
     void HierarchyViewUIComponent::DrawArrow(ImDrawList* dl, ImVec2 pos, float row_h, bool expanded, ImU32 color)
     {
-        float cx  = pos.x + 8.f;
-        float cy  = pos.y + row_h * 0.5f;
-        float sz  = 5.f;
+        float cx = pos.x + 8.f;
+        float cy = pos.y + row_h * 0.5f;
+        float sz = 5.f;
         if (expanded)
             dl->AddTriangleFilled({cx - sz, cy - sz * 0.5f}, {cx + sz, cy - sz * 0.5f}, {cx, cy + sz * 0.65f}, color);
         else
@@ -76,14 +76,13 @@ namespace Tetragrama::Components
 
         if (is_collection)
         {
-            ImU32 col  = ImGui::ColorConvertFloat4ToU32({0.85f, 0.65f, 0.15f, 0.95f});
-            float fw   = sz * 0.80f;
-            float fh   = sz * 0.65f;
-            float ix   = pos.x + (sz - fw) * 0.5f;
-            float iy   = pos.y + sz - fh;
+            ImU32 col = ImGui::ColorConvertFloat4ToU32({0.85f, 0.65f, 0.15f, 0.95f});
+            float fw  = sz * 0.80f;
+            float fh  = sz * 0.65f;
+            float ix  = pos.x + (sz - fw) * 0.5f;
+            float iy  = pos.y + sz - fh;
             dl->AddRectFilled({ix, iy + fh * 0.28f}, {ix + fw, iy + fh}, col, 1.5f);
-            dl->AddRectFilled({ix, iy}, {ix + fw * 0.44f, iy + fh * 0.32f}, col, 1.5f,
-                              ImDrawFlags_RoundCornersTopLeft | ImDrawFlags_RoundCornersTopRight);
+            dl->AddRectFilled({ix, iy}, {ix + fw * 0.44f, iy + fh * 0.32f}, col, 1.5f, ImDrawFlags_RoundCornersTopLeft | ImDrawFlags_RoundCornersTopRight);
             return;
         }
 
@@ -104,10 +103,10 @@ namespace Tetragrama::Components
             float ray  = sz * 0.40f;
             float diag = ray * 0.70f;
             dl->AddCircleFilled({cx, cy}, r, col, 8);
-            dl->AddLine({cx, cy - ray},  {cx, cy - r},  col, 1.2f);
-            dl->AddLine({cx, cy + r},    {cx, cy + ray}, col, 1.2f);
-            dl->AddLine({cx - ray, cy},  {cx - r, cy},  col, 1.2f);
-            dl->AddLine({cx + r, cy},    {cx + ray, cy}, col, 1.2f);
+            dl->AddLine({cx, cy - ray}, {cx, cy - r}, col, 1.2f);
+            dl->AddLine({cx, cy + r}, {cx, cy + ray}, col, 1.2f);
+            dl->AddLine({cx - ray, cy}, {cx - r, cy}, col, 1.2f);
+            dl->AddLine({cx + r, cy}, {cx + ray, cy}, col, 1.2f);
             dl->AddLine({cx - diag, cy - diag}, {cx - r * 0.7f, cy - r * 0.7f}, col, 1.0f);
             dl->AddLine({cx + r * 0.7f, cy - r * 0.7f}, {cx + diag, cy - diag}, col, 1.0f);
             dl->AddLine({cx - diag, cy + diag}, {cx - r * 0.7f, cy + r * 0.7f}, col, 1.0f);
@@ -124,7 +123,7 @@ namespace Tetragrama::Components
             dl->AddRect({bx, by}, {bx + hw * 2, by + hh * 2}, col, 0.f, 0, 1.0f);
             // Back face
             dl->AddRect({bx + d, by - d}, {bx + hw * 2 + d, by + hh * 2 - d}, col, 0.f, 0, 0.6f);
-            dl->AddLine({bx, by},          {bx + d, by - d},          col, 0.6f);
+            dl->AddLine({bx, by}, {bx + d, by - d}, col, 0.6f);
             dl->AddLine({bx + hw * 2, by}, {bx + hw * 2 + d, by - d}, col, 0.6f);
             dl->AddLine({bx, by + hh * 2}, {bx + d, by + hh * 2 - d}, col, 0.6f);
             return;
@@ -175,24 +174,25 @@ namespace Tetragrama::Components
             ImGui::SameLine();
 
             // Folder+ — New Collection
-            ImVec2 btn_pos    = ImGui::GetCursorScreenPos();
+            ImVec2 btn_pos     = ImGui::GetCursorScreenPos();
             bool   clicked_add = ImGui::InvisibleButton("##new_collection", {btn_sz, btn_sz});
-            bool   col_hov    = ImGui::IsItemHovered();
-            if (col_hov) ImGui::SetTooltip("New Collection");
+            bool   col_hov     = ImGui::IsItemHovered();
+            if (col_hov)
+                ImGui::SetTooltip("New Collection");
             {
                 ImDrawList* fdl = ImGui::GetWindowDrawList();
-                ImU32 col = ImGui::ColorConvertFloat4ToU32(col_hov ? ImVec4(0.85f, 0.85f, 0.90f, 1.f) : ImVec4(0.55f, 0.58f, 0.65f, 1.f));
-                float x = btn_pos.x, y = btn_pos.y, s = btn_sz;
-                float m   = s * 0.12f;
-                float bx0 = x + m,     by0 = y + s * 0.32f;
-                float bx1 = x + s - m, by1 = y + s - m;
+                ImU32       col = ImGui::ColorConvertFloat4ToU32(col_hov ? ImVec4(0.85f, 0.85f, 0.90f, 1.f) : ImVec4(0.55f, 0.58f, 0.65f, 1.f));
+                float       x = btn_pos.x, y = btn_pos.y, s = btn_sz;
+                float       m   = s * 0.12f;
+                float       bx0 = x + m, by0 = y + s * 0.32f;
+                float       bx1 = x + s - m, by1 = y + s - m;
                 fdl->AddRectFilled({bx0, by0}, {bx1, by1}, col, 2.f);
                 float tx0 = bx0, ty0 = by0 - s * 0.14f;
                 float tx1 = bx0 + (bx1 - bx0) * 0.45f, ty1 = by0 + 1.f;
                 fdl->AddRectFilled({tx0, ty0}, {tx1, ty1}, col, 2.f, ImDrawFlags_RoundCornersTopLeft | ImDrawFlags_RoundCornersTopRight);
                 float cx = (bx0 + bx1) * 0.5f, cy = (by0 + by1) * 0.5f;
-                float hl  = s * 0.18f, thk = 1.5f;
-                ImU32 bg  = ImGui::ColorConvertFloat4ToU32(ImVec4(0.14f, 0.15f, 0.18f, 1.f));
+                float hl = s * 0.18f, thk = 1.5f;
+                ImU32 bg = ImGui::ColorConvertFloat4ToU32(ImVec4(0.14f, 0.15f, 0.18f, 1.f));
                 fdl->AddLine({cx - hl, cy}, {cx + hl, cy}, bg, thk + 1.5f);
                 fdl->AddLine({cx, cy - hl}, {cx, cy + hl}, bg, thk + 1.5f);
                 fdl->AddLine({cx - hl, cy}, {cx + hl, cy}, col, thk);
@@ -207,7 +207,7 @@ namespace Tetragrama::Components
                 ImVec2      gp  = ImGui::GetItemRectMin();
                 float       gs  = btn_sz * 0.45f;
                 float       gcx = gp.x + btn_sz * 0.5f, gcy = gp.y + btn_sz * 0.5f;
-                ImU32       gc  = ImGui::ColorConvertFloat4ToU32({0.65f, 0.65f, 0.70f, 1.f});
+                ImU32       gc = ImGui::ColorConvertFloat4ToU32({0.65f, 0.65f, 0.70f, 1.f});
                 gdl->AddCircle({gcx, gcy}, gs * 0.5f, gc, 8, 1.5f);
                 gdl->AddCircleFilled({gcx, gcy}, gs * 0.2f, gc);
             }
@@ -229,21 +229,30 @@ namespace Tetragrama::Components
         ImGui::Spacing();
 
         // O(n) Build
-        auto     scratch    = ZGetScratch(&ParentLayer->LocalArena);
-        uint32_t n          = ctx->ActorManager->Count();
+        auto     scratch = ZGetScratch(&ParentLayer->LocalArena);
+        uint32_t n       = ctx->ActorManager->Count();
 
-        struct OutlinerNode { ActorHandle Handle; EntityID EID; EntityID Parent; };
+        struct OutlinerNode
+        {
+            ActorHandle Handle;
+            EntityID    EID;
+            EntityID    Parent;
+        };
 
-        OutlinerNode* nodes      = static_cast<OutlinerNode*>(scratch.Arena->Allocate(n * sizeof(OutlinerNode), alignof(OutlinerNode)));
+        OutlinerNode* nodes       = static_cast<OutlinerNode*>(scratch.Arena->Allocate(n * sizeof(OutlinerNode), alignof(OutlinerNode)));
         uint32_t*     first_child = static_cast<uint32_t*>(scratch.Arena->Allocate(n * sizeof(uint32_t), alignof(uint32_t)));
         uint32_t*     next_sib    = static_cast<uint32_t*>(scratch.Arena->Allocate(n * sizeof(uint32_t), alignof(uint32_t)));
         uint32_t      nc          = 0;
 
-        for (uint32_t i = 0; i < n; ++i) { first_child[i] = UINT32_MAX; next_sib[i] = UINT32_MAX; }
+        for (uint32_t i = 0; i < n; ++i)
+        {
+            first_child[i] = UINT32_MAX;
+            next_sib[i]    = UINT32_MAX;
+        }
 
         ctx->ActorManager->ForEach([&](ActorHandle h, Actor* actor) {
-            auto* pc      = actor->GetComponent<ParentComponent>();
-            nodes[nc++]   = {h, actor->GetEntityID(), (pc && pc->Parent != INVALID_ENTITY) ? pc->Parent : INVALID_ENTITY};
+            auto* pc    = actor->GetComponent<ParentComponent>();
+            nodes[nc++] = {h, actor->GetEntityID(), (pc && pc->Parent != INVALID_ENTITY) ? pc->Parent : INVALID_ENTITY};
         });
 
         ZEngine::Core::Containers::UnorderedHashMap<EntityID, uint32_t> eid_to_idx;
@@ -253,48 +262,54 @@ namespace Tetragrama::Components
 
         for (uint32_t i = 0; i < nc; ++i)
         {
-            if (nodes[i].Parent == INVALID_ENTITY) continue;
+            if (nodes[i].Parent == INVALID_ENTITY)
+                continue;
             auto* pidx = eid_to_idx.find(nodes[i].Parent);
-            if (!pidx) continue;
-            next_sib[i] = first_child[*pidx];
+            if (!pidx)
+                continue;
+            next_sib[i]        = first_child[*pidx];
             first_child[*pidx] = i;
         }
 
-        struct DFSEntry { uint32_t idx; int depth; };
-        DFSEntry* stk  = static_cast<DFSEntry*>(scratch.Arena->Allocate(nc * 2 * sizeof(DFSEntry), alignof(DFSEntry)));
-        int32_t   sp   = 0;
-        for (int32_t i = (int32_t)nc - 1; i >= 0; --i)
+        struct DFSEntry
+        {
+            uint32_t idx;
+            int      depth;
+        };
+        DFSEntry* stk = static_cast<DFSEntry*>(scratch.Arena->Allocate(nc * 2 * sizeof(DFSEntry), alignof(DFSEntry)));
+        int32_t   sp  = 0;
+        for (int32_t i = (int32_t) nc - 1; i >= 0; --i)
             if (nodes[i].Parent == INVALID_ENTITY)
-                stk[sp++] = {(uint32_t)i, 0};
+                stk[sp++] = {(uint32_t) i, 0};
 
         // Table
-        ActorHandle pending_delete               = {};
-        ActorHandle pending_reparent_child       = {};
-        EntityID    pending_reparent_parent      = INVALID_ENTITY;
-        ActorHandle pending_remove_parent_handle = {};
-        uint32_t    total_actors = nc;
-        uint32_t    selected_count = 0;
+        ActorHandle            pending_delete               = {};
+        ActorHandle            pending_reparent_child       = {};
+        EntityID               pending_reparent_parent      = INVALID_ENTITY;
+        ActorHandle            pending_remove_parent_handle = {};
+        uint32_t               total_actors                 = nc;
+        uint32_t               selected_count               = 0;
 
-        constexpr float  ROW_H        = 22.f;
-        constexpr float  ICON_SZ      = 13.f;
-        constexpr float  INDENT_W     = 16.f;
-        constexpr float  ARROW_W      = 16.f;
-        const ImU32      COL_ARROW    = ImGui::ColorConvertFloat4ToU32({0.65f, 0.65f, 0.70f, 1.f});
-        const ImU32      COL_SEL      = ImGui::ColorConvertFloat4ToU32({0.26f, 0.44f, 0.70f, 0.60f});
-        const ImU32      COL_HOVER    = ImGui::ColorConvertFloat4ToU32({0.26f, 0.44f, 0.70f, 0.25f});
-        const ImU32      COL_TEXT     = ImGui::ColorConvertFloat4ToU32(ImGui::GetStyleColorVec4(ImGuiCol_Text));
-        const ImU32      COL_DIMTEXT  = ImGui::ColorConvertFloat4ToU32({0.55f, 0.55f, 0.60f, 1.f});
+        constexpr float        ROW_H                        = 22.f;
+        constexpr float        ICON_SZ                      = 13.f;
+        constexpr float        INDENT_W                     = 16.f;
+        constexpr float        ARROW_W                      = 16.f;
+        const ImU32            COL_ARROW                    = ImGui::ColorConvertFloat4ToU32({0.65f, 0.65f, 0.70f, 1.f});
+        const ImU32            COL_SEL                      = ImGui::ColorConvertFloat4ToU32({0.26f, 0.44f, 0.70f, 0.60f});
+        const ImU32            COL_HOVER                    = ImGui::ColorConvertFloat4ToU32({0.26f, 0.44f, 0.70f, 0.25f});
+        const ImU32            COL_TEXT                     = ImGui::ColorConvertFloat4ToU32(ImGui::GetStyleColorVec4(ImGuiCol_Text));
+        const ImU32            COL_DIMTEXT                  = ImGui::ColorConvertFloat4ToU32({0.55f, 0.55f, 0.60f, 1.f});
 
-        static ImGuiTableFlags tbl_flags = ImGuiTableFlags_ScrollY | ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersInnerV;
-        float  tbl_h = ImGui::GetContentRegionAvail().y - ROW_H - ImGui::GetStyle().ItemSpacing.y * 2.f;
-        ImVec2 tbl_sz = {0.f, tbl_h};
+        static ImGuiTableFlags tbl_flags                    = ImGuiTableFlags_ScrollY | ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersInnerV;
+        float                  tbl_h                        = ImGui::GetContentRegionAvail().y - ROW_H - ImGui::GetStyle().ItemSpacing.y * 2.f;
+        ImVec2                 tbl_sz                       = {0.f, tbl_h};
 
         if (ImGui::BeginTable("##outliner", 3, tbl_flags, tbl_sz))
         {
             ImGui::TableSetupScrollFreeze(0, 1);
             ImGui::TableSetupColumn("Item Label", ImGuiTableColumnFlags_WidthStretch, 0.60f);
-            ImGui::TableSetupColumn("Type",       ImGuiTableColumnFlags_WidthStretch, 0.25f);
-            ImGui::TableSetupColumn("Level",      ImGuiTableColumnFlags_WidthStretch, 0.15f);
+            ImGui::TableSetupColumn("Type", ImGuiTableColumnFlags_WidthStretch, 0.25f);
+            ImGui::TableSetupColumn("Level", ImGuiTableColumnFlags_WidthStretch, 0.15f);
 
             // Column headers
             ImGui::TableNextRow(ImGuiTableRowFlags_Headers);
@@ -305,7 +320,7 @@ namespace Tetragrama::Components
                 ImVec2      hp  = ImGui::GetCursorScreenPos();
                 float       hs  = ImGui::GetTextLineHeight();
                 ImU32       hc  = COL_DIMTEXT;
-                float       ex  = hp.x + 7.f, ey = hp.y + hs * 0.5f;
+                float       ex = hp.x + 7.f, ey = hp.y + hs * 0.5f;
                 // Eye icon: two arcs (top + bottom) with a pupil dot
                 hdl->AddCircle({ex, ey}, 3.5f, hc, 8, 1.2f);
                 hdl->AddCircleFilled({ex, ey}, 1.5f, hc);
@@ -313,8 +328,10 @@ namespace Tetragrama::Components
                 ImGui::SameLine(0.f, 2.f);
             }
             ImGui::TableHeader("Item Label");
-            ImGui::TableSetColumnIndex(1); ImGui::TableHeader("Type");
-            ImGui::TableSetColumnIndex(2); ImGui::TableHeader("Level");
+            ImGui::TableSetColumnIndex(1);
+            ImGui::TableHeader("Type");
+            ImGui::TableSetColumnIndex(2);
+            ImGui::TableHeader("Level");
 
             ImDrawList* dl = ImGui::GetWindowDrawList();
 
@@ -322,22 +339,24 @@ namespace Tetragrama::Components
             {
                 ImGui::TableNextRow(ImGuiTableRowFlags_None, ROW_H);
                 ImGui::TableSetColumnIndex(0);
-                ImVec2 row_p = ImGui::GetCursorScreenPos();
+                ImVec2 row_p          = ImGui::GetCursorScreenPos();
 
-                bool root_collapsed = m_scene_root_collapsed;
-                bool root_selected  = false; // scene root can't be selected
+                bool   root_collapsed = m_scene_root_collapsed;
+                bool   root_selected  = false; // scene root can't be selected
 
                 // Hover / bg
-                ImVec2 row_end = {row_p.x + ImGui::GetContentRegionAvail().x + ImGui::GetScrollX() + 800.f, row_p.y + ROW_H};
-                bool   hov     = ImGui::IsMouseHoveringRect(row_p, row_end);
-                if (hov) dl->AddRectFilled(row_p, row_end, COL_HOVER);
+                ImVec2 row_end        = {row_p.x + ImGui::GetContentRegionAvail().x + ImGui::GetScrollX() + 800.f, row_p.y + ROW_H};
+                bool   hov            = ImGui::IsMouseHoveringRect(row_p, row_end);
+                if (hov)
+                    dl->AddRectFilled(row_p, row_end, COL_HOVER);
 
                 // Arrow
                 float ax = row_p.x + 2.f;
                 ImGui::SetCursorScreenPos({ax, row_p.y});
                 ImGui::PushID(0xFFFF0000);
                 ImGui::InvisibleButton("##root_arrow", {ARROW_W, ROW_H});
-                if (ImGui::IsItemClicked()) m_scene_root_collapsed = !m_scene_root_collapsed;
+                if (ImGui::IsItemClicked())
+                    m_scene_root_collapsed = !m_scene_root_collapsed;
                 ImGui::PopID();
                 DrawArrow(dl, {ax, row_p.y}, ROW_H, !root_collapsed, COL_ARROW);
 
@@ -362,42 +381,40 @@ namespace Tetragrama::Components
             {
                 while (sp > 0)
                 {
-                    DFSEntry e    = stk[--sp];
-                    uint32_t ni   = e.idx;
+                    DFSEntry e     = stk[--sp];
+                    uint32_t ni    = e.idx;
                     Actor*   actor = ctx->ActorManager->Access(nodes[ni].Handle);
-                    if (!actor) continue;
+                    if (!actor)
+                        continue;
 
                     auto*       nc_comp = actor->GetComponent<NameComponent>();
                     const char* label   = (nc_comp && nc_comp->Value[0]) ? nc_comp->Value : "Actor";
 
-                    if (m_filter_buf[0] && !strstr(label, m_filter_buf)) continue;
+                    if (m_filter_buf[0] && !strstr(label, m_filter_buf))
+                        continue;
 
-                    bool is_collection = !actor->HasComponent<MeshComponent>() &&
-                                         !actor->HasComponent<LightComponent>() &&
-                                         !actor->HasComponent<CameraComponent>();
-                    const char* type_str = is_collection                          ? "Collection"  :
-                                           actor->HasComponent<LightComponent>()  ? "Light"       :
-                                           actor->HasComponent<CameraComponent>() ? "Camera"      :
-                                           actor->HasComponent<MeshComponent>()   ? "Static Mesh" : "Actor";
+                    bool        is_collection = !actor->HasComponent<MeshComponent>() && !actor->HasComponent<LightComponent>() && !actor->HasComponent<CameraComponent>();
+                    const char* type_str      = is_collection ? "Collection" : actor->HasComponent<LightComponent>() ? "Light" : actor->HasComponent<CameraComponent>() ? "Camera" : actor->HasComponent<MeshComponent>() ? "Static Mesh" : "Actor";
 
-                    bool has_children = (first_child[ni] != UINT32_MAX);
-                    bool collapsed    = has_children && IsCollapsed(nodes[ni].EID);
-                    bool selected     = (current_scene->SelectedActorHandle.Index      == nodes[ni].Handle.Index &&
-                                         current_scene->SelectedActorHandle.Generation == nodes[ni].Handle.Generation);
-                    if (selected) ++selected_count;
+                    bool        has_children  = (first_child[ni] != UINT32_MAX);
+                    bool        collapsed     = has_children && IsCollapsed(nodes[ni].EID);
+                    bool        selected      = (current_scene->SelectedActorHandle.Index == nodes[ni].Handle.Index && current_scene->SelectedActorHandle.Generation == nodes[ni].Handle.Generation);
+                    if (selected)
+                        ++selected_count;
 
-                    bool renaming = (m_renaming_handle.Index      == nodes[ni].Handle.Index &&
-                                     m_renaming_handle.Generation == nodes[ni].Handle.Generation);
+                    bool renaming = (m_renaming_handle.Index == nodes[ni].Handle.Index && m_renaming_handle.Generation == nodes[ni].Handle.Generation);
 
                     ImGui::TableNextRow(ImGuiTableRowFlags_None, ROW_H);
                     ImGui::TableSetColumnIndex(0);
-                    ImVec2 row_p  = ImGui::GetCursorScreenPos();
+                    ImVec2 row_p   = ImGui::GetCursorScreenPos();
                     ImVec2 row_end = {row_p.x + ImGui::GetContentRegionAvail().x + ImGui::GetScrollX() + 800.f, row_p.y + ROW_H};
 
                     // Row background
-                    bool hov = ImGui::IsMouseHoveringRect(row_p, row_end);
-                    if (selected) dl->AddRectFilled(row_p, row_end, COL_SEL);
-                    else if (hov) dl->AddRectFilled(row_p, row_end, COL_HOVER);
+                    bool   hov     = ImGui::IsMouseHoveringRect(row_p, row_end);
+                    if (selected)
+                        dl->AddRectFilled(row_p, row_end, COL_SEL);
+                    else if (hov)
+                        dl->AddRectFilled(row_p, row_end, COL_HOVER);
 
                     // Row click
                     if (hov && ImGui::IsMouseClicked(0))
@@ -414,9 +431,9 @@ namespace Tetragrama::Components
                     float indent = (e.depth + 1) * INDENT_W; // +1 because everything is under scene root
 
                     // Arrow area
-                    float ax = row_p.x + indent;
+                    float ax     = row_p.x + indent;
                     ImGui::SetCursorScreenPos({ax, row_p.y});
-                    ImGui::PushID((int)nodes[ni].Handle.Index);
+                    ImGui::PushID((int) nodes[ni].Handle.Index);
                     ImGui::InvisibleButton("##arrow", {ARROW_W, ROW_H});
                     if (ImGui::IsItemClicked() && has_children)
                         ToggleCollapsed(nodes[ni].EID);
@@ -431,13 +448,12 @@ namespace Tetragrama::Components
                     // Label / rename
                     float lx = ix + ICON_SZ + 5.f;
                     ImGui::SetCursorScreenPos({lx, row_p.y + (ROW_H - ImGui::GetFrameHeight()) * 0.5f});
-                    ImGui::PushID((int)nodes[ni].Handle.Index + 1000);
+                    ImGui::PushID((int) nodes[ni].Handle.Index + 1000);
 
                     if (renaming)
                     {
                         ImGui::SetNextItemWidth(120.f);
-                        if (ImGui::InputText("##ren", m_rename_buf, sizeof(m_rename_buf),
-                                             ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AutoSelectAll))
+                        if (ImGui::InputText("##ren", m_rename_buf, sizeof(m_rename_buf), ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AutoSelectAll))
                         {
                             if (nc_comp && m_rename_buf[0])
                                 Helpers::secure_strncpy(nc_comp->Value, sizeof(nc_comp->Value), m_rename_buf, sizeof(m_rename_buf) - 1);
@@ -492,7 +508,8 @@ namespace Tetragrama::Components
                             auto* mc = actor->GetComponent<MeshComponent>();
                             if (mc && mc->RenderInstanceId != UINT32_MAX)
                                 current_scene->RemoveMeshInstance(mc->RenderInstanceId, ctx->RenderResourceManager);
-                            if (selected) current_scene->SelectedActorHandle = {};
+                            if (selected)
+                                current_scene->SelectedActorHandle = {};
                             pending_delete = nodes[ni].Handle;
                         }
                         ImGui::EndPopup();
@@ -511,9 +528,14 @@ namespace Tetragrama::Components
                     // Push children
                     if (has_children && !collapsed)
                     {
-                        uint32_t tmp[256]; int tc = 0;
-                        uint32_t c = first_child[ni];
-                        while (c != UINT32_MAX && tc < 256) { tmp[tc++] = c; c = next_sib[c]; }
+                        uint32_t tmp[256];
+                        int      tc = 0;
+                        uint32_t c  = first_child[ni];
+                        while (c != UINT32_MAX && tc < 256)
+                        {
+                            tmp[tc++] = c;
+                            c         = next_sib[c];
+                        }
                         for (int ci = tc - 1; ci >= 0; --ci)
                             stk[sp++] = {tmp[ci], e.depth + 1};
                     }
@@ -568,7 +590,8 @@ namespace Tetragrama::Components
         if (pending_remove_parent_handle.Valid())
         {
             Actor* a = ctx->ActorManager->Access(pending_remove_parent_handle);
-            if (a) a->RemoveComponent<ParentComponent>();
+            if (a)
+                a->RemoveComponent<ParentComponent>();
         }
         if (pending_delete.Valid())
             ctx->ActorManager->Destroy(pending_delete);
@@ -605,11 +628,11 @@ namespace Tetragrama::Components
         auto       projection = camera->GetProjection();
         projection[1][1]      = -projection[1][1];
 
-        Mat4f transform = tc->WorldTransform;
+        Mat4f transform       = tc->WorldTransform;
 
-        int   gizmo_op  = app->Configuration->GizmoOperation;
-        float snap_val  = 0.5f;
-        bool  snapping  = app->CurrentWindow && IDevice::As<Keyboard>() && IDevice::As<Keyboard>()->IsKeyPressed(ZENGINE_KEY_LEFT_CONTROL, app->CurrentWindow);
+        int   gizmo_op        = app->Configuration->GizmoOperation;
+        float snap_val        = 0.5f;
+        bool  snapping        = app->CurrentWindow && IDevice::As<Keyboard>() && IDevice::As<Keyboard>()->IsKeyPressed(ZENGINE_KEY_LEFT_CONTROL, app->CurrentWindow);
         if (snapping && static_cast<ImGuizmo::OPERATION>(gizmo_op) == ImGuizmo::ROTATE)
             snap_val = 45.0f;
         float snap_arr[3] = {snap_val, snap_val, snap_val};

--- a/Tetragrama/Components/HierarchyViewUIComponent.cpp
+++ b/Tetragrama/Components/HierarchyViewUIComponent.cpp
@@ -18,37 +18,137 @@
 using namespace ZEngine;
 using namespace ZEngine::ECS;
 using namespace ZEngine::ECS::Components;
-using namespace ZEngine::Windows::Inputs;
 using namespace ZEngine::Core::Maths;
+using namespace ZEngine::Windows::Inputs;
 
 namespace Tetragrama::Components
 {
-    HierarchyViewUIComponent::HierarchyViewUIComponent() {}
-    HierarchyViewUIComponent::~HierarchyViewUIComponent() {}
+    HierarchyViewUIComponent::HierarchyViewUIComponent()  = default;
+    HierarchyViewUIComponent::~HierarchyViewUIComponent() = default;
 
     void HierarchyViewUIComponent::Initialize(Layers::ImguiLayer* parent, const char* name, bool visibility, bool closed)
     {
         UIComponent::Initialize(parent, name, visibility, closed);
+        parent->LocalArena.CreateSubArena(ZKilo(512), &m_outliner_arena);
+        m_collapsed.init(&m_outliner_arena, 64);
     }
 
-    void HierarchyViewUIComponent::Update(ZEngine::Core::TimeStep /*dt*/)
+    void HierarchyViewUIComponent::Update(ZEngine::Core::TimeStep /*dt*/) {}
+
+    bool HierarchyViewUIComponent::IsCollapsed(EntityID eid) const
     {
-        if (!ParentLayer || !ParentLayer->CurrentApp)
-            return;
-
-        auto  window   = ParentLayer->CurrentApp->CurrentWindow;
-        auto* keyboard = IDevice::As<Keyboard>();
-        if (!keyboard)
-            return;
-
-        auto* app = reinterpret_cast<EditorPtr>(ParentLayer->CurrentApp);
-        if (keyboard->IsKeyPressed(ZENGINE_KEY_T, window))
-            app->Configuration->GizmoOperation = ImGuizmo::OPERATION::TRANSLATE;
-        if (keyboard->IsKeyPressed(ZENGINE_KEY_R, window))
-            app->Configuration->GizmoOperation = ImGuizmo::OPERATION::ROTATE;
-        if (keyboard->IsKeyPressed(ZENGINE_KEY_S, window))
-            app->Configuration->GizmoOperation = ImGuizmo::OPERATION::SCALE;
+        for (uint32_t i = 0; i < m_collapsed.size(); ++i)
+            if (m_collapsed[i] == eid)
+                return true;
+        return false;
     }
+
+    void HierarchyViewUIComponent::ToggleCollapsed(EntityID eid)
+    {
+        for (uint32_t i = 0; i < m_collapsed.size(); ++i)
+        {
+            if (m_collapsed[i] == eid)
+            {
+                m_collapsed[i] = INVALID_ENTITY; // sentinel slot; IsCollapsed skips it (valid entities have Generation!=0)
+                return;
+            }
+        }
+        m_collapsed.push(eid);
+    }
+
+    // ── Static helpers ────────────────────────────────────────────────────────
+
+    void HierarchyViewUIComponent::DrawArrow(ImDrawList* dl, ImVec2 pos, float row_h, bool expanded, ImU32 color)
+    {
+        float cx  = pos.x + 8.f;
+        float cy  = pos.y + row_h * 0.5f;
+        float sz  = 5.f;
+        if (expanded)
+            dl->AddTriangleFilled({cx - sz, cy - sz * 0.5f}, {cx + sz, cy - sz * 0.5f}, {cx, cy + sz * 0.65f}, color);
+        else
+            dl->AddTriangleFilled({cx - sz * 0.5f, cy - sz}, {cx + sz * 0.65f, cy}, {cx - sz * 0.5f, cy + sz}, color);
+    }
+
+    void HierarchyViewUIComponent::DrawTypeIcon(ImDrawList* dl, ImVec2 pos, float sz, const char* type, bool is_collection)
+    {
+        float cx = pos.x + sz * 0.5f;
+        float cy = pos.y + sz * 0.5f;
+
+        if (is_collection)
+        {
+            ImU32 col  = ImGui::ColorConvertFloat4ToU32({0.85f, 0.65f, 0.15f, 0.95f});
+            float fw   = sz * 0.80f;
+            float fh   = sz * 0.65f;
+            float ix   = pos.x + (sz - fw) * 0.5f;
+            float iy   = pos.y + sz - fh;
+            dl->AddRectFilled({ix, iy + fh * 0.28f}, {ix + fw, iy + fh}, col, 1.5f);
+            dl->AddRectFilled({ix, iy}, {ix + fw * 0.44f, iy + fh * 0.32f}, col, 1.5f,
+                              ImDrawFlags_RoundCornersTopLeft | ImDrawFlags_RoundCornersTopRight);
+            return;
+        }
+
+        if (Helpers::secure_strcmp(type, "World") == 0)
+        {
+            ImU32 col = ImGui::ColorConvertFloat4ToU32({0.35f, 0.80f, 0.45f, 1.0f});
+            float r   = sz * 0.40f;
+            dl->AddCircle({cx, cy}, r, col, 16, 1.2f);
+            dl->AddLine({cx - r, cy}, {cx + r, cy}, col, 1.0f);
+            dl->AddLine({cx, cy - r}, {cx, cy + r}, col, 1.0f);
+            return;
+        }
+
+        if (Helpers::secure_strcmp(type, "Light") == 0)
+        {
+            ImU32 col  = ImGui::ColorConvertFloat4ToU32({1.0f, 0.85f, 0.20f, 1.0f});
+            float r    = sz * 0.20f;
+            float ray  = sz * 0.40f;
+            float diag = ray * 0.70f;
+            dl->AddCircleFilled({cx, cy}, r, col, 8);
+            dl->AddLine({cx, cy - ray},  {cx, cy - r},  col, 1.2f);
+            dl->AddLine({cx, cy + r},    {cx, cy + ray}, col, 1.2f);
+            dl->AddLine({cx - ray, cy},  {cx - r, cy},  col, 1.2f);
+            dl->AddLine({cx + r, cy},    {cx + ray, cy}, col, 1.2f);
+            dl->AddLine({cx - diag, cy - diag}, {cx - r * 0.7f, cy - r * 0.7f}, col, 1.0f);
+            dl->AddLine({cx + r * 0.7f, cy - r * 0.7f}, {cx + diag, cy - diag}, col, 1.0f);
+            dl->AddLine({cx - diag, cy + diag}, {cx - r * 0.7f, cy + r * 0.7f}, col, 1.0f);
+            dl->AddLine({cx + r * 0.7f, cy + r * 0.7f}, {cx + diag, cy + diag}, col, 1.0f);
+            return;
+        }
+
+        if (Helpers::secure_strcmp(type, "Static Mesh") == 0)
+        {
+            ImU32 col = ImGui::ColorConvertFloat4ToU32({0.55f, 0.75f, 0.90f, 1.0f});
+            float hw = sz * 0.28f, hh = sz * 0.28f, d = sz * 0.16f;
+            float bx = cx - hw, by = cy;
+            // Front face
+            dl->AddRect({bx, by}, {bx + hw * 2, by + hh * 2}, col, 0.f, 0, 1.0f);
+            // Back face
+            dl->AddRect({bx + d, by - d}, {bx + hw * 2 + d, by + hh * 2 - d}, col, 0.f, 0, 0.6f);
+            dl->AddLine({bx, by},          {bx + d, by - d},          col, 0.6f);
+            dl->AddLine({bx + hw * 2, by}, {bx + hw * 2 + d, by - d}, col, 0.6f);
+            dl->AddLine({bx, by + hh * 2}, {bx + d, by + hh * 2 - d}, col, 0.6f);
+            return;
+        }
+
+        if (Helpers::secure_strcmp(type, "Camera") == 0)
+        {
+            ImU32 col = ImGui::ColorConvertFloat4ToU32({0.45f, 0.85f, 0.55f, 1.0f});
+            float bw = sz * 0.55f, bh = sz * 0.40f;
+            float bx = pos.x + sz * 0.05f, by = cy - bh * 0.5f;
+            dl->AddRectFilled({bx, by}, {bx + bw, by + bh}, col, 1.5f);
+            dl->AddTriangleFilled({bx + bw, by + bh * 0.1f}, {bx + bw + sz * 0.25f, cy}, {bx + bw, by + bh * 0.9f}, col);
+            return;
+        }
+
+        // Default — grey diamond
+        {
+            ImU32 col = ImGui::ColorConvertFloat4ToU32({0.55f, 0.55f, 0.60f, 1.0f});
+            float r   = sz * 0.35f;
+            dl->AddQuadFilled({cx, cy - r}, {cx + r, cy}, {cx, cy + r}, {cx - r, cy}, col);
+        }
+    }
+
+    // ── Render ────────────────────────────────────────────────────────────────
 
     void HierarchyViewUIComponent::Render(ZEngine::Rendering::Renderers::GraphicRenderer* const /*renderer*/, ZEngine::Hardwares::CommandBuffer* const /*command_buffer*/)
     {
@@ -63,132 +163,400 @@ namespace Tetragrama::Components
 
         ImGui::Begin(Name, CanBeClosed ? &CanBeClosed : nullptr, ImGuiWindowFlags_NoCollapse);
 
-        if (ImGui::IsMouseDown(0) && ImGui::IsWindowHovered())
-            current_scene->SelectedActorHandle = {};
-
+        // ── Search + Buttons ─────────────────────────────────────────────────
         {
             const float btn_sz  = 22.f;
             const float spacing = ImGui::GetStyle().ItemSpacing.x;
             const float avail   = ImGui::GetContentRegionAvail().x;
-            const float box_w   = avail - btn_sz - spacing;
+            const float box_w   = avail - btn_sz * 2.f - spacing * 2.f;
 
             ImGui::SetNextItemWidth(box_w);
             ImGui::InputText("##filter", m_filter_buf, sizeof(m_filter_buf));
             ImGui::SameLine();
 
-            ImVec2 btn_pos = ImGui::GetCursorScreenPos();
-            bool   clicked = ImGui::InvisibleButton("##new_collection", {btn_sz, btn_sz});
-            bool   hovered = ImGui::IsItemHovered();
-            if (ImGui::IsItemHovered())
-                ImGui::SetTooltip("New Collection");
+            // "+" — New Collection
+            bool clicked_add = ImGui::Button("+", {btn_sz, btn_sz});
+            if (ImGui::IsItemHovered()) ImGui::SetTooltip("New Collection");
+            ImGui::SameLine();
 
+            // Settings gear placeholder
+            ImGui::Button("##gear", {btn_sz, btn_sz});
             {
-                ImDrawList* dl  = ImGui::GetWindowDrawList();
-                ImU32       col = ImGui::ColorConvertFloat4ToU32(hovered ? ImVec4(0.85f, 0.85f, 0.90f, 1.f) : ImVec4(0.55f, 0.58f, 0.65f, 1.f));
-
-                float       x = btn_pos.x, y = btn_pos.y, s = btn_sz;
-                float       m   = s * 0.12f;
-                float       bx0 = x + m, by0 = y + s * 0.32f;
-                float       bx1 = x + s - m, by1 = y + s - m;
-                dl->AddRectFilled({bx0, by0}, {bx1, by1}, col, 2.f);
-
-                float tx0 = bx0, ty0 = by0 - s * 0.14f;
-                float tx1 = bx0 + (bx1 - bx0) * 0.45f, ty1 = by0 + 1.f;
-                dl->AddRectFilled({tx0, ty0}, {tx1, ty1}, col, 2.f, ImDrawFlags_RoundCornersTopLeft | ImDrawFlags_RoundCornersTopRight);
-
-                float cx = (bx0 + bx1) * 0.5f, cy = (by0 + by1) * 0.5f;
-                float hl  = s * 0.18f;
-                float thk = 1.5f;
-                ImU32 bg  = ImGui::ColorConvertFloat4ToU32(ImVec4(0.14f, 0.15f, 0.18f, 1.f));
-                dl->AddLine({cx - hl, cy}, {cx + hl, cy}, bg, thk + 1.5f);
-                dl->AddLine({cx, cy - hl}, {cx, cy + hl}, bg, thk + 1.5f);
-                dl->AddLine({cx - hl, cy}, {cx + hl, cy}, col, thk);
-                dl->AddLine({cx, cy - hl}, {cx, cy + hl}, col, thk);
+                ImDrawList* gdl = ImGui::GetWindowDrawList();
+                ImVec2      gp  = ImGui::GetItemRectMin();
+                float       gs  = btn_sz * 0.45f;
+                float       gcx = gp.x + btn_sz * 0.5f, gcy = gp.y + btn_sz * 0.5f;
+                ImU32       gc  = ImGui::ColorConvertFloat4ToU32({0.65f, 0.65f, 0.70f, 1.f});
+                gdl->AddCircle({gcx, gcy}, gs * 0.5f, gc, 8, 1.5f);
+                gdl->AddCircleFilled({gcx, gcy}, gs * 0.2f, gc);
             }
 
-            if (clicked)
-                ZENGINE_CORE_INFO("Create collection — not yet implemented")
-        }
-        ImGui::Dummy({0, 3});
-
-        static ImGuiTableFlags table_flags = ImGuiTableFlags_RowBg | ImGuiTableFlags_ScrollY;
-
-        ImVec2                 table_size  = {0.f, ImGui::GetContentRegionAvail().y - 2.f};
-        if (ImGui::BeginTable("##outliner", 3, table_flags, table_size))
-        {
-            ImGui::TableSetupColumn("##label", ImGuiTableColumnFlags_WidthStretch, 0.55f);
-            ImGui::TableSetupColumn("##type", ImGuiTableColumnFlags_WidthStretch, 0.25f);
-            ImGui::TableSetupColumn("##level", ImGuiTableColumnFlags_WidthStretch, 0.20f);
-
-            ImGui::TableNextRow();
-            ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.55f, 0.55f, 0.60f, 1.f));
-            ImGui::TableSetColumnIndex(0);
-            ImGui::TextUnformatted("Label");
-            ImGui::TableSetColumnIndex(1);
-            ImGui::TextUnformatted("Type");
-            ImGui::TableSetColumnIndex(2);
-            ImGui::TextUnformatted("Level");
-            ImGui::PopStyleColor();
-
-            ActorHandle pending_delete = {};
-            ctx->ActorManager->ForEach([&](ActorHandle h, Actor* actor) {
-                const char* label = "Actor";
-                auto*       nc    = actor->GetComponent<NameComponent>();
-                if (nc && nc->Value[0])
-                    label = nc->Value;
-
-                if (m_filter_buf[0] != '\0' && !strstr(label, m_filter_buf))
-                    return;
-
-                const char* type = "Actor";
-                if (actor->HasComponent<MeshComponent>())
-                    type = "Static Mesh";
-                else if (actor->HasComponent<LightComponent>())
-                    type = "Light";
-                else if (actor->HasComponent<CameraComponent>())
-                    type = "Camera";
-
-                bool selected = (current_scene->SelectedActorHandle.Index == h.Index && current_scene->SelectedActorHandle.Generation == h.Generation);
-
-                ImGui::TableNextRow();
-                ImGui::TableSetColumnIndex(0);
-
-                ImGui::PushID((int) h.Index);
-                if (ImGui::Selectable(label, selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowOverlap))
-                    current_scene->SelectedActorHandle = h;
-
-                if (ImGui::BeginPopupContextItem("##actor_ctx"))
+            if (clicked_add)
+            {
+                ActorHandle coll_h = ctx->ActorManager->Create();
+                Actor*      coll_a = ctx->ActorManager->Access(coll_h);
+                if (coll_a)
                 {
-                    if (ImGui::MenuItem("Delete"))
-                    {
-                        auto* mc = actor->GetComponent<MeshComponent>();
-                        if (mc && mc->RenderInstanceId != UINT32_MAX)
-                            current_scene->RemoveMeshInstance(mc->RenderInstanceId, ctx->RenderResourceManager);
-                        if (selected)
-                            current_scene->SelectedActorHandle = {};
-                        pending_delete = h;
-                    }
-                    ImGui::EndPopup();
+                    NameComponent nc = {};
+                    Helpers::secure_strncpy(nc.Value, sizeof(nc.Value), "Collection", 10);
+                    coll_a->AddComponent<NameComponent>(nc);
+                    coll_a->AddComponent<TransformComponent>({});
+                    current_scene->SelectedActorHandle = coll_h;
                 }
+            }
+        }
+        ImGui::Spacing();
+
+        // ── O(n) Build ───────────────────────────────────────────────────────
+        auto     scratch    = ZGetScratch(&ParentLayer->LocalArena);
+        uint32_t n          = ctx->ActorManager->Count();
+
+        struct OutlinerNode { ActorHandle Handle; EntityID EID; EntityID Parent; };
+
+        OutlinerNode* nodes      = static_cast<OutlinerNode*>(scratch.Arena->Allocate(n * sizeof(OutlinerNode), alignof(OutlinerNode)));
+        uint32_t*     first_child = static_cast<uint32_t*>(scratch.Arena->Allocate(n * sizeof(uint32_t), alignof(uint32_t)));
+        uint32_t*     next_sib    = static_cast<uint32_t*>(scratch.Arena->Allocate(n * sizeof(uint32_t), alignof(uint32_t)));
+        uint32_t      nc          = 0;
+
+        for (uint32_t i = 0; i < n; ++i) { first_child[i] = UINT32_MAX; next_sib[i] = UINT32_MAX; }
+
+        ctx->ActorManager->ForEach([&](ActorHandle h, Actor* actor) {
+            auto* pc      = actor->GetComponent<ParentComponent>();
+            nodes[nc++]   = {h, actor->GetEntityID(), (pc && pc->Parent != INVALID_ENTITY) ? pc->Parent : INVALID_ENTITY};
+        });
+
+        ZEngine::Core::Containers::UnorderedHashMap<EntityID, uint32_t> eid_to_idx;
+        eid_to_idx.init(scratch.Arena, nc * 2);
+        for (uint32_t i = 0; i < nc; ++i)
+            eid_to_idx.insert(nodes[i].EID, i);
+
+        for (uint32_t i = 0; i < nc; ++i)
+        {
+            if (nodes[i].Parent == INVALID_ENTITY) continue;
+            auto* pidx = eid_to_idx.find(nodes[i].Parent);
+            if (!pidx) continue;
+            next_sib[i] = first_child[*pidx];
+            first_child[*pidx] = i;
+        }
+
+        struct DFSEntry { uint32_t idx; int depth; };
+        DFSEntry* stk  = static_cast<DFSEntry*>(scratch.Arena->Allocate(nc * 2 * sizeof(DFSEntry), alignof(DFSEntry)));
+        int32_t   sp   = 0;
+        for (int32_t i = (int32_t)nc - 1; i >= 0; --i)
+            if (nodes[i].Parent == INVALID_ENTITY)
+                stk[sp++] = {(uint32_t)i, 0};
+
+        // ── Table ─────────────────────────────────────────────────────────────
+        ActorHandle pending_delete               = {};
+        ActorHandle pending_reparent_child       = {};
+        EntityID    pending_reparent_parent      = INVALID_ENTITY;
+        ActorHandle pending_remove_parent_handle = {};
+        uint32_t    total_actors = nc;
+        uint32_t    selected_count = 0;
+
+        constexpr float  ROW_H        = 22.f;
+        constexpr float  ICON_SZ      = 13.f;
+        constexpr float  INDENT_W     = 16.f;
+        constexpr float  ARROW_W      = 16.f;
+        const ImU32      COL_ARROW    = ImGui::ColorConvertFloat4ToU32({0.65f, 0.65f, 0.70f, 1.f});
+        const ImU32      COL_SEL      = ImGui::ColorConvertFloat4ToU32({0.26f, 0.44f, 0.70f, 0.60f});
+        const ImU32      COL_HOVER    = ImGui::ColorConvertFloat4ToU32({0.26f, 0.44f, 0.70f, 0.25f});
+        const ImU32      COL_TEXT     = ImGui::ColorConvertFloat4ToU32(ImGui::GetStyleColorVec4(ImGuiCol_Text));
+        const ImU32      COL_DIMTEXT  = ImGui::ColorConvertFloat4ToU32({0.55f, 0.55f, 0.60f, 1.f});
+
+        static ImGuiTableFlags tbl_flags = ImGuiTableFlags_ScrollY | ImGuiTableFlags_RowBg | ImGuiTableFlags_BordersInnerV;
+        float  tbl_h = ImGui::GetContentRegionAvail().y - ROW_H - ImGui::GetStyle().ItemSpacing.y * 2.f;
+        ImVec2 tbl_sz = {0.f, tbl_h};
+
+        if (ImGui::BeginTable("##outliner", 3, tbl_flags, tbl_sz))
+        {
+            ImGui::TableSetupScrollFreeze(0, 1);
+            ImGui::TableSetupColumn("Item Label", ImGuiTableColumnFlags_WidthStretch, 0.60f);
+            ImGui::TableSetupColumn("Type",       ImGuiTableColumnFlags_WidthStretch, 0.25f);
+            ImGui::TableSetupColumn("Level",      ImGuiTableColumnFlags_WidthStretch, 0.15f);
+
+            // Column headers
+            ImGui::TableNextRow(ImGuiTableRowFlags_Headers);
+            ImGui::TableSetColumnIndex(0);
+            {
+                // Eye icon in header
+                ImDrawList* hdl = ImGui::GetWindowDrawList();
+                ImVec2      hp  = ImGui::GetCursorScreenPos();
+                float       hs  = ImGui::GetTextLineHeight();
+                ImU32       hc  = COL_DIMTEXT;
+                float       ex  = hp.x + 7.f, ey = hp.y + hs * 0.5f;
+                // Eye icon: two arcs (top + bottom) with a pupil dot
+                hdl->AddCircle({ex, ey}, 3.5f, hc, 8, 1.2f);
+                hdl->AddCircleFilled({ex, ey}, 1.5f, hc);
+                ImGui::Dummy({14.f, hs});
+                ImGui::SameLine(0.f, 2.f);
+            }
+            ImGui::TableHeader("Item Label");
+            ImGui::TableSetColumnIndex(1); ImGui::TableHeader("Type");
+            ImGui::TableSetColumnIndex(2); ImGui::TableHeader("Level");
+
+            ImDrawList* dl = ImGui::GetWindowDrawList();
+
+            // ── Scene Root row ────────────────────────────────────────────────
+            {
+                ImGui::TableNextRow(ImGuiTableRowFlags_None, ROW_H);
+                ImGui::TableSetColumnIndex(0);
+                ImVec2 row_p = ImGui::GetCursorScreenPos();
+
+                bool root_collapsed = m_scene_root_collapsed;
+                bool root_selected  = false; // scene root can't be selected
+
+                // Hover / bg
+                ImVec2 row_end = {row_p.x + ImGui::GetContentRegionAvail().x + ImGui::GetScrollX() + 800.f, row_p.y + ROW_H};
+                bool   hov     = ImGui::IsMouseHoveringRect(row_p, row_end);
+                if (hov) dl->AddRectFilled(row_p, row_end, COL_HOVER);
+
+                // Arrow
+                float ax = row_p.x + 2.f;
+                ImGui::SetCursorScreenPos({ax, row_p.y});
+                ImGui::PushID(0xFFFF0000);
+                ImGui::InvisibleButton("##root_arrow", {ARROW_W, ROW_H});
+                if (ImGui::IsItemClicked()) m_scene_root_collapsed = !m_scene_root_collapsed;
                 ImGui::PopID();
+                DrawArrow(dl, {ax, row_p.y}, ROW_H, !root_collapsed, COL_ARROW);
+
+                // Icon
+                float ix = ax + ARROW_W + 2.f;
+                DrawTypeIcon(dl, {ix, row_p.y + (ROW_H - ICON_SZ) * 0.5f}, ICON_SZ, "World", false);
+
+                // Label
+                float lx = ix + ICON_SZ + 5.f;
+                ImGui::SetCursorScreenPos({lx, row_p.y + (ROW_H - ImGui::GetTextLineHeight()) * 0.5f});
+                const char* scene_name = (current_scene->Name && current_scene->Name[0]) ? current_scene->Name : "DefaultScene";
+                ImGui::TextUnformatted(scene_name);
 
                 ImGui::TableSetColumnIndex(1);
-                ImGui::TextUnformatted(type);
+                ImGui::SetCursorPosY(ImGui::GetCursorPosY() + (ROW_H - ImGui::GetTextLineHeight()) * 0.5f);
+                ImGui::TextDisabled("World");
+            }
 
-                ImGui::TableSetColumnIndex(2);
-                ImGui::TextUnformatted("Persistent");
-            });
+            // ── Actor rows (DFS) ──────────────────────────────────────────────
+            bool scene_root_collapsed = m_scene_root_collapsed;
+            if (!scene_root_collapsed)
+            {
+                while (sp > 0)
+                {
+                    DFSEntry e    = stk[--sp];
+                    uint32_t ni   = e.idx;
+                    Actor*   actor = ctx->ActorManager->Access(nodes[ni].Handle);
+                    if (!actor) continue;
 
-            if (pending_delete.Valid())
-                ctx->ActorManager->Destroy(pending_delete);
+                    auto*       nc_comp = actor->GetComponent<NameComponent>();
+                    const char* label   = (nc_comp && nc_comp->Value[0]) ? nc_comp->Value : "Actor";
+
+                    if (m_filter_buf[0] && !strstr(label, m_filter_buf)) continue;
+
+                    bool is_collection = !actor->HasComponent<MeshComponent>() &&
+                                         !actor->HasComponent<LightComponent>() &&
+                                         !actor->HasComponent<CameraComponent>();
+                    const char* type_str = is_collection                          ? "Collection"  :
+                                           actor->HasComponent<LightComponent>()  ? "Light"       :
+                                           actor->HasComponent<CameraComponent>() ? "Camera"      :
+                                           actor->HasComponent<MeshComponent>()   ? "Static Mesh" : "Actor";
+
+                    bool has_children = (first_child[ni] != UINT32_MAX);
+                    bool collapsed    = has_children && IsCollapsed(nodes[ni].EID);
+                    bool selected     = (current_scene->SelectedActorHandle.Index      == nodes[ni].Handle.Index &&
+                                         current_scene->SelectedActorHandle.Generation == nodes[ni].Handle.Generation);
+                    if (selected) ++selected_count;
+
+                    bool renaming = (m_renaming_handle.Index      == nodes[ni].Handle.Index &&
+                                     m_renaming_handle.Generation == nodes[ni].Handle.Generation);
+
+                    ImGui::TableNextRow(ImGuiTableRowFlags_None, ROW_H);
+                    ImGui::TableSetColumnIndex(0);
+                    ImVec2 row_p  = ImGui::GetCursorScreenPos();
+                    ImVec2 row_end = {row_p.x + ImGui::GetContentRegionAvail().x + ImGui::GetScrollX() + 800.f, row_p.y + ROW_H};
+
+                    // Row background
+                    bool hov = ImGui::IsMouseHoveringRect(row_p, row_end);
+                    if (selected) dl->AddRectFilled(row_p, row_end, COL_SEL);
+                    else if (hov) dl->AddRectFilled(row_p, row_end, COL_HOVER);
+
+                    // Row click
+                    if (hov && ImGui::IsMouseClicked(0))
+                        current_scene->SelectedActorHandle = nodes[ni].Handle;
+
+                    // Double-click rename
+                    if (hov && ImGui::IsMouseDoubleClicked(0) && !renaming)
+                    {
+                        m_renaming_handle = nodes[ni].Handle;
+                        Helpers::secure_strncpy(m_rename_buf, sizeof(m_rename_buf), label, sizeof(m_rename_buf) - 1);
+                    }
+
+                    // Indent
+                    float indent = (e.depth + 1) * INDENT_W; // +1 because everything is under scene root
+
+                    // Arrow area
+                    float ax = row_p.x + indent;
+                    ImGui::SetCursorScreenPos({ax, row_p.y});
+                    ImGui::PushID((int)nodes[ni].Handle.Index);
+                    ImGui::InvisibleButton("##arrow", {ARROW_W, ROW_H});
+                    if (ImGui::IsItemClicked() && has_children)
+                        ToggleCollapsed(nodes[ni].EID);
+                    ImGui::PopID();
+                    if (has_children)
+                        DrawArrow(dl, {ax, row_p.y}, ROW_H, !collapsed, COL_ARROW);
+
+                    // Icon
+                    float ix = ax + ARROW_W + 2.f;
+                    DrawTypeIcon(dl, {ix, row_p.y + (ROW_H - ICON_SZ) * 0.5f}, ICON_SZ, type_str, is_collection);
+
+                    // Label / rename
+                    float lx = ix + ICON_SZ + 5.f;
+                    ImGui::SetCursorScreenPos({lx, row_p.y + (ROW_H - ImGui::GetFrameHeight()) * 0.5f});
+                    ImGui::PushID((int)nodes[ni].Handle.Index + 1000);
+
+                    if (renaming)
+                    {
+                        ImGui::SetNextItemWidth(120.f);
+                        if (ImGui::InputText("##ren", m_rename_buf, sizeof(m_rename_buf),
+                                             ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AutoSelectAll))
+                        {
+                            if (nc_comp && m_rename_buf[0])
+                                Helpers::secure_strncpy(nc_comp->Value, sizeof(nc_comp->Value), m_rename_buf, sizeof(m_rename_buf) - 1);
+                            m_renaming_handle = {};
+                        }
+                        else if (!ImGui::IsItemActive() && ImGui::IsItemDeactivated())
+                        {
+                            if (nc_comp && m_rename_buf[0])
+                                Helpers::secure_strncpy(nc_comp->Value, sizeof(nc_comp->Value), m_rename_buf, sizeof(m_rename_buf) - 1);
+                            m_renaming_handle = {};
+                        }
+                        else
+                            ImGui::SetKeyboardFocusHere(-1);
+                    }
+                    else
+                    {
+                        ImGui::SetCursorScreenPos({lx, row_p.y + (ROW_H - ImGui::GetTextLineHeight()) * 0.5f});
+                        dl->AddText(ImGui::GetCursorScreenPos(), selected ? 0xFFFFFFFF : COL_TEXT, label);
+                        ImGui::Dummy({ImGui::CalcTextSize(label).x, ImGui::GetTextLineHeight()});
+                    }
+
+                    // Drag source
+                    if (ImGui::BeginDragDropSource(ImGuiDragDropFlags_SourceAllowNullID))
+                    {
+                        ImGui::SetDragDropPayload("ACTOR_REPARENT", &nodes[ni].Handle, sizeof(ActorHandle));
+                        ImGui::Text("Move: %s", label);
+                        ImGui::EndDragDropSource();
+                    }
+
+                    // Drop target
+                    if (ImGui::BeginDragDropTarget())
+                    {
+                        if (const ImGuiPayload* p = ImGui::AcceptDragDropPayload("ACTOR_REPARENT"))
+                        {
+                            ActorHandle dragged = *reinterpret_cast<const ActorHandle*>(p->Data);
+                            if (dragged.Index != nodes[ni].Handle.Index)
+                            {
+                                pending_reparent_child  = dragged;
+                                pending_reparent_parent = nodes[ni].EID;
+                            }
+                        }
+                        ImGui::EndDragDropTarget();
+                    }
+
+                    // Context menu
+                    if (ImGui::BeginPopupContextItem("##ctx"))
+                    {
+                        if (nodes[ni].Parent != INVALID_ENTITY && ImGui::MenuItem("Remove from Parent"))
+                            pending_remove_parent_handle = nodes[ni].Handle;
+                        if (ImGui::MenuItem("Delete"))
+                        {
+                            auto* mc = actor->GetComponent<MeshComponent>();
+                            if (mc && mc->RenderInstanceId != UINT32_MAX)
+                                current_scene->RemoveMeshInstance(mc->RenderInstanceId, ctx->RenderResourceManager);
+                            if (selected) current_scene->SelectedActorHandle = {};
+                            pending_delete = nodes[ni].Handle;
+                        }
+                        ImGui::EndPopup();
+                    }
+                    ImGui::PopID();
+
+                    // Other columns
+                    ImGui::TableSetColumnIndex(1);
+                    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + (ROW_H - ImGui::GetTextLineHeight()) * 0.5f);
+                    ImGui::TextDisabled("%s", type_str);
+
+                    ImGui::TableSetColumnIndex(2);
+                    ImGui::SetCursorPosY(ImGui::GetCursorPosY() + (ROW_H - ImGui::GetTextLineHeight()) * 0.5f);
+                    ImGui::TextDisabled("Default");
+
+                    // Push children
+                    if (has_children && !collapsed)
+                    {
+                        uint32_t tmp[256]; int tc = 0;
+                        uint32_t c = first_child[ni];
+                        while (c != UINT32_MAX && tc < 256) { tmp[tc++] = c; c = next_sib[c]; }
+                        for (int ci = tc - 1; ci >= 0; --ci)
+                            stk[sp++] = {tmp[ci], e.depth + 1};
+                    }
+                }
+            }
+
+            // Root-level drop zone
+            ImGui::TableNextRow();
+            ImGui::TableSetColumnIndex(0);
+            ImGui::InvisibleButton("##root_drop_zone", {ImGui::GetContentRegionAvail().x, 8.f});
+            if (ImGui::BeginDragDropTarget())
+            {
+                if (const ImGuiPayload* p = ImGui::AcceptDragDropPayload("ACTOR_REPARENT"))
+                {
+                    pending_reparent_child  = *reinterpret_cast<const ActorHandle*>(p->Data);
+                    pending_reparent_parent = INVALID_ENTITY;
+                }
+                ImGui::EndDragDropTarget();
+            }
 
             ImGui::EndTable();
         }
 
-        RenderGuizmo(app, current_scene);
+        ZReleaseScratch(scratch);
 
+        // ── Status bar ────────────────────────────────────────────────────────
+        ImGui::Separator();
+        ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 2.f);
+        if (selected_count > 0)
+            ImGui::TextDisabled("%u actor%s (%u selected)", total_actors, total_actors == 1 ? "" : "s", selected_count);
+        else
+            ImGui::TextDisabled("%u actor%s", total_actors, total_actors == 1 ? "" : "s");
+
+        // ── Deferred mutations ────────────────────────────────────────────────
+        if (pending_reparent_child.Valid())
+        {
+            Actor* child = ctx->ActorManager->Access(pending_reparent_child);
+            if (child)
+            {
+                if (pending_reparent_parent == INVALID_ENTITY)
+                    child->RemoveComponent<ParentComponent>();
+                else
+                {
+                    ParentComponent pc_new = {pending_reparent_parent};
+                    if (child->HasComponent<ParentComponent>())
+                        child->GetComponent<ParentComponent>()->Parent = pending_reparent_parent;
+                    else
+                        child->AddComponent<ParentComponent>(pc_new);
+                }
+            }
+        }
+        if (pending_remove_parent_handle.Valid())
+        {
+            Actor* a = ctx->ActorManager->Access(pending_remove_parent_handle);
+            if (a) a->RemoveComponent<ParentComponent>();
+        }
+        if (pending_delete.Valid())
+            ctx->ActorManager->Destroy(pending_delete);
+
+        RenderGuizmo(app, current_scene);
         ImGui::End();
     }
+
+    // ── Gizmo ─────────────────────────────────────────────────────────────────
 
     void HierarchyViewUIComponent::RenderGuizmo(EditorPtr app, EditorScenePtr scene)
     {
@@ -214,15 +582,13 @@ namespace Tetragrama::Components
 
         const auto view       = camera->GetView();
         auto       projection = camera->GetProjection();
-        // ImGuizmo expects OpenGL-style Y-up projection; un-flip the Vulkan Y scale.
         projection[1][1]      = -projection[1][1];
 
-        // Gizmo operates on WorldTransform — already computed by HierarchySystem.
-        Mat4f transform       = tc->WorldTransform;
+        Mat4f transform = tc->WorldTransform;
 
-        int   gizmo_op        = app->Configuration->GizmoOperation;
-        float snap_val        = 0.5f;
-        bool  snapping        = IDevice::As<Keyboard>() && IDevice::As<Keyboard>()->IsKeyPressed(ZENGINE_KEY_LEFT_CONTROL, app->CurrentWindow);
+        int   gizmo_op  = app->Configuration->GizmoOperation;
+        float snap_val  = 0.5f;
+        bool  snapping  = app->CurrentWindow && IDevice::As<Keyboard>() && IDevice::As<Keyboard>()->IsKeyPressed(ZENGINE_KEY_LEFT_CONTROL, app->CurrentWindow);
         if (snapping && static_cast<ImGuizmo::OPERATION>(gizmo_op) == ImGuizmo::ROTATE)
             snap_val = 45.0f;
         float snap_arr[3] = {snap_val, snap_val, snap_val};
@@ -232,7 +598,6 @@ namespace Tetragrama::Components
 
         if (ImGuizmo::IsUsing())
         {
-            // Decompose new world transform back to local space.
             Mat4f local_mat = transform;
             auto* pc        = actor->GetComponent<ParentComponent>();
             if (pc && pc->Parent != INVALID_ENTITY)
@@ -252,5 +617,4 @@ namespace Tetragrama::Components
             }
         }
     }
-
 } // namespace Tetragrama::Components

--- a/Tetragrama/Components/HierarchyViewUIComponent.cpp
+++ b/Tetragrama/Components/HierarchyViewUIComponent.cpp
@@ -56,7 +56,7 @@ namespace Tetragrama::Components
         m_collapsed.push(eid);
     }
 
-    // ── Static helpers ────────────────────────────────────────────────────────
+    // Static helpers
 
     void HierarchyViewUIComponent::DrawArrow(ImDrawList* dl, ImVec2 pos, float row_h, bool expanded, ImU32 color)
     {
@@ -148,7 +148,7 @@ namespace Tetragrama::Components
         }
     }
 
-    // ── Render ────────────────────────────────────────────────────────────────
+    // Render
 
     void HierarchyViewUIComponent::Render(ZEngine::Rendering::Renderers::GraphicRenderer* const /*renderer*/, ZEngine::Hardwares::CommandBuffer* const /*command_buffer*/)
     {
@@ -163,7 +163,7 @@ namespace Tetragrama::Components
 
         ImGui::Begin(Name, CanBeClosed ? &CanBeClosed : nullptr, ImGuiWindowFlags_NoCollapse);
 
-        // ── Search + Buttons ─────────────────────────────────────────────────
+        // Search + Buttons
         {
             const float btn_sz  = 22.f;
             const float spacing = ImGui::GetStyle().ItemSpacing.x;
@@ -174,9 +174,30 @@ namespace Tetragrama::Components
             ImGui::InputText("##filter", m_filter_buf, sizeof(m_filter_buf));
             ImGui::SameLine();
 
-            // "+" — New Collection
-            bool clicked_add = ImGui::Button("+", {btn_sz, btn_sz});
-            if (ImGui::IsItemHovered()) ImGui::SetTooltip("New Collection");
+            // Folder+ — New Collection
+            ImVec2 btn_pos    = ImGui::GetCursorScreenPos();
+            bool   clicked_add = ImGui::InvisibleButton("##new_collection", {btn_sz, btn_sz});
+            bool   col_hov    = ImGui::IsItemHovered();
+            if (col_hov) ImGui::SetTooltip("New Collection");
+            {
+                ImDrawList* fdl = ImGui::GetWindowDrawList();
+                ImU32 col = ImGui::ColorConvertFloat4ToU32(col_hov ? ImVec4(0.85f, 0.85f, 0.90f, 1.f) : ImVec4(0.55f, 0.58f, 0.65f, 1.f));
+                float x = btn_pos.x, y = btn_pos.y, s = btn_sz;
+                float m   = s * 0.12f;
+                float bx0 = x + m,     by0 = y + s * 0.32f;
+                float bx1 = x + s - m, by1 = y + s - m;
+                fdl->AddRectFilled({bx0, by0}, {bx1, by1}, col, 2.f);
+                float tx0 = bx0, ty0 = by0 - s * 0.14f;
+                float tx1 = bx0 + (bx1 - bx0) * 0.45f, ty1 = by0 + 1.f;
+                fdl->AddRectFilled({tx0, ty0}, {tx1, ty1}, col, 2.f, ImDrawFlags_RoundCornersTopLeft | ImDrawFlags_RoundCornersTopRight);
+                float cx = (bx0 + bx1) * 0.5f, cy = (by0 + by1) * 0.5f;
+                float hl  = s * 0.18f, thk = 1.5f;
+                ImU32 bg  = ImGui::ColorConvertFloat4ToU32(ImVec4(0.14f, 0.15f, 0.18f, 1.f));
+                fdl->AddLine({cx - hl, cy}, {cx + hl, cy}, bg, thk + 1.5f);
+                fdl->AddLine({cx, cy - hl}, {cx, cy + hl}, bg, thk + 1.5f);
+                fdl->AddLine({cx - hl, cy}, {cx + hl, cy}, col, thk);
+                fdl->AddLine({cx, cy - hl}, {cx, cy + hl}, col, thk);
+            }
             ImGui::SameLine();
 
             // Settings gear placeholder
@@ -207,7 +228,7 @@ namespace Tetragrama::Components
         }
         ImGui::Spacing();
 
-        // ── O(n) Build ───────────────────────────────────────────────────────
+        // O(n) Build
         auto     scratch    = ZGetScratch(&ParentLayer->LocalArena);
         uint32_t n          = ctx->ActorManager->Count();
 
@@ -246,7 +267,7 @@ namespace Tetragrama::Components
             if (nodes[i].Parent == INVALID_ENTITY)
                 stk[sp++] = {(uint32_t)i, 0};
 
-        // ── Table ─────────────────────────────────────────────────────────────
+        // Table
         ActorHandle pending_delete               = {};
         ActorHandle pending_reparent_child       = {};
         EntityID    pending_reparent_parent      = INVALID_ENTITY;
@@ -297,7 +318,7 @@ namespace Tetragrama::Components
 
             ImDrawList* dl = ImGui::GetWindowDrawList();
 
-            // ── Scene Root row ────────────────────────────────────────────────
+            // Scene Root row
             {
                 ImGui::TableNextRow(ImGuiTableRowFlags_None, ROW_H);
                 ImGui::TableSetColumnIndex(0);
@@ -335,7 +356,7 @@ namespace Tetragrama::Components
                 ImGui::TextDisabled("World");
             }
 
-            // ── Actor rows (DFS) ──────────────────────────────────────────────
+            // Actor rows (DFS)
             bool scene_root_collapsed = m_scene_root_collapsed;
             if (!scene_root_collapsed)
             {
@@ -518,7 +539,7 @@ namespace Tetragrama::Components
 
         ZReleaseScratch(scratch);
 
-        // ── Status bar ────────────────────────────────────────────────────────
+        // Status bar
         ImGui::Separator();
         ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 2.f);
         if (selected_count > 0)
@@ -526,7 +547,7 @@ namespace Tetragrama::Components
         else
             ImGui::TextDisabled("%u actor%s", total_actors, total_actors == 1 ? "" : "s");
 
-        // ── Deferred mutations ────────────────────────────────────────────────
+        // Deferred mutations
         if (pending_reparent_child.Valid())
         {
             Actor* child = ctx->ActorManager->Access(pending_reparent_child);
@@ -556,7 +577,7 @@ namespace Tetragrama::Components
         ImGui::End();
     }
 
-    // ── Gizmo ─────────────────────────────────────────────────────────────────
+    // Gizmo
 
     void HierarchyViewUIComponent::RenderGuizmo(EditorPtr app, EditorScenePtr scene)
     {

--- a/Tetragrama/Components/HierarchyViewUIComponent.cpp
+++ b/Tetragrama/Components/HierarchyViewUIComponent.cpp
@@ -8,6 +8,7 @@
 #include <ZEngine/ECS/Components/LightComponent.h>
 #include <ZEngine/ECS/Components/MeshComponent.h>
 #include <ZEngine/ECS/Components/NameComponent.h>
+#include <ZEngine/ECS/Components/ParentComponent.h>
 #include <ZEngine/ECS/Components/TransformComponent.h>
 #include <ZEngine/Engine.h>
 #include <ZEngine/Windows/Inputs/KeyCodeDefinition.h>
@@ -216,7 +217,8 @@ namespace Tetragrama::Components
         // ImGuizmo expects OpenGL-style Y-up projection; un-flip the Vulkan Y scale.
         projection[1][1]      = -projection[1][1];
 
-        Mat4f transform       = ComposeTransformMatrix(tc->Position, tc->Rotation, tc->Scale);
+        // Gizmo operates on WorldTransform — already computed by HierarchySystem.
+        Mat4f transform       = tc->WorldTransform;
 
         int   gizmo_op        = app->Configuration->GizmoOperation;
         float snap_val        = 0.5f;
@@ -230,17 +232,23 @@ namespace Tetragrama::Components
 
         if (ImGuizmo::IsUsing())
         {
+            // Decompose new world transform back to local space.
+            Mat4f local_mat = transform;
+            auto* pc        = actor->GetComponent<ParentComponent>();
+            if (pc && pc->Parent != INVALID_ENTITY)
+            {
+                auto* parent_tc = ctx->Scene->GetComponent<TransformComponent>(pc->Parent);
+                if (parent_tc)
+                    local_mat = parent_tc->WorldTransform.Inverse() * transform;
+            }
+
             Vec3f new_pos, new_rot, new_scale;
-            if (DecomposeTransformComponent(transform, new_pos, new_rot, new_scale))
+            if (DecomposeTransformComponent(local_mat, new_pos, new_rot, new_scale))
             {
                 tc->Position         = new_pos;
                 tc->Rotation         = new_rot;
                 tc->Scale            = new_scale;
                 tc->PreviousPosition = new_pos;
-
-                auto* mc             = actor->GetComponent<MeshComponent>();
-                if (mc && mc->RenderInstanceId != UINT32_MAX)
-                    scene->SetInstanceTransform(mc->RenderInstanceId, transform);
             }
         }
     }

--- a/Tetragrama/Components/HierarchyViewUIComponent.h
+++ b/Tetragrama/Components/HierarchyViewUIComponent.h
@@ -20,23 +20,23 @@ namespace Tetragrama::Components
         virtual void Render(ZEngine::Rendering::Renderers::GraphicRenderer* const renderer, ZEngine::Hardwares::CommandBuffer* const command_buffer) override;
 
     private:
-        void RenderGuizmo(EditorPtr app, EditorScenePtr scene);
+        void                                                     RenderGuizmo(EditorPtr app, EditorScenePtr scene);
 
-        static void DrawArrow(ImDrawList* dl, ImVec2 pos, float row_h, bool expanded, ImU32 color);
-        static void DrawTypeIcon(ImDrawList* dl, ImVec2 pos, float sz, const char* type, bool is_collection);
+        static void                                              DrawArrow(ImDrawList* dl, ImVec2 pos, float row_h, bool expanded, ImU32 color);
+        static void                                              DrawTypeIcon(ImDrawList* dl, ImVec2 pos, float sz, const char* type, bool is_collection);
 
-        int  m_gizmo_operation{-1};
-        char m_filter_buf[128] = {};
+        int                                                      m_gizmo_operation{-1};
+        char                                                     m_filter_buf[128]      = {};
 
-        ZEngine::ECS::ActorHandle m_renaming_handle = {};
-        char                      m_rename_buf[128]  = {};
+        ZEngine::ECS::ActorHandle                                m_renaming_handle      = {};
+        char                                                     m_rename_buf[128]      = {};
 
         // Collapsed entity IDs — everything NOT in this list is expanded by default.
-        ZEngine::Core::Memory::ArenaAllocator                    m_outliner_arena      = {};
-        ZEngine::Core::Containers::Array<ZEngine::ECS::EntityID> m_collapsed           = {};
-        bool                                                      m_scene_root_collapsed = false;
+        ZEngine::Core::Memory::ArenaAllocator                    m_outliner_arena       = {};
+        ZEngine::Core::Containers::Array<ZEngine::ECS::EntityID> m_collapsed            = {};
+        bool                                                     m_scene_root_collapsed = false;
 
-        bool IsCollapsed(ZEngine::ECS::EntityID eid) const;
-        void ToggleCollapsed(ZEngine::ECS::EntityID eid);
+        bool                                                     IsCollapsed(ZEngine::ECS::EntityID eid) const;
+        void                                                     ToggleCollapsed(ZEngine::ECS::EntityID eid);
     };
 } // namespace Tetragrama::Components

--- a/Tetragrama/Components/HierarchyViewUIComponent.h
+++ b/Tetragrama/Components/HierarchyViewUIComponent.h
@@ -1,6 +1,10 @@
 #pragma once
 #include <Tetragrama/Components/UIComponent.h>
 #include <Tetragrama/Editor.h>
+#include <ZEngine/Core/Containers/Array.h>
+#include <ZEngine/Core/Memory/Allocator.h>
+#include <ZEngine/ECS/ActorManager.h>
+#include <ZEngine/ECS/EntityID.h>
 #include <imgui.h>
 
 namespace Tetragrama::Components
@@ -18,7 +22,21 @@ namespace Tetragrama::Components
     private:
         void RenderGuizmo(EditorPtr app, EditorScenePtr scene);
 
+        static void DrawArrow(ImDrawList* dl, ImVec2 pos, float row_h, bool expanded, ImU32 color);
+        static void DrawTypeIcon(ImDrawList* dl, ImVec2 pos, float sz, const char* type, bool is_collection);
+
         int  m_gizmo_operation{-1};
         char m_filter_buf[128] = {};
+
+        ZEngine::ECS::ActorHandle m_renaming_handle = {};
+        char                      m_rename_buf[128]  = {};
+
+        // Collapsed entity IDs — everything NOT in this list is expanded by default.
+        ZEngine::Core::Memory::ArenaAllocator                    m_outliner_arena      = {};
+        ZEngine::Core::Containers::Array<ZEngine::ECS::EntityID> m_collapsed           = {};
+        bool                                                      m_scene_root_collapsed = false;
+
+        bool IsCollapsed(ZEngine::ECS::EntityID eid) const;
+        void ToggleCollapsed(ZEngine::ECS::EntityID eid);
     };
 } // namespace Tetragrama::Components

--- a/ZEngine/ZEngine/ECS/Components/ParentComponent.h
+++ b/ZEngine/ZEngine/ECS/Components/ParentComponent.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <ZEngine/ECS/EntityID.h>
+#include <ZEngine/ZEngineDef.h>
+
+namespace ZEngine::ECS::Components
+{
+    // Links an entity to its parent in the scene hierarchy.
+    // Entities without this component are roots — their WorldTransform equals their local transform.
+    // HierarchySystem propagates parent WorldTransform × local matrix each frame.
+    struct ParentComponent
+    {
+        EntityID Parent = INVALID_ENTITY;
+    };
+
+    static_assert(sizeof(ParentComponent) <= 8, "ParentComponent exceeds expected size");
+} // namespace ZEngine::ECS::Components

--- a/ZEngine/ZEngine/ECS/Components/TransformComponent.h
+++ b/ZEngine/ZEngine/ECS/Components/TransformComponent.h
@@ -1,21 +1,21 @@
 #pragma once
+#include <ZEngine/Core/Maths/Matrix.h>
 #include <ZEngine/Core/Maths/Vec.h>
 #include <ZEngine/ZEngineDef.h>
 
 namespace ZEngine::ECS::Components
 {
-    // Plain-data transform. No methods, no computed matrix.
-    // Separate from Rendering::Components::TransformComponent which has methods and a Mat4f.
+    // Position, Rotation, Scale are LOCAL-space values edited by the user/gizmo.
+    // WorldTransform is computed each frame by HierarchySystem and consumed by
+    // TransformSyncSystem and LightSyncSystem — never set directly.
     struct TransformComponent
     {
         Core::Maths::Vec3f Position         = {0.f, 0.f, 0.f};
         Core::Maths::Vec3f Rotation         = {0.f, 0.f, 0.f}; // radians (pitch, yaw, roll)
         Core::Maths::Vec3f Scale            = {1.f, 1.f, 1.f};
-
-        // Previous-frame position for fixed-timestep interpolation (game-loop.md)
         Core::Maths::Vec3f PreviousPosition = {0.f, 0.f, 0.f};
+        Core::Maths::Mat4f WorldTransform   = Core::Maths::Identity<Core::Maths::Mat4f>();
     };
 
-    static_assert(sizeof(TransformComponent) <= 64, "TransformComponent exceeds cache line");
     static_assert(alignof(TransformComponent) <= 16, "TransformComponent misaligned");
 } // namespace ZEngine::ECS::Components

--- a/ZEngine/ZEngine/ECS/Systems/HierarchySystem.cpp
+++ b/ZEngine/ZEngine/ECS/Systems/HierarchySystem.cpp
@@ -1,0 +1,42 @@
+#include <ZEngine/Core/Maths/Matrix.h>
+#include <ZEngine/ECS/Components/ParentComponent.h>
+#include <ZEngine/ECS/Components/TransformComponent.h>
+#include <ZEngine/ECS/Systems/HierarchySystem.h>
+
+using namespace ZEngine::Core::Maths;
+using namespace ZEngine::ECS::Components;
+
+namespace ZEngine::ECS::Systems
+{
+    void SyncHierarchy(ECS::Scene& scene)
+    {
+        // Pass 1 — roots: WorldTransform = local matrix
+        scene.ForEach<TransformComponent>([&](EntityID id, TransformComponent& tc) {
+            if (scene.HasComponent<ParentComponent>(id))
+                return;
+            tc.WorldTransform = ComposeTransformMatrix(tc.Position, tc.Rotation, tc.Scale);
+        });
+
+        // Pass 2+ — children: WorldTransform = parent.World × local
+        // Repeat until no change to handle arbitrary nesting depth.
+        bool changed = true;
+        while (changed)
+        {
+            changed = false;
+            scene.ForEach<TransformComponent, ParentComponent>([&](EntityID, TransformComponent& tc, ParentComponent& pc) {
+                if (pc.Parent == INVALID_ENTITY)
+                    return;
+                TransformComponent* parent_tc = scene.GetComponent<TransformComponent>(pc.Parent);
+                if (!parent_tc)
+                    return;
+                Mat4f local = ComposeTransformMatrix(tc.Position, tc.Rotation, tc.Scale);
+                Mat4f world = parent_tc->WorldTransform * local;
+                if (world(0, 0) != tc.WorldTransform(0, 0) || world(0, 3) != tc.WorldTransform(0, 3) || world(1, 3) != tc.WorldTransform(1, 3) || world(2, 3) != tc.WorldTransform(2, 3))
+                {
+                    tc.WorldTransform = world;
+                    changed           = true;
+                }
+            });
+        }
+    }
+} // namespace ZEngine::ECS::Systems

--- a/ZEngine/ZEngine/ECS/Systems/HierarchySystem.h
+++ b/ZEngine/ZEngine/ECS/Systems/HierarchySystem.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <ZEngine/ECS/Scene.h>
+
+namespace ZEngine::ECS::Systems
+{
+    // Propagates local→world transforms top-down each frame.
+    //
+    // Two passes per frame:
+    //   Pass 1 — roots (no ParentComponent): WorldTransform = ComposeTransformMatrix(local)
+    //   Pass 2 — children: WorldTransform = parent.WorldTransform × ComposeTransformMatrix(local)
+    //            Repeated until stable to handle arbitrary hierarchy depth.
+    //
+    // Must run before SyncECSToRenderScene and SyncECSToLights.
+    void SyncHierarchy(Scene& scene);
+} // namespace ZEngine::ECS::Systems

--- a/ZEngine/ZEngine/ECS/Systems/LightSyncSystem.cpp
+++ b/ZEngine/ZEngine/ECS/Systems/LightSyncSystem.cpp
@@ -16,14 +16,11 @@ namespace ZEngine::ECS::Systems
         scene.ForEach<TransformComponent, LightComponent>([&](EntityID, TransformComponent& tc, LightComponent& lc) {
             if (lc.LightType == LightComponent::Type::Directional && lights.DirectionalCount < 4)
             {
-                // Build rotation-only matrix and extract forward direction (column 2).
-                // ComposeTransformMatrix uses YXZ Euler order; column 2 = (-sy, sx*cy, cx*cy).
-                Mat4f rot       = ComposeTransformMatrix(Vec3f(0.f, 0.f, 0.f), tc.Rotation, Vec3f(1.f, 1.f, 1.f));
-
+                // Forward direction = column 2 of WorldTransform (already includes parent rotation).
                 auto& dir       = lights.DirectionalLights[lights.DirectionalCount++];
-                dir.Direction.x = rot(0, 2);
-                dir.Direction.y = rot(1, 2);
-                dir.Direction.z = rot(2, 2);
+                dir.Direction.x = tc.WorldTransform(0, 2);
+                dir.Direction.y = tc.WorldTransform(1, 2);
+                dir.Direction.z = tc.WorldTransform(2, 2);
                 dir.Direction.w = 0.f;
                 dir.Color.x     = lc.Color[0];
                 dir.Color.y     = lc.Color[1];
@@ -33,10 +30,11 @@ namespace ZEngine::ECS::Systems
             }
             else if (lc.LightType == LightComponent::Type::Point && lights.PointCount < 8)
             {
+                // World position = translation column of WorldTransform.
                 auto& pt      = lights.PointLights[lights.PointCount++];
-                pt.Position.x = tc.Position.x;
-                pt.Position.y = tc.Position.y;
-                pt.Position.z = tc.Position.z;
+                pt.Position.x = tc.WorldTransform(0, 3);
+                pt.Position.y = tc.WorldTransform(1, 3);
+                pt.Position.z = tc.WorldTransform(2, 3);
                 pt.Position.w = 1.f;
                 pt.Color.x    = lc.Color[0];
                 pt.Color.y    = lc.Color[1];

--- a/ZEngine/ZEngine/ECS/Systems/TransformSyncSystem.cpp
+++ b/ZEngine/ZEngine/ECS/Systems/TransformSyncSystem.cpp
@@ -10,14 +10,10 @@ namespace ZEngine::ECS::Systems
         using namespace Components;
         using namespace Core::Maths;
 
-        // Use Position directly — interpolation between PreviousPosition and Position
-        // is deferred until fixed-timestep physics/simulation systems are active.
-        // Applying alpha here conflicts with immediate gizmo-driven position updates.
         scene.ForEach<TransformComponent, MeshComponent>([&](EntityID, TransformComponent& tc, MeshComponent& mc) {
             if (mc.RenderInstanceId == UINT32_MAX)
                 return;
-            Mat4f mat = ComposeTransformMatrix(tc.Position, tc.Rotation, tc.Scale);
-            render_scene.SetInstanceTransform(mc.RenderInstanceId, mat);
+            render_scene.SetInstanceTransform(mc.RenderInstanceId, tc.WorldTransform);
         });
     }
 } // namespace ZEngine::ECS::Systems

--- a/ZEngine/ZEngine/Engine.cpp
+++ b/ZEngine/ZEngine/Engine.cpp
@@ -6,6 +6,7 @@
 #include <ZEngine/Core/VFS/VFSPath.h>
 #include <ZEngine/ECS/Reflection/BuiltInComponentReflection.h>
 #include <ZEngine/ECS/Reflection/ComponentReflectionRegistry.h>
+#include <ZEngine/ECS/Systems/HierarchySystem.h>
 #include <ZEngine/ECS/Systems/LightSyncSystem.h>
 #include <ZEngine/ECS/Systems/TransformSyncSystem.h>
 #include <ZEngine/Engine.h>
@@ -291,6 +292,7 @@ namespace ZEngine
 
             if (g_engine_ctx->Scene && g_app->CurrentScene)
             {
+                ECS::Systems::SyncHierarchy(*g_engine_ctx->Scene);
                 ECS::Systems::SyncECSToRenderScene(*g_engine_ctx->Scene, alpha, *g_app->CurrentScene);
                 ECS::Systems::SyncECSToLights(*g_engine_ctx->Scene, *g_app->CurrentScene);
             }


### PR DESCRIPTION
## Summary

- **Scene graph**: `TransformComponent.Position/Rotation/Scale` are now local-space values. A new `WorldTransform` (Mat4f) field is computed each frame by `HierarchySystem` and consumed by `TransformSyncSystem` and `LightSyncSystem`. A new `ParentComponent` records the parent `EntityID`.
- **HierarchySystem**: two-pass propagation — roots get `WorldTransform = local`, children get `parent.WorldTransform × local`; iterates until stable to handle arbitrary nesting depth.
- **UE5-style outliner**: full rewrite of `HierarchyViewUIComponent` — O(n) DFS using first_child/next_sib linked-list arrays on a scratch arena, custom `ImDrawList` rendering (no `TreeNodeEx`), per-type icons (World, Collection, Light, Camera, StaticMesh), Item Label / Type / Level columns, filter bar, status bar, folder+ button.
- **Collapse/expand fix**: scene root was using `INVALID_ENTITY` as its collapse key and as the removal sentinel — replaced with a dedicated `bool m_scene_root_collapsed`.
- **Gizmo**: reads `WorldTransform` for position; decomposes back to local space via parent-inverse multiply when actor has a parent.

## Files changed

| File | Change |
|---|---|
| `ZEngine/ZEngine/ECS/Components/TransformComponent.h` | Add `Mat4f WorldTransform`; Position/Rotation/Scale are now local |
| `ZEngine/ZEngine/ECS/Components/ParentComponent.h` | New — `EntityID Parent` |
| `ZEngine/ZEngine/ECS/Systems/HierarchySystem.h/.cpp` | New — `SyncHierarchy(Scene&)` |
| `ZEngine/ZEngine/Engine.cpp` | Call `SyncHierarchy` before other sync systems |
| `ZEngine/ZEngine/ECS/Systems/TransformSyncSystem.cpp` | Use `tc.WorldTransform` |
| `ZEngine/ZEngine/ECS/Systems/LightSyncSystem.cpp` | Extract direction/position from `WorldTransform` |
| `Tetragrama/Components/HierarchyViewUIComponent.h/.cpp` | Full outliner rewrite + collapse fix + gizmo local-space |

## Test plan

- [x] Existing root actors move correctly with the gizmo (local == world for roots)
- [x] Outliner shows all actors with correct per-type icons
- [x] Collapse/expand on any row (including World root) toggles correctly and is re-expandable
- [x] Filter bar narrows the actor list
- [x] New Collection button is visible with folder+ icon
- [x] Build clean — no warnings