### PR TITLE
fix(ui): clamp dock tree root rect in ZUIDockLayout

### DIFF
--- a/ZEngine/ZEngine/UI/ZUIDockspace.cpp
+++ b/ZEngine/ZEngine/UI/ZUIDockspace.cpp
@@ -162,8 +162,16 @@ namespace ZEngine::UI
         }
         tree->Root->RectMin[0] = root_rect[0];
         tree->Root->RectMin[1] = root_rect[1];
-        tree->Root->RectMax[0] = root_rect[2];
-        tree->Root->RectMax[1] = root_rect[3];
+        // Floor the root rect to kMinPanelPx. A transient window/menu/status-bar height
+        // mismatch (e.g. during a Windows resize or DPI-change race, where the client
+        // area briefly reports a height smaller than menu_h + status_h) can otherwise
+        // hand down a negative-height or negative-width root rect. When the tree has no
+        // splits yet — root is itself a leaf — LayoutNode's per-child clamp never runs
+        // on this rect at all, so it must be floored here at the single entry point.
+        float min_x1           = root_rect[0] + kMinPanelPx;
+        float min_y1           = root_rect[1] + kMinPanelPx;
+        tree->Root->RectMax[0] = (root_rect[2] < min_x1) ? min_x1 : root_rect[2];
+        tree->Root->RectMax[1] = (root_rect[3] < min_y1) ? min_y1 : root_rect[3];
         LayoutNode(tree->Root);
     }
 


### PR DESCRIPTION
Follow-up to #732 / PR #733 — the scissor overflow was still reproducing on Windows with a fresh build after that fix merged.

## Root cause

PR #733 clamped each child's span inside `LayoutNode`'s per-node loop, but that loop only runs for a node **with** children. When the dock tree's root is itself a leaf (no splits — e.g. a single docked panel), `ZUIDockLayout` assigns `root_rect` directly to `tree->Root` and `LayoutNode` returns immediately on the leaf early-out, never reaching the clamp.

`ZUIPanelManager::BuildUI` computes `root_rect` as `{0, menu_h, sw, sh - status_h}`. During a Windows-specific resize or DPI-change race, `sh` can transiently report a value smaller than `menu_h + status_h`, producing a negative-height root rect that flows straight through `ZUIDockRectForKey` to the panel's scissor rect — the same `vkCmdSetScissor` overflow as #732, via a path the prior fix didn't cover.

## Fix

Floor `RectMax` to `RectMin + kMinPanelPx` in `ZUIDockLayout` itself — the single entry point every `root_rect` passes through — so both the single-leaf-root case and the multi-split case (redundant with, but consistent with, `LayoutNode`'s per-child floor) are covered.

## Test plan

- [x] Manual on Windows: reproduce the original resize/dock sequence that triggered the `vkCmdSetScissor` error — confirm it no longer appears in the log
- [x] Manual: single docked panel (no splits), rapid window resize — no scissor errors