### PR TITLE
feat(ecs): Scene::AddComponentRaw + InspectorPanel Add Component popup

### DIFF
--- a/Tetragrama/Panels/InspectorPanel.cpp
+++ b/Tetragrama/Panels/InspectorPanel.cpp
@@ -392,10 +392,15 @@ namespace Tetragrama::Panels
             return;
         }
 
-        // Actor header — name editing
+        ArchetypeMask mask     = actor->GetComponentMask();
+        const auto&   registry = ComponentReflectionRegistry::Get();
+
+        // Actor header — name editing + Add Component
         {
-            ZUIBox* hdr = ZUIBeginColumn(ctx, "##insp_hdr", ZFill(), ZPx(fh + 16.f));
-            hdr->Flags  = hdr->Flags | ZUI_DrawBackground;
+            constexpr float kAddBtnW = 70.f;
+
+            ZUIBox*         hdr      = ZUIBeginColumn(ctx, "##insp_hdr", ZFill(), ZPx(fh + 16.f));
+            hdr->Flags               = hdr->Flags | ZUI_DrawBackground;
             ZUIBoxSetColor(hdr, 0.18f, 0.18f, 0.22f, 1.f);
             hdr->EdgeSoftness = 0.f;
             hdr->Padding[1]   = 6.f; // top padding — vertically centers the field
@@ -405,11 +410,46 @@ namespace Tetragrama::Panels
             ZUIBeginRow(ctx, "##insp_hdr_r", ZFill(), ZPx(fh));
             ZUISpacer(ctx, 8.f);
             if (nc_comp)
-                ZUITextField(ctx, "##actor_name", nc_comp->Value, sizeof(nc_comp->Value), fmaxf(pw - 24.f, 80.f));
+                ZUITextField(ctx, "##actor_name", nc_comp->Value, sizeof(nc_comp->Value), fmaxf(pw - 32.f - kAddBtnW, 80.f));
             else
                 ZUILabel(ctx, "Actor", ctx->Theme.TextDefault);
             ZUISpacer(ctx, 8.f);
+
+            static constexpr const char* kAddBtnLabel = "+ Add";
+            if (ZUIButton(ctx, kAddBtnLabel, ZPx(kAddBtnW), ZPx(fh)).Flags & ZUI_SignalClicked)
+            {
+                // The button sits flush against the panel's right edge, so opening at
+                // the click position (ZUIOpenPopup's default) clips the list against
+                // the window edge — anchor leftward from the button's own right edge
+                // instead, same pattern ZUIBeginCombo uses for its dropdown.
+                uint64_t            btn_key = ZUIHashStr(kAddBtnLabel, (uint32_t) strlen(kAddBtnLabel));
+                ZUIPersistentState* ps      = ZUIStateGetOrInsert(&ctx->StateStore, btn_key);
+                float               py      = (ps && ps->ScreenMaxY > 0.f) ? ps->ScreenMaxY : ctx->MousePos[1];
+                float               px      = (ps && ps->ScreenMaxX > 0.f) ? fmaxf(ps->ScreenMaxX - ctx->Style.PopupMinWidth, 0.f) : ctx->MousePos[0];
+                ZUIOpenPopup(ctx, "##add_component_popup", px, py);
+            }
+
+            ZUISpacer(ctx, 8.f);
             ZUIEndRow(ctx);
+
+            if (ZUIBeginPopup(ctx, "##add_component_popup"))
+            {
+                bool any = false;
+                registry.ForEach([&](const ComponentMeta& meta) {
+                    if (MaskHas(mask, meta.TypeID))
+                        return; // already on the actor
+                    if (!meta.Add)
+                        return; // display-only, cannot be constructed
+                    any = true;
+                    if (ZUIMenuItem(ctx, meta.TypeName))
+                        eng->Scene->AddComponentRaw(actor->GetEntityID(), meta.TypeID);
+                });
+
+                if (!any)
+                    ZUIMenuItem(ctx, "No components left to add", false);
+
+                ZUIEndPopup(ctx);
+            }
 
             ZUIEndColumn(ctx);
         }
@@ -515,9 +555,7 @@ namespace Tetragrama::Panels
         ZUIPaddingXY(scroll, 0.f, 4.f); // 4px top/bottom breathing room
 
         // Reflection-driven component sections
-        ArchetypeMask mask     = actor->GetComponentMask();
-        uint32_t      comp_idx = 0;
-        const auto&   registry = ComponentReflectionRegistry::Get();
+        uint32_t comp_idx = 0;
 
         // HOT PATH — runs every frame, no heap allocation allowed.
         registry.ForEach([&](const ComponentMeta& meta) {
@@ -570,39 +608,6 @@ namespace Tetragrama::Panels
 
             ++comp_idx;
         });
-
-        {
-            ZUISpacer(ctx, 6.f);
-            if (ZUIButton(ctx, "+ Add Component", ZPct(1.f), ZPx(24.f)).Flags & ZUI_SignalClicked)
-                ZUIOpenPopup(ctx, "##add_component_popup");
-
-            if (ZUIBeginPopup(ctx, "##add_component_popup"))
-            {
-                bool any = false;
-                registry.ForEach([&](const ComponentMeta& meta) {
-                    if (MaskHas(mask, meta.TypeID))
-                    {
-                        return; // already on the actor
-                    }
-                    if (!meta.Add)
-                    {
-                        return; // display-only, cannot be constructed
-                    }
-                    any = true;
-                    if (ZUIMenuItem(ctx, meta.TypeName))
-                    {
-                        eng->Scene->AddComponentRaw(actor->GetEntityID(), meta.TypeID);
-                    }
-                });
-
-                if (!any)
-                {
-                    ZUIMenuItem(ctx, "No components left to add", false);
-                }
-
-                ZUIEndPopup(ctx);
-            }
-        }
 
         ZUIEndScrollRegion(ctx);
         ZUIEndColumn(ctx);

--- a/Tetragrama/Panels/InspectorPanel.cpp
+++ b/Tetragrama/Panels/InspectorPanel.cpp
@@ -571,6 +571,39 @@ namespace Tetragrama::Panels
             ++comp_idx;
         });
 
+        {
+            ZUISpacer(ctx, 6.f);
+            if (ZUIButton(ctx, "+ Add Component", ZPct(1.f), ZPx(24.f)).Flags & ZUI_SignalClicked)
+                ZUIOpenPopup(ctx, "##add_component_popup");
+
+            if (ZUIBeginPopup(ctx, "##add_component_popup"))
+            {
+                bool any = false;
+                registry.ForEach([&](const ComponentMeta& meta) {
+                    if (MaskHas(mask, meta.TypeID))
+                    {
+                        return; // already on the actor
+                    }
+                    if (!meta.Add)
+                    {
+                        return; // display-only, cannot be constructed
+                    }
+                    any = true;
+                    if (ZUIMenuItem(ctx, meta.TypeName))
+                    {
+                        eng->Scene->AddComponentRaw(actor->GetEntityID(), meta.TypeID);
+                    }
+                });
+
+                if (!any)
+                {
+                    ZUIMenuItem(ctx, "No components left to add", false);
+                }
+
+                ZUIEndPopup(ctx);
+            }
+        }
+
         ZUIEndScrollRegion(ctx);
         ZUIEndColumn(ctx);
     }

--- a/ZEngine/ZEngine/ECS/ComponentStorage.h
+++ b/ZEngine/ZEngine/ECS/ComponentStorage.h
@@ -120,6 +120,15 @@ namespace ZEngine::ECS
                 fn(m_dense_ids[i], m_dense[i]);
         }
 
+        void AddRaw(EntityID id) override
+        {
+            if (!id.IsValid() || Has(id))
+            {
+                return;
+            }
+            Add(id, T{});
+        }
+
         void* GetRaw(EntityID id) override
         {
             return Has(id) ? static_cast<void*>(Get(id)) : nullptr;

--- a/ZEngine/ZEngine/ECS/Components/CameraComponent.cpp
+++ b/ZEngine/ZEngine/ECS/Components/CameraComponent.cpp
@@ -1,5 +1,6 @@
 #include <ZEngine/ECS/Components/CameraComponent.h>
 #include <ZEngine/ECS/Reflection/ComponentReflectionRegistry.h>
+#include <ZEngine/ECS/Scene.h>
 
 namespace ZEngine::ECS::Components
 {
@@ -23,6 +24,7 @@ namespace ZEngine::ECS::Components
             .Fields     = kFields,
             .FieldCount = static_cast<uint32_t>(sizeof(kFields) / sizeof(kFields[0])),
             .Category   = "Camera",
+            .Add        = [](Scene& scene, EntityID id) { scene.AddComponent<CC>(id, {}); },
         });
     }
 } // namespace ZEngine::ECS::Components

--- a/ZEngine/ZEngine/ECS/Components/LightComponent.cpp
+++ b/ZEngine/ZEngine/ECS/Components/LightComponent.cpp
@@ -1,5 +1,6 @@
 #include <ZEngine/ECS/Components/LightComponent.h>
 #include <ZEngine/ECS/Reflection/ComponentReflectionRegistry.h>
+#include <ZEngine/ECS/Scene.h>
 
 namespace ZEngine::ECS::Components
 {
@@ -33,6 +34,7 @@ namespace ZEngine::ECS::Components
             .Fields     = kFields,
             .FieldCount = static_cast<uint32_t>(sizeof(kFields) / sizeof(kFields[0])),
             .Category   = "Lighting",
+            .Add        = [](Scene& scene, EntityID id) { scene.AddComponent<LC>(id, {}); },
         });
     }
 } // namespace ZEngine::ECS::Components

--- a/ZEngine/ZEngine/ECS/Components/MaterialComponent.cpp
+++ b/ZEngine/ZEngine/ECS/Components/MaterialComponent.cpp
@@ -1,5 +1,6 @@
 #include <ZEngine/ECS/Components/MaterialComponent.h>
 #include <ZEngine/ECS/Reflection/ComponentReflectionRegistry.h>
+#include <ZEngine/ECS/Scene.h>
 
 namespace ZEngine::ECS::Components
 {
@@ -19,6 +20,7 @@ namespace ZEngine::ECS::Components
             .Fields     = kFields,
             .FieldCount = static_cast<uint32_t>(sizeof(kFields) / sizeof(kFields[0])),
             .Category   = "Rendering",
+            .Add        = [](Scene& scene, EntityID id) { scene.AddComponent<MatC>(id, {}); },
         });
     }
 } // namespace ZEngine::ECS::Components

--- a/ZEngine/ZEngine/ECS/Components/MeshComponent.cpp
+++ b/ZEngine/ZEngine/ECS/Components/MeshComponent.cpp
@@ -1,5 +1,6 @@
 #include <ZEngine/ECS/Components/MeshComponent.h>
 #include <ZEngine/ECS/Reflection/ComponentReflectionRegistry.h>
+#include <ZEngine/ECS/Scene.h>
 
 namespace ZEngine::ECS::Components
 {
@@ -20,6 +21,7 @@ namespace ZEngine::ECS::Components
             .Fields     = kFields,
             .FieldCount = static_cast<uint32_t>(sizeof(kFields) / sizeof(kFields[0])),
             .Category   = "Rendering",
+            .Add        = [](Scene& scene, EntityID id) { scene.AddComponent<MC>(id, {}); },
         });
     }
 } // namespace ZEngine::ECS::Components

--- a/ZEngine/ZEngine/ECS/Components/NameComponent.cpp
+++ b/ZEngine/ZEngine/ECS/Components/NameComponent.cpp
@@ -1,5 +1,6 @@
 #include <ZEngine/ECS/Components/NameComponent.h>
 #include <ZEngine/ECS/Reflection/ComponentReflectionRegistry.h>
+#include <ZEngine/ECS/Scene.h>
 
 namespace ZEngine::ECS::Components
 {
@@ -19,6 +20,7 @@ namespace ZEngine::ECS::Components
             .Fields     = kFields,
             .FieldCount = static_cast<uint32_t>(sizeof(kFields) / sizeof(kFields[0])),
             .Category   = "General",
+            .Add        = [](Scene& scene, EntityID id) { scene.AddComponent<NC>(id, {}); },
         });
     }
 } // namespace ZEngine::ECS::Components

--- a/ZEngine/ZEngine/ECS/Components/RigidBodyComponent.cpp
+++ b/ZEngine/ZEngine/ECS/Components/RigidBodyComponent.cpp
@@ -1,5 +1,6 @@
 #include <ZEngine/ECS/Components/RigidBodyComponent.h>
 #include <ZEngine/ECS/Reflection/ComponentReflectionRegistry.h>
+#include <ZEngine/ECS/Scene.h>
 
 namespace ZEngine::ECS::Components
 {
@@ -29,6 +30,7 @@ namespace ZEngine::ECS::Components
             .Fields     = kFields,
             .FieldCount = static_cast<uint32_t>(sizeof(kFields) / sizeof(kFields[0])),
             .Category   = "Physics",
+            .Add        = [](Scene& scene, EntityID id) { scene.AddComponent<RBC>(id, {}); },
         });
     }
 } // namespace ZEngine::ECS::Components

--- a/ZEngine/ZEngine/ECS/Components/TransformComponent.cpp
+++ b/ZEngine/ZEngine/ECS/Components/TransformComponent.cpp
@@ -1,5 +1,6 @@
 #include <ZEngine/ECS/Components/TransformComponent.h>
 #include <ZEngine/ECS/Reflection/ComponentReflectionRegistry.h>
+#include <ZEngine/ECS/Scene.h>
 
 namespace ZEngine::ECS::Components
 {
@@ -23,6 +24,7 @@ namespace ZEngine::ECS::Components
             .Fields     = kFields,
             .FieldCount = static_cast<uint32_t>(sizeof(kFields) / sizeof(kFields[0])),
             .Category   = "Transform",
+            .Add        = [](Scene& scene, EntityID id) { scene.AddComponent<TC>(id, {}); },
         });
     }
 } // namespace ZEngine::ECS::Components

--- a/ZEngine/ZEngine/ECS/Components/UUIDComponent.cpp
+++ b/ZEngine/ZEngine/ECS/Components/UUIDComponent.cpp
@@ -1,5 +1,6 @@
 #include <ZEngine/ECS/Components/UUIDComponent.h>
 #include <ZEngine/ECS/Reflection/ComponentReflectionRegistry.h>
+#include <ZEngine/ECS/Scene.h>
 
 namespace ZEngine::ECS::Components
 {
@@ -19,6 +20,7 @@ namespace ZEngine::ECS::Components
             .Fields     = kFields,
             .FieldCount = static_cast<uint32_t>(sizeof(kFields) / sizeof(kFields[0])),
             .Category   = "General",
+            .Add        = [](Scene& scene, EntityID id) { scene.AddComponent<UC>(id, {}); },
         });
     }
 } // namespace ZEngine::ECS::Components

--- a/ZEngine/ZEngine/ECS/IComponentStorage.h
+++ b/ZEngine/ZEngine/ECS/IComponentStorage.h
@@ -16,6 +16,7 @@ namespace ZEngine::ECS
         // Returns true if this entity has a component in this storage.
         virtual bool        HasRaw(EntityID id) const = 0;
 
+        virtual void        AddRaw(EntityID id)       = 0;
         virtual void*       GetRaw(EntityID id)       = 0;
         virtual const void* GetRaw(EntityID id) const = 0;
     };

--- a/ZEngine/ZEngine/ECS/Reflection/ComponentMeta.h
+++ b/ZEngine/ZEngine/ECS/Reflection/ComponentMeta.h
@@ -1,10 +1,12 @@
 #pragma once
 #include <ZEngine/ECS/ComponentTypeID.h>
+#include <ZEngine/ECS/EntityID.h>
 #include <ZEngine/ECS/Reflection/FieldType.h>
 #include <cstdint>
 
 namespace ZEngine::ECS
 {
+    class Scene;
 
     struct EnumValue
     {
@@ -40,6 +42,9 @@ namespace ZEngine::ECS
         uint32_t               FieldCount = 0;
         const char*            Category   = "General"; // compare with strcmp, not ==
         const char*            Tooltip    = nullptr;
+
+        using AddFn                       = void (*)(Scene&, EntityID);
+        AddFn Add                         = nullptr;
     };
 
 } // namespace ZEngine::ECS

--- a/ZEngine/ZEngine/ECS/Scene.cpp
+++ b/ZEngine/ZEngine/ECS/Scene.cpp
@@ -1,4 +1,5 @@
 #include <ZEngine/ECS/Components/TransformComponent.h>
+#include <ZEngine/ECS/Reflection/ComponentReflectionRegistry.h>
 #include <ZEngine/ECS/Scene.h>
 #include <ZEngine/ZEngineDef.h>
 
@@ -68,6 +69,20 @@ namespace ZEngine::ECS
             rt.Scale    = t.Scale;
             out.push(rt);
         });
+    }
+
+    void Scene::AddComponentRaw(EntityID id, ComponentTypeID type_id)
+    {
+        if (!IsAlive(id) || MaskHas(m_registry.GetMask(id), type_id))
+        {
+            return;
+        }
+
+        const ComponentMeta* meta = ComponentReflectionRegistry::Get().Lookup(type_id);
+        if (meta && meta->Add)
+        {
+            meta->Add(*this, id);
+        }
     }
 
     void* Scene::GetComponentRaw(EntityID id, ComponentTypeID type_id)

--- a/ZEngine/ZEngine/ECS/Scene.cpp
+++ b/ZEngine/ZEngine/ECS/Scene.cpp
@@ -71,7 +71,7 @@ namespace ZEngine::ECS
         });
     }
 
-    void Scene::AddComponentRaw(EntityID id, ComponentTypeID type_id)
+    void Scene::AddComponentRaw(EntityID id, ComponentTypeID type_id, uint32_t size, uint32_t align)
     {
         if (!IsAlive(id) || MaskHas(m_registry.GetMask(id), type_id))
         {
@@ -79,7 +79,22 @@ namespace ZEngine::ECS
         }
 
         const ComponentMeta* meta = ComponentReflectionRegistry::Get().Lookup(type_id);
-        if (meta && meta->Add)
+        if (!meta)
+        {
+            return;
+        }
+
+        ZENGINE_VALIDATE_ASSERT(size == 0 || size == meta->Size, "Scene::AddComponentRaw: size does not match the registered component size")
+        ZENGINE_VALIDATE_ASSERT(align == 0 || align == meta->Align, "Scene::AddComponentRaw: align does not match the registered component alignment")
+
+        if (IComponentStorage** found = m_storages.find(type_id))
+        {
+            (*found)->AddRaw(id);
+            m_registry.SetMaskBit(id, MaskBit(type_id));
+            return;
+        }
+
+        if (meta->Add)
         {
             meta->Add(*this, id);
         }

--- a/ZEngine/ZEngine/ECS/Scene.h
+++ b/ZEngine/ZEngine/ECS/Scene.h
@@ -102,7 +102,7 @@ namespace ZEngine::ECS
         // Call once per render frame before submitting to the renderer.
         void        FillRenderableTransforms(float alpha, Core::Containers::Array<RenderableTransform>& out);
 
-        void        AddComponentRaw(EntityID id, ComponentTypeID type_id);
+        void        AddComponentRaw(EntityID id, ComponentTypeID type_id, uint32_t size = 0, uint32_t align = 0);
         void*       GetComponentRaw(EntityID id, ComponentTypeID type_id);
         const void* GetComponentRaw(EntityID id, ComponentTypeID type_id) const;
 

--- a/ZEngine/ZEngine/ECS/Scene.h
+++ b/ZEngine/ZEngine/ECS/Scene.h
@@ -102,6 +102,7 @@ namespace ZEngine::ECS
         // Call once per render frame before submitting to the renderer.
         void        FillRenderableTransforms(float alpha, Core::Containers::Array<RenderableTransform>& out);
 
+        void        AddComponentRaw(EntityID id, ComponentTypeID type_id);
         void*       GetComponentRaw(EntityID id, ComponentTypeID type_id);
         const void* GetComponentRaw(EntityID id, ComponentTypeID type_id) const;
 

--- a/ZEngine/tests/ECS/ComponentReflectionTest.cpp
+++ b/ZEngine/tests/ECS/ComponentReflectionTest.cpp
@@ -169,3 +169,76 @@ TEST(ComponentReflection, EveryFieldFitsWithinItsComponent)
         }
     });
 }
+
+class ReflectionSceneFixture : public ::testing::Test
+{
+protected:
+    MemoryManager m_manager;
+    Scene         m_scene;
+
+    void          SetUp() override
+    {
+        Registry();
+        m_manager.Initialize(ZMega(64), {});
+        m_scene.Initialize(&m_manager.MainArena);
+    }
+
+    void TearDown() override
+    {
+        m_scene.Shutdown();
+    }
+};
+
+TEST_F(ReflectionSceneFixture, EveryBuiltInHasAnAddFactory)
+{
+    Registry().ForEach([](const ComponentMeta& meta) { EXPECT_NE(meta.Add, nullptr) << meta.TypeName; });
+}
+
+TEST_F(ReflectionSceneFixture, AddComponentRawCreatesEveryBuiltInType)
+{
+    EntityID id = m_scene.CreateEntity();
+
+    Registry().ForEach([&](const ComponentMeta& meta) {
+        EXPECT_EQ(m_scene.GetComponentRaw(id, meta.TypeID), nullptr) << meta.TypeName;
+        m_scene.AddComponentRaw(id, meta.TypeID);
+        EXPECT_NE(m_scene.GetComponentRaw(id, meta.TypeID), nullptr) << meta.TypeName;
+        EXPECT_TRUE(MaskHas(m_scene.GetMask(id), meta.TypeID)) << meta.TypeName;
+    });
+}
+
+TEST_F(ReflectionSceneFixture, AddComponentRawAppliesDefaultMemberInitializers)
+{
+    EntityID id = m_scene.CreateEntity();
+    m_scene.AddComponentRaw(id, ComponentTypeOf<TransformComponent>());
+
+    auto* tc = m_scene.GetComponent<TransformComponent>(id);
+    ASSERT_NE(tc, nullptr);
+    // NOT memset-to-zero: a zeroed Scale would make every added actor invisible.
+    EXPECT_FLOAT_EQ(tc->Scale.x, 1.f);
+    EXPECT_FLOAT_EQ(tc->Scale.y, 1.f);
+    EXPECT_FLOAT_EQ(tc->Scale.z, 1.f);
+    EXPECT_FLOAT_EQ(tc->Position.x, 0.f);
+}
+
+TEST_F(ReflectionSceneFixture, AddComponentRawIsANoOpOnDuplicate)
+{
+    EntityID id = m_scene.CreateEntity();
+    m_scene.AddComponentRaw(id, ComponentTypeOf<CameraComponent>());
+
+    void* first = m_scene.GetComponentRaw(id, ComponentTypeOf<CameraComponent>());
+    ASSERT_NE(first, nullptr);
+
+    m_scene.AddComponentRaw(id, ComponentTypeOf<CameraComponent>());
+    EXPECT_EQ(m_scene.GetComponentRaw(id, ComponentTypeOf<CameraComponent>()), first);
+}
+
+TEST_F(ReflectionSceneFixture, AddComponentRawIgnoresUnknownTypesAndDeadEntities)
+{
+    EntityID id = m_scene.CreateEntity();
+    m_scene.AddComponentRaw(id, 9999u);
+    EXPECT_EQ(m_scene.GetComponentRaw(id, 9999u), nullptr);
+
+    m_scene.DestroyEntity(id);
+    m_scene.AddComponentRaw(id, ComponentTypeOf<NameComponent>()); // dead entity
+    EXPECT_EQ(m_scene.GetComponentRaw(id, ComponentTypeOf<NameComponent>()), nullptr);
+}

--- a/ZEngine/tests/ECS/ComponentReflectionTest.cpp
+++ b/ZEngine/tests/ECS/ComponentReflectionTest.cpp
@@ -242,3 +242,44 @@ TEST_F(ReflectionSceneFixture, AddComponentRawIgnoresUnknownTypesAndDeadEntities
     m_scene.AddComponentRaw(id, ComponentTypeOf<NameComponent>()); // dead entity
     EXPECT_EQ(m_scene.GetComponentRaw(id, ComponentTypeOf<NameComponent>()), nullptr);
 }
+
+TEST_F(ReflectionSceneFixture, AddComponentRawUsesExistingStorageForLaterEntities)
+{
+    EntityID first = m_scene.CreateEntity();
+    m_scene.AddComponentRaw(first, ComponentTypeOf<LightComponent>());
+
+    EntityID second = m_scene.CreateEntity();
+    m_scene.AddComponentRaw(second, ComponentTypeOf<LightComponent>());
+
+    auto* lc = m_scene.GetComponent<LightComponent>(second);
+    ASSERT_NE(lc, nullptr);
+    EXPECT_TRUE(MaskHas(m_scene.GetMask(second), ComponentTypeOf<LightComponent>()));
+    EXPECT_FLOAT_EQ(lc->Intensity, 1.f);
+    EXPECT_FLOAT_EQ(lc->Color[0], 1.f);
+}
+
+TEST_F(ReflectionSceneFixture, AddComponentRawPreservesInactiveSentinels)
+{
+    EntityID id = m_scene.CreateEntity();
+    m_scene.AddComponentRaw(id, ComponentTypeOf<MeshComponent>());
+    m_scene.AddComponentRaw(id, ComponentTypeOf<RigidBodyComponent>());
+
+    auto* mc = m_scene.GetComponent<MeshComponent>(id);
+    auto* rb = m_scene.GetComponent<RigidBodyComponent>(id);
+    ASSERT_NE(mc, nullptr);
+    ASSERT_NE(rb, nullptr);
+
+    EXPECT_EQ(mc->RenderInstanceId, UINT32_MAX);
+    EXPECT_EQ(rb->BodyID, UINT32_MAX);
+    EXPECT_FLOAT_EQ(rb->Mass, 1.f);
+}
+
+TEST_F(ReflectionSceneFixture, AddComponentRawAcceptsMatchingSizeAndAlign)
+{
+    const ComponentMeta* meta = Registry().Lookup(ComponentTypeOf<CameraComponent>());
+    ASSERT_NE(meta, nullptr);
+
+    EntityID id = m_scene.CreateEntity();
+    m_scene.AddComponentRaw(id, meta->TypeID, meta->Size, meta->Align);
+    EXPECT_NE(m_scene.GetComponentRaw(id, meta->TypeID), nullptr);
+}


### PR DESCRIPTION
## Summary
- Implements `Scene::AddComponentRaw` — type-erased, size/align-validated component addition, backed by a new `IComponentStorage::AddRaw` virtual and a per-component `ComponentMeta::Add` factory pointer registered on all 8 built-in components.
- Implements the "Add Component" popup in `InspectorPanel` — a button in the actor header opens a popup listing every registered component type not already on the selected actor, driven entirely by `ComponentReflectionRegistry::ForEach`; selecting one calls `Scene::AddComponentRaw`.
- Adds 8 tests to `ComponentReflectionTest.cpp`: default-member-initializer semantics (not memset-zero — a zeroed `Scale` would make actors invisible), duplicate-add no-ops, dead-entity/unknown-type guards, sentinel-field preservation, and size/align validation.

## Test plan
- [x] `ZEngineTests` builds and passes via `ctest`, including the 8 new `ReflectionSceneFixture` cases
- [x] Full suite: 562/562 passing, no regressions
- [x] Manually verified in Obelisk: selecting an actor, clicking "+ Add", picking an unowned component immediately shows it in the panel

Closes #704
Closes #706