### PR TITLE
fix(ecs): guard against capacity overflow in ComponentReflectionRegistry::Register

### DIFF
--- a/ZEngine/ZEngine/ECS/Reflection/ComponentReflectionRegistry.cpp
+++ b/ZEngine/ZEngine/ECS/Reflection/ComponentReflectionRegistry.cpp
@@ -32,6 +32,8 @@ namespace ZEngine::ECS
             return;
         }
 
+        ZENGINE_VALIDATE_ASSERT(m_meta.size() < m_meta.capacity(), "ComponentReflectionRegistry::Register: exceeded reserved capacity")
+
         m_meta.push(meta);
     }
 


### PR DESCRIPTION
## Summary

- Adds a `ZENGINE_VALIDATE_ASSERT` before `m_meta.push(meta)` in `ComponentReflectionRegistry::Register` to catch capacity overflows at the call site.
- Without this guard, pushing beyond the reserved capacity would silently overflow or trigger an assertion deeper inside the push implementation, making the root cause harder to diagnose.

## Changes

- [ComponentReflectionRegistry.cpp](ZEngine/ZEngine/ECS/Reflection/ComponentReflectionRegistry.cpp): capacity check assert added before `m_meta.push(meta)`

## Test plan

- [ ] Register components up to and beyond the reserved capacity and confirm the assert fires with a clear message.
- [x] Confirm no regression in normal component registration paths.