### PR TITLE
fix(ui): clamp dock-split span to kMinPanelPx in LayoutNode

### DIFF
--- a/ZEngine/ZEngine/UI/ZUIDockspace.cpp
+++ b/ZEngine/ZEngine/UI/ZUIDockspace.cpp
@@ -66,6 +66,13 @@ namespace ZEngine::UI
         {
             // Last child takes exact remainder — eliminates sub-pixel gaps.
             float span = c->Next ? (total * c->SizePx / size_sum) : ((node->SplitAxis == ZUIAxis::X) ? (x1 - cursor) : (y1 - cursor));
+            // Floor to the same minimum enforced during interactive drag (ZUIDockResize).
+            // Stale absolute SizePx sums — left behind by a window resize or a new dock
+            // insertion that hasn't been re-proportioned yet — can otherwise push the
+            // last child's remainder negative, producing a degenerate rect that wraps to
+            // a huge uint32_t once cast into a VkRect2D scissor extent (issue #732).
+            if (span < kMinPanelPx)
+                span = kMinPanelPx;
             if (node->SplitAxis == ZUIAxis::X)
             {
                 c->RectMin[0] = cursor;


### PR DESCRIPTION
Closes #732.

## Root cause

`LayoutNode()` in `ZUIDockspace.cpp` computes the last child in a dock split as an exact remainder — `x1 - cursor` / `y1 - cursor` — with no floor. `SizePx` values are absolute pixels persisted across frames. When they go stale (a window resize changes the parent's `total`, or a new dock insertion hasn't been re-proportioned yet), `cursor` can overshoot the parent's edge and the last child's span goes negative.

That negative rect flows unclamped through:
- `ZUIPanel.cpp` (`rect[2] - rect[0]` box sizing)
- `ZUILayout.cpp` (`ComputedSize`, `ScreenMax`)
- `ZUIDrawList.cpp` (`ClipW`/`ClipH` as floats)
- `ZUIRenderer.cpp` — cast to `uint32_t` for the scissor rect, wrapping a negative float to a huge unsigned value
- `VulkanDevice.cpp` — lands in `VkRect2D::extent`, triggering the `vkCmdSetScissor` validation error

## Fix

Floor every computed span in `LayoutNode()` to `kMinPanelPx` (60px) — the same minimum already enforced during interactive drag in `ZUIDockResize`. `header_h` (19px) stays well under 60px, so the header-height subtraction downstream in `ZUIPanel.cpp` remains positive without needing its own clamp — one fix at the source closes the whole chain.

## Test plan

- [x] Manual: dock several panels into a tight split, then resize the window rapidly — no more `vkCmdSetScissor` validation errors in the log
- [x] Manual: drag-resize a dock splitter to its minimum, confirm panels don't visually disappear or overlap
- No existing ZUI test infrastructure to extend with a regression test — flagging in case that's wanted as a follow-up