### PR TITLE
chore(deps): upgrade Dear ImGui 1.89.9 -> 1.92.9b-docking

### DIFF
--- a/Tetragrama/Helpers/UIComponentDrawerHelper.cpp
+++ b/Tetragrama/Helpers/UIComponentDrawerHelper.cpp
@@ -20,7 +20,7 @@ namespace Tetragrama::Helpers
         ImGui::PushMultiItemsWidths(4, ImGui::CalcItemWidth());
         ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2{0.5f, 0});
 
-        float  line_height = GImGui->Font->FontSize + GImGui->Style.FramePadding.y * 2.0f;
+        float  line_height = GImGui->Font->LegacySize + GImGui->Style.FramePadding.y * 2.0f;
         ImVec2 button_size = {line_height + 3.0f, line_height};
 
         ImGui::PushStyleColor(ImGuiCol_Button, ImVec4{0.8f, 0.1f, 0.15f, 1.0f});
@@ -147,7 +147,7 @@ namespace Tetragrama::Helpers
         ImGui::PushMultiItemsWidths(5, ImGui::CalcItemWidth());
         ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2{1.0f, 0});
 
-        float  line_height = GImGui->Font->FontSize + GImGui->Style.FramePadding.y * 2.0f;
+        float  line_height = GImGui->Font->LegacySize + GImGui->Style.FramePadding.y * 2.0f;
         ImVec2 button_size = {line_height + 3.0f, line_height};
 
         ImGui::PushStyleColor(ImGuiCol_Button, ImVec4{0.8f, 0.1f, 0.15f, 1.0f});
@@ -250,7 +250,7 @@ namespace Tetragrama::Helpers
         ImGui::PushMultiItemsWidths(2, ImGui::CalcItemWidth());
         ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2{0.5f, 0});
 
-        float  line_height = GImGui->Font->FontSize + GImGui->Style.FramePadding.y * 2.0f;
+        float  line_height = GImGui->Font->LegacySize + GImGui->Style.FramePadding.y * 2.0f;
         ImVec2 button_size = {line_height + 3.0f, line_height};
 
         ImGui::PushStyleColor(ImGuiCol_Button, ImVec4{0.8f, 0.1f, 0.15f, 1.0f});
@@ -380,7 +380,7 @@ namespace Tetragrama::Helpers
 
         ImGui::TableNextColumn();
         auto   table_colum_width = ImGui::GetColumnWidth();
-        float  line_height       = GImGui->Font->FontSize + GImGui->Style.FramePadding.y * 2.0f;
+        float  line_height       = GImGui->Font->LegacySize + GImGui->Style.FramePadding.y * 2.0f;
         ImVec2 button_size       = {table_colum_width, line_height};
 
         if (ImGui::Button(label.data(), button_size))
@@ -462,10 +462,10 @@ namespace Tetragrama::Helpers
         ImGui::PushMultiItemsWidths(1, ImGui::CalcItemWidth() + 60.f);
         ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2{0.5f, 0});
 
-        float  line_height = GImGui->Font->FontSize + GImGui->Style.FramePadding.y * 2.0f;
+        float  line_height = GImGui->Font->LegacySize + GImGui->Style.FramePadding.y * 2.0f;
         ImVec2 button_size = {line_height + 3.0f, line_height};
 
-        if (ImGui::ImageButton(texture_id, button_size, ImVec2(0, 0), ImVec2(1, 1), 1, ImVec4(0, 0, 0, 0), ImVec4{tint_color.x, tint_color.y, tint_color.z, tint_color.w}))
+        if (ImGui::ImageButton("##imgbtn", texture_id, button_size, ImVec2(0, 0), ImVec2(1, 1), ImVec4(0, 0, 0, 0), ImVec4{tint_color.x, tint_color.y, tint_color.z, tint_color.w}))
         {
             if (image_click_callback)
             {
@@ -477,7 +477,7 @@ namespace Tetragrama::Helpers
             if (ImGui::IsItemHovered())
             {
                 ImGui::BeginTooltip();
-                ImGui::Image(texture_id, ImVec2(200, 200), {0, 0}, {1, 1}, ImVec4{tint_color.x, tint_color.y, tint_color.z, tint_color.w});
+                ImGui::Image(texture_id, ImVec2(200, 200));
                 ImGui::EndTooltip();
             }
         }

--- a/ZEngine/ZEngine/Rendering/Renderers/ImGUIRenderer.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/ImGUIRenderer.cpp
@@ -125,15 +125,15 @@ namespace ZEngine::Rendering::Renderers
             .SetLocation(0, 0)
             .SetBinding(0, 0)
             .SetFormat(0, Specifications::ImageFormat::R32G32_SFLOAT)
-            .SetOffset(0, IM_OFFSETOF(ImDrawVert, pos))
+            .SetOffset(0, offsetof(ImDrawVert, pos))
             .SetLocation(1, 1)
             .SetBinding(1, 0)
             .SetFormat(1, Specifications::ImageFormat::R32G32_SFLOAT)
-            .SetOffset(1, IM_OFFSETOF(ImDrawVert, uv))
+            .SetOffset(1, offsetof(ImDrawVert, uv))
             .SetLocation(2, 2)
             .SetBinding(2, 0)
             .SetFormat(2, Specifications::ImageFormat::R8G8B8A8_UNORM)
-            .SetOffset(2, IM_OFFSETOF(ImDrawVert, col))
+            .SetOffset(2, offsetof(ImDrawVert, col))
 
             .UseShader("imgui")
             // .SetShaderOverloadMaxSet(2000) // Todo : deprecated API - should be removed
@@ -287,7 +287,7 @@ namespace ZEngine::Rendering::Renderers
                         scissor.extent.width                           = (uint32_t) (clip_rect.z - clip_rect.x);
                         scissor.extent.height                          = (uint32_t) (clip_rect.w - clip_rect.y);
 
-                        r_payload.TextureIds[r_payload.DrawDataIndex]  = (uint32_t) (intptr_t) pcmd->TextureId;
+                        r_payload.TextureIds[r_payload.DrawDataIndex]  = (uint32_t) (intptr_t) pcmd->GetTexID();
                         r_payload.ScissorCmds[r_payload.DrawDataIndex] = ScissorCmd{scissor.extent.width, scissor.extent.height, scissor.offset.x, scissor.offset.y};
                         r_payload.IndexedCmds[r_payload.DrawDataIndex] = IndexedCmd{pcmd->ElemCount, 1, pcmd->IdxOffset + global_idx_offset, (int32_t) (pcmd->VtxOffset + global_vtx_offset), 0};
 

--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -11,7 +11,7 @@ FetchContent_Declare(
   imgui
   GIT_REPOSITORY https://github.com/ocornut/imgui.git
   GIT_SHALLOW TRUE
-  GIT_TAG v1.89.9-docking
+  GIT_TAG v1.92.9b-docking
   SOURCE_DIR "${FETCHCONTENT_BASE_DIR}/imgui"
   )
 
@@ -21,6 +21,7 @@ FetchContent_Declare(
   GIT_SHALLOW TRUE
   GIT_TAG 1.83
   SOURCE_DIR "${FETCHCONTENT_BASE_DIR}/ImGuizmo"
+  PATCH_COMMAND python3 "${CMAKE_SOURCE_DIR}/patches/imguizmo_imgui192_compat.py" "${FETCHCONTENT_BASE_DIR}/ImGuizmo/ImGuizmo.cpp"
   )
 
 FetchContent_Declare(

--- a/patches/imguizmo_imgui192_compat.py
+++ b/patches/imguizmo_imgui192_compat.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Patches ImGuizmo 1.83 for compatibility with Dear ImGui >= 1.92.
+# Usage: python3 imguizmo_imgui192_compat.py <path/to/ImGuizmo.cpp>
+#
+# Changes:
+#   - ImGui::CaptureMouseFromApp() removed in 1.90 -> SetNextFrameWantCaptureMouse(true)
+#   - ImDrawList::AddPolyline() signature changed in 1.92.8: thickness and flags swapped,
+#     and the old bool 'closed' parameter became ImDrawFlags_Closed.
+
+import sys
+import os
+
+if len(sys.argv) < 2:
+    print("Usage: imguizmo_imgui192_compat.py <path/to/ImGuizmo.cpp>")
+    sys.exit(1)
+
+path = sys.argv[1]
+if not os.path.exists(path):
+    print(f"File not found: {path}")
+    sys.exit(1)
+
+with open(path, 'r') as f:
+    text = f.read()
+
+original = text
+
+# Fix 1: CaptureMouseFromApp removed in 1.90
+text = text.replace(
+    'ImGui::CaptureMouseFromApp()',
+    'ImGui::SetNextFrameWantCaptureMouse(true)'
+)
+
+# Fix 2: AddPolyline signature — (points, count, col, closed_bool, thickness)
+#                             -> (points, count, col, thickness, flags)
+text = text.replace(
+    'drawList->AddPolyline(circlePos, circleMul * halfCircleSegmentCount + 1, colors[3 - axis], false, 2);',
+    'drawList->AddPolyline(circlePos, circleMul * halfCircleSegmentCount + 1, colors[3 - axis], 2.f, 0);'
+)
+text = text.replace(
+    'drawList->AddPolyline(circlePos, halfCircleSegmentCount, IM_COL32(0xFF, 0x80, 0x10, 0xFF), true, 2);',
+    'drawList->AddPolyline(circlePos, halfCircleSegmentCount, IM_COL32(0xFF, 0x80, 0x10, 0xFF), 2.f, ImDrawFlags_Closed);'
+)
+text = text.replace(
+    'drawList->AddPolyline(screenQuadPts, 4, directionColor[i], true, 1.0f);',
+    'drawList->AddPolyline(screenQuadPts, 4, directionColor[i], 1.0f, ImDrawFlags_Closed);'
+)
+
+if text == original:
+    print("ImGuizmo: already patched, nothing to do.")
+else:
+    with open(path, 'w') as f:
+        f.write(text)
+    print("ImGuizmo: patched for ImGui 1.92 compatibility.")


### PR DESCRIPTION
## Summary

Upgrades Dear ImGui from `v1.89.9-docking` to `v1.92.9b-docking`.

## Breaking changes fixed

**ImGuizmo 1.83 (vendor patch — `patches/imguizmo_imgui192_compat.py`):**
- `ImGui::CaptureMouseFromApp()` removed in 1.90 → `SetNextFrameWantCaptureMouse(true)` (6 sites)
- `ImDrawList::AddPolyline()` signature changed in 1.92.8: `thickness`/`flags` swapped, `bool closed` → `ImDrawFlags_Closed` (3 sites)
- Patch is applied automatically via `PATCH_COMMAND` in `FetchContent_Declare`

**`ImGUIRenderer.cpp`:**
- `IM_OFFSETOF` macro obsoleted in 1.90 → standard `offsetof`
- `ImDrawCmd::TextureId` field removed in 1.92 → `ImDrawCmd::GetTexID()`

**`UIComponentDrawerHelper.cpp`:**
- `ImFont::FontSize` renamed to `ImFont::LegacySize` in 1.92 (5 sites)
- `ImageButton` gained mandatory `const char* str_id` first parameter in 1.89.4 (was still using old form)
- `Image()` tint/border params removed in 1.92 (use `ImageWithBg()` for tinted images)

## Test plan

- [x] Build clean — no errors or warnings
- [x] Editor launches, all panels render correctly
- [x] Gizmo (ImGuizmo) works in viewport — rotate, translate, scale
- [x] Texture previews in Inspector still display