### PR TITLE
fix(importer): guard meshopt against out-of-range submesh indices

### DIFF
--- a/ZEngine/ZEngine/Importers/FbxImporter.cpp
+++ b/ZEngine/ZEngine/Importers/FbxImporter.cpp
@@ -328,14 +328,26 @@ namespace ZEngine::Importers
 
             {
                 // Optimize: convert absolute indices → relative, run 3-pass optimization, restore.
-                const uint32_t sub_vc  = static_cast<uint32_t>(vtx_map.size());
-                const uint32_t sub_ic  = static_cast<uint32_t>(mesh.Indices.size()) - sub_idx_start;
-                uint32_t*      sub_idx = mesh.Indices.data() + sub_idx_start;
-                for (uint32_t j = 0; j < sub_ic; ++j)
-                    sub_idx[j] -= sub_vtx_start;
-                OptimizeMeshSubmesh(mesh.Vertices.data() + sub_vtx_start * 8, sub_vc, sub_idx, sub_ic);
-                for (uint32_t j = 0; j < sub_ic; ++j)
-                    sub_idx[j] += sub_vtx_start;
+                const uint32_t sub_vc   = static_cast<uint32_t>(vtx_map.size());
+                const uint32_t sub_ic   = static_cast<uint32_t>(mesh.Indices.size()) - sub_idx_start;
+                uint32_t*      sub_idx  = mesh.Indices.data() + sub_idx_start;
+
+                // See GltfImporter.cpp for the same guard: an index outside this submesh's
+                // own vertex range would underflow on rebase and crash meshopt. Skip
+                // optimization for this submesh rather than crash.
+                bool           in_range = true;
+                for (uint32_t j = 0; j < sub_ic && in_range; ++j)
+                    if (sub_idx[j] < sub_vtx_start || sub_idx[j] >= sub_vtx_start + sub_vc)
+                        in_range = false;
+
+                if (in_range)
+                {
+                    for (uint32_t j = 0; j < sub_ic; ++j)
+                        sub_idx[j] -= sub_vtx_start;
+                    OptimizeMeshSubmesh(mesh.Vertices.data() + sub_vtx_start * 8, sub_vc, sub_idx, sub_ic);
+                    for (uint32_t j = 0; j < sub_ic; ++j)
+                        sub_idx[j] += sub_vtx_start;
+                }
             }
 
             AssetSubMesh sub         = {};

--- a/ZEngine/ZEngine/Importers/GltfImporter.cpp
+++ b/ZEngine/ZEngine/Importers/GltfImporter.cpp
@@ -554,8 +554,21 @@ namespace ZEngine::Importers
         // Optimize each submesh: vertex cache, overdraw, vertex fetch.
         for (uint32_t si = 0; si < mesh.SubMeshes.size(); ++si)
         {
-            auto&     sub     = mesh.SubMeshes[si];
-            uint32_t* sub_idx = mesh.Indices.data() + sub.IndexOffset;
+            auto&     sub      = mesh.SubMeshes[si];
+            uint32_t* sub_idx  = mesh.Indices.data() + sub.IndexOffset;
+
+            // Cross-primitive index contamination or a malformed GLTF can leave an index
+            // outside this submesh's own vertex range. Rebasing such an index underflows
+            // (uint32_t subtraction), which meshopt::buildTriangleAdjacency asserts on.
+            // Skip optimization for this submesh rather than crash — indices are left
+            // untouched (still correct against the unmodified vertex buffer).
+            bool      in_range = true;
+            for (uint32_t j = 0; j < sub.IndexCount && in_range; ++j)
+                if (sub_idx[j] < sub.VertexOffset || sub_idx[j] >= sub.VertexOffset + sub.VertexCount)
+                    in_range = false;
+            if (!in_range)
+                continue;
+
             for (uint32_t j = 0; j < sub.IndexCount; ++j)
                 sub_idx[j] -= sub.VertexOffset;
             Importers::OptimizeMeshSubmesh(mesh.Vertices.data() + sub.VertexOffset * 8, sub.VertexCount, sub_idx, sub.IndexCount);


### PR DESCRIPTION
Closes #684.

## Root cause

Both `GltfImporter` and `FbxImporter` rebase submesh indices (subtract `VertexOffset`) before passing them to meshopt for vertex-cache/overdraw/fetch optimization, then rebase back afterward. If any index in a submesh lies outside its own `[VertexOffset, VertexOffset + VertexCount)` range — from cross-primitive index contamination or a malformed source file — the `uint32_t` subtraction underflows to a huge value, which `meshopt::buildTriangleAdjacency` asserts on, crashing the import (reproducible with a multi-submesh car model GLTF per the issue).

## Fix

Validate every index is in range before rebasing. If any index is out of range, skip optimization for that submesh entirely — indices are left untouched (still correct against the unmodified vertex buffer) rather than crashing.

- `GltfImporter.cpp`: `continue` to the next submesh in the optimize loop.
- `FbxImporter.cpp`: wrap the rebase/optimize/restore block in the range check directly, since the loop body still needs to register the `AssetSubMesh` afterward regardless of whether optimization ran.

## Test plan

- [ ] Manual: re-import the car model GLTF that originally reproduced the crash — import completes without SIGABRT
- [ ] Manual: import a well-formed multi-submesh GLTF/FBX — optimization still runs normally (no regression in mesh quality/vertex cache behavior)
- No existing importer test infrastructure to extend with a regression test — flagging in case that's wanted as a follow-up