### PR TITLE
feat(memory): TLSFSlab wrapper — closes #687

### DIFF
--- a/ZEngine/ZEngine/Core/Memory/TLSFSlab.cpp
+++ b/ZEngine/ZEngine/Core/Memory/TLSFSlab.cpp
@@ -1,0 +1,62 @@
+#include <ZEngine/Core/Memory/TLSFSlab.h>
+#include <ZEngine/ZEngineDef.h>
+#include <tlsf.h>
+
+namespace ZEngine::Core::Memory
+{
+    void TLSFSlab::Init(ArenaAllocator* arena, size_t bytes)
+    {
+        ZENGINE_VALIDATE_ASSERT(arena != nullptr, "TLSFSlab::Init: arena must not be null")
+        ZENGINE_VALIDATE_ASSERT(bytes > tlsf_size(), "TLSFSlab::Init: bytes too small for TLSF metadata")
+
+        Backing = arena->AllocateNoZero(bytes);
+        ZENGINE_VALIDATE_ASSERT(Backing != nullptr, "TLSFSlab::Init: arena out of memory")
+
+        Pool = tlsf_create_with_pool(Backing, bytes);
+        ZENGINE_VALIDATE_ASSERT(Pool != nullptr, "TLSFSlab::Init: tlsf_create_with_pool failed")
+    }
+
+    void* TLSFSlab::Alloc(size_t n)
+    {
+        ZENGINE_VALIDATE_ASSERT(n > 0, "TLSFSlab::Alloc: size must be > 0")
+
+        void* p = tlsf_malloc(Pool, n);
+        ZENGINE_VALIDATE_ASSERT(p != nullptr, "TLSFSlab::Alloc: slab exhausted — increase slab capacity at Init")
+        return p;
+    }
+
+    void* TLSFSlab::Realloc(void* ptr, size_t n)
+    {
+        ZENGINE_VALIDATE_ASSERT(n > 0, "TLSFSlab::Realloc: size must be > 0")
+
+        if (ptr == nullptr)
+            return Alloc(n);
+
+        void* p = tlsf_realloc(Pool, ptr, n);
+        ZENGINE_VALIDATE_ASSERT(p != nullptr, "TLSFSlab::Realloc: slab exhausted — increase slab capacity at Init")
+        return p;
+    }
+
+    void TLSFSlab::Free(void* ptr)
+    {
+        if (ptr)
+            tlsf_free(Pool, ptr);
+    }
+
+    void TLSFSlab::Shutdown()
+    {
+        if (Pool)
+        {
+            tlsf_destroy(Pool);
+            Pool = nullptr;
+        }
+        // Backing is owned by the parent arena — do not free it here.
+        Backing = nullptr;
+    }
+
+    size_t TLSFSlab::Overhead() const
+    {
+        return Pool ? tlsf_size() : 0;
+    }
+
+} // namespace ZEngine::Core::Memory

--- a/ZEngine/ZEngine/Core/Memory/TLSFSlab.h
+++ b/ZEngine/ZEngine/Core/Memory/TLSFSlab.h
@@ -1,0 +1,56 @@
+#pragma once
+#include <ZEngine/Core/Memory/Allocator.h>
+#include <cstddef>
+
+// Forward-declare the TLSF opaque handle so callers do not need to include tlsf.h.
+typedef void* tlsf_t;
+
+namespace ZEngine::Core::Memory
+{
+    /// @brief Arena-backed slab that uses the TLSF allocator for O(1) variable-size
+    ///        allocations with individual free.
+    ///
+    /// Fills the gap between ArenaAllocator (no individual free) and PoolAllocator
+    /// (fixed chunk size): upload decode buffers, asset metadata containers, and any
+    /// allocation whose size varies at runtime and whose lifetime is individual.
+    ///
+    /// The backing memory is carved from a parent ArenaAllocator exactly once at Init.
+    /// All subsequent Alloc/Free calls never touch the arena. The arena cursor advances
+    /// by `bytes` at Init and is not reclaimed until the arena itself is Shutdown.
+    ///
+    /// Thread safety: a TLSFSlab is NOT thread-safe. Each worker thread must have its
+    /// own slab. Cross-thread Free is a data race — see issue #690.
+    struct TLSFSlab
+    {
+        /// @brief Carve `bytes` from `arena` and initialise the TLSF pool over it.
+        /// @param arena Parent arena that provides the backing memory.
+        /// @param bytes Total slab size in bytes. Must be > tlsf_size() (~3 KB overhead).
+        void   Init(ArenaAllocator* arena, size_t bytes);
+
+        /// @brief Allocate `n` bytes from the slab. Asserts on exhaustion.
+        /// @param n Requested byte count. Must be > 0.
+        /// @returns Aligned pointer into the slab. Never null — asserts on failure.
+        void*  Alloc(size_t n);
+
+        /// @brief Reallocate `ptr` to `n` bytes. O(1) if in-place, O(n) copy otherwise.
+        /// @param ptr Previously Alloc'd pointer, or nullptr (delegates to Alloc).
+        /// @param n   New size in bytes.
+        void*  Realloc(void* ptr, size_t n);
+
+        /// @brief Return `ptr` to the slab. No-op on nullptr. O(1), coalesces neighbours.
+        /// @param ptr Pointer previously returned by Alloc or Realloc, or nullptr.
+        void   Free(void* ptr);
+
+        /// @brief Destroy the TLSF pool. Does NOT free the backing memory — the parent
+        ///        arena owns it and reclaims it on Shutdown.
+        void   Shutdown();
+
+        /// @brief Bytes consumed by TLSF metadata (~3 KB per slab). Diagnostic use only.
+        /// @returns Overhead in bytes.
+        size_t Overhead() const;
+
+        void*  Backing = nullptr; ///< Raw backing buffer carved from the parent arena.
+        tlsf_t Pool    = nullptr; ///< TLSF pool handle (opaque pointer).
+    };
+
+} // namespace ZEngine::Core::Memory

--- a/ZEngine/tests/Memory/TLSFSlabTest.cpp
+++ b/ZEngine/tests/Memory/TLSFSlabTest.cpp
@@ -1,0 +1,160 @@
+#include <ZEngine/Core/Memory/Allocator.h>
+#include <ZEngine/Core/Memory/MemoryManager.h>
+#include <ZEngine/Core/Memory/TLSFSlab.h>
+#include <gtest/gtest.h>
+
+using namespace ZEngine::Core::Memory;
+
+namespace
+{
+    struct Env
+    {
+        MemoryManager Manager;
+        Env()
+        {
+            Manager.Initialize(ZMega(4), {});
+        }
+        ~Env()
+        {
+            Manager.Shutdown();
+        }
+        ArenaAllocator* Arena()
+        {
+            return &Manager.MainArena;
+        }
+    };
+} // namespace
+
+TEST(TLSFSlabTest, InitAndShutdown)
+{
+    Env      env;
+    TLSFSlab slab{};
+    slab.Init(env.Arena(), ZMega(1));
+    EXPECT_NE(slab.Backing, nullptr);
+    EXPECT_NE(slab.Pool, nullptr);
+    EXPECT_GT(slab.Overhead(), 0u);
+    slab.Shutdown();
+    EXPECT_EQ(slab.Pool, nullptr);
+    EXPECT_EQ(slab.Backing, nullptr);
+}
+
+TEST(TLSFSlabTest, AllocReturnsAligned)
+{
+    Env      env;
+    TLSFSlab slab{};
+    slab.Init(env.Arena(), ZMega(1));
+
+    void* p = slab.Alloc(64);
+    ASSERT_NE(p, nullptr);
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(p) % 8u, 0u) << "default alignment";
+
+    slab.Shutdown();
+}
+
+TEST(TLSFSlabTest, AllocFreeAlloc)
+{
+    Env      env;
+    TLSFSlab slab{};
+    slab.Init(env.Arena(), ZMega(1));
+
+    void* p1 = slab.Alloc(ZKilo(16));
+    ASSERT_NE(p1, nullptr);
+    slab.Free(p1);
+
+    void* p2 = slab.Alloc(ZKilo(14));
+    ASSERT_NE(p2, nullptr);
+    EXPECT_EQ(p2, p1) << "TLSF must reuse freed block via coalesce";
+
+    slab.Shutdown();
+}
+
+TEST(TLSFSlabTest, FreeNullIsNoop)
+{
+    Env      env;
+    TLSFSlab slab{};
+    slab.Init(env.Arena(), ZMega(1));
+
+    EXPECT_NO_FATAL_FAILURE(slab.Free(nullptr));
+
+    slab.Shutdown();
+}
+
+TEST(TLSFSlabTest, ReallocNullDelegatesToAlloc)
+{
+    Env      env;
+    TLSFSlab slab{};
+    slab.Init(env.Arena(), ZMega(1));
+
+    void* p = slab.Realloc(nullptr, 128);
+    EXPECT_NE(p, nullptr);
+
+    slab.Shutdown();
+}
+
+TEST(TLSFSlabTest, ReallocGrows)
+{
+    Env      env;
+    TLSFSlab slab{};
+    slab.Init(env.Arena(), ZMega(1));
+
+    auto* p = reinterpret_cast<uint8_t*>(slab.Alloc(64));
+    ASSERT_NE(p, nullptr);
+    for (int i = 0; i < 64; ++i)
+        p[i] = static_cast<uint8_t>(i);
+
+    auto* p2 = reinterpret_cast<uint8_t*>(slab.Realloc(p, 256));
+    ASSERT_NE(p2, nullptr);
+    for (int i = 0; i < 64; ++i)
+        EXPECT_EQ(p2[i], static_cast<uint8_t>(i)) << "Realloc must preserve existing data at byte " << i;
+
+    slab.Shutdown();
+}
+
+TEST(TLSFSlabTest, ManyAllocsAndFrees)
+{
+    Env      env;
+    TLSFSlab slab{};
+    slab.Init(env.Arena(), ZMega(2));
+
+    static constexpr int N = 64;
+    void*                ptrs[N];
+    for (int i = 0; i < N; ++i)
+    {
+        ptrs[i] = slab.Alloc(static_cast<size_t>(128 + i * 16));
+        ASSERT_NE(ptrs[i], nullptr) << "alloc " << i;
+    }
+    for (int i = N - 1; i >= 0; --i)
+        slab.Free(ptrs[i]);
+
+    void* big = slab.Alloc(ZKilo(512));
+    EXPECT_NE(big, nullptr) << "after freeing all blocks TLSF must coalesce into one large free block";
+
+    slab.Shutdown();
+}
+
+TEST(TLSFSlabTest, ArenaBackingNotFreedOnShutdown)
+{
+    Env    env;
+    size_t offset_before = env.Arena()->m_current_offset;
+
+    {
+        TLSFSlab slab{};
+        slab.Init(env.Arena(), ZMega(1));
+        slab.Shutdown();
+    }
+
+    size_t offset_after = env.Arena()->m_current_offset;
+    EXPECT_GT(offset_after, offset_before) << "arena cursor must have advanced for the backing memory";
+    EXPECT_NE(env.Arena()->m_memory, nullptr) << "arena must still be valid after slab shutdown";
+}
+
+TEST(TLSFSlabTest, ExhaustionAsserts)
+{
+    Env      env;
+    TLSFSlab slab{};
+    slab.Init(env.Arena(), ZMega(1));
+
+    EXPECT_DEATH(slab.Alloc(ZMega(2)), "");
+
+    slab.Shutdown();
+}

--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -109,8 +109,13 @@ Fetchcontent_Declare(
     GIT_REPOSITORY https://github.com/mattconte/tlsf
     GIT_SHALLOW TRUE
     SOURCE_DIR ${FETCHCONTENT_BASE_DIR}/tlsf
-    
 )
+FetchContent_GetProperties(tlsf)
+if(NOT tlsf_POPULATED)
+    FetchContent_Populate(tlsf)
+endif()
+add_library(tlsf STATIC ${FETCHCONTENT_BASE_DIR}/tlsf/tlsf.c)
+target_include_directories(tlsf PUBLIC ${FETCHCONTENT_BASE_DIR}/tlsf)
 
 Fetchcontent_Declare(
     CLI11
@@ -226,7 +231,6 @@ FetchContent_MakeAvailable(
   SPIRV-Headers
   spirv_cross_core
   nlohmann_json
-  tlsf
   CLI11
   rapidhash
   SPIRV-Tools
@@ -298,6 +302,7 @@ target_link_libraries(External_libs
          ufbx
          meshoptimizer
          freetype
+         tlsf
 )
 
 if(ZENGINE_TRACY)


### PR DESCRIPTION
Closes #687 — Phase 1 foundation for upload pipeline TLSF work.

## What
`TLSFSlab` wraps `mattconte/tlsf` with a backing buffer carved from a parent `ArenaAllocator`. Fills the gap between Arena (no individual free) and Pool (fixed chunk size) for variable-size, individually-freed allocations.

## API
- `Init(arena, bytes)` — carves backing via `AllocateNoZero` (skips zeroing for large buffers), initialises TLSF pool
- `Alloc(n)` / `Realloc(ptr, n)` — assert on exhaustion, never return null  
- `Free(ptr)` — no-op on nullptr, O(1) with neighbour coalescing
- `Shutdown()` — calls `tlsf_destroy`; backing stays in arena

## Build
`dependencies.cmake`: compile `tlsf.c` as a static library target (same pattern as ufbx/meshoptimizer)

## Tests (9/9 passing)
init/shutdown, alignment, alloc-free-alloc coalesce, realloc growth with data preservation, 64-allocation stress, arena-owned backing verification, exhaustion death test