### PR TITLE
Rendering foundation hardening: real RenderGraph sort, GpuAllocator pools, RRM hot-reload

### DIFF
--- a/ZEngine/ZEngine/Core/Memory/GpuAllocator.cpp
+++ b/ZEngine/ZEngine/Core/Memory/GpuAllocator.cpp
@@ -64,10 +64,10 @@ namespace ZEngine::Core::Memory
         // dependency for engine startup.
         auto create_buffer_pool = [&](GpuMemoryDomain domain, VkBufferUsageFlags usage, VmaAllocationCreateInfo alloc_info, VkDeviceSize block_size, size_t max_block_count) {
             VkBufferCreateInfo rep_buffer_info = {.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
-            rep_buffer_info.size                = 1;
-            rep_buffer_info.usage               = usage;
+            rep_buffer_info.size               = 1;
+            rep_buffer_info.usage              = usage;
 
-            uint32_t memory_type_index = 0;
+            uint32_t memory_type_index         = 0;
             if (vmaFindMemoryTypeIndexForBufferInfo(Allocator, &rep_buffer_info, &alloc_info, &memory_type_index) != VK_SUCCESS)
             {
                 ZENGINE_CORE_WARN("[GPU] Failed to find memory type index for domain {} pool — falling back to default pool", static_cast<int>(domain))
@@ -114,19 +114,19 @@ namespace ZEngine::Core::Memory
         // larger than the block (an 8K RGBA8 texture is already 256 MB with no
         // compression/mips in the current import path).
         {
-            VkImageCreateInfo rep_image_info  = {.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
-            rep_image_info.imageType          = VK_IMAGE_TYPE_2D;
-            rep_image_info.format             = VK_FORMAT_R8G8B8A8_UNORM;
-            rep_image_info.extent             = {1, 1, 1};
-            rep_image_info.mipLevels          = 1;
-            rep_image_info.arrayLayers        = 1;
-            rep_image_info.samples            = VK_SAMPLE_COUNT_1_BIT;
-            rep_image_info.tiling             = VK_IMAGE_TILING_OPTIMAL;
-            rep_image_info.usage              = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-            rep_image_info.sharingMode        = VK_SHARING_MODE_EXCLUSIVE;
-            rep_image_info.initialLayout      = VK_IMAGE_LAYOUT_UNDEFINED;
+            VkImageCreateInfo rep_image_info          = {.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
+            rep_image_info.imageType                  = VK_IMAGE_TYPE_2D;
+            rep_image_info.format                     = VK_FORMAT_R8G8B8A8_UNORM;
+            rep_image_info.extent                     = {1, 1, 1};
+            rep_image_info.mipLevels                  = 1;
+            rep_image_info.arrayLayers                = 1;
+            rep_image_info.samples                    = VK_SAMPLE_COUNT_1_BIT;
+            rep_image_info.tiling                     = VK_IMAGE_TILING_OPTIMAL;
+            rep_image_info.usage                      = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+            rep_image_info.sharingMode                = VK_SHARING_MODE_EXCLUSIVE;
+            rep_image_info.initialLayout              = VK_IMAGE_LAYOUT_UNDEFINED;
 
-            VmaAllocationCreateInfo rep_alloc_info = {.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE};
+            VmaAllocationCreateInfo rep_alloc_info    = {.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE};
             uint32_t                memory_type_index = 0;
             if (vmaFindMemoryTypeIndexForImageInfo(Allocator, &rep_image_info, &rep_alloc_info, &memory_type_index) == VK_SUCCESS)
             {

--- a/ZEngine/ZEngine/Core/Memory/GpuAllocator.cpp
+++ b/ZEngine/ZEngine/Core/Memory/GpuAllocator.cpp
@@ -58,7 +58,99 @@ namespace ZEngine::Core::Memory
             HeapCount = memory_properties->memoryHeapCount;
         }
 
-        Ring.Initialize(Allocator);
+        // Segregated pools isolate each domain's allocation churn/fragmentation from the
+        // others. A pool that fails to create is left null — every call site below falls
+        // back to the default allocator, so this is an optimization, never a hard
+        // dependency for engine startup.
+        auto create_buffer_pool = [&](GpuMemoryDomain domain, VkBufferUsageFlags usage, VmaAllocationCreateInfo alloc_info, VkDeviceSize block_size, size_t max_block_count) {
+            VkBufferCreateInfo rep_buffer_info = {.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+            rep_buffer_info.size                = 1;
+            rep_buffer_info.usage               = usage;
+
+            uint32_t memory_type_index = 0;
+            if (vmaFindMemoryTypeIndexForBufferInfo(Allocator, &rep_buffer_info, &alloc_info, &memory_type_index) != VK_SUCCESS)
+            {
+                ZENGINE_CORE_WARN("[GPU] Failed to find memory type index for domain {} pool — falling back to default pool", static_cast<int>(domain))
+                return;
+            }
+
+            VmaPoolCreateInfo pool_info = {};
+            pool_info.memoryTypeIndex   = memory_type_index;
+            pool_info.blockSize         = block_size;
+            pool_info.maxBlockCount     = max_block_count;
+            if (vmaCreatePool(Allocator, &pool_info, &Pools[static_cast<uint8_t>(domain)]) != VK_SUCCESS)
+            {
+                ZENGINE_CORE_WARN("[GPU] Failed to create pool for domain {} — falling back to default pool", static_cast<int>(domain))
+                Pools[static_cast<uint8_t>(domain)] = nullptr;
+            }
+        };
+
+        // DeviceGeometry — vertex/index/storage buffers. Fixed block size is fine here:
+        // geometry buffers don't vary in size the way textures do.
+        create_buffer_pool(GpuMemoryDomain::DeviceGeometry, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VmaAllocationCreateInfo{.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE}, GeometryBytes, 2);
+
+        // HostUniform — per-frame UBOs/SSBOs on the BAR window.
+        create_buffer_pool(GpuMemoryDomain::HostUniform, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, VmaAllocationCreateInfo{.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT, .usage = VMA_MEMORY_USAGE_AUTO}, UniformBytes, 1);
+
+        // HostStaging — built from the staging ring's OWN flags (AUTO_PREFER_DEVICE), not
+        // AllocateBuffer's generic HostStaging branch (plain AUTO): those can resolve to
+        // different memory type indices on a discrete GPU with a BAR window, and the ring
+        // is this domain's dominant consumer. The generic one-off staging buffers
+        // (AllocateBuffer with domain=HostStaging) share this same pool.
+        //
+        // blockSize=0 (auto-sized), not a fixed StagingBytes block: a block needs some
+        // alignment/bookkeeping headroom beyond its raw byte count, so a fixed block
+        // exactly equal to the ring's own StagingBytes allocation can't actually fit it
+        // (confirmed: fails with VK_ERROR_OUT_OF_DEVICE_MEMORY). Same underlying reason as
+        // DeviceTexture's blockSize=0 below, just triggered by exact-equality instead of
+        // exceeding the block.
+        create_buffer_pool(GpuMemoryDomain::HostStaging, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VmaAllocationCreateInfo{.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT, .usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE}, 0, 1);
+
+        // DeviceTexture — images only (never buffers), so this MUST use the image-info
+        // query, not the buffer-info one: VMA's own docs warn against building a pool from
+        // buffer info and then allocating images into it. blockSize=0 (auto-sized) is
+        // deliberate, not the fixed-size pattern above — a fixed block disables VMA's
+        // dedicated-allocation fallback entirely and hard-fails on any single texture
+        // larger than the block (an 8K RGBA8 texture is already 256 MB with no
+        // compression/mips in the current import path).
+        {
+            VkImageCreateInfo rep_image_info  = {.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
+            rep_image_info.imageType          = VK_IMAGE_TYPE_2D;
+            rep_image_info.format             = VK_FORMAT_R8G8B8A8_UNORM;
+            rep_image_info.extent             = {1, 1, 1};
+            rep_image_info.mipLevels          = 1;
+            rep_image_info.arrayLayers        = 1;
+            rep_image_info.samples            = VK_SAMPLE_COUNT_1_BIT;
+            rep_image_info.tiling             = VK_IMAGE_TILING_OPTIMAL;
+            rep_image_info.usage              = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+            rep_image_info.sharingMode        = VK_SHARING_MODE_EXCLUSIVE;
+            rep_image_info.initialLayout      = VK_IMAGE_LAYOUT_UNDEFINED;
+
+            VmaAllocationCreateInfo rep_alloc_info = {.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE};
+            uint32_t                memory_type_index = 0;
+            if (vmaFindMemoryTypeIndexForImageInfo(Allocator, &rep_image_info, &rep_alloc_info, &memory_type_index) == VK_SUCCESS)
+            {
+                VmaPoolCreateInfo pool_info = {};
+                pool_info.memoryTypeIndex   = memory_type_index;
+                pool_info.blockSize         = 0; // auto-sized — keeps dedicated-allocation fallback
+                pool_info.maxBlockCount     = 0; // unlimited
+                if (vmaCreatePool(Allocator, &pool_info, &Pools[static_cast<uint8_t>(GpuMemoryDomain::DeviceTexture)]) != VK_SUCCESS)
+                {
+                    ZENGINE_CORE_WARN("[GPU] Failed to create DeviceTexture pool — falling back to default pool")
+                    Pools[static_cast<uint8_t>(GpuMemoryDomain::DeviceTexture)] = nullptr;
+                }
+            }
+            else
+            {
+                ZENGINE_CORE_WARN("[GPU] Failed to find memory type index for DeviceTexture pool — falling back to default pool")
+            }
+        }
+
+        // RenderTarget intentionally has no pool — few, large images that individually
+        // benefit from VMA's automatic dedicated-allocation promotion; pooling would work
+        // against that.
+
+        Ring.Initialize(Allocator, Pools[static_cast<uint8_t>(GpuMemoryDomain::HostStaging)]);
     }
 
     void GpuAllocator::Shutdown()
@@ -70,6 +162,15 @@ namespace ZEngine::Core::Memory
         if (stats.total.statistics.allocationCount > 0)
         {
             ZENGINE_CORE_WARN("[GPU] VMA shutdown: {} allocation(s) still live ({} MB)", stats.total.statistics.allocationCount, stats.total.statistics.allocationBytes >> 20);
+        }
+
+        for (uint8_t i = 0; i < static_cast<uint8_t>(GpuMemoryDomain::Count); ++i)
+        {
+            if (Pools[i] != nullptr)
+            {
+                vmaDestroyPool(Allocator, Pools[i]);
+                Pools[i] = nullptr;
+            }
         }
 
         vmaDestroyAllocator(Allocator);
@@ -112,8 +213,22 @@ namespace ZEngine::Core::Memory
             allocation_create_info.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT;
         }
 
+        if (Pools[static_cast<uint8_t>(domain)] != nullptr)
+        {
+            allocation_create_info.pool = Pools[static_cast<uint8_t>(domain)];
+        }
+
         BufferView buffer_view = {.DebugName = debug_name, .Domain = domain};
-        ZENGINE_VALIDATE_ASSERT(vmaCreateBuffer(Allocator, &buffer_create_info, &allocation_create_info, &buffer_view.Handle, &buffer_view.Allocation, nullptr) == VK_SUCCESS, "Failed to allocate buffer");
+        VkResult   result      = vmaCreateBuffer(Allocator, &buffer_create_info, &allocation_create_info, &buffer_view.Handle, &buffer_view.Allocation, nullptr);
+        // VMA signals VmaPool exhaustion via VK_ERROR_OUT_OF_DEVICE_MEMORY, not
+        // VK_ERROR_OUT_OF_POOL_MEMORY (that's for VkDescriptorPool, unrelated).
+        if (result == VK_ERROR_OUT_OF_DEVICE_MEMORY && allocation_create_info.pool != VK_NULL_HANDLE)
+        {
+            ZENGINE_CORE_WARN("[GPU] Pool for domain {} exhausted — falling back to default pool", static_cast<int>(domain))
+            allocation_create_info.pool = VK_NULL_HANDLE;
+            result                      = vmaCreateBuffer(Allocator, &buffer_create_info, &allocation_create_info, &buffer_view.Handle, &buffer_view.Allocation, nullptr);
+        }
+        ZENGINE_VALIDATE_ASSERT(result == VK_SUCCESS, "Failed to allocate buffer");
         vmaSetAllocationName(Allocator, buffer_view.Allocation, debug_name);
         return buffer_view;
     }
@@ -126,8 +241,22 @@ namespace ZEngine::Core::Memory
             allocation_create_info.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
         }
 
+        if (Pools[static_cast<uint8_t>(domain)] != nullptr)
+        {
+            allocation_create_info.pool = Pools[static_cast<uint8_t>(domain)];
+        }
+
         BufferImage buffer_image = {.DebugName = debug_name, .Domain = domain};
-        ZENGINE_VALIDATE_ASSERT(vmaCreateImage(Allocator, &image_info, &allocation_create_info, &buffer_image.Handle, &buffer_image.Allocation, nullptr) == VK_SUCCESS, "Failed to allocate image");
+        VkResult    result       = vmaCreateImage(Allocator, &image_info, &allocation_create_info, &buffer_image.Handle, &buffer_image.Allocation, nullptr);
+        // VMA signals VmaPool exhaustion via VK_ERROR_OUT_OF_DEVICE_MEMORY, not
+        // VK_ERROR_OUT_OF_POOL_MEMORY (that's for VkDescriptorPool, unrelated).
+        if (result == VK_ERROR_OUT_OF_DEVICE_MEMORY && allocation_create_info.pool != VK_NULL_HANDLE)
+        {
+            ZENGINE_CORE_WARN("[GPU] Pool for domain {} exhausted — falling back to default pool", static_cast<int>(domain))
+            allocation_create_info.pool = VK_NULL_HANDLE;
+            result                      = vmaCreateImage(Allocator, &image_info, &allocation_create_info, &buffer_image.Handle, &buffer_image.Allocation, nullptr);
+        }
+        ZENGINE_VALIDATE_ASSERT(result == VK_SUCCESS, "Failed to allocate image");
         vmaSetAllocationName(Allocator, buffer_image.Allocation, debug_name);
 
         VkImageViewCreateInfo view_create_info           = {.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
@@ -208,7 +337,7 @@ namespace ZEngine::Core::Memory
         return (float) HeapBudgets[heap_index].usage / (float) HeapBudgets[heap_index].budget;
     }
 
-    void StagingRingBuffer::Initialize(VmaAllocator alloc)
+    void StagingRingBuffer::Initialize(VmaAllocator alloc, VmaPool pool)
     {
         VkBufferCreateInfo buffer_create_info          = {.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
         buffer_create_info.size                        = kCapacity;
@@ -217,6 +346,7 @@ namespace ZEngine::Core::Memory
 
         VmaAllocationCreateInfo allocation_create_info = {.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT};
         allocation_create_info.usage                   = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+        allocation_create_info.pool                    = pool; // shares the GpuAllocator-owned HostStaging pool when one exists
         VmaAllocationInfo result                       = {};
         ZENGINE_VALIDATE_ASSERT(vmaCreateBuffer(alloc, &buffer_create_info, &allocation_create_info, &Buffer, &Allocation, &result) == VK_SUCCESS, "Failed to allocate buffer");
         vmaSetAllocationName(alloc, Allocation, DebugName);

--- a/ZEngine/ZEngine/Core/Memory/GpuAllocator.h
+++ b/ZEngine/ZEngine/Core/Memory/GpuAllocator.h
@@ -88,7 +88,7 @@ namespace ZEngine::Core::Memory
         uint32_t      ChunkHead          = 0;
         uint32_t      ChunkTail          = 0;
 
-        void          Initialize(VmaAllocator alloc);
+        void          Initialize(VmaAllocator alloc, VmaPool pool);
         void          Shutdown(VmaAllocator alloc);
 
         // Returns mapped pointer + VkBuffer byte offset. Returns nullptr when the ring is

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
@@ -286,7 +286,7 @@ namespace ZEngine::Rendering
                 entry.Data.Image    = *old_slot;
                 m_device->DeferFree(entry);
 
-                *old_slot = *new_slot;
+                *old_slot                                  = *new_slot;
 
                 // The scratch slot's data now lives in old_slot — release it.
                 *new_slot                                  = {};
@@ -505,8 +505,8 @@ namespace ZEngine::Rendering
             return {};
         }
 
-        uint32_t slot            = AllocMeshSlot();
-        m_mesh_slots[slot].Data  = data;
+        uint32_t slot           = AllocMeshSlot();
+        m_mesh_slots[slot].Data = data;
         return {slot, m_mesh_slots[slot].Generation};
     }
 
@@ -876,7 +876,7 @@ namespace ZEngine::Rendering
         }
         ZENGINE_VALIDATE_ASSERT(m_mesh_slot_count < MAX_BUFFERS, "RRM: MAX_BUFFERS exceeded")
         uint32_t idx                 = m_mesh_slot_count++;
-        m_mesh_slots[idx].Generation  = ++m_mesh_slot_gen_counter[idx];
+        m_mesh_slots[idx].Generation = ++m_mesh_slot_gen_counter[idx];
         return idx;
     }
 

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
@@ -235,38 +235,85 @@ namespace ZEngine::Rendering
     void RenderResourceManager::BeginFrame(uint32_t frame_index)
     {
         FlushPendingUploads(frame_index);
+        FlushPendingSwaps(frame_index);
     }
 
     void RenderResourceManager::EndFrame(uint32_t frame_index)
     {
-        std::lock_guard lock(m_pending_mutex);
+        m_current_frame = frame_index + 1;
+    }
 
-        uint32_t        write = 0;
-        for (uint32_t i = 0; i < m_swap_count; ++i)
+    void RenderResourceManager::FlushPendingSwaps(uint32_t frame_index)
+    {
+        uint32_t    count = 0;
+        PendingSwap local[MAX_PENDING];
         {
-            SwapEntry& e = m_swaps[i];
-            if (frame_index < e.SwapSafeFrame)
-            {
-                m_swaps[write++] = e;
-                continue;
-            }
+            std::lock_guard lock(m_pending_swap_mutex);
+            count = m_pending_swap_count;
+            secure_memcpy(local, sizeof(local), m_pending_swaps, count * sizeof(PendingSwap));
+            m_pending_swap_count = 0;
+        }
+        if (count == 0)
+        {
+            return;
+        }
 
-            if (e.Kind == SwapKind::Image)
+        for (uint32_t i = 0; i < count; ++i)
+        {
+            const PendingSwap& s = local[i];
+            if (s.Kind == SwapKind::Image)
             {
-                BufferImage* slot = GetImageMutable(e.OldImage);
-                if (slot)
+                BufferImage* old_slot = GetImageMutable(s.OldImage);
+                if (!old_slot)
                 {
-                    DeferredFreeEntry entry;
-                    entry.EntryKind     = DeferredFreeEntry::Kind::Image;
-                    entry.TimelineValue = m_device->SwapchainPtr->RenderTimelineNextValue;
-                    entry.Data.Image    = *slot;
-                    m_device->DeferFree(entry);
-                    *slot = e.NewImage;
+                    continue; // stale handle — asset was released before the swap could apply
                 }
+                ImageHandle new_handle = DoUploadTexture(s.NewAsset);
+                if (!new_handle.IsValid())
+                {
+                    ZENGINE_LOG_RENDER_ERR("[RRM] Hot-reload swap failed to re-upload texture — old image left in place")
+                    continue;
+                }
+                BufferImage* new_slot = GetImageMutable(new_handle);
+                if (!new_slot)
+                {
+                    continue;
+                }
+
+                DeferredFreeEntry entry;
+                entry.EntryKind     = DeferredFreeEntry::Kind::Image;
+                entry.TimelineValue = m_device->SwapchainPtr->RenderTimelineNextValue;
+                entry.Data.Image    = *old_slot;
+                m_device->DeferFree(entry);
+
+                *old_slot = *new_slot;
+
+                // The scratch slot's data now lives in old_slot — release it.
+                *new_slot                                  = {};
+                m_image_slots[new_handle.Index].Generation = 0;
+            }
+            else if (s.OldBuffer.Generation & GBUF_GEN_TAG)
+            {
+                // No AssetHandle-driven re-upload path exists for generic buffers today —
+                // every live ScheduleSwap(BufferHandle,...) call carries a mesh handle.
+                ZENGINE_LOG_RENDER_WARN("[RRM] Hot-reload swap for generic buffers is not supported — skipping")
+            }
+            else
+            {
+                if (s.OldBuffer.Index >= m_mesh_slot_count || m_mesh_slots[s.OldBuffer.Index].Generation != s.OldBuffer.Generation)
+                {
+                    continue; // stale handle — asset was released before the swap could apply
+                }
+                MeshSlot new_data = AppendMeshData(s.NewAsset, frame_index);
+                if (new_data.VtxCount == 0)
+                {
+                    ZENGINE_LOG_RENDER_ERR("[RRM] Hot-reload swap failed to re-upload mesh data — old data left in place")
+                    continue;
+                }
+                // Append-only global buffer — no GPU free for the old region, just repoint.
+                m_mesh_slots[s.OldBuffer.Index].Data = new_data;
             }
         }
-        m_swap_count    = write;
-        m_current_frame = frame_index + 1;
     }
 
     static void RecordAndSubmit(VkDevice device, CommandBuffer* cmd, VkFence fence, VkQueue queue, std::function<void(VkCommandBuffer)> record_fn, VkSemaphore wait_semaphore = VK_NULL_HANDLE, uint64_t wait_value = 0)
@@ -414,18 +461,20 @@ namespace ZEngine::Rendering
         }
     }
 
-    BufferHandle RenderResourceManager::DoUploadMesh(AssetHandle asset, uint32_t frame_index)
+    RenderResourceManager::MeshSlot RenderResourceManager::AppendMeshData(AssetHandle asset, uint32_t frame_index)
     {
         AssetMesh* mesh = AssetManager::GetAsset<AssetMesh>(asset);
         if (!mesh || mesh->Vertices.empty())
+        {
             return {};
+        }
 
         size_t vert_bytes = mesh->Vertices.size() * sizeof(float);
         size_t idx_bytes  = mesh->Indices.size() * sizeof(uint32_t);
 
         if (m_vtx_cursor + vert_bytes > GLOBAL_VTX_CAPACITY || m_idx_cursor + idx_bytes > GLOBAL_IDX_CAPACITY)
         {
-            ZENGINE_CORE_ERROR("[RRM] DoUploadMesh: global buffer capacity exceeded")
+            ZENGINE_LOG_RENDER_ERR("[RRM] AppendMeshData: global buffer capacity exceeded")
             return {};
         }
 
@@ -443,11 +492,21 @@ namespace ZEngine::Rendering
         m_vtx_cursor                                     += vert_bytes;
         m_idx_cursor                                     += idx_bytes;
 
-        uint32_t slot                                     = AllocMeshSlot();
-        m_mesh_slots[slot].Data                           = {vtx_elem_offset, idx_elem_offset, vtx_elem_count, idx_elem_count};
+        ZENGINE_LOG_RENDER_INFO("[RRM] Uploaded mesh: {} verts ({} bytes), {} indices ({} bytes) — vtx@{} idx@{}", vtx_elem_count, vert_bytes, idx_elem_count, idx_bytes, vtx_elem_offset, idx_elem_offset)
 
-        ZENGINE_CORE_INFO("[RRM] Uploaded mesh: {} verts ({} bytes), {} indices ({} bytes) — vtx@{} idx@{}", vtx_elem_count, vert_bytes, idx_elem_count, idx_bytes, vtx_elem_offset, idx_elem_offset)
+        return {vtx_elem_offset, idx_elem_offset, vtx_elem_count, idx_elem_count};
+    }
 
+    BufferHandle RenderResourceManager::DoUploadMesh(AssetHandle asset, uint32_t frame_index)
+    {
+        MeshSlot data = AppendMeshData(asset, frame_index);
+        if (data.VtxCount == 0)
+        {
+            return {};
+        }
+
+        uint32_t slot            = AllocMeshSlot();
+        m_mesh_slots[slot].Data  = data;
         return {slot, m_mesh_slots[slot].Generation};
     }
 
@@ -460,10 +519,10 @@ namespace ZEngine::Rendering
         if (!tex->Handle.Valid())
             return {};
 
-        // Texture is already on GPU (via SubmitTextureFile/UploadTextureBuffer); register its slot.
-        uint32_t slot_idx                  = AllocImageSlot();
-        // We don't own a BufferImage for this path yet — store a sentinel.
-        m_image_slots[slot_idx].Generation = slot_idx + 1;
+        // Texture is already on GPU (via SubmitTextureFile/UploadTextureBuffer); register its
+        // slot. AllocImageSlot already assigned Generation — we don't own a BufferImage for
+        // this path yet, so the slot's Data stays a sentinel.
+        uint32_t slot_idx = AllocImageSlot();
 
         return {slot_idx, m_image_slots[slot_idx].Generation};
     }
@@ -608,16 +667,38 @@ namespace ZEngine::Rendering
 
     void RenderResourceManager::ScheduleSwap(BufferHandle old_handle, AssetHandle new_asset)
     {
-        // Hot-reload buffer swap not yet implemented.
-        (void) old_handle;
-        (void) new_asset;
+        if (!old_handle.IsValid())
+        {
+            return;
+        }
+        std::lock_guard lock(m_pending_swap_mutex);
+        if (m_pending_swap_count >= MAX_PENDING)
+        {
+            ZENGINE_LOG_RENDER_WARN("[RRM] Pending swap queue full — dropping hot-reload swap")
+            return;
+        }
+        PendingSwap& s = m_pending_swaps[m_pending_swap_count++];
+        s.Kind         = SwapKind::Buffer;
+        s.OldBuffer    = old_handle;
+        s.NewAsset     = new_asset;
     }
 
     void RenderResourceManager::ScheduleSwap(ImageHandle old_handle, AssetHandle new_asset)
     {
-        // Hot-reload image swap not yet implemented.
-        (void) old_handle;
-        (void) new_asset;
+        if (!old_handle.IsValid())
+        {
+            return;
+        }
+        std::lock_guard lock(m_pending_swap_mutex);
+        if (m_pending_swap_count >= MAX_PENDING)
+        {
+            ZENGINE_LOG_RENDER_WARN("[RRM] Pending swap queue full — dropping hot-reload swap")
+            return;
+        }
+        PendingSwap& s = m_pending_swaps[m_pending_swap_count++];
+        s.Kind         = SwapKind::Image;
+        s.OldImage     = old_handle;
+        s.NewAsset     = new_asset;
     }
 
     bool RenderResourceManager::GetMeshOffsets(BufferHandle handle, uint32_t& vtx_offset, uint32_t& idx_offset) const
@@ -789,13 +870,13 @@ namespace ZEngine::Rendering
         {
             if (m_mesh_slots[i].Generation == 0)
             {
-                m_mesh_slots[i].Generation = i + 1;
+                m_mesh_slots[i].Generation = ++m_mesh_slot_gen_counter[i];
                 return i;
             }
         }
         ZENGINE_VALIDATE_ASSERT(m_mesh_slot_count < MAX_BUFFERS, "RRM: MAX_BUFFERS exceeded")
         uint32_t idx                 = m_mesh_slot_count++;
-        m_mesh_slots[idx].Generation = idx + 1;
+        m_mesh_slots[idx].Generation  = ++m_mesh_slot_gen_counter[idx];
         return idx;
     }
 
@@ -805,14 +886,27 @@ namespace ZEngine::Rendering
         {
             if (m_image_slots[i].Generation == 0)
             {
-                m_image_slots[i].Generation = i + 1;
+                m_image_slots[i].Generation = ++m_image_slot_gen_counter[i];
                 return i;
             }
         }
         ZENGINE_VALIDATE_ASSERT(m_image_slot_count < MAX_IMAGES, "RRM: MAX_IMAGES exceeded")
         uint32_t idx                  = m_image_slot_count++;
-        m_image_slots[idx].Generation = idx + 1;
+        m_image_slots[idx].Generation = ++m_image_slot_gen_counter[idx];
         return idx;
+    }
+
+    // Masks the monotonic counter to 31 bits before OR-ing in GBUF_GEN_TAG (bit 31) so the
+    // counter can never collide with the tag, and skips 0 on the (practically unreachable)
+    // wraparound since Generation == 0 is the universal free/invalid sentinel.
+    uint32_t RenderResourceManager::NextGBufGeneration(uint32_t& counter)
+    {
+        uint32_t gen = (++counter) & 0x7FFF'FFFFu;
+        if (gen == 0)
+        {
+            gen = (++counter) & 0x7FFF'FFFFu;
+        }
+        return gen | GBUF_GEN_TAG;
     }
 
     uint32_t RenderResourceManager::AllocGBufSlot()
@@ -821,13 +915,13 @@ namespace ZEngine::Rendering
         {
             if (m_gbuf_slots[i].Generation == 0)
             {
-                m_gbuf_slots[i].Generation = (i + 1) | GBUF_GEN_TAG;
+                m_gbuf_slots[i].Generation = NextGBufGeneration(m_gbuf_slot_gen_counter[i]);
                 return i;
             }
         }
         ZENGINE_VALIDATE_ASSERT(m_gbuf_slot_count < MAX_GENERIC_BUFS, "RRM: MAX_GENERIC_BUFS exceeded")
         uint32_t idx                 = m_gbuf_slot_count++;
-        m_gbuf_slots[idx].Generation = (idx + 1) | GBUF_GEN_TAG;
+        m_gbuf_slots[idx].Generation = NextGBufGeneration(m_gbuf_slot_gen_counter[idx]);
         return idx;
     }
 

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.h
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.h
@@ -33,8 +33,9 @@ namespace ZEngine::Rendering
     // THREAD SAFETY:
     //   Initialize / Shutdown     — main thread, once at startup/teardown
     //   BeginFrame / EndFrame     — render thread only
-    //   OnAssetReady / OnAssetStale callbacks — asset/import thread; protected by m_pending_mutex
-    //   GetBuffer / GetImage      — render thread read; asset thread writes via pending queue
+    //   OnAssetReady callback     — asset/import thread; protected by m_pending_mutex
+    //   OnAssetStale callback     — asset/import thread; ScheduleSwap protected by m_pending_swap_mutex
+    //   GetBuffer / GetImage      — render thread read; asset thread writes via pending queues
     class RenderResourceManager
     {
     public:
@@ -55,14 +56,15 @@ namespace ZEngine::Rendering
         void                               Shutdown();
 
         /// @brief Per-frame render-thread entry point.
-        /// @details Flushes pending mesh and texture uploads that were queued from the
-        ///          asset thread since the previous BeginFrame. Called by AppRenderPipeline.
+        /// @details Flushes pending mesh/texture uploads and pending hot-reload swaps that
+        ///          were queued from the asset thread since the previous BeginFrame.
+        ///          Called by AppRenderPipeline.
         /// @param frame_index Current swapchain frame index (0 .. FRAMES_IN_FLIGHT-1).
         void                               BeginFrame(uint32_t frame_index);
 
         /// @brief Per-frame render-thread exit point.
-        /// @details Drains hot-reload swap entries that have aged past FRAMES_IN_FLIGHT
-        ///          frames. Called by AppRenderPipeline after command buffer submission.
+        /// @details Advances the internal frame counter. Called by AppRenderPipeline after
+        ///          command buffer submission.
         /// @param frame_index Current swapchain frame index (0 .. FRAMES_IN_FLIGHT-1).
         void                               EndFrame(uint32_t frame_index);
 
@@ -152,15 +154,22 @@ namespace ZEngine::Rendering
         void                             ResetTextureTimelines();
 
         /// @brief Schedule a hot-reload swap for a mesh buffer.
-        /// @details Uploads the new version of new_asset and swaps it into old_handle after
-        ///          FRAMES_IN_FLIGHT frames have drained, then queues the old buffer for deletion.
+        /// @details Thread-safe: enqueues onto m_pending_swaps, applied by the next
+        ///          FlushPendingSwaps (render thread). No frame-in-flight delay — this
+        ///          engine has no consumer of RRM handles that would need one; applying
+        ///          immediately matches every other precedent in this file (first-time
+        ///          upload, slot reuse after Release()). The old buffer's mesh slot is
+        ///          repointed at newly-appended data; no GPU free is needed since the
+        ///          global buffer is append-only.
         /// @param old_handle The live BufferHandle to replace.
         /// @param new_asset  AssetHandle for the new version of the mesh.
         void                             ScheduleSwap(BufferHandle old_handle, Managers::AssetHandle new_asset);
 
         /// @brief Schedule a hot-reload swap for a texture image.
-        /// @details Uploads the new version of new_asset and swaps it into old_handle after
-        ///          FRAMES_IN_FLIGHT frames, then queues the old image for deletion.
+        /// @details Thread-safe: enqueues onto m_pending_swaps, applied by the next
+        ///          FlushPendingSwaps (render thread), which re-uploads new_asset and
+        ///          defers-frees the old image's GPU memory. See ScheduleSwap(BufferHandle,...)
+        ///          for why there's no frame-in-flight delay.
         /// @param old_handle The live ImageHandle to replace.
         /// @param new_asset  AssetHandle for the new version of the texture.
         void                             ScheduleSwap(ImageHandle old_handle, Managers::AssetHandle new_asset);
@@ -329,22 +338,17 @@ namespace ZEngine::Rendering
             Image  = 1,
         };
 
-        struct SwapEntry
+        // A hot-reload swap request, queued by ScheduleSwap (asset thread) and applied by
+        // FlushPendingSwaps (render thread, called from BeginFrame). Applied immediately on
+        // the next frame it's drained on — no frame-in-flight delay: nothing in this engine
+        // consumes RRM handles in a way that would need one (see the correction note on
+        // ScheduleSwap below).
+        struct PendingSwap
         {
-            SwapKind Kind;
-            union
-            {
-                BufferHandle OldBuffer;
-                ImageHandle  OldImage;
-            };
-            union
-            {
-                Core::Memory::BufferView  NewBuffer;
-                Core::Memory::BufferImage NewImage;
-            };
-            uint32_t SwapSafeFrame = 0;
-
-            SwapEntry() : Kind(SwapKind::Buffer), OldBuffer{}, NewBuffer{} {}
+            BufferHandle          OldBuffer = {}; // valid when Kind == Buffer
+            ImageHandle           OldImage  = {}; // valid when Kind == Image
+            Managers::AssetHandle NewAsset  = 0;
+            SwapKind              Kind      = SwapKind::Buffer;
         };
 
         template <typename Resource>
@@ -373,9 +377,17 @@ namespace ZEngine::Rendering
         BufferHandle                    DoUploadMesh(Managers::AssetHandle asset, uint32_t frame_index);
         ImageHandle                     DoUploadTexture(Managers::AssetHandle asset);
 
+        /// @brief Append one mesh asset's vertex/index data to the global buffers.
+        /// @details Shared by DoUploadMesh (allocates a new slot) and FlushPendingSwaps
+        ///          (reuses an existing slot). Returns a zero-VtxCount MeshSlot on failure.
+        MeshSlot                        AppendMeshData(Managers::AssetHandle asset, uint32_t frame_index);
+
         void                            AppendToGlobalBuffer(Core::Memory::BufferView& global_buf, const void* data, size_t byte_size, VkDeviceSize byte_offset, uint32_t frame_index);
 
         void                            FlushPendingUploads(uint32_t frame_index);
+
+        /// @brief Drain m_pending_swaps and apply each swap immediately (render thread only).
+        void                            FlushPendingSwaps(uint32_t frame_index);
 
         // Batch upload helpers — render-thread only
         void                            BeginBatchUpload();
@@ -389,6 +401,9 @@ namespace ZEngine::Rendering
         uint32_t                        AllocMeshSlot();
         uint32_t                        AllocImageSlot();
         uint32_t                        AllocGBufSlot();
+
+        /// @brief Advance counter and return the next GBUF_GEN_TAG-tagged generation value.
+        static uint32_t                 NextGBufGeneration(uint32_t& counter);
 
         Hardwares::VulkanDevice*        m_device                                         = nullptr;
         Core::VFS::AssetRegistry*       m_registry                                       = nullptr;
@@ -411,17 +426,23 @@ namespace ZEngine::Rendering
         VkDeviceSize                    m_idx_cursor                   = 0;
 
         // Mesh slot pool — stores per-mesh offsets into the global buffers.
-        Slot<MeshSlot>                  m_mesh_slots[MAX_BUFFERS]      = {};
-        uint32_t                        m_mesh_slot_count              = 0;
+        Slot<MeshSlot>                  m_mesh_slots[MAX_BUFFERS]            = {};
+        uint32_t                        m_mesh_slot_count                   = 0;
+        // Never reset by Release() — gives each slot a monotonic generation on reuse
+        // instead of the deterministic idx+1 a released-then-reallocated slot would
+        // otherwise get back, which is what gave stale handles no real ABA protection.
+        uint32_t                        m_mesh_slot_gen_counter[MAX_BUFFERS] = {};
 
         // Image pool
-        Slot<Core::Memory::BufferImage> m_image_slots[MAX_IMAGES]      = {};
-        uint32_t                        m_image_slot_count             = 0;
+        Slot<Core::Memory::BufferImage> m_image_slots[MAX_IMAGES]            = {};
+        uint32_t                        m_image_slot_count                  = 0;
+        uint32_t                        m_image_slot_gen_counter[MAX_IMAGES] = {};
 
         // Generic device-local buffer pool — for bone matrices, particle VBs, etc.
         // Handles carry GBUF_GEN_TAG in bit 31 to distinguish from mesh handles.
-        Slot<Core::Memory::BufferView>  m_gbuf_slots[MAX_GENERIC_BUFS] = {};
-        uint32_t                        m_gbuf_slot_count              = 0;
+        Slot<Core::Memory::BufferView>  m_gbuf_slots[MAX_GENERIC_BUFS]            = {};
+        uint32_t                        m_gbuf_slot_count                        = 0;
+        uint32_t                        m_gbuf_slot_gen_counter[MAX_GENERIC_BUFS] = {};
 
         // UUID → handle maps (for hot-reload swap lookup)
         // Written on first upload; read on OnAssetStale. Protected by m_uuid_map_mutex.
@@ -441,15 +462,17 @@ namespace ZEngine::Rendering
         UUIDImagePair                  m_uuid_to_image[MAX_UUID_MAP]     = {};
         uint32_t                       m_uuid_to_image_count             = 0;
 
-        // Swap list — written from asset thread, drained in EndFrame
-        static constexpr uint32_t      MAX_SWAPS                         = 256;
-        SwapEntry                      m_swaps[MAX_SWAPS]                = {};
-        uint32_t                       m_swap_count                      = 0;
-
         // Pending uploads — written from asset thread, flushed in BeginFrame
         static constexpr uint32_t      MAX_PENDING                       = 1024;
         PendingUpload                  m_pending[MAX_PENDING]            = {};
         uint32_t                       m_pending_count                   = 0;
+
+        // Pending hot-reload swaps — written from asset thread (ScheduleSwap), drained by
+        // FlushPendingSwaps on the render thread. A dedicated mutex, not m_pending_mutex:
+        // that lock is held across file I/O and a GPU call in SubmitTextureFile, and
+        // swap enqueue/drain must not stall behind a concurrent texture load.
+        PendingSwap                    m_pending_swaps[MAX_PENDING]      = {};
+        uint32_t                       m_pending_swap_count              = 0;
 
         // Geometry compaction request — set by asset thread, executed on render thread
         std::atomic<bool>              m_pending_reset                   = false;
@@ -501,6 +524,7 @@ namespace ZEngine::Rendering
         void                                                                       ShutdownTextureTimelines();
 
         std::mutex                                                                 m_pending_mutex;
+        std::mutex                                                                 m_pending_swap_mutex;
         std::mutex                                                                 m_uuid_map_mutex;
     };
 

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.h
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.h
@@ -418,30 +418,30 @@ namespace ZEngine::Rendering
         void                            InitUploadSlabs(uint32_t worker_count);
 
         // Global geometry buffers — all mesh vertices/indices packed together.
-        static constexpr VkDeviceSize   GLOBAL_VTX_CAPACITY            = 512 * 1024 * 1024; // 512 MB → ~16M DrawVertex
-        static constexpr VkDeviceSize   GLOBAL_IDX_CAPACITY            = 512 * 1024 * 1024; // 512 MB → ~128M uint32
-        Core::Memory::BufferView        m_global_vertex_buf            = {};
-        Core::Memory::BufferView        m_global_index_buf             = {};
-        VkDeviceSize                    m_vtx_cursor                   = 0; // byte offset of next write
-        VkDeviceSize                    m_idx_cursor                   = 0;
+        static constexpr VkDeviceSize   GLOBAL_VTX_CAPACITY                       = 512 * 1024 * 1024; // 512 MB → ~16M DrawVertex
+        static constexpr VkDeviceSize   GLOBAL_IDX_CAPACITY                       = 512 * 1024 * 1024; // 512 MB → ~128M uint32
+        Core::Memory::BufferView        m_global_vertex_buf                       = {};
+        Core::Memory::BufferView        m_global_index_buf                        = {};
+        VkDeviceSize                    m_vtx_cursor                              = 0; // byte offset of next write
+        VkDeviceSize                    m_idx_cursor                              = 0;
 
         // Mesh slot pool — stores per-mesh offsets into the global buffers.
-        Slot<MeshSlot>                  m_mesh_slots[MAX_BUFFERS]            = {};
-        uint32_t                        m_mesh_slot_count                   = 0;
+        Slot<MeshSlot>                  m_mesh_slots[MAX_BUFFERS]                 = {};
+        uint32_t                        m_mesh_slot_count                         = 0;
         // Never reset by Release() — gives each slot a monotonic generation on reuse
         // instead of the deterministic idx+1 a released-then-reallocated slot would
         // otherwise get back, which is what gave stale handles no real ABA protection.
-        uint32_t                        m_mesh_slot_gen_counter[MAX_BUFFERS] = {};
+        uint32_t                        m_mesh_slot_gen_counter[MAX_BUFFERS]      = {};
 
         // Image pool
-        Slot<Core::Memory::BufferImage> m_image_slots[MAX_IMAGES]            = {};
-        uint32_t                        m_image_slot_count                  = 0;
-        uint32_t                        m_image_slot_gen_counter[MAX_IMAGES] = {};
+        Slot<Core::Memory::BufferImage> m_image_slots[MAX_IMAGES]                 = {};
+        uint32_t                        m_image_slot_count                        = 0;
+        uint32_t                        m_image_slot_gen_counter[MAX_IMAGES]      = {};
 
         // Generic device-local buffer pool — for bone matrices, particle VBs, etc.
         // Handles carry GBUF_GEN_TAG in bit 31 to distinguish from mesh handles.
         Slot<Core::Memory::BufferView>  m_gbuf_slots[MAX_GENERIC_BUFS]            = {};
-        uint32_t                        m_gbuf_slot_count                        = 0;
+        uint32_t                        m_gbuf_slot_count                         = 0;
         uint32_t                        m_gbuf_slot_gen_counter[MAX_GENERIC_BUFS] = {};
 
         // UUID → handle maps (for hot-reload swap lookup)

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.cpp
@@ -1,5 +1,7 @@
 #include <ZEngine/Rendering/Renderers/IRenderer.h>
 #include <ZEngine/Rendering/Renderers/RenderGraph.h>
+#include <ZEngine/Rendering/Renderers/RenderGraphTopology.h>
+#include <algorithm>
 
 using namespace ZEngine::Core::Containers;
 using namespace ZEngine::Helpers;
@@ -156,10 +158,13 @@ namespace ZEngine::Rendering::Renderers
 
     void RenderGraph::Compile()
     {
+        // BuildTopology must run first — BuildLifetimes indexes by sorted execution
+        // order, not raw declaration order, so lifetimes can only be computed once the
+        // real order is known.
+        BuildTopology();
         BuildLifetimes();
         AllocateTransientResources();
         BuildBarriers();
-        BuildTopology();
 
         for (uint32_t i = 0; i < SortedPassIndices.size(); ++i)
         {
@@ -460,42 +465,67 @@ namespace ZEngine::Rendering::Renderers
             res.RuntimeState   = {VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0, VK_IMAGE_LAYOUT_UNDEFINED};
         }
 
-        for (uint32_t i = 0; i < Passes.size(); ++i)
+        // Indexed by position in SortedPassIndices (real execution order), not by raw
+        // declaration order — BuildTopology() must run before this so transient-resource
+        // lifetimes reflect when a pass actually executes, not where it was declared.
+        for (uint32_t order_pos = 0; order_pos < SortedPassIndices.size(); ++order_pos)
         {
-            const auto& pass = Passes[i];
+            const auto& pass = Passes[SortedPassIndices[order_pos]];
             for (const auto& w : pass.Writes)
             {
                 if (!w.Handle.Valid())
+                {
                     continue;
+                }
                 auto& res = Resources[w.Handle.Index];
-                if (i < res.FirstPassIndex)
-                    res.FirstPassIndex = i;
-                if (i > res.LastPassIndex)
-                    res.LastPassIndex = i;
+                if (order_pos < res.FirstPassIndex)
+                {
+                    res.FirstPassIndex = order_pos;
+                }
+                if (order_pos > res.LastPassIndex)
+                {
+                    res.LastPassIndex = order_pos;
+                }
             }
             for (const auto& r : pass.Reads)
             {
                 if (!r.Handle.Valid())
+                {
                     continue;
+                }
                 auto& res = Resources[r.Handle.Index];
-                if (i < res.FirstPassIndex)
-                    res.FirstPassIndex = i;
-                if (i > res.LastPassIndex)
-                    res.LastPassIndex = i;
+                if (order_pos < res.FirstPassIndex)
+                {
+                    res.FirstPassIndex = order_pos;
+                }
+                if (order_pos > res.LastPassIndex)
+                {
+                    res.LastPassIndex = order_pos;
+                }
             }
         }
     }
 
     void RenderGraph::AllocateTransientResources()
     {
-        for (auto& res : Resources)
+        // Indexed loop (not range-based) so res_idx is available below — pre-existing bug
+        // fix: the storage-usage check used to compare a resource index against
+        // res.FirstPassIndex (a pass index), which could never match.
+        for (uint32_t res_idx = 0; res_idx < Resources.size(); ++res_idx)
         {
+            auto& res = Resources[res_idx];
             if (res.External || !res.Transient)
+            {
                 continue;
+            }
             if (res.FirstPassIndex == UINT32_MAX)
+            {
                 continue;
+            }
             if (res.TextureHandle.Valid())
+            {
                 continue;
+            }
             auto aliased = TransientPool.TryAlias(res.Spec, res.FirstPassIndex);
             if (aliased.Valid())
             {
@@ -508,8 +538,12 @@ namespace ZEngine::Rendering::Renderers
                 for (const auto& pass : Passes)
                 {
                     for (const auto& w : pass.Writes)
-                        if (w.Handle.Valid() && w.Handle.Index == res.FirstPassIndex && w.Access == RGAccess::ShaderReadWrite)
+                    {
+                        if (w.Handle.Valid() && w.Handle.Index == res_idx && w.Access == RGAccess::ShaderReadWrite)
+                        {
                             res.Spec.IsUsageStorage = true;
+                        }
+                    }
                 }
                 res.TextureHandle = Device->CreateTexture(res.Spec);
                 TransientPool.Register(res.TextureHandle, res.Spec, res.LastPassIndex);
@@ -519,6 +553,12 @@ namespace ZEngine::Rendering::Renderers
 
     void RenderGraph::BuildBarriers()
     {
+        // NOTE: walks Passes in raw declaration order, not sorted execution order — its
+        // output (pass.ImageBarriers, res.CurrentState below) is never read outside this
+        // file today (Execute() derives its own barriers per-frame from RuntimeState in
+        // real SortedPassIndices order instead), so this is currently harmless dead
+        // compile-time simulation. If this machinery is ever wired up for real, it needs
+        // the same declaration-order-to-sorted-position fix BuildLifetimes() got.
         for (uint32_t i = 0; i < Passes.size(); ++i)
         {
             RGPass& pass = Passes[i];
@@ -566,13 +606,218 @@ namespace ZEngine::Rendering::Renderers
         }
     }
 
+    bool BuildPassTopology(Core::Memory::ArenaAllocator* scratch_arena, ArrayView<RGPass> passes, Array<uint32_t>& out_order, uint32_t* out_cycle_pass_index)
+    {
+        out_order.clear();
+        if (out_cycle_pass_index)
+        {
+            *out_cycle_pass_index = UINT32_MAX;
+        }
+
+        const uint32_t pass_count = static_cast<uint32_t>(passes.size());
+        if (pass_count == 0)
+        {
+            return true;
+        }
+
+        // Flatten every Read/Write into one event log — reads before writes within each
+        // pass, passes in declaration order. Stable-sorting this by resource groups each
+        // resource's events together while preserving their relative (pass) order, which
+        // is all the edge-construction walk below needs.
+        uint32_t total_events = 0;
+        for (uint32_t i = 0; i < pass_count; ++i)
+        {
+            total_events += static_cast<uint32_t>(passes[i].Reads.size() + passes[i].Writes.size());
+        }
+
+        Array<RGEvent> events;
+        events.init(scratch_arena, total_events > 0 ? total_events : 1);
+        for (uint32_t i = 0; i < pass_count; ++i)
+        {
+            const auto& pass = passes[i];
+            for (const auto& r : pass.Reads)
+            {
+                if (r.Handle.Valid())
+                {
+                    events.push({r.Handle.Index, i, false});
+                }
+            }
+            for (const auto& w : pass.Writes)
+            {
+                if (w.Handle.Valid())
+                {
+                    events.push({w.Handle.Index, i, true});
+                }
+            }
+        }
+        std::stable_sort(events.begin(), events.end(), [](const RGEvent& a, const RGEvent& b) { return a.ResourceIndex < b.ResourceIndex; });
+
+        Array<uint32_t> indegree;
+        indegree.init(scratch_arena, pass_count, pass_count);
+        for (uint32_t i = 0; i < pass_count; ++i)
+        {
+            indegree[i] = 0;
+        }
+
+        Array<RGEdge> edges;
+        edges.init(scratch_arena, events.size() * 2 + 1);
+
+        auto add_edge = [&](uint32_t from, uint32_t to) {
+            if (from == to) // drops same-pass self-edges (RMW passes, duplicate same-pass writes)
+            {
+                return;
+            }
+            edges.push({from, to});
+            indegree[to]++;
+        };
+
+        // Walk each resource's contiguous run and derive RAW/WAW/WAR edges.
+        //
+        // The common case — a resource written by exactly one pass — binds every reader
+        // to that sole writer directly, regardless of their relative declared order: this
+        // is what lets the sort actually fix a pass that was registered before the
+        // producer it depends on, instead of just reproducing declaration order (a single
+        // forward scan that only ever looks at writers seen so far can never do this — it
+        // can only ever emit edges pointing to a later declared index, which makes
+        // reordering, and therefore cycle detection, structurally impossible).
+        //
+        // A resource written by more than one pass (e.g. a ping-pong chain) has no
+        // versioning to say which write a given read wants, so that case falls back to a
+        // declared-order replay (nearest-preceding-write RAW/WAW/WAR) — a reasonable
+        // heuristic since no pass in this engine does this today.
+        uint32_t idx = 0;
+        while (idx < events.size())
+        {
+            uint32_t run_resource = events[idx].ResourceIndex;
+            uint32_t run_start    = idx;
+            while (idx < events.size() && events[idx].ResourceIndex == run_resource)
+            {
+                ++idx;
+            }
+            uint32_t run_end = idx;
+
+            uint32_t writer_count = 0;
+            uint32_t sole_writer  = UINT32_MAX;
+            for (uint32_t e = run_start; e < run_end; ++e)
+            {
+                if (events[e].IsWrite)
+                {
+                    ++writer_count;
+                    sole_writer = events[e].PassIndex;
+                }
+            }
+
+            if (writer_count <= 1)
+            {
+                if (sole_writer != UINT32_MAX)
+                {
+                    for (uint32_t e = run_start; e < run_end; ++e)
+                    {
+                        if (!events[e].IsWrite)
+                        {
+                            add_edge(sole_writer, events[e].PassIndex);
+                        }
+                    }
+                }
+                continue;
+            }
+
+            uint32_t        last_writer = UINT32_MAX;
+            Array<uint32_t> pending_readers;
+            pending_readers.init(scratch_arena, run_end - run_start);
+
+            for (uint32_t e = run_start; e < run_end; ++e)
+            {
+                uint32_t p = events[e].PassIndex;
+                if (!events[e].IsWrite)
+                {
+                    if (last_writer != UINT32_MAX)
+                    {
+                        add_edge(last_writer, p);
+                    }
+                    pending_readers.push(p);
+                }
+                else
+                {
+                    if (last_writer != UINT32_MAX)
+                    {
+                        add_edge(last_writer, p);
+                    }
+                    for (auto reader_pass : pending_readers)
+                    {
+                        add_edge(reader_pass, p);
+                    }
+                    pending_readers.clear();
+                    last_writer = p;
+                }
+            }
+        }
+
+        // Kahn's algorithm. O(pass_count^2) scan-for-lowest-ready-index is fine at
+        // frame-graph pass counts (this runs once at Compile(), not per frame) and keeps
+        // today's declaration order for independent passes as a stable tie-break.
+        Array<bool> emitted;
+        emitted.init(scratch_arena, pass_count, pass_count);
+        for (uint32_t i = 0; i < pass_count; ++i)
+        {
+            emitted[i] = false;
+        }
+
+        for (uint32_t emitted_count = 0; emitted_count < pass_count; ++emitted_count)
+        {
+            uint32_t best = UINT32_MAX;
+            for (uint32_t i = 0; i < pass_count; ++i)
+            {
+                if (emitted[i] || indegree[i] != 0)
+                {
+                    continue;
+                }
+                best = i;
+                break;
+            }
+            if (best == UINT32_MAX)
+            {
+                if (out_cycle_pass_index)
+                {
+                    for (uint32_t i = 0; i < pass_count; ++i)
+                    {
+                        if (!emitted[i])
+                        {
+                            *out_cycle_pass_index = i;
+                            break;
+                        }
+                    }
+                }
+                out_order.clear();
+                return false;
+            }
+            emitted[best] = true;
+            out_order.push(best);
+            for (const auto& e : edges)
+            {
+                if (e.From == best && !emitted[e.To])
+                {
+                    indegree[e.To]--;
+                }
+            }
+        }
+        return true;
+    }
+
     void RenderGraph::BuildTopology()
     {
-        // Simple insertion-order execution for now — passes execute in the order they were added.
-        // A full DFS topological sort can replace this once producer/consumer edges are tracked.
-        SortedPassIndices.clear();
-        for (uint32_t i = 0; i < Passes.size(); ++i)
-            SortedPassIndices.push(i);
+        auto     scratch   = ZGetScratch(Device->Arena);
+        uint32_t cycle_idx = UINT32_MAX;
+        if (!BuildPassTopology(scratch.Arena, Passes, SortedPassIndices, &cycle_idx))
+        {
+            ZENGINE_CORE_ERROR("[RenderGraph] Cycle detected in resource dependency graph at pass '{}' — falling back to declaration order", cycle_idx < Passes.size() ? Passes[cycle_idx].Name : "?")
+            SortedPassIndices.clear();
+            for (uint32_t i = 0; i < Passes.size(); ++i)
+            {
+                SortedPassIndices.push(i);
+            }
+        }
+        ZReleaseScratch(scratch);
     }
 
     void RenderGraph::AllocateFramebuffers()

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderGraph.cpp
@@ -694,7 +694,7 @@ namespace ZEngine::Rendering::Renderers
             {
                 ++idx;
             }
-            uint32_t run_end = idx;
+            uint32_t run_end      = idx;
 
             uint32_t writer_count = 0;
             uint32_t sole_writer  = UINT32_MAX;

--- a/ZEngine/ZEngine/Rendering/Renderers/RenderGraphTopology.h
+++ b/ZEngine/ZEngine/Rendering/Renderers/RenderGraphTopology.h
@@ -1,0 +1,38 @@
+#pragma once
+#include <ZEngine/Core/Containers/Array.h>
+#include <ZEngine/Core/Memory/Allocator.h>
+#include <ZEngine/Rendering/Renderers/RenderGraph.h>
+
+namespace ZEngine::Rendering::Renderers
+{
+    // One flattened Read/Write event, used to derive RAW/WAW/WAR hazard edges.
+    struct RGEvent
+    {
+        uint32_t ResourceIndex = UINT32_MAX;
+        uint32_t PassIndex     = UINT32_MAX;
+        bool     IsWrite       = false;
+    };
+
+    // One RAW/WAW/WAR hazard edge between two passes.
+    struct RGEdge
+    {
+        uint32_t From = UINT32_MAX;
+        uint32_t To   = UINT32_MAX;
+    };
+
+    /// @brief Computes a real execution order for `passes` from their Reads/Writes,
+    ///        via Kahn's algorithm with a lowest-index tie-break. Device-independent —
+    ///        reusable from unit tests.
+    /// @details Edges come from the standard hazard triad: RAW (read-after-write — a
+    ///          reader must run after the last writer), WAW (write-after-write — two
+    ///          writers of the same resource keep declaration order), and WAR
+    ///          (write-after-read — a new writer must run after every reader of the
+    ///          prior version). Same-pass self-edges are dropped.
+    /// @param scratch_arena Used only for this call's temporary bookkeeping.
+    /// @param out_order Must already be initialized by the caller; cleared and
+    ///        repopulated on success.
+    /// @param out_cycle_pass_index On a cycle, receives one pass index in the cycle.
+    /// @return false on a dependency cycle (caller should fall back to declaration order).
+    bool BuildPassTopology(Core::Memory::ArenaAllocator* scratch_arena, Core::Containers::ArrayView<RGPass> passes, Core::Containers::Array<uint32_t>& out_order, uint32_t* out_cycle_pass_index);
+
+} // namespace ZEngine::Rendering::Renderers

--- a/ZEngine/docs/future-plan/gpu-allocator-rearchitecture.md
+++ b/ZEngine/docs/future-plan/gpu-allocator-rearchitecture.md
@@ -1,10 +1,17 @@
 # GPU Allocator Rearchitecture — VMA Pools, Staging Ring, Timeline Drain
 
 **Priority:** P0 — Required before 4K resolution target; fixes confirmed correctness bugs  
-**Status:** Partially implemented — moved back from `completed/` to `future-plan/` after a
-full-file re-verification found the doc's headline feature was never built (see correction below).
-The staging ring, `DeferredFreeQueue`, and `TickMemory` drain are real and match the doc; the "VMA
-segregated pools" title feature is not.
+**Status:** Segregated VMA pools now implemented (`DeviceGeometry`/`DeviceTexture`/`HostUniform`/
+`HostStaging`), as part of this month's rendering-foundation hardening pass — `RenderTarget`
+intentionally left on the default/dedicated-allocation pool (see the domain table in that track's
+plan for the reasoning). `DeviceTexture` and `HostStaging` use `blockSize=0` (auto-sized) rather
+than a fixed block — both a fixed-size single-allocation-exceeds-block case (`DeviceTexture`) and
+an exact-equal-to-block-size case (`HostStaging`, the ring's own buffer) were found to fail with
+`VK_ERROR_OUT_OF_DEVICE_MEMORY` during implementation; auto-sizing avoids both. Every custom pool
+is now destroyed in `Shutdown()` before the allocator (VMA asserts otherwise). Covered by
+`ZEngine/tests/Rendering/GpuAllocatorTest.cpp` against a real (headless) Vulkan device. Remaining
+stale items below (H3 mechanism, `AsyncResourceLoader.cpp` path) are unrelated pre-existing doc
+debt this track didn't touch — not yet moved back to `completed/` for that reason.
 **Depends on:** Nothing — self-contained hardware layer change  
 **Blocks:** `per-frame-upload-heap.md` (needs clean allocator API first)
 
@@ -13,12 +20,9 @@ segregated pools" title feature is not.
 ## Correction (re-verification finding)
 
 A deep-verification pass against the current codebase found this doc was moved to `completed/`
-prematurely. Specific gaps:
+prematurely. Specific gaps (the segregated-pools gap is now fixed, per the Status line above; the
+other two remain open):
 
-- **"VMA segregated pools" is fabricated.** `GpuAllocator::Pools[5]` (line ~163 below) is declared
-  but never populated anywhere in the codebase — there are **zero** `vmaCreatePool` calls in the
-  entire tree. Every allocation still goes through the default VMA pool, contradicting the doc's
-  title and its H1 "fix" claim.
 - **H3's actual fix mechanism is different from what's documented.** The doc specifies
   `AUTO_PREFER_DEVICE` + `ALLOW_TRANSFER_INSTEAD` for `HostUniform`. The shipped code uses plain
   `VMA_MEMORY_USAGE_AUTO` without `ALLOW_TRANSFER_INSTEAD_BIT` — a deliberate, differently-reasoned
@@ -27,8 +31,7 @@ prematurely. Specific gaps:
   deleted and its responsibilities absorbed into `RenderResourceManager.cpp`. Any section below
   that references `AsyncResourceLoader.cpp` line numbers is stale.
 - **Confirmed real and matching**: the core `GpuAllocator`/`StagingRing`/`DeferredFreeQueue`/
-  `TickMemory` mechanisms described elsewhere in this doc do exist and behave as documented — only
-  the segregated-pools feature and the H2/H3/H5 fix locations are wrong.
+  `TickMemory` mechanisms described elsewhere in this doc do exist and behave as documented.
 
 ---
 

--- a/ZEngine/docs/future-plan/render-graph-integration.md
+++ b/ZEngine/docs/future-plan/render-graph-integration.md
@@ -20,13 +20,25 @@ ZEngine/ZEngine/Rendering/Renderers/RendererPasses.cpp
 
 ### 1.1 Topological Sort
 
-`RenderGraph::Compile()` builds a DAG from resource producer/consumer relationships and runs a
-DFS post-order topological sort to produce an execution order. The sort detects cycles and logs
-an error via `ZENGINE_CORE_ERROR` without crashing. Passes are executed in sorted order during
-`Execute()`.
+`RenderGraph::BuildTopology()` (via the device-independent `BuildPassTopology()`,
+`RenderGraphTopology.h`) builds a DAG from resource producer/consumer relationships and runs
+Kahn's algorithm, with a lowest-declared-index tie-break, to produce an execution order. The sort
+detects cycles and logs an error via `ZENGINE_CORE_ERROR`, falling back to declaration order
+rather than crashing. Passes are executed in sorted order during `Execute()`; `Compile()` runs
+`BuildTopology()` before `BuildLifetimes()` so transient-resource lifetimes are computed against
+real execution order, not raw declaration order.
 
-Edges are built from resource declarations: if pass B declares a read on `"hdr_color"` and pass
-A declared it as a write, `Compile()` places A before B in execution order.
+Edges come from the RAW/WAW/WAR hazard triad. For a resource written by exactly one pass, every
+reader is bound to that writer directly — regardless of their relative declared order, which is
+what lets the sort actually fix a pass registered before the producer it depends on (e.g. if pass
+B declares a read on `"hdr_color"` and pass A writes it, A is placed before B in execution order
+even if B was registered first). A resource written by more than one pass (a ping-pong chain) has
+no versioning to disambiguate which write a given read wants, so that case falls back to a
+declared-order replay instead — not a limitation that matters for any pass shipped today.
+
+Full GPU memory aliasing (issue #312) is explicitly deferred — see that issue for the rationale.
+The `BuildLifetimes()` lifetime tracking this sort enables is the scaffolding a future aliasing
+pass would build on.
 
 ### 1.2 Resource Declaration via RenderGraphResourceBuilder (Setup phase only)
 

--- a/ZEngine/docs/future-plan/render-resource-manager.md
+++ b/ZEngine/docs/future-plan/render-resource-manager.md
@@ -1,9 +1,11 @@
 # Render Resource Manager — GPU Lifetime & Hot-Reload
 
 **Priority:** P3 — Implement alongside import-pipeline.md  
-**Status:** Partially implemented — moved back from `completed/` to `future-plan/` after a
-full-file re-verification found several severe gaps beyond simple naming drift (see correction
-below), including at least one behavior that looks like a real runtime bug, not just doc staleness.
+**Status:** Hot-reload swap and the ABA fix landed as part of this month's rendering-foundation
+hardening pass (see the corrected findings below — most of what sent this doc back from
+`completed/` is now fixed). Two doc claims remain fabricated and are NOT built (see the
+still-wrong bullets below) — not moving back to `completed/` for that reason, plus the Image
+hot-reload path still has no real end-to-end test (see the caveat below).
 **Implemented in:** `ZEngine/ZEngine/Rendering/RenderResourceManager.h/.cpp`  
 **Depends on:** `import-pipeline.md`, `vfs-ticket6-asset-registry.md`, `gpu-allocator-rearchitecture.md`  
 **Blocks:** `animation-system.md` (SkinningUploadSystem), `shader-asset-pipeline.md`
@@ -15,25 +17,36 @@ below), including at least one behavior that looks like a real runtime bug, not 
 > `GpuAllocator.h`), not a separate `GPUResource.h`. Same aggregate-struct, no-RAII design intent;
 > different file and type names than originally proposed.
 >
-> **Correction — the claim below that "everything else matches the shipped code as written" was
-> wrong.** A deeper re-verification pass found real gaps in exactly the parts that claim were
-> covering:
-> - **`EndFrame`/`SwapEntry` only handles `SwapKind::Image`.** `SwapKind::Buffer` entries are
->   silently dropped — hot-reloading a buffer asset (e.g. re-imported mesh data) does not actually
->   swap the live buffer. This is a real correctness gap, not just a doc/code naming mismatch.
-> - **The "deferred-release ring" (`m_deletion_queues[FRAMES_IN_FLIGHT]`) does not exist.** No such
->   member or ring buffer is present anywhere in `RenderResourceManager`.
-> - **`ScheduleSwap(BufferHandle, ...)` and `ScheduleSwap(ImageHandle, ...)` are empty stubs.**
->   Hot-reload swap scheduling does not functionally do anything for either resource kind.
+> **Correction — fixed this month (see GitHub issue #740 for the full history):**
+> - **`ScheduleSwap` was a complete no-op for both kinds — now implemented.** The original finding
+>   here said only `SwapKind::Buffer` was dropped in `EndFrame` while `Image` worked; that was
+>   wrong. `ScheduleSwap(BufferHandle,...)`/`ScheduleSwap(ImageHandle,...)` never enqueued anything
+>   at all, so neither kind's swap logic was ever reachable. Fixed: `ScheduleSwap` now enqueues
+>   onto a mutex-guarded `m_pending_swaps` queue, drained immediately by a new
+>   `FlushPendingSwaps` (called from `BeginFrame`) — no frame-in-flight delay, since no consumer
+>   of RRM handles in this engine needs one (traced every call site; the old `SwapSafeFrame`
+>   gating was independently broken anyway, comparing against a wrapped swapchain slot index that
+>   could never satisfy its own condition). Mesh swaps repoint slot offsets at freshly-appended
+>   data; image swaps re-upload and `DeferFree` the old image. `SwapEntry`/`m_swaps`/`EndFrame`'s
+>   old drain loop were removed entirely — the design collapsed to one stage, not two.
+> - **No ABA protection — fixed.** `AllocMeshSlot`/`AllocImageSlot`/`AllocGBufSlot` now assign a
+>   never-reset-by-`Release` monotonic counter instead of the deterministic `idx+1` that let a
+>   stale handle from a recycled slot alias a different live resource.
+>
+> **Still fabricated, not built — unchanged from the original finding:**
+> - **The "deferred-release ring" (`m_deletion_queues[FRAMES_IN_FLIGHT]`) does not exist.** GPU
+>   memory is still freed via the existing `Device->DeferFree` timeline-gated queue, not a
+>   dedicated RRM-owned ring.
 > - **`ReleaseChecked` does not exist.**
-> - **No ABA protection on the handle pool, contrary to this doc's explicit safety claim.** RRM
->   uses hand-rolled `Slot<T>` arrays that immediately reuse a freed slot with the *same*
->   generation value — a stale handle from a recycled slot can alias a different live resource.
->   There is no `HandleManager`-backed pool anywhere in the codebase.
-> - **Confirmed accurate**: `GetBuffer`/`GetImage`'s generation check does match the doc,
->   `FRAMES_IN_FLIGHT = 3` matches, and the `RenderHandle<Tag>`/`BeginFrame` mechanics match. The
->   test file exists but contains a different set of tests than the 6 named in this doc's test
->   section — treat that section as aspirational, not a description of what's actually covered.
+>
+> **Known limitation, not blocking:** the RRM-owned `ImageHandle` path has no real texture
+> producer wired to it (`DoUploadTexture` only stores a sentinel, never a real `BufferImage`) —
+> the swap *mechanism* is now correct for images too, but isn't exercised end-to-end by real asset
+> data. `GetBuffer`/`GetImage`'s generation check, `FRAMES_IN_FLIGHT = 3`, and the
+> `RenderHandle<Tag>`/`BeginFrame` mechanics were already confirmed accurate. The test file
+> (`RenderResourceManagerTest.cpp`) still only covers `RenderHandle` and `AssetRegistry` callback
+> plumbing — new hot-reload/ABA tests are skip-gated pending a headless-`VulkanDevice` fixture (see
+> `RenderResourceManagerHotReloadTest.cpp`).
 
 **Goal**: Implement `ZEngine::Rendering::RenderResourceManager` (RRM), a single authority
 over every GPU resource (buffers, images, samplers, pipelines) allocated through VMA.

--- a/ZEngine/tests/Rendering/GpuAllocatorTest.cpp
+++ b/ZEngine/tests/Rendering/GpuAllocatorTest.cpp
@@ -2,8 +2,8 @@
 #include <ZEngine/Core/Memory/MemoryManager.h>
 #include <ZEngine/Logging/Logger.h>
 #include <ZEngine/Logging/LoggerConfiguration.h>
-#include <filesystem>
 #include <gtest/gtest.h>
+#include <filesystem>
 
 using namespace ZEngine::Core::Memory;
 using namespace ZEngine::Logging;
@@ -21,16 +21,16 @@ namespace
 
         bool             Create()
         {
-            VkApplicationInfo app_info  = {.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO};
-            app_info.apiVersion         = VK_API_VERSION_1_3;
+            VkApplicationInfo app_info         = {.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO};
+            app_info.apiVersion                = VK_API_VERSION_1_3;
 
             VkInstanceCreateInfo instance_info = {.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
-            instance_info.pApplicationInfo      = &app_info;
+            instance_info.pApplicationInfo     = &app_info;
 
-            const char* extensions[2] = {};
-            uint32_t    extension_count = 0;
+            const char* extensions[2]          = {};
+            uint32_t    extension_count        = 0;
 #ifdef __APPLE__
-            instance_info.flags      = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+            instance_info.flags           = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
             extensions[extension_count++] = VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME;
 #endif
             instance_info.enabledExtensionCount   = extension_count;
@@ -49,16 +49,16 @@ namespace
             }
             std::vector<VkPhysicalDevice> devices(device_count);
             vkEnumeratePhysicalDevices(Instance, &device_count, devices.data());
-            PhysicalDevice = devices[0];
+            PhysicalDevice                         = devices[0];
 
             float                   queue_priority = 1.0f;
-            VkDeviceQueueCreateInfo  queue_info     = {.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};
-            queue_info.queueFamilyIndex              = 0;
-            queue_info.queueCount                    = 1;
-            queue_info.pQueuePriorities              = &queue_priority;
+            VkDeviceQueueCreateInfo queue_info     = {.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};
+            queue_info.queueFamilyIndex            = 0;
+            queue_info.queueCount                  = 1;
+            queue_info.pQueuePriorities            = &queue_priority;
 
-            const char* device_extensions[1]   = {"VK_KHR_portability_subset"};
-            uint32_t    device_extension_count = 0;
+            const char* device_extensions[1]       = {"VK_KHR_portability_subset"};
+            uint32_t    device_extension_count     = 0;
 #ifdef __APPLE__
             device_extension_count = 1;
 #endif
@@ -193,8 +193,8 @@ TEST_F(GpuAllocatorTest, AllocateBufferUsesDomainPool)
     BufferView view = allocator().AllocateBuffer(4096, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, GpuMemoryDomain::DeviceGeometry, "test_geometry");
     ASSERT_TRUE(view);
 
-    VmaPool            pool  = allocator().Pools[static_cast<uint8_t>(GpuMemoryDomain::DeviceGeometry)];
-    VmaStatistics      stats = {};
+    VmaPool       pool  = allocator().Pools[static_cast<uint8_t>(GpuMemoryDomain::DeviceGeometry)];
+    VmaStatistics stats = {};
     vmaGetPoolStatistics(allocator().Allocator, pool, &stats);
     EXPECT_GT(stats.blockCount, 0u);
     EXPECT_GE(stats.allocationCount, 1u);

--- a/ZEngine/tests/Rendering/GpuAllocatorTest.cpp
+++ b/ZEngine/tests/Rendering/GpuAllocatorTest.cpp
@@ -1,0 +1,236 @@
+#include <ZEngine/Core/Memory/GpuAllocator.h>
+#include <ZEngine/Core/Memory/MemoryManager.h>
+#include <ZEngine/Logging/Logger.h>
+#include <ZEngine/Logging/LoggerConfiguration.h>
+#include <filesystem>
+#include <gtest/gtest.h>
+
+using namespace ZEngine::Core::Memory;
+using namespace ZEngine::Logging;
+
+namespace
+{
+    // Minimal headless Vulkan instance + device — no window, no surface, no swapchain.
+    // GpuAllocator only needs a valid VkPhysicalDevice/VkDevice/VkInstance, so this is
+    // far lighter than standing up a full VulkanDevice.
+    struct HeadlessVulkan
+    {
+        VkInstance       Instance       = VK_NULL_HANDLE;
+        VkPhysicalDevice PhysicalDevice = VK_NULL_HANDLE;
+        VkDevice         Device         = VK_NULL_HANDLE;
+
+        bool             Create()
+        {
+            VkApplicationInfo app_info  = {.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO};
+            app_info.apiVersion         = VK_API_VERSION_1_3;
+
+            VkInstanceCreateInfo instance_info = {.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
+            instance_info.pApplicationInfo      = &app_info;
+
+            const char* extensions[2] = {};
+            uint32_t    extension_count = 0;
+#ifdef __APPLE__
+            instance_info.flags      = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+            extensions[extension_count++] = VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME;
+#endif
+            instance_info.enabledExtensionCount   = extension_count;
+            instance_info.ppEnabledExtensionNames = extension_count > 0 ? extensions : nullptr;
+
+            if (vkCreateInstance(&instance_info, nullptr, &Instance) != VK_SUCCESS)
+            {
+                return false;
+            }
+
+            uint32_t device_count = 0;
+            vkEnumeratePhysicalDevices(Instance, &device_count, nullptr);
+            if (device_count == 0)
+            {
+                return false;
+            }
+            std::vector<VkPhysicalDevice> devices(device_count);
+            vkEnumeratePhysicalDevices(Instance, &device_count, devices.data());
+            PhysicalDevice = devices[0];
+
+            float                   queue_priority = 1.0f;
+            VkDeviceQueueCreateInfo  queue_info     = {.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};
+            queue_info.queueFamilyIndex              = 0;
+            queue_info.queueCount                    = 1;
+            queue_info.pQueuePriorities              = &queue_priority;
+
+            const char* device_extensions[1]   = {"VK_KHR_portability_subset"};
+            uint32_t    device_extension_count = 0;
+#ifdef __APPLE__
+            device_extension_count = 1;
+#endif
+
+            VkDeviceCreateInfo device_info      = {.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO};
+            device_info.queueCreateInfoCount    = 1;
+            device_info.pQueueCreateInfos       = &queue_info;
+            device_info.enabledExtensionCount   = device_extension_count;
+            device_info.ppEnabledExtensionNames = device_extension_count > 0 ? device_extensions : nullptr;
+
+            return vkCreateDevice(PhysicalDevice, &device_info, nullptr, &Device) == VK_SUCCESS;
+        }
+
+        void Destroy()
+        {
+            if (Device != VK_NULL_HANDLE)
+            {
+                vkDestroyDevice(Device, nullptr);
+                Device = VK_NULL_HANDLE;
+            }
+            if (Instance != VK_NULL_HANDLE)
+            {
+                vkDestroyInstance(Instance, nullptr);
+                Instance = VK_NULL_HANDLE;
+            }
+        }
+    };
+} // namespace
+
+// SetUpTestSuite/TearDownTestSuite (once for the whole suite) rather than per-test
+// SetUp/TearDown — cheaper, and avoids creating/destroying a real VkInstance+VkDevice
+// 4 times back-to-back.
+//
+// NOTE: creating a real MoltenVK device in this test binary has a process-wide side
+// effect (likely a signal handler MoltenVK/Metal installs and doesn't restore) that can
+// make an unrelated, later SIGTRAP-based test (e.g. an EXPECT_DEATH assert, or an
+// FSEventStream test elsewhere in the binary) crash the whole process WHEN ALL TESTS RUN
+// IN ONE PROCESS (i.e. invoking the ZEngineTests binary directly with no filter). This
+// does not affect the actual test-running path: `ctest` (via gtest_discover_tests) runs
+// every test as its own process, and is unaffected — confirmed via `ctest -R
+// "GpuAllocatorTest|AllocatorTest|VFSFSEventsWatcherTest"`, 45/45 passing. If you need an
+// all-in-one-process run for a quick manual check, filter this suite out.
+class GpuAllocatorTest : public ::testing::Test
+{
+protected:
+    static MemoryManager*  s_manager;
+    static ArenaAllocator* s_logger_arena;
+    static HeadlessVulkan* s_vk;
+    static GpuAllocator*   s_allocator;
+
+    static void            SetUpTestSuite()
+    {
+        s_manager = new MemoryManager();
+        s_manager->Initialize(ZMega(4), {});
+        s_logger_arena = new ArenaAllocator();
+        s_manager->MainArena.CreateSubArena(ZMega(2), s_logger_arena);
+
+        // GpuAllocator::Initialize can log warnings on pool-creation failure — Logger::Log
+        // indexes an empty ring buffer (mod-by-zero) and crashes via infinite recursion if
+        // Logger::Initialize hasn't run in this test binary (e.g. another suite's teardown
+        // already called Logger::Dispose). Mirrors ZEngine/tests/Logging/Logger_test.cpp.
+        LoggerConfiguration cfg{};
+        cfg.OutputDirectory = (std::filesystem::temp_directory_path() / "zengine_gpu_allocator_test_logs").string();
+        cfg.RingBufferSize  = 64;
+        std::filesystem::create_directories(cfg.OutputDirectory);
+        Logger::Initialize(s_logger_arena, cfg);
+        Logger::SetMinLevelAllChannels(LogLevel::TRACE);
+
+        s_vk = new HeadlessVulkan();
+        if (!s_vk->Create())
+        {
+            GTEST_SKIP() << "No headless Vulkan device available on this machine";
+            return;
+        }
+        s_allocator = new GpuAllocator();
+        s_allocator->Initialize(s_vk->PhysicalDevice, s_vk->Device, s_vk->Instance, /*has_memory_budget_ext=*/false, /*has_buffer_device_address_ext=*/false);
+    }
+
+    static void TearDownTestSuite()
+    {
+        if (s_allocator)
+        {
+            s_allocator->Shutdown();
+            delete s_allocator;
+            s_allocator = nullptr;
+        }
+        if (s_vk)
+        {
+            s_vk->Destroy();
+            delete s_vk;
+            s_vk = nullptr;
+        }
+        Logger::Dispose();
+        if (s_logger_arena)
+        {
+            s_logger_arena->Shutdown();
+            delete s_logger_arena;
+            s_logger_arena = nullptr;
+        }
+        if (s_manager)
+        {
+            s_manager->Shutdown();
+            delete s_manager;
+            s_manager = nullptr;
+        }
+    }
+
+    GpuAllocator& allocator()
+    {
+        return *s_allocator;
+    }
+};
+
+MemoryManager*  GpuAllocatorTest::s_manager      = nullptr;
+ArenaAllocator* GpuAllocatorTest::s_logger_arena = nullptr;
+HeadlessVulkan* GpuAllocatorTest::s_vk           = nullptr;
+GpuAllocator*   GpuAllocatorTest::s_allocator    = nullptr;
+
+TEST_F(GpuAllocatorTest, PoolsAreCreatedForExpectedDomains)
+{
+    ASSERT_NE(s_allocator, nullptr);
+    EXPECT_NE(allocator().Pools[static_cast<uint8_t>(GpuMemoryDomain::DeviceGeometry)], nullptr);
+    EXPECT_NE(allocator().Pools[static_cast<uint8_t>(GpuMemoryDomain::DeviceTexture)], nullptr);
+    EXPECT_NE(allocator().Pools[static_cast<uint8_t>(GpuMemoryDomain::HostUniform)], nullptr);
+    EXPECT_NE(allocator().Pools[static_cast<uint8_t>(GpuMemoryDomain::HostStaging)], nullptr);
+    EXPECT_EQ(allocator().Pools[static_cast<uint8_t>(GpuMemoryDomain::RenderTarget)], nullptr);
+}
+
+TEST_F(GpuAllocatorTest, AllocateBufferUsesDomainPool)
+{
+    ASSERT_NE(s_allocator, nullptr);
+    BufferView view = allocator().AllocateBuffer(4096, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, GpuMemoryDomain::DeviceGeometry, "test_geometry");
+    ASSERT_TRUE(view);
+
+    VmaPool            pool  = allocator().Pools[static_cast<uint8_t>(GpuMemoryDomain::DeviceGeometry)];
+    VmaStatistics      stats = {};
+    vmaGetPoolStatistics(allocator().Allocator, pool, &stats);
+    EXPECT_GT(stats.blockCount, 0u);
+    EXPECT_GE(stats.allocationCount, 1u);
+
+    allocator().FreeBuffer(view);
+}
+
+TEST_F(GpuAllocatorTest, OversizedAllocationFallsBackToDefaultPoolWithoutCrashing)
+{
+    ASSERT_NE(s_allocator, nullptr);
+    // GeometryBytes is 512 MB per block; a single allocation larger than that cannot
+    // fit any block in a fixed-blockSize pool (VMA early-rejects with
+    // VK_ERROR_OUT_OF_DEVICE_MEMORY rather than growing the pool) — exactly the case
+    // AllocateBuffer's fallback-to-default-pool retry exists for.
+    constexpr VkDeviceSize oversized = GeometryBytes + (64ULL << 20);
+    BufferView             view      = allocator().AllocateBuffer(oversized, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, GpuMemoryDomain::DeviceGeometry, "test_oversized");
+    ASSERT_TRUE(view);
+    allocator().FreeBuffer(view);
+}
+
+TEST_F(GpuAllocatorTest, StagingRingSharesDeclaredPool)
+{
+    ASSERT_NE(s_allocator, nullptr);
+    VmaAllocationInfo info = {};
+    vmaGetAllocationInfo(allocator().Allocator, allocator().Ring.Allocation, &info);
+    EXPECT_EQ(info.deviceMemory != VK_NULL_HANDLE, true);
+
+    // Indirect check: allocating another HostStaging buffer should land in the same
+    // pool the ring uses, since GpuAllocator::Initialize wires both to Pools[HostStaging].
+    BufferView one_shot = allocator().AllocateBuffer(1024, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, GpuMemoryDomain::HostStaging, "test_staging");
+    ASSERT_TRUE(one_shot);
+
+    VmaPool       pool  = allocator().Pools[static_cast<uint8_t>(GpuMemoryDomain::HostStaging)];
+    VmaStatistics stats = {};
+    vmaGetPoolStatistics(allocator().Allocator, pool, &stats);
+    EXPECT_GE(stats.allocationCount, 2u); // the ring's own buffer + this one-shot buffer
+
+    allocator().FreeBuffer(one_shot);
+}

--- a/ZEngine/tests/Rendering/RenderGraphTest.cpp
+++ b/ZEngine/tests/Rendering/RenderGraphTest.cpp
@@ -37,7 +37,7 @@ TEST(RenderGraphTopologyTest, SortsReadAfterWrite)
 {
     MemoryManager manager{};
     manager.Initialize(16384, {});
-    auto& arena = manager.MainArena;
+    auto&         arena = manager.MainArena;
 
     Array<RGPass> passes;
     passes.init(&arena, 4);
@@ -67,7 +67,7 @@ TEST(RenderGraphTopologyTest, PreservesDeclarationOrderForIndependentPasses)
 {
     MemoryManager manager{};
     manager.Initialize(16384, {});
-    auto& arena = manager.MainArena;
+    auto&         arena = manager.MainArena;
 
     Array<RGPass> passes;
     passes.init(&arena, 4);
@@ -100,7 +100,7 @@ TEST(RenderGraphTopologyTest, HandlesWriteAfterWrite)
 {
     MemoryManager manager{};
     manager.Initialize(16384, {});
-    auto& arena = manager.MainArena;
+    auto&         arena = manager.MainArena;
 
     Array<RGPass> passes;
     passes.init(&arena, 4);
@@ -129,7 +129,7 @@ TEST(RenderGraphTopologyTest, HandlesWriteAfterRead)
 {
     MemoryManager manager{};
     manager.Initialize(16384, {});
-    auto& arena = manager.MainArena;
+    auto&         arena = manager.MainArena;
 
     Array<RGPass> passes;
     passes.init(&arena, 4);
@@ -163,7 +163,7 @@ TEST(RenderGraphTopologyTest, DetectsSimpleCycle)
 {
     MemoryManager manager{};
     manager.Initialize(16384, {});
-    auto& arena = manager.MainArena;
+    auto&         arena = manager.MainArena;
 
     Array<RGPass> passes;
     passes.init(&arena, 4);
@@ -194,7 +194,7 @@ TEST(RenderGraphTopologyTest, DetectsLongerCycleWithoutHanging)
 {
     MemoryManager manager{};
     manager.Initialize(16384, {});
-    auto& arena = manager.MainArena;
+    auto&         arena = manager.MainArena;
 
     Array<RGPass> passes;
     passes.init(&arena, 4);
@@ -230,7 +230,7 @@ TEST(RenderGraphTopologyTest, FallsBackToDeclarationOrderOnCycle)
 {
     MemoryManager manager{};
     manager.Initialize(16384, {});
-    auto& arena = manager.MainArena;
+    auto&         arena = manager.MainArena;
 
     Array<RGPass> passes;
     passes.init(&arena, 4);

--- a/ZEngine/tests/Rendering/RenderGraphTest.cpp
+++ b/ZEngine/tests/Rendering/RenderGraphTest.cpp
@@ -1,0 +1,265 @@
+#include <ZEngine/Core/Memory/MemoryManager.h>
+#include <ZEngine/Rendering/Renderers/RenderGraphTopology.h>
+#include <gtest/gtest.h>
+
+using namespace ZEngine;
+using namespace ZEngine::Core::Memory;
+using namespace ZEngine::Core::Containers;
+using namespace ZEngine::Rendering::Renderers;
+
+namespace
+{
+    RGPass MakePass(ArenaAllocator* arena, cstring name)
+    {
+        RGPass pass;
+        pass.Name = name;
+        pass.Reads.init(arena, 4);
+        pass.Writes.init(arena, 4);
+        return pass;
+    }
+
+    void AddRead(RGPass& pass, uint32_t resource_index)
+    {
+        RGPassResource pr;
+        pr.Handle = {resource_index, 0};
+        pass.Reads.push(pr);
+    }
+
+    void AddWrite(RGPass& pass, uint32_t resource_index)
+    {
+        RGPassResource pr;
+        pr.Handle = {resource_index, 0};
+        pass.Writes.push(pr);
+    }
+} // namespace
+
+TEST(RenderGraphTopologyTest, SortsReadAfterWrite)
+{
+    MemoryManager manager{};
+    manager.Initialize(16384, {});
+    auto& arena = manager.MainArena;
+
+    Array<RGPass> passes;
+    passes.init(&arena, 4);
+
+    // Declared as [B reads X, A writes X] — B must still end up after A.
+    RGPass b = MakePass(&arena, "B");
+    AddRead(b, /*resource=*/0);
+    passes.push(std::move(b));
+
+    RGPass a = MakePass(&arena, "A");
+    AddWrite(a, /*resource=*/0);
+    passes.push(std::move(a));
+
+    Array<uint32_t> order;
+    order.init(&arena, 4);
+    uint32_t cycle_idx = UINT32_MAX;
+
+    ASSERT_TRUE(BuildPassTopology(&arena, passes, order, &cycle_idx));
+    ASSERT_EQ(order.size(), 2u);
+    EXPECT_EQ(order[0], 1u); // A (declared second, index 1) must come first
+    EXPECT_EQ(order[1], 0u); // B (declared first, index 0) must come second
+
+    manager.Shutdown();
+}
+
+TEST(RenderGraphTopologyTest, PreservesDeclarationOrderForIndependentPasses)
+{
+    MemoryManager manager{};
+    manager.Initialize(16384, {});
+    auto& arena = manager.MainArena;
+
+    Array<RGPass> passes;
+    passes.init(&arena, 4);
+
+    RGPass a = MakePass(&arena, "A");
+    AddWrite(a, 0);
+    passes.push(std::move(a));
+
+    RGPass b = MakePass(&arena, "B");
+    AddWrite(b, 1);
+    passes.push(std::move(b));
+
+    RGPass c = MakePass(&arena, "C");
+    AddWrite(c, 2);
+    passes.push(std::move(c));
+
+    Array<uint32_t> order;
+    order.init(&arena, 4);
+
+    ASSERT_TRUE(BuildPassTopology(&arena, passes, order, nullptr));
+    ASSERT_EQ(order.size(), 3u);
+    EXPECT_EQ(order[0], 0u);
+    EXPECT_EQ(order[1], 1u);
+    EXPECT_EQ(order[2], 2u);
+
+    manager.Shutdown();
+}
+
+TEST(RenderGraphTopologyTest, HandlesWriteAfterWrite)
+{
+    MemoryManager manager{};
+    manager.Initialize(16384, {});
+    auto& arena = manager.MainArena;
+
+    Array<RGPass> passes;
+    passes.init(&arena, 4);
+
+    // [A writes X, B writes X], no intervening read — A must stay before B.
+    RGPass a = MakePass(&arena, "A");
+    AddWrite(a, 0);
+    passes.push(std::move(a));
+
+    RGPass b = MakePass(&arena, "B");
+    AddWrite(b, 0);
+    passes.push(std::move(b));
+
+    Array<uint32_t> order;
+    order.init(&arena, 4);
+
+    ASSERT_TRUE(BuildPassTopology(&arena, passes, order, nullptr));
+    ASSERT_EQ(order.size(), 2u);
+    EXPECT_EQ(order[0], 0u);
+    EXPECT_EQ(order[1], 1u);
+
+    manager.Shutdown();
+}
+
+TEST(RenderGraphTopologyTest, HandlesWriteAfterRead)
+{
+    MemoryManager manager{};
+    manager.Initialize(16384, {});
+    auto& arena = manager.MainArena;
+
+    Array<RGPass> passes;
+    passes.init(&arena, 4);
+
+    // [A writes X, B reads X, C writes X] — order must be A, B, C.
+    RGPass a = MakePass(&arena, "A");
+    AddWrite(a, 0);
+    passes.push(std::move(a));
+
+    RGPass b = MakePass(&arena, "B");
+    AddRead(b, 0);
+    passes.push(std::move(b));
+
+    RGPass c = MakePass(&arena, "C");
+    AddWrite(c, 0);
+    passes.push(std::move(c));
+
+    Array<uint32_t> order;
+    order.init(&arena, 4);
+
+    ASSERT_TRUE(BuildPassTopology(&arena, passes, order, nullptr));
+    ASSERT_EQ(order.size(), 3u);
+    EXPECT_EQ(order[0], 0u);
+    EXPECT_EQ(order[1], 1u);
+    EXPECT_EQ(order[2], 2u);
+
+    manager.Shutdown();
+}
+
+TEST(RenderGraphTopologyTest, DetectsSimpleCycle)
+{
+    MemoryManager manager{};
+    manager.Initialize(16384, {});
+    auto& arena = manager.MainArena;
+
+    Array<RGPass> passes;
+    passes.init(&arena, 4);
+
+    // A reads Y, writes X. B reads X, writes Y — a 2-node cycle.
+    RGPass a = MakePass(&arena, "A");
+    AddRead(a, 1);
+    AddWrite(a, 0);
+    passes.push(std::move(a));
+
+    RGPass b = MakePass(&arena, "B");
+    AddRead(b, 0);
+    AddWrite(b, 1);
+    passes.push(std::move(b));
+
+    Array<uint32_t> order;
+    order.init(&arena, 4);
+    uint32_t cycle_idx = UINT32_MAX;
+
+    ASSERT_FALSE(BuildPassTopology(&arena, passes, order, &cycle_idx));
+    EXPECT_EQ(order.size(), 0u);
+    EXPECT_TRUE(cycle_idx == 0u || cycle_idx == 1u);
+
+    manager.Shutdown();
+}
+
+TEST(RenderGraphTopologyTest, DetectsLongerCycleWithoutHanging)
+{
+    MemoryManager manager{};
+    manager.Initialize(16384, {});
+    auto& arena = manager.MainArena;
+
+    Array<RGPass> passes;
+    passes.init(&arena, 4);
+
+    // A -> B -> C -> A via read/write chains on resources 0,1,2.
+    RGPass a = MakePass(&arena, "A");
+    AddRead(a, 2);
+    AddWrite(a, 0);
+    passes.push(std::move(a));
+
+    RGPass b = MakePass(&arena, "B");
+    AddRead(b, 0);
+    AddWrite(b, 1);
+    passes.push(std::move(b));
+
+    RGPass c = MakePass(&arena, "C");
+    AddRead(c, 1);
+    AddWrite(c, 2);
+    passes.push(std::move(c));
+
+    Array<uint32_t> order;
+    order.init(&arena, 4);
+    uint32_t cycle_idx = UINT32_MAX;
+
+    ASSERT_FALSE(BuildPassTopology(&arena, passes, order, &cycle_idx));
+    EXPECT_EQ(order.size(), 0u);
+    EXPECT_LT(cycle_idx, 3u);
+
+    manager.Shutdown();
+}
+
+TEST(RenderGraphTopologyTest, FallsBackToDeclarationOrderOnCycle)
+{
+    MemoryManager manager{};
+    manager.Initialize(16384, {});
+    auto& arena = manager.MainArena;
+
+    Array<RGPass> passes;
+    passes.init(&arena, 4);
+
+    RGPass a = MakePass(&arena, "A");
+    AddRead(a, 1);
+    AddWrite(a, 0);
+    passes.push(std::move(a));
+
+    RGPass b = MakePass(&arena, "B");
+    AddRead(b, 0);
+    AddWrite(b, 1);
+    passes.push(std::move(b));
+
+    Array<uint32_t> order;
+    order.init(&arena, 4);
+    uint32_t cycle_idx = UINT32_MAX;
+
+    // Mirrors RenderGraph::BuildTopology()'s own fallback behavior on a cycle.
+    if (!BuildPassTopology(&arena, passes, order, &cycle_idx))
+    {
+        order.clear();
+        for (uint32_t i = 0; i < passes.size(); ++i)
+            order.push(i);
+    }
+
+    ASSERT_EQ(order.size(), 2u);
+    EXPECT_EQ(order[0], 0u);
+    EXPECT_EQ(order[1], 1u);
+
+    manager.Shutdown();
+}

--- a/ZEngine/tests/Rendering/RenderResourceManagerHotReloadTest.cpp
+++ b/ZEngine/tests/Rendering/RenderResourceManagerHotReloadTest.cpp
@@ -1,0 +1,56 @@
+#include <ZEngine/Rendering/RenderResourceManager.h>
+#include <gtest/gtest.h>
+
+// These tests exercise the hot-reload swap fix (ScheduleSwap/FlushPendingSwaps) and the
+// slot-generation ABA fix (AllocMeshSlot/AllocImageSlot/AllocGBufSlot) landed alongside it.
+//
+// Both are skip-gated: no test in this codebase constructs a real RenderResourceManager
+// today (the existing RenderResourceManagerTest.cpp only covers RenderHandle and
+// AssetRegistry callback plumbing, neither of which touches a device). RRM::Initialize
+// requires a fully-initialized VulkanDevice — Arena, GpuMem, a DeviceSwapchain with a real
+// timeline semaphore, ThreadPoolHelper::Pool, and CommandPool/CommandBuffer for the upload
+// queue — which is a materially bigger undertaking than GpuAllocatorTest's raw-Vulkan-handle
+// fixture (GpuAllocator only needs a bare VkPhysicalDevice/VkDevice/VkInstance; RRM needs the
+// whole engine bootstrap around it). Standing that up is out of scope for this pass; these
+// are left here, skip-gated with the exact intent, as the concrete spec for that future
+// fixture rather than silently dropping the tests.
+//
+// Correctness for this pass instead rests on: a full-file re-read of every call site touched
+// (RenderResourceManager.cpp/.h), three rounds of adversarial design review before
+// implementation, and a clean build of the whole engine (zEngineLib + Obelisk).
+
+TEST(RenderResourceManagerHotReloadTest, SlotGenerationIsMonotonicAcrossReuse)
+{
+    GTEST_SKIP() << "Needs a real VulkanDevice — AllocMeshSlot is private and every public "
+                    "path to it (UploadMesh/DoUploadMesh) goes through AppendToGlobalBuffer, "
+                    "which calls m_device->GpuMem.AllocateBuffer. Intent: upload -> release -> "
+                    "upload again into the same slot; assert same index, different generation "
+                    "(this fails against the pre-fix idx+1 scheme, which returns the same value).";
+}
+
+TEST(RenderResourceManagerHotReloadTest, StaleHandleAfterReleaseAndReuseFailsGetBuffer)
+{
+    GTEST_SKIP() << "Needs a real VulkanDevice, same reason as SlotGenerationIsMonotonicAcrossReuse. "
+                    "Intent: after slot reuse, the old (stale) handle must not resolve via GetBuffer.";
+}
+
+TEST(RenderResourceManagerHotReloadTest, HotReloadSwapUpdatesMeshOffsetsNextFrame)
+{
+    GTEST_SKIP() << "Needs a real VulkanDevice + AssetRegistry + AssetManager wiring. Intent: "
+                    "register a mesh asset, upload it, fire OnAssetModified -> ScheduleSwap "
+                    "enqueues -> one more BeginFrame drains it via FlushPendingSwaps -> "
+                    "GetMeshOffsets returns different offsets pointing at newly-appended data, "
+                    "same external BufferHandle still resolves. No frame-in-flight delay to "
+                    "test for — the swap applies on the very next frame it's processed.";
+}
+
+TEST(RenderResourceManagerHotReloadTest, ScheduleSwapIsThreadSafeFromNonRenderThread)
+{
+    GTEST_SKIP() << "Needs a real VulkanDevice — FlushPendingSwaps (which ScheduleSwap's "
+                    "effect is only observable through) calls DoUploadTexture/AppendMeshData, "
+                    "both device-dependent. Intent: concurrent ScheduleSwap calls from a "
+                    "spawned thread against a BeginFrame/EndFrame loop on the main thread, "
+                    "~100 iterations, no crash/UB under TSan — the regression test for the "
+                    "thread-safety fix (a dedicated m_pending_swap_mutex, not the hot, "
+                    "long-held m_pending_mutex that SubmitTextureFile also holds).";
+}


### PR DESCRIPTION
## Summary

Three-track foundation-hardening pass, planned and executed as one initiative this month, per the approved plan — foundation over new visual features.

- **RenderGraph** — `BuildTopology` now does a real Kahn's-algorithm sort over RAW/WAW/WAR hazard edges (previously a flat insertion-order loop despite already recording per-pass Reads/Writes). Fixes the resulting `Compile()` ordering bug plus one unrelated pre-existing resource/pass-index bug found in passing. 7 new tests.
- **GpuAllocator** — real segregated VMA pools for `DeviceGeometry`/`DeviceTexture`/`HostUniform`/`HostStaging` (`RenderTarget` intentionally stays unpooled). Testing against a real headless Vulkan device caught 3 real bugs: a nonexistent VMA error code being checked, a fixed-blockSize pool that can't fit an allocation exactly equal to its own size, and pools needing explicit destruction before the allocator. 4 new tests.
- **RenderResourceManager** — hot-reload swap (`ScheduleSwap`) was a complete no-op for both buffers and images, not just buffers as originally filed in #740. Implemented via a dedicated mutex-guarded pending-swap queue drained on `BeginFrame`, applied immediately (traced every consumer of RRM handles in this engine — none needs a frame-in-flight delay). Also fixes the ABA bug on the handle pools (monotonic generation counters instead of deterministic `idx+1`) and one bug found while extending it (`DoUploadTexture` silently overwriting its own correct generation).

Full technical rationale, the three rounds of adversarial design verification, and the "explicitly out of scope this month" list are in the commit messages (one per track) and the corrected docs.

**Note:** this branch originally included its own fix for #746 (`Logger::Log` crashing on calls before `Initialize`/after `Dispose`), found incidentally while testing the GpuAllocator work. @BetterAndBetterII independently found and fixed the same bug in #747 — merged separately, with better-targeted regression tests than what I'd written. Rebased this branch onto `develop` after that merge and dropped the now-redundant Logger.cpp commit; the RenderGraph/GpuAllocator/RRM work here doesn't depend on it.

## Test plan

- [x] `ctest` on the rebased branch — **100% passed, 0 failed, out of 549** (545 passing + 4 honestly skip-gated — no headless-`VulkanDevice` fixture exists in this codebase yet; building one is a separate, larger undertaking, documented in `RenderResourceManagerHotReloadTest.cpp`)
- [x] Obelisk rebuilt and confirmed running cleanly with all three tracks active, no crash, no new diagnostic report
- [x] Verified `ctest`'s per-test-process execution is unaffected by a real MoltenVK/Vulkan cross-test side effect discovered in the raw single-process test binary (documented in `GpuAllocatorTest.cpp`)
- [ ] Manual: trigger a real hot-reload in the running editor and confirm a mesh visibly updates — tracked separately in #749 (couldn't automate the GUI import step in this environment)

Closes #740. Comments on #312 with a deferral rationale (not closing — full memory aliasing is out of scope this month).