### PR TITLE
fix(memory): 64-bit page-size mask + ArenaAllocator move semantics

### DIFF
--- a/ZEngine/ZEngine/Core/Memory/Allocator.cpp
+++ b/ZEngine/ZEngine/Core/Memory/Allocator.cpp
@@ -9,7 +9,7 @@
 
 namespace ZEngine::Core::Memory
 {
-    void ArenaAllocator::Initialize(uint64_t size, unsigned long page_size)
+    void ArenaAllocator::Initialize(uint64_t size, size_t page_size)
     {
 #ifdef _WIN32
         // Reserve the full range. Pages are committed lazily in ArenaAllocateRaw via
@@ -84,7 +84,11 @@ namespace ZEngine::Core::Memory
         if ((offset + size) > a->m_committed_size)
         {
             size_t commit_size = (offset + size + a->m_mem_page_size - 1) & ~(a->m_mem_page_size - 1);
-            void*  r           = VirtualAlloc(a->m_memory + a->m_committed_size, commit_size - a->m_committed_size, MEM_COMMIT, PAGE_READWRITE);
+            // Commit the whole [base, commit_size) range rather than just the delta —
+            // VirtualAlloc(MEM_COMMIT) on an already-committed page is a documented no-op,
+            // so this is safe. Avoids relying on commit_size - a->m_committed_size staying
+            // correct across the page-align mask above.
+            void*  r           = VirtualAlloc(a->m_memory, commit_size, MEM_COMMIT, PAGE_READWRITE);
             if (!r)
                 return nullptr;
             a->m_committed_size = commit_size;
@@ -143,7 +147,7 @@ namespace ZEngine::Core::Memory
                         if (new_end > m_committed_size)
                         {
                             size_t commit_size   = (new_end + m_mem_page_size - 1) & ~(m_mem_page_size - 1);
-                            void*  commit_result = VirtualAlloc(m_memory + m_committed_size, commit_size - m_committed_size, MEM_COMMIT, PAGE_READWRITE);
+                            void*  commit_result = VirtualAlloc(m_memory, commit_size, MEM_COMMIT, PAGE_READWRITE);
                             ZENGINE_VALIDATE_ASSERT(commit_result != nullptr, "ArenaAllocator::Resize: failed to commit new pages")
                             if (!commit_result)
                                 return nullptr;
@@ -191,19 +195,14 @@ namespace ZEngine::Core::Memory
         ZENGINE_VALIDATE_ASSERT(size > 0, "ArenaAllocator::CreateSubArena: size must be > 0")
         ZENGINE_VALIDATE_ASSERT(m_memory != nullptr, "ArenaAllocator::CreateSubArena: parent arena not initialized")
 
-        // Windows: align to page size so that VirtualAlloc(MEM_COMMIT) commit boundaries
-        // are clean — a non-page-aligned m_memory would cause Windows to round the commit
-        // address down, silently committing bytes that belong to the preceding sub-arena.
-        // macOS/Linux: DEFAULT_ALIGNMENT is sufficient — mmap overcommit means we never
-        // call mprotect, so page alignment has no effect on correctness or performance.
-#ifdef _WIN32
-        const size_t sub_alignment = m_mem_page_size;
-#else
-        const size_t sub_alignment = DEFAULT_ALIGNMENT;
-#endif
-
+        // Page-align the sub-arena start on every platform. On Windows this keeps
+        // VirtualAlloc(MEM_COMMIT) boundaries clean — a non-page-aligned m_memory would
+        // round the commit address down, silently committing bytes from the preceding
+        // sub-arena. macOS/Linux don't need this for correctness (no mprotect on the
+        // commit path), but the wasted padding (<= one page per sub-arena) is negligible
+        // against multi-GB budgets, so we keep boundaries uniform across platforms.
         uintptr_t current_ptr  = (uintptr_t) m_memory + (uintptr_t) m_current_offset;
-        uintptr_t offset       = Helpers::memory_align(current_ptr, sub_alignment);
+        uintptr_t offset       = Helpers::memory_align(current_ptr, m_mem_page_size);
         offset                -= (uintptr_t) m_memory;
 
         ZENGINE_VALIDATE_ASSERT((offset + size) <= m_total_size, "ArenaAllocator::CreateSubArena: not enough space in parent arena")
@@ -233,6 +232,15 @@ namespace ZEngine::Core::Memory
         // No commit is done here — each platform handles commit in its own way above.
         m_previous_offset = offset;
         m_current_offset  = offset + size;
+
+#ifdef _WIN32
+        // Advance the parent's m_committed_size to match so that a subsequent direct
+        // Allocate on the parent (e.g. Device->Arena == MainArena in Engine.cpp) does
+        // not attempt to commit the entire sub-arena region in one VirtualAlloc call.
+        // The sub-arena pages remain PAGE_NOACCESS; each sub-arena commits lazily.
+        if (m_committed_size < m_current_offset)
+            m_committed_size = m_current_offset;
+#endif
     }
 
     ArenaTemp BeginTempArena(ArenaAllocator* arena)

--- a/ZEngine/ZEngine/Core/Memory/Allocator.h
+++ b/ZEngine/ZEngine/Core/Memory/Allocator.h
@@ -40,38 +40,79 @@ namespace ZEngine::Core::Memory
     //      allocations, corrupting them.
     struct ArenaAllocator
     {
+        ArenaAllocator() = default;
         ~ArenaAllocator()
         {
             Shutdown();
-        };
+        }
 
-        void          Initialize(uint64_t size, unsigned long page_size);
-        void          Shutdown();
+        // Copying would shallow-copy m_memory — both instances would then call
+        // VirtualFree/munmap on the same pointer at destruction (double-free).
+        ArenaAllocator(const ArenaAllocator&)            = delete;
+        ArenaAllocator& operator=(const ArenaAllocator&) = delete;
 
-        void*         Allocate(size_t size, size_t alignment = DEFAULT_ALIGNMENT);
-        void*         Allocate(size_t size, size_t alignment, const char* file, int line);
+        ArenaAllocator(ArenaAllocator&& other) noexcept
+        {
+            MoveFrom(other);
+        }
+
+        ArenaAllocator& operator=(ArenaAllocator&& other) noexcept
+        {
+            if (this != &other)
+            {
+                Shutdown();
+                MoveFrom(other);
+            }
+            return *this;
+        }
+
+        void     Initialize(uint64_t size, size_t page_size);
+        void     Shutdown();
+
+        void*    Allocate(size_t size, size_t alignment = DEFAULT_ALIGNMENT);
+        void*    Allocate(size_t size, size_t alignment, const char* file, int line);
 
         // AllocateNoZero — same as Allocate but skips the secure_memset zeroing step.
         // Use only when the caller will fully initialize the returned memory before reading it
         // (e.g. large decode buffers, staging allocations). Saves up to 0.4 ms for 16 MB
         // allocations. Do NOT use for structs whose fields rely on zero-initialization.
-        void*         AllocateNoZero(size_t size, size_t alignment = DEFAULT_ALIGNMENT);
+        void*    AllocateNoZero(size_t size, size_t alignment = DEFAULT_ALIGNMENT);
 
-        void*         Resize(void* old_memory, size_t old_size, size_t new_size, size_t alignment = DEFAULT_ALIGNMENT);
-        void          Clear();
+        void*    Resize(void* old_memory, size_t old_size, size_t new_size, size_t alignment = DEFAULT_ALIGNMENT);
+        void     Clear();
 
-        void          CreateSubArena(size_t size, ArenaAllocator* out_arena);
+        void     CreateSubArena(size_t size, ArenaAllocator* out_arena);
 
-        uint8_t*      m_memory                  = nullptr;
-        bool          m_is_sub_arena            = false;
-        size_t        m_total_size              = 0;
-        size_t        m_initial_current_offset  = 0;
-        size_t        m_initial_previous_offset = 0;
-        size_t        m_current_offset          = 0;
-        size_t        m_previous_offset         = 0;
-        size_t        m_committed_size          = 0;
-        unsigned long m_mem_page_size           = 0;
+        uint8_t* m_memory                  = nullptr;
+        bool     m_is_sub_arena            = false;
+        size_t   m_total_size              = 0;
+        size_t   m_initial_current_offset  = 0;
+        size_t   m_initial_previous_offset = 0;
+        size_t   m_current_offset          = 0;
+        size_t   m_previous_offset         = 0;
+        size_t   m_committed_size          = 0;
+        // size_t, not unsigned long: unsigned long is 32-bit on Windows LLP64, which
+        // truncates the page-align mask past 4 GB (see ArenaAllocateRaw / Resize).
+        size_t   m_mem_page_size           = 0;
 
+    private:
+        void MoveFrom(ArenaAllocator& other) noexcept
+        {
+            m_memory                  = other.m_memory;
+            m_is_sub_arena            = other.m_is_sub_arena;
+            m_total_size              = other.m_total_size;
+            m_initial_current_offset  = other.m_initial_current_offset;
+            m_initial_previous_offset = other.m_initial_previous_offset;
+            m_current_offset          = other.m_current_offset;
+            m_previous_offset         = other.m_previous_offset;
+            m_committed_size          = other.m_committed_size;
+            m_mem_page_size           = other.m_mem_page_size;
+
+            other.m_memory            = nullptr;
+            other.m_total_size        = 0;
+            other.m_committed_size    = 0;
+            other.m_is_sub_arena      = false;
+        }
     }; // struct ArenaAllocator
 
     struct PoolFreeNode
@@ -104,22 +145,30 @@ namespace ZEngine::Core::Memory
     //      program in both debug and release builds.
     struct PoolAllocator
     {
-        using Arena = ArenaAllocator;
+        using Arena     = ArenaAllocator;
 
+        PoolAllocator() = default;
         ~PoolAllocator() {};
 
-        void          Initialize(Arena* arena, size_t size, size_t chunk_size, size_t alignment = DEFAULT_ALIGNMENT);
+        // PoolAllocator does not own its backing memory (the parent arena does), so a
+        // shallow copy is not immediately unsafe — but it silently duplicates the free
+        // list, letting two independent PoolAllocator instances hand out the same chunk.
+        // Deleted until there's a real use case for copying a pool.
+        PoolAllocator(const PoolAllocator&)            = delete;
+        PoolAllocator& operator=(const PoolAllocator&) = delete;
 
-        void*         Allocate();
-        void*         Allocate(const char* file, int line);
+        void           Initialize(Arena* arena, size_t size, size_t chunk_size, size_t alignment = DEFAULT_ALIGNMENT);
 
-        void          Free(void* ptr);
-        void          Clear();
+        void*          Allocate();
+        void*          Allocate(const char* file, int line);
 
-        uint8_t*      memory     = nullptr;
-        PoolFreeNode* head       = nullptr;
-        size_t        total_size = 0;
-        size_t        chunk_size = 0;
+        void           Free(void* ptr);
+        void           Clear();
+
+        uint8_t*       memory     = nullptr;
+        PoolFreeNode*  head       = nullptr;
+        size_t         total_size = 0;
+        size_t         chunk_size = 0;
     };
 
     ArenaTemp BeginTempArena(ArenaAllocator* arena);

--- a/ZEngine/ZEngine/Core/Memory/MemoryManager.cpp
+++ b/ZEngine/ZEngine/Core/Memory/MemoryManager.cpp
@@ -16,7 +16,7 @@ namespace ZEngine::Core::Memory
         Budget = config;
         config.Validate(buffer_size);
 
-        unsigned long page_size = 0ul;
+        size_t page_size = 0;
 #ifdef _WIN32
         SYSTEM_INFO sys_info;
         GetSystemInfo(&sys_info);

--- a/ZEngine/tests/Memory/allocator_test.cpp
+++ b/ZEngine/tests/Memory/allocator_test.cpp
@@ -1,9 +1,3 @@
-#ifdef _WIN32
-// clang-format off
-#include <windows.h>
-// clang-format on
-#include <sysinfoapi.h>
-#endif
 #include <ZEngine/Core/Memory/Allocator.h>
 #include <ZEngine/Core/Memory/MemoryManager.h>
 #include <ZEngine/Helpers/MemoryOperations.h>
@@ -23,7 +17,7 @@ TEST(AllocatorTest, ArenaAllocate)
 {
     MemoryManager manager{};
     manager.Initialize(200, {});
-    auto arena = manager.MainArena;
+    auto& arena = manager.MainArena;
 
     for (int i = 0; i < 10; ++i)
     {
@@ -347,15 +341,10 @@ TEST(AllocatorTest, ArenaSubArenaMultipleLargeSubArenas)
     manager.Shutdown();
 }
 
-#ifdef _WIN32
-// Windows-only: sub-arena m_memory must be page-aligned so VirtualAlloc(MEM_COMMIT)
-// commit addresses do not cross into adjacent sub-arenas' pages.
-TEST(AllocatorTest, ArenaSubArenaPageAlignedOnWindows)
+// Sub-arena m_memory must be page-aligned on every platform — on Windows this keeps
+// VirtualAlloc(MEM_COMMIT) boundaries clean; elsewhere it's just a uniform guarantee.
+TEST(AllocatorTest, ArenaSubArenaPageAligned)
 {
-    SYSTEM_INFO si{};
-    GetSystemInfo(&si);
-    const size_t  page_size = si.dwPageSize;
-
     MemoryManager manager{};
     manager.Initialize(ZMega(4), {});
     auto* parent = &(manager.MainArena);
@@ -367,12 +356,11 @@ TEST(AllocatorTest, ArenaSubArenaPageAlignedOnWindows)
     parent->CreateSubArena(ZMega(1), &sub);
 
     ASSERT_NE(sub.m_memory, nullptr);
-    EXPECT_EQ(reinterpret_cast<uintptr_t>(sub.m_memory) % page_size, 0u);
+    EXPECT_EQ(reinterpret_cast<uintptr_t>(sub.m_memory) % parent->m_mem_page_size, 0u);
 
     sub.Shutdown();
     manager.Shutdown();
 }
-#endif
 
 TEST(AllocatorTest, TempArenaRestoresOffsets)
 {


### PR DESCRIPTION
## Root cause

The Windows crash (`m_upload_pool` allocation, access violation writing at a null pointer) traces to `m_mem_page_size` being declared `unsigned long`, which is 32-bit under Windows' LLP64 data model (64-bit on macOS/Linux LP64).

The page-align mask:
```cpp
(offset + size + m_mem_page_size - 1) & ~(m_mem_page_size - 1)
```
computes `~(page_size - 1)` in 32-bit `unsigned long`, then zero-extends that 32-bit pattern to 64-bit when ANDed against the 64-bit `size_t` operand. Once `offset + size` crosses 4 GB — exactly where this project's sub-arena budget total lands (VFS 64MB + AssetManager 1GB + Input 4MB + ECS 512MB + ImportPipeline 3.5GB + UIContext 128MB ≈ 5.19 GB) — the zero-extended mask clears bit 32, collapsing `commit_size` to a value smaller than what's already committed. The subsequent `commit_size - m_committed_size` underflows, and the garbage size passed to `VirtualAlloc(MEM_COMMIT)` fails, returning `nullptr` — which `secure_memset` then dereferences.

## Fix

- `m_mem_page_size` is now `size_t` everywhere: the `Allocator.h` field, `Initialize`'s parameter, and the local in `MemoryManager.cpp`. All arithmetic sites (`ArenaAllocateRaw`, `Resize`, `CreateSubArena`) now do pure 64-bit arithmetic.
- Both `VirtualAlloc(MEM_COMMIT)` call sites now commit the full `[base, commit_size)` range each time instead of the delta from `m_committed_size` — committing an already-committed page is a documented Windows no-op, so this removes the only other place a stale/incorrect `m_committed_size` could produce an invalid commit size.
- `CreateSubArena` page-aligns the sub-arena start on every platform (was Windows-only): correctness-required on Windows for clean `VirtualAlloc` boundaries; on macOS/Linux it costs at most one page of padding per sub-arena in exchange for a single code path instead of two.
- `ArenaAllocator` and `PoolAllocator` now delete their copy constructor/assignment — a shallow copy would double-`VirtualFree`/`munmap` the same pointer at destruction. `ArenaAllocator` gains move construction/assignment so it can still be relocated safely. Updated the one call site that copied `MemoryManager::MainArena` by value (`allocator_test.cpp`) to use a reference instead.

## Test plan

- [x] All 532 existing tests pass (macOS)
- [ ] Manual: engine starts on Windows past the `m_upload_pool` allocation without access violation