### PR TITLE
fix(vulkan): wait on full frame-context pool before swapchain recreation

### DIFF
--- a/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
+++ b/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
@@ -237,6 +237,21 @@ namespace ZEngine::Hardwares
                 }
             }
 
+            // Defense-in-depth: ImageInFlights/PresentCompletes are sized SwapchainImageCount,
+            // but the engine allows up to FrameContextPoolSize (BufferredFrameCount * 4) frames'
+            // command buffers to be concurrently in-flight — more than those two arrays track.
+            // Wait on every frame context's own fence too, so recreation never proceeds while a
+            // command buffer beyond the swapchain-image-indexed slots is still executing
+            // (issue #736).
+            for (uint32_t i = 0; i < FrameContexts.size(); ++i)
+            {
+                if (FrameContexts[i].Fence->GetState() == Rendering::Primitives::FenceState::Submitted)
+                {
+                    FrameContexts[i].Fence->Wait(UINT64_MAX);
+                    FrameContexts[i].Fence->Reset();
+                }
+            }
+
             for (int i = 0; i < FrameContextPoolSizeFactor; ++i)
             {
                 FrameContexts[i + FrameContextOffset].Acquired->SetState(Primitives::SemaphoreState::Idle);


### PR DESCRIPTION
Option B from the #736 analysis — stacked on top of #738 (Option A). This PR's diff is additive on top of that one; merge #738 first, then this.

## Root cause (independent of #738)

`ImageInFlights`/`PresentCompletes` are sized `SwapchainImageCount` (typically 3), but the engine allows up to `FrameContextPoolSize` (`BufferredFrameCount * 4`, e.g. 8–12) frames' command buffers to be concurrently in-flight. The existing wait loop in `AcquireNextImage`'s recreation path only covers the smaller set — a command buffer using a frame context beyond those tracked slots could still be executing GPU work when recreation proceeds to destroy old framebuffers/images.

## Fix

Add a wait over every `FrameContexts[i].Fence` (checking `Submitted` state first, mirroring the existing `PresentCompletes` pattern) before `Clear()` runs. This closes the undersized-wait gap independently of #738's timeline-clamp fix — even if some other code path reintroduces a timeline miscalculation in the future, this ensures recreation genuinely waits for the full in-flight depth the engine allows before destroying anything referenced by those frames.

## Test plan

- [x] Sanity-checked on macOS with both #738 and this fix stacked: 15 rapid random resizes, Khronos validation layer active, no errors, engine remained alive
- [ ] **Needs verification on Windows + Intel iGPU** — same caveat as #738, I cannot reproduce the original driver/timing-specific race from this environment