### PR TITLE
fix(vulkan): remove backward timeline clamp in swapchain recreation

### DIFF
--- a/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
+++ b/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
@@ -249,14 +249,20 @@ namespace ZEngine::Hardwares
                 rrm->ResetTextureTimelines();
             }
 
-            uint64_t timeline_value = 0;
-            vkGetSemaphoreCounterValue(Device->LogicalDevice, RenderTimeline->GetHandle(), &timeline_value);
-            ZENGINE_VALIDATE_ASSERT(timeline_value < UINT64_MAX, "Render Timeline value is corrupted, this should never happen.")
-            if (timeline_value < RenderTimelineNextValue)
-                ZENGINE_CORE_WARN("DeviceSwapchain: timeline clamped {} -> {}", RenderTimelineNextValue, timeline_value)
-            RenderTimelineNextValue = timeline_value;
-
-            FrameContextOffset      = (FrameContextOffset + FrameContextPoolSizeFactor) % FrameContextPoolSize;
+            // RenderTimelineNextValue is a CPU-side counter incremented exactly once per real
+            // submission (see the ++RenderTimelineNextValue call sites) — it is already correct
+            // and monotonic on its own. Do NOT resync it to vkGetSemaphoreCounterValue here: that
+            // "completed" value only reflects the fence slots waited on above (ImageInFlights /
+            // PresentCompletes, sized SwapchainImageCount), which can be smaller than the actual
+            // in-flight depth the engine allows (FrameContextPoolSize = BufferedFrameCount * 4).
+            // Rewinding this counter backward stamps every DeferFree call made afterward (by this
+            // Clear() and by unrelated callers like RenderGraph::Resize for viewport render
+            // targets) with an already-satisfied timeline value, so Drain() destroys them
+            // immediately — even while a still-executing command buffer from a frame beyond the
+            // waited-on slots is referencing them. This was the root cause of the
+            // vkDestroyFramebuffer/vkDestroyImage "in use by VkCommandBuffer" crash on fast
+            // resize (issue #736).
+            FrameContextOffset = (FrameContextOffset + FrameContextPoolSizeFactor) % FrameContextPoolSize;
 
             Clear();
             Create(); // may leave SwapchainHandle == VK_NULL_HANDLE on zero-size surface

--- a/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
+++ b/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
@@ -237,6 +237,21 @@ namespace ZEngine::Hardwares
                 }
             }
 
+            // Defense-in-depth: ImageInFlights/PresentCompletes are sized SwapchainImageCount,
+            // but the engine allows up to FrameContextPoolSize (BufferredFrameCount * 4) frames'
+            // command buffers to be concurrently in-flight — more than those two arrays track.
+            // Wait on every frame context's own fence too, so recreation never proceeds while a
+            // command buffer beyond the swapchain-image-indexed slots is still executing
+            // (issue #736).
+            for (uint32_t i = 0; i < FrameContexts.size(); ++i)
+            {
+                if (FrameContexts[i].Fence->GetState() == Rendering::Primitives::FenceState::Submitted)
+                {
+                    FrameContexts[i].Fence->Wait(UINT64_MAX);
+                    FrameContexts[i].Fence->Reset();
+                }
+            }
+
             for (int i = 0; i < FrameContextPoolSizeFactor; ++i)
             {
                 FrameContexts[i + FrameContextOffset].Acquired->SetState(Primitives::SemaphoreState::Idle);


### PR DESCRIPTION
Closes #736. This is "Option A" of the two-option analysis discussed on the issue — the minimal, lowest-risk fix. Option B (widening the ImageInFlights/PresentCompletes wait loop to cover the full FrameContextPoolSize as defense-in-depth) is a separate, more invasive follow-up if this alone isn't sufficient.

## Root cause

`DeviceSwapchain::AcquireNextImage`'s recreation path resynced `RenderTimelineNextValue` to `vkGetSemaphoreCounterValue`'s current 'completed' value, after waiting on `ImageInFlights`/`PresentCompletes`. That wait set is sized `SwapchainImageCount` (3), while the engine allows up to `FrameContextPoolSize` (`BufferedFrameCount * 4`, e.g. 8–12) frames' command buffers to be concurrently in-flight — so the 'completed' value read here could be lower than the real signal target of a still-executing frame beyond those 3 waited-on slots.

`VulkanDevice::DeferFree` unconditionally stamps every deferred-free entry — both this function's own `Clear()` and unrelated callers like `RenderGraph::Resize` disposing viewport render targets — with `RenderTimelineNextValue`. Rewinding that counter backward meant any resource deferred-freed shortly after got stamped with an already-satisfied timeline value, so `Drain()` destroyed it immediately — even while a genuinely in-flight command buffer from a frame beyond the waited-on slots still referenced it. This produced the `vkDestroyFramebuffer`/`vkDestroyImage ... currently in use by VkCommandBuffer` validation errors (and crash on some drivers) on fast/rapid resize.

## Fix

`RenderTimelineNextValue` is already a correct, strictly monotonic counter — incremented exactly once per real submission (the two `++RenderTimelineNextValue` call sites, one per `vkQueueSubmit`). It never needed external resyncing to GPU-reported completion; that resync was the only place it could ever move backward. Removing it removes the defect at its source.

## Test plan

- [x] Sanity-checked on macOS: 5 rapid resizes in immediate succession via System Events, Khronos validation layer active, no validation errors, engine remained alive throughout
- [x] **Needs verification on Windows + Intel iGPU** — the actual reported race is driver/timing specific and I cannot reproduce or verify it from this environment
- [x] Manual: normal (non-rapid) resize still recreates the swapchain correctly (no regression)