### PR TITLE
fix(logging): no-op Logger::Log when not initialized

### DIFF
--- a/ZEngine/ZEngine/Logging/Logger.cpp
+++ b/ZEngine/ZEngine/Logging/Logger.cpp
@@ -160,6 +160,11 @@ namespace ZEngine::Logging
 
     void Logger::Log(LogChannel channel, LogLevel level, std::string_view msg)
     {
+        if (!IsInitialized())
+        {
+            return;
+        }
+
         const int min = k_min_level[static_cast<size_t>(channel)];
         if (static_cast<int>(level) < min)
         {

--- a/ZEngine/tests/Logging/Logger_test.cpp
+++ b/ZEngine/tests/Logging/Logger_test.cpp
@@ -51,6 +51,18 @@ protected:
 std::string LoggerTest::s_log_dir;
 std::string LoggerTest::s_crash_dir;
 
+TEST(LoggerUninitialized, LogBeforeInitializeDoesNotCrash)
+{
+    if (Logger::IsInitialized())
+    {
+        Logger::Dispose();
+    }
+
+    EXPECT_FALSE(Logger::IsInitialized());
+    Logger::Log(LogChannel::ENGINE, LogLevel::WARN, "before initialize");
+    ZENGINE_CORE_WARN("before initialize via macro");
+}
+
 TEST_F(LoggerTest, IsInitializedAfterInit)
 {
     EXPECT_TRUE(Logger::IsInitialized());
@@ -318,4 +330,12 @@ TEST_F(LoggerTest, LevelToStringAllValues)
     EXPECT_STREQ(Logger::LevelToString(LogLevel::WARN), "warn");
     EXPECT_STREQ(Logger::LevelToString(LogLevel::ERR), "error");
     EXPECT_STREQ(Logger::LevelToString(LogLevel::CRITICAL), "critical");
+}
+
+TEST_F(LoggerTest, LogAfterDisposeDoesNotCrash)
+{
+    Logger::Dispose();
+    EXPECT_FALSE(Logger::IsInitialized());
+    Logger::Log(LogChannel::ENGINE, LogLevel::ERR, "after dispose");
+    ZENGINE_CORE_ERROR("after dispose via macro");
 }


### PR DESCRIPTION
## Summary

`Logger::Log` indexed the ring buffer with `fetch_add(...) % s_log_message_rb.size()` without checking initialization. Before `Initialize()` the capacity is zero (modulo-by-zero / `SIGFPE`). After `Dispose()` the same path can recurse through assert macros back into `Log` until the stack overflows.

Return immediately when `!IsInitialized()`. `IsInitialized()` already exists; this just uses it at the top of `Log`.

## Test plan

- [x] `LoggerUninitialized.LogBeforeInitializeDoesNotCrash` — was RED (`SIGFPE`), now GREEN
- [x] `LoggerTest.LogAfterDisposeDoesNotCrash` — GREEN
- [x] Existing `LoggerTest.*` still pass (15/15 in the isolated Logger binary)

```bash
ZEngineTests --gtest_filter='LoggerUninitialized.*:LoggerTest.*'
```

Fixes #746