### PR TITLE
feat(memory): m_upload_slabs[MAX_WORKERS] in RRM + RegisterWorkerInit — closes #689

### DIFF
--- a/ZEngine/ZEngine/Helpers/ThreadPool.h
+++ b/ZEngine/ZEngine/Helpers/ThreadPool.h
@@ -3,6 +3,7 @@
 #include <ZEngine/Core/Memory/TLSFSlab.h>
 #include <ZEngine/Helpers/IntrusivePtr.h>
 #include <ZEngine/ZEngineDef.h>
+#include <atomic>
 #include <condition_variable>
 #include <mutex>
 #include <thread>
@@ -48,6 +49,10 @@ namespace ZEngine::Helpers
     {
         return t_worker_slab;
     }
+
+    // Called once per worker thread at the start of its task loop.
+    // Signature: fn(ctx, worker_idx)
+    using WorkerInitFn = void (*)(void* ctx, size_t worker_idx);
 
     struct ThreadPool
     {
@@ -97,8 +102,25 @@ namespace ZEngine::Helpers
             task();
         }
 
+        /// @brief Register a per-worker init callback.
+        ///        Called exactly once per worker at the start of its task loop.
+        ///        If called after workers have started (the typical case — RRM
+        ///        initialises after the pool is constructed), all idle workers
+        ///        are woken via notify_one so they pick up the callback immediately.
+        ///        The callback runs before any queued tasks on each worker thread.
+        /// @param fn  Callback — fn(ctx, worker_idx). Must be thread-safe.
+        /// @param ctx Caller context forwarded to fn.
+        void RegisterWorkerInit(WorkerInitFn fn, void* ctx)
+        {
+            m_init_ctx.value.store(ctx, std::memory_order_relaxed);
+            m_init_fn.value.store(fn, std::memory_order_release); // release: ctx visible after fn
+            for (size_t i = 0; i < WorkerCount; ++i)
+                m_workers[i].cv.notify_one();
+        }
+
         void Shutdown()
         {
+            m_init_fn.value.store(nullptr, std::memory_order_relaxed);
             m_cancellation.value.store(true, std::memory_order_release);
             for (size_t i = 0; i < WorkerCount; ++i)
                 m_workers[i].cv.notify_one();
@@ -119,13 +141,21 @@ namespace ZEngine::Helpers
             std::condition_variable                                 cv;
         };
 
-        Worker                 m_workers[MAX_WORKERS];
-        PaddedAtomic<uint32_t> m_cursor{};
-        PaddedAtomic<bool>     m_cancellation{};
-        PaddedAtomic<uint32_t> m_active_workers{}; // decremented by each worker on exit
+        Worker                     m_workers[MAX_WORKERS];
+        PaddedAtomic<uint32_t>     m_cursor{};
+        PaddedAtomic<bool>         m_cancellation{};
+        PaddedAtomic<uint32_t>     m_active_workers{}; // decremented by each worker on exit
+        PaddedAtomic<WorkerInitFn> m_init_fn{};        // per-worker init callback; set by RegisterWorkerInit
+        PaddedAtomic<void*>        m_init_ctx{};       // context passed to m_init_fn
 
-        void                   WorkerRun(size_t idx)
+        void                       WorkerRun(size_t idx)
         {
+            // Call per-worker init callback if registered (e.g. set t_worker_slab).
+            // Runs before the first task — guaranteed by RegisterWorkerInit waking the worker.
+            WorkerInitFn init = m_init_fn.value.load(std::memory_order_acquire);
+            if (init)
+                init(m_init_ctx.value.load(std::memory_order_relaxed), idx);
+
             Worker& w = m_workers[idx];
             while (!m_cancellation.value.load(std::memory_order_acquire))
             {

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
@@ -42,6 +42,7 @@ namespace ZEngine::Rendering
         InitUploadPool();
         InitGlobalBuffers();
         InitTextureTimelines();
+        InitUploadSlabs(static_cast<uint32_t>(Helpers::ThreadPoolHelper::Pool->WorkerCount));
 
         registry->SetOnReadyCallback(this, [](void* ctx, const uuids::uuid& uuid, AssetHandle handle) {
             auto*              rrm = static_cast<RenderResourceManager*>(ctx);
@@ -151,6 +152,14 @@ namespace ZEngine::Rendering
 
         m_device->QueueWaitAll();
         ShutdownTextureTimelines();
+
+        // Shut down per-worker upload slabs. Clear the worker init callback first so
+        // any worker that wakes after this does not call SetWorkerSlab on a dead slab.
+        if (Helpers::ThreadPoolHelper::Pool)
+            Helpers::ThreadPoolHelper::Pool->RegisterWorkerInit(nullptr, nullptr);
+        for (uint32_t i = 0; i < m_upload_slab_count; ++i)
+            m_upload_slabs[i].Shutdown();
+        m_upload_slab_count = 0;
 
         // Free command buffers before destroying their parent pools, then destroy pools.
         // Arena-allocated objects have no automatic destructor — explicit calls are required.
@@ -866,6 +875,32 @@ namespace ZEngine::Rendering
                 m_tex_transfer_next_values[i].store(1, std::memory_order_release);
             }
         }
+    }
+
+    void RenderResourceManager::InitUploadSlabs(uint32_t worker_count)
+    {
+        ZENGINE_VALIDATE_ASSERT(Helpers::ThreadPoolHelper::Pool != nullptr, "RenderResourceManager::InitUploadSlabs: ThreadPool not initialized")
+
+        worker_count        = worker_count < Helpers::ThreadPool::MAX_WORKERS ? worker_count : Helpers::ThreadPool::MAX_WORKERS;
+        m_upload_slab_count = worker_count;
+
+        for (uint32_t i = 0; i < worker_count; ++i)
+            m_upload_slabs[i].Init(m_device->Arena, UPLOAD_SLAB_BYTES);
+
+        // Register per-worker init callback so each worker sets its thread-local slab pointer.
+        // The callback runs before any tasks on each worker — no submit-vs-init race.
+        struct Ctx
+        {
+            Core::Memory::TLSFSlab* slabs;
+        };
+        auto* ctx  = ZPushStructCtor(m_device->Arena, Ctx);
+        ctx->slabs = m_upload_slabs;
+        Helpers::ThreadPoolHelper::Pool->RegisterWorkerInit(
+            [](void* raw, size_t idx) {
+                auto* c = static_cast<Ctx*>(raw);
+                Helpers::SetWorkerSlab(&c->slabs[idx]);
+            },
+            ctx);
     }
 
     void RenderResourceManager::ShutdownTextureTimelines()

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.h
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.h
@@ -1,9 +1,11 @@
 #pragma once
 #include <ZEngine/Core/Containers/Array.h>
 #include <ZEngine/Core/Memory/GpuAllocator.h>
+#include <ZEngine/Core/Memory/TLSFSlab.h>
 #include <ZEngine/Core/VFS/Registry/AssetRegistry.h>
 #include <ZEngine/Core/VFS/VFSError.h>
 #include <ZEngine/Hardwares/DeferredFreeQueue.h>
+#include <ZEngine/Helpers/ThreadPool.h>
 #include <ZEngine/Helpers/ThreadSafeQueue.h>
 #include <ZEngine/Managers/AssetManager.h>
 #include <ZEngine/Rendering/Pools/CommandPool.h>
@@ -387,8 +389,17 @@ namespace ZEngine::Rendering
         uint32_t                        AllocImageSlot();
         uint32_t                        AllocGBufSlot();
 
-        Hardwares::VulkanDevice*        m_device                       = nullptr;
-        Core::VFS::AssetRegistry*       m_registry                     = nullptr;
+        Hardwares::VulkanDevice*        m_device                                         = nullptr;
+        Core::VFS::AssetRegistry*       m_registry                                       = nullptr;
+
+        // Per-worker TLSF upload slabs — carved from Device->Arena at Initialize.
+        // Each worker owns one slab exclusively via t_worker_slab (ThreadPool.h).
+        // Sized to cover the worst-case decode buffer: equirect→cubemap ≈ 96 MB.
+        static constexpr size_t         UPLOAD_SLAB_BYTES                                = 128 * 1024 * 1024; // 128 MB per worker
+        Core::Memory::TLSFSlab          m_upload_slabs[Helpers::ThreadPool::MAX_WORKERS] = {};
+        uint32_t                        m_upload_slab_count                              = 0;
+
+        void                            InitUploadSlabs(uint32_t worker_count);
 
         // Global geometry buffers — all mesh vertices/indices packed together.
         static constexpr VkDeviceSize   GLOBAL_VTX_CAPACITY            = 512 * 1024 * 1024; // 512 MB → ~16M DrawVertex


### PR DESCRIPTION
Closes #689. Also updates #688 (adds RegisterWorkerInit to ThreadPool).

## ThreadPool changes
- `WorkerInitFn` callback type (`void(*)(void*, size_t worker_idx)`)
- `RegisterWorkerInit(fn, ctx)`: stores via `PaddedAtomic`, wakes all workers so they call the callback before the first task — no submit-vs-init race
- `WorkerRun`: loads `m_init_fn` and calls it at thread start before the task loop
- `Shutdown`: clears `m_init_fn` before signalling cancellation

## RenderResourceManager changes
- `m_upload_slabs[MAX_WORKERS]` — 128 MB each, carved from `Device->Arena` at `Initialize`
- `InitUploadSlabs(worker_count)`: creates slabs + calls `RegisterWorkerInit` so each worker's `t_worker_slab` is set before any upload tasks run
- `Shutdown`: clears init callback first, then calls `slab.Shutdown()`

## Depends on
#687 (TLSFSlab), #688 (t_worker_slab)