### PR TITLE
feat(memory): Phase 2 — typed allocator + AssetManagerSlab — closes #694 #695

### DIFF
--- a/ZEngine/ZEngine/Core/Containers/Array.h
+++ b/ZEngine/ZEngine/Core/Containers/Array.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <ZEngine/Core/Containers/InitializerList.h>
 #include <ZEngine/Core/Memory/Allocator.h>
+#include <ZEngine/Core/Memory/TLSFSlab.h>
 
 using namespace ZEngine::Core::Memory;
 
@@ -19,13 +20,14 @@ namespace ZEngine::Core::Containers
         using iterator        = T*;
         using const_iterator  = const T*;
 
-        Array() : m_allocator(nullptr), m_size(0), m_capacity(0), m_data(nullptr) {}
+        Array() : m_allocator(nullptr), m_slab(nullptr), m_size(0), m_capacity(0), m_data(nullptr) {}
 
         Array(const Array&)            = delete;
         Array& operator=(const Array&) = delete;
 
-        Array(Array&& other) noexcept : m_allocator(other.m_allocator), m_size(other.m_size), m_capacity(other.m_capacity), m_data(other.m_data)
+        Array(Array&& other) noexcept : m_allocator(other.m_allocator), m_slab(other.m_slab), m_size(other.m_size), m_capacity(other.m_capacity), m_data(other.m_data)
         {
+            other.m_slab     = nullptr;
             other.m_size     = 0;
             other.m_capacity = 0;
             other.m_data     = nullptr;
@@ -36,9 +38,11 @@ namespace ZEngine::Core::Containers
             if (this != &other)
             {
                 m_allocator      = other.m_allocator;
+                m_slab           = other.m_slab;
                 m_size           = other.m_size;
                 m_capacity       = other.m_capacity;
                 m_data           = other.m_data;
+                other.m_slab     = nullptr;
                 other.m_size     = 0;
                 other.m_capacity = 0;
                 other.m_data     = nullptr;
@@ -49,6 +53,7 @@ namespace ZEngine::Core::Containers
         void init(Memory::ArenaAllocator* allocator, size_type initial_capacity, size_type initial_size)
         {
             m_allocator = allocator;
+            m_slab      = nullptr;
             m_size      = initial_size;
             m_capacity  = 0;
             m_data      = nullptr;
@@ -58,6 +63,7 @@ namespace ZEngine::Core::Containers
         void init(Memory::ArenaAllocator* allocator, size_type initial_capacity)
         {
             m_allocator = allocator;
+            m_slab      = nullptr;
             m_size      = 0;
             m_capacity  = 0;
             m_data      = nullptr;
@@ -68,9 +74,29 @@ namespace ZEngine::Core::Containers
         {
             init(allocator, std::max(initial_capacity, list.size()));
             for (const auto& item : list)
-            {
                 push(item);
-            }
+        }
+
+        /// @brief Init backed by a TLSFSlab — Realloc extends in-place when possible,
+        ///        eliminating dead-block accumulation from arena-backed grows.
+        void init(Memory::TLSFSlab* slab, size_type initial_capacity)
+        {
+            m_allocator = nullptr;
+            m_slab      = slab;
+            m_size      = 0;
+            m_capacity  = 0;
+            m_data      = nullptr;
+            reserve(initial_capacity);
+        }
+
+        void init(Memory::TLSFSlab* slab, size_type initial_capacity, size_type initial_size)
+        {
+            m_allocator = nullptr;
+            m_slab      = slab;
+            m_size      = initial_size;
+            m_capacity  = 0;
+            m_data      = nullptr;
+            reserve(std::max(initial_capacity, initial_size));
         }
 
         const_reference operator[](size_type index) const
@@ -241,6 +267,8 @@ namespace ZEngine::Core::Containers
         ~Array()
         {
             clear();
+            if (m_slab && m_data)
+                m_slab->Free(m_data);
             m_data     = nullptr;
             m_capacity = 0;
         }
@@ -248,20 +276,24 @@ namespace ZEngine::Core::Containers
         void reserve(size_type new_capacity)
         {
             if (new_capacity <= m_capacity)
-            {
                 return;
-            }
 
             size_t old_alloc_size = m_capacity * sizeof(T);
             size_t new_alloc_size = new_capacity * sizeof(T);
-            m_data                = static_cast<pointer>(ZResize(m_allocator, m_data, old_alloc_size, new_alloc_size, ZAlignof(value_type)));
-            m_capacity            = new_capacity;
+
+            if (m_slab)
+                m_data = static_cast<pointer>(m_slab->Realloc(m_data, new_alloc_size));
+            else
+                m_data = static_cast<pointer>(ZResize(m_allocator, m_data, old_alloc_size, new_alloc_size, ZAlignof(value_type)));
+
+            m_capacity = new_capacity;
         }
 
-        Memory::ArenaAllocator* m_allocator;
-        size_type               m_size;
-        size_type               m_capacity;
-        pointer                 m_data;
+        Memory::ArenaAllocator* m_allocator = nullptr;
+        Memory::TLSFSlab*       m_slab      = nullptr;
+        size_type               m_size      = 0;
+        size_type               m_capacity  = 0;
+        pointer                 m_data      = nullptr;
     };
 
     template <typename T>

--- a/ZEngine/ZEngine/Core/Containers/UnorderedHashMap.h
+++ b/ZEngine/ZEngine/Core/Containers/UnorderedHashMap.h
@@ -109,9 +109,22 @@ namespace ZEngine::Core::Containers
         void init(Memory::ArenaAllocator* arena, size_type slot_capacity = 16)
         {
             m_allocator     = arena;
+            m_slab          = nullptr;
             size_type cap   = next_pow2(slot_capacity < 16 ? 16 : slot_capacity);
             m_capacity_mask = cap - 1;
             m_entries.init(arena, cap, cap);
+            Helpers::secure_memset(m_entries.data(), 0, cap * sizeof(Entry), cap * sizeof(Entry));
+            m_size = 0;
+        }
+
+        /// @brief Init backed by a TLSFSlab — rehash reallocates in-place when possible.
+        void init(Memory::TLSFSlab* slab, size_type slot_capacity = 16)
+        {
+            m_allocator     = nullptr;
+            m_slab          = slab;
+            size_type cap   = next_pow2(slot_capacity < 16 ? 16 : slot_capacity);
+            m_capacity_mask = cap - 1;
+            m_entries.init(slab, cap, cap);
             Helpers::secure_memset(m_entries.data(), 0, cap * sizeof(Entry), cap * sizeof(Entry));
             m_size = 0;
         }
@@ -335,7 +348,10 @@ namespace ZEngine::Core::Containers
             size_type    old_cap = old.size();
 
             m_capacity_mask      = new_cap - 1;
-            m_entries.init(m_allocator, new_cap, new_cap);
+            if (m_slab)
+                m_entries.init(m_slab, new_cap, new_cap);
+            else
+                m_entries.init(m_allocator, new_cap, new_cap);
             Helpers::secure_memset(m_entries.data(), 0, new_cap * sizeof(Entry), new_cap * sizeof(Entry));
             m_size = 0;
 
@@ -351,6 +367,7 @@ namespace ZEngine::Core::Containers
         }
 
         Memory::ArenaAllocator* m_allocator     = nullptr;
+        Memory::TLSFSlab*       m_slab          = nullptr;
         Array<Entry>            m_entries       = {};
         size_type               m_capacity_mask = 0;
         size_type               m_size          = 0;

--- a/ZEngine/ZEngine/Managers/AssetManager.cpp
+++ b/ZEngine/ZEngine/Managers/AssetManager.cpp
@@ -43,14 +43,20 @@ namespace ZEngine::Managers
         s_Instance->Device                  = device;
         s_Instance->CurrentWorkingSpacePath = working_space_path;
 
-        s_Instance->NodeHierarchies.init(s_Instance->Arena, 5000);
-        s_Instance->Meshes.init(s_Instance->Arena, 5000);
-        s_Instance->Materials.init(s_Instance->Arena, 5000);
+        // Initialise the container slab. Growing containers (Meshes, NodeHierarchies,
+        // Materials, UUIDToTextureHandle, UUIDToMaterialSlot) back into the slab so
+        // realloc can extend in-place — zero dead-block accumulation on grow.
+        s_Instance->ContainerSlab.Init(s_Instance->Arena, AssetManager::CONTAINER_SLAB_BYTES);
+        auto* slab = &s_Instance->ContainerSlab;
+
+        s_Instance->NodeHierarchies.init(slab, 5000);
+        s_Instance->Meshes.init(slab, 5000);
+        s_Instance->Materials.init(slab, 5000);
         s_Instance->GPUMeshMaterials.init(s_Instance->Arena, 5000);
         s_Instance->Textures.init(s_Instance->Arena, 5000);
-        s_Instance->UUIDToTextureHandle.init(s_Instance->Arena, 5000);
+        s_Instance->UUIDToTextureHandle.init(slab, 5000);
         s_Instance->MeshToHierarchySlot.init(s_Instance->Arena, 5000);
-        s_Instance->UUIDToMaterialSlot.init(s_Instance->Arena, 5000);
+        s_Instance->UUIDToMaterialSlot.init(slab, 5000);
 
         static Core::VFS::AssetRegistry s_registry;
         s_registry.Initialize(s_Instance->Arena);
@@ -66,7 +72,11 @@ namespace ZEngine::Managers
         ZENGINE_LOG_ASSET_INFO("Fallback texture ready")
     }
 
-    void        AssetManager::Shutdown() {}
+    void AssetManager::Shutdown()
+    {
+        if (s_Instance)
+            s_Instance->ContainerSlab.Shutdown();
+    }
 
     AssetHandle AssetManager::RegisterAsset(AssetType type, const uuids::uuid& uuid, uint32_t slot_index, const Core::VFS::VFSPath& path, const Core::VFS::MetaFileData& meta)
     {

--- a/ZEngine/ZEngine/Managers/AssetManager.h
+++ b/ZEngine/ZEngine/Managers/AssetManager.h
@@ -2,6 +2,7 @@
 #include <ZEngine/Core/Containers/Array.h>
 #include <ZEngine/Core/Containers/Strings.h>
 #include <ZEngine/Core/Memory/Allocator.h>
+#include <ZEngine/Core/Memory/TLSFSlab.h>
 #include <ZEngine/Core/VFS/IVFSContext.h>
 #include <ZEngine/Core/VFS/Registry/AssetRecord.h>
 #include <ZEngine/Core/VFS/Registry/AssetRegistry.h>
@@ -19,6 +20,12 @@ namespace ZEngine::Managers
     {
         Core::Memory::ArenaAllocator*                                                       Arena                   = nullptr;
         cstring                                                                             CurrentWorkingSpacePath = "";
+
+        // TLSF slab for the 5 long-lived growing containers below.
+        // Realloc extends in-place when the following block is free — eliminates
+        // the dead-block accumulation from arena-backed grows (~20 MB per 100 sessions).
+        static constexpr size_t                                                             CONTAINER_SLAB_BYTES    = 256 * 1024 * 1024; // 256 MB
+        Core::Memory::TLSFSlab                                                              ContainerSlab           = {};
 
         // CPU-side import buffers — owned by the import pipeline.
         Core::Containers::Array<Importers::AssetNodeHierarchy>                              NodeHierarchies         = {};


### PR DESCRIPTION
Closes #694, #695. Phase 2 of the TLSF memory roadmap.

## #694 — Typed allocator for Array<T> and UnorderedHashMap
- `Array::init(TLSFSlab*, capacity)` and `init(TLSFSlab*, capacity, size)`
- `reserve()` calls `slab->Realloc` (O(1) in-place) vs `ZResize` on arena
- Destructor calls `slab->Free(m_data)` — slab-backed arrays return memory on destroy
- Move constructor/assignment propagate `m_slab`, null the source
- `UnorderedHashMap::init(TLSFSlab*, capacity)` — `rehash()` uses slab when set

## #695 — AssetManagerSlab + container migration
- 256 MB `ContainerSlab` carved from `Arena` at `Initialize`
- 5 long-lived growing containers migrated: `NodeHierarchies`, `Meshes`, `Materials`, `UUIDToTextureHandle`, `UUIDToMaterialSlot`
- Expected impact: ~217 KB dead blocks per import session → near zero; ~20 MB reclaimed after 100 sessions