### PR TITLE
fix(assets): keep asset UUID identity consistent across import, meta, and scan

### DIFF
--- a/Tetragrama/Panels/AssetImporterPanel.cpp
+++ b/Tetragrama/Panels/AssetImporterPanel.cpp
@@ -749,8 +749,12 @@ namespace Tetragrama::Panels
 
         if (has_mesh && mesh_path)
         {
+            // Read once, shared by the meta write below and the add-to-scene block.
+            ZEngine::Importers::AssetCodec::AssetMeshFileHeader header{};
+            bool                                                has_header = ZEngine::Importers::AssetCodec::ReadAssetMeshFileHeader(mesh_path, header);
+
             // Write meta file (source path for re-import)
-            auto* ctx_engine = ZEngine::Engine::GetContext();
+            auto*                                               ctx_engine = ZEngine::Engine::GetContext();
             if (ctx_engine && ctx_engine->VFS)
             {
                 auto*   vfs    = reinterpret_cast<ZEngine::Core::VFS::IVFSContext*>(ctx_engine->VFS);
@@ -765,6 +769,10 @@ namespace Tetragrama::Panels
                     {
                         auto                             meta_result = ZEngine::Core::VFS::MetaFileIO::Read(*vfs, rel.Value());
                         ZEngine::Core::VFS::MetaFileData meta        = meta_result.Succeeded() ? meta_result.Value() : ZEngine::Core::VFS::MetaFileData{};
+                        // Sync to the file's own embedded UUID — otherwise a nil
+                        // AssetUUID gets locked in forever (#755).
+                        if (has_header)
+                            meta.AssetUUID = header.Id;
                         secure_strncpy(meta.SourcePath, sizeof(meta.SourcePath), self->m_path_buf, sizeof(meta.SourcePath) - 1);
                         secure_strncpy(meta.ArtifactPath, sizeof(meta.ArtifactPath), mesh_path, sizeof(meta.ArtifactPath) - 1);
                         secure_strncpy(meta.ImporterName, sizeof(meta.ImporterName), "GltfImporter/AssimpImporter", sizeof(meta.ImporterName) - 1);
@@ -774,33 +782,29 @@ namespace Tetragrama::Panels
             }
 
             // Add mesh instance to scene if triggered by drag-drop
-            if (self->m_add_to_scene)
+            if (self->m_add_to_scene && has_header)
             {
-                ZEngine::Importers::AssetCodec::AssetMeshFileHeader header{};
-                if (ZEngine::Importers::AssetCodec::ReadAssetMeshFileHeader(mesh_path, header))
+                auto* app   = self->m_layer ? reinterpret_cast<EditorPtr>(self->m_layer->CurrentApp) : nullptr;
+                auto* scene = app ? reinterpret_cast<EditorScenePtr>(app->CurrentScene) : nullptr;
+                if (scene)
                 {
-                    auto* app   = self->m_layer ? reinterpret_cast<EditorPtr>(self->m_layer->CurrentApp) : nullptr;
-                    auto* scene = app ? reinterpret_cast<EditorScenePtr>(app->CurrentScene) : nullptr;
-                    if (scene)
+                    char iname[256] = {};
+                    if (self->m_instance_name[0])
+                        secure_strncpy(iname, sizeof(iname), self->m_instance_name, sizeof(iname) - 1);
+                    else
                     {
-                        char iname[256] = {};
-                        if (self->m_instance_name[0])
-                            secure_strncpy(iname, sizeof(iname), self->m_instance_name, sizeof(iname) - 1);
-                        else
+                        auto pr = VFSPath::Parse(self->m_path_buf);
+                        if (pr.Succeeded())
                         {
-                            auto pr = VFSPath::Parse(self->m_path_buf);
-                            if (pr.Succeeded())
-                            {
-                                auto s = pr.Value().Stem();
-                                snprintf(iname, sizeof(iname), "%.*s", (int) s.Length, s.Data);
-                            }
+                            auto s = pr.Value().Stem();
+                            snprintf(iname, sizeof(iname), "%.*s", (int) s.Length, s.Data);
                         }
-                        uint32_t render_id              = scene->AddMeshInstance(header.Id, iname);
-                        self->m_pending_actor.uuid      = header.Id;
-                        self->m_pending_actor.render_id = render_id;
-                        self->m_pending_actor.valid     = true;
-                        secure_strncpy(self->m_pending_actor.name, sizeof(self->m_pending_actor.name), iname, sizeof(self->m_pending_actor.name) - 1);
                     }
+                    uint32_t render_id              = scene->AddMeshInstance(header.Id, iname);
+                    self->m_pending_actor.uuid      = header.Id;
+                    self->m_pending_actor.render_id = render_id;
+                    self->m_pending_actor.valid     = true;
+                    secure_strncpy(self->m_pending_actor.name, sizeof(self->m_pending_actor.name), iname, sizeof(self->m_pending_actor.name) - 1);
                 }
             }
             self->m_add_to_scene     = false;

--- a/ZEngine/ZEngine/Core/VFS/VFSScanner.cpp
+++ b/ZEngine/ZEngine/Core/VFS/VFSScanner.cpp
@@ -3,6 +3,11 @@
 #include <ZEngine/Core/VFS/VFSScanner.h>
 #include <ZEngine/Helpers/MemoryOperations.h>
 #include <ZEngine/Helpers/ThreadPool.h>
+#include <ZEngine/ZEngineDef.h>
+#include <nlohmann/json.hpp>
+#include <uuid.h>
+#include <cstring>
+#include <optional>
 
 namespace ZEngine::Core::VFS
 {
@@ -16,6 +21,69 @@ namespace ZEngine::Core::VFS
                 if (ext.Equals(candidate))
                     return true;
             return false;
+        }
+
+        // .zemesh/.zematerial embed their own UUID at cook time. Peeking it here
+        // lets the caller pre-seed a .meta instead of GetOrCreate minting an
+        // unrelated random one (#755). Duplicated rather than depending on
+        // Importers from Core::VFS — ZEMESH_MAGIC/ASSET_FILE_VERSION are already
+        // shared, low-level constants (ZEngineDef.h).
+        static std::optional<uuids::uuid> PeekEmbeddedUUID(IVFSContext& ctx, const VFSPath& path, Managers::AssetType type)
+        {
+            if (type != Managers::AssetType::MESH && type != Managers::AssetType::MATERIAL)
+                return std::nullopt;
+
+            auto open_result = ctx.Open(path, VFSOpenFlags::Read);
+            if (open_result.Failed())
+                return std::nullopt;
+            IVFSFile*                  file = open_result.Value();
+
+            std::optional<uuids::uuid> result;
+
+            if (type == Managers::AssetType::MESH)
+            {
+                // Layout matches AssetCodec::AssetMeshFileHeader: uint32 magic, uint32 version, 16-byte uuid.
+                uint8_t buf[24];
+                auto    read_result = file->Read({buf, sizeof(buf)}, 0);
+                if (read_result.Succeeded() && read_result.Value() == sizeof(buf))
+                {
+                    uint32_t magic = 0, version = 0;
+                    std::memcpy(&magic, buf, sizeof(magic));
+                    std::memcpy(&version, buf + sizeof(magic), sizeof(version));
+                    if (magic == ZEMESH_MAGIC && version == ASSET_FILE_VERSION)
+                    {
+                        uuids::uuid id;
+                        std::memcpy(&id, buf + sizeof(magic) + sizeof(version), sizeof(id));
+                        if (!id.is_nil())
+                            result = id;
+                    }
+                }
+            }
+            else // MATERIAL — JSON, top-level "uuid" field (matches AssetCodec::SerializeMaterialAssetFile)
+            {
+                static constexpr size_t kReadCap    = 16384;
+                auto                    size_result = file->Size();
+                if (size_result.Succeeded() && size_result.Value() < kReadCap)
+                {
+                    uint8_t buf[kReadCap];
+                    size_t  size        = (size_t) size_result.Value();
+                    auto    read_result = file->ReadAll({buf, size});
+                    if (read_result.Succeeded())
+                    {
+                        buf[size] = '\0';
+                        auto j    = nlohmann::json::parse(reinterpret_cast<const char*>(buf), nullptr, /*allow_exceptions=*/false);
+                        if (!j.is_discarded() && j.contains("uuid") && j["uuid"].is_string())
+                        {
+                            auto parsed = uuids::uuid::from_string(j["uuid"].get<std::string>());
+                            if (parsed.has_value() && !parsed.value().is_nil())
+                                result = parsed.value();
+                        }
+                    }
+                }
+            }
+
+            ctx.Close(file);
+            return result;
         }
     } // namespace
 
@@ -115,6 +183,22 @@ namespace ZEngine::Core::VFS
 
                 if (IsAssetExtension(entries[i].Path))
                 {
+                    ZEngine::Managers::AssetType type = ZEngine::Core::VFS::AssetRegistry::InferTypeFromExtension(entries[i].Path);
+
+                    // Pre-seed .meta from the embedded UUID before GetOrCreate mints an
+                    // unrelated random one (#755).
+                    if (MetaFileIO::Read(*ctx.Context, entries[i].Path).Failed())
+                    {
+                        auto embedded = PeekEmbeddedUUID(*ctx.Context, entries[i].Path, type);
+                        if (embedded.has_value())
+                        {
+                            MetaFileData seed = {};
+                            seed.AssetUUID    = *embedded;
+                            Helpers::secure_strncpy(seed.ImporterName, sizeof(seed.ImporterName), "VFSScanner", sizeof(seed.ImporterName) - 1);
+                            MetaFileIO::Write(*ctx.Context, entries[i].Path, seed);
+                        }
+                    }
+
                     auto hash_result = MetaFileIO::ComputeHash(*ctx.Context, entries[i].Path);
                     auto meta        = MetaFileIO::GetOrCreate(*ctx.Context, entries[i].Path, "VFSScanner", hash_result.Succeeded() ? hash_result.Value() : 0);
                     if (meta.Succeeded())
@@ -136,7 +220,6 @@ namespace ZEngine::Core::VFS
 
                         if (m_registry != nullptr)
                         {
-                            ZEngine::Managers::AssetType type = ZEngine::Core::VFS::AssetRegistry::InferTypeFromExtension(entries[i].Path);
                             m_registry->OnScanFileDiscovered(*ctx.Context, entries[i].Path, type);
                         }
                     }

--- a/ZEngine/ZEngine/Importers/AssimpImporter.cpp
+++ b/ZEngine/ZEngine/Importers/AssimpImporter.cpp
@@ -173,21 +173,37 @@ namespace ZEngine::Importers
                     CopyTextureFiles(arena, textures, config);
                     for (size_t m = 0; m < materials.size(); ++m)
                     {
-                        auto set_path = [&](const uuids::uuid& uuid, Core::Containers::String& path_out) {
+                        // ExtractTextures assigned a throwaway random UUID (#755); now
+                        // that the file is at its final path, replace it with a stable,
+                        // content-hashed one, matched by the original UUID still held
+                        // in the material fields.
+                        auto sync_texture = [&](uuids::uuid& uuid_field, Core::Containers::String& path_out) {
                             for (size_t t = 0; t < textures.size(); ++t)
                             {
-                                if (textures[t].TextureUUID == uuid && !textures[t].Path.empty())
+                                if (textures[t].TextureUUID == uuid_field && !textures[t].Path.empty())
                                 {
                                     path_out.init(arena, textures[t].Path.c_str());
+
+                                    auto vfs_path = Core::VFS::VFSPath::Parse(textures[t].Path.c_str());
+                                    if (vfs_path.Succeeded() && config.VFS)
+                                    {
+                                        auto hash_result = Core::VFS::MetaFileIO::ComputeHash(*config.VFS, vfs_path.Value());
+                                        auto meta_result = Core::VFS::MetaFileIO::GetOrCreate(*config.VFS, vfs_path.Value(), "AssimpImporter", hash_result.Succeeded() ? hash_result.Value() : 0);
+                                        if (meta_result.Succeeded())
+                                        {
+                                            textures[t].TextureUUID = meta_result.Value().AssetUUID;
+                                            uuid_field              = meta_result.Value().AssetUUID;
+                                        }
+                                    }
                                     return;
                                 }
                             }
                         };
-                        set_path(materials[m].AlbedoTexUUID, materials[m].AlbedoTexPath);
-                        set_path(materials[m].EmissiveTexUUID, materials[m].EmissiveTexPath);
-                        set_path(materials[m].NormalTexUUID, materials[m].NormalTexPath);
-                        set_path(materials[m].OpacityTexUUID, materials[m].OpacityTexPath);
-                        set_path(materials[m].SpecularTexUUID, materials[m].SpecularTexPath);
+                        sync_texture(materials[m].AlbedoTexUUID, materials[m].AlbedoTexPath);
+                        sync_texture(materials[m].EmissiveTexUUID, materials[m].EmissiveTexPath);
+                        sync_texture(materials[m].NormalTexUUID, materials[m].NormalTexPath);
+                        sync_texture(materials[m].OpacityTexUUID, materials[m].OpacityTexPath);
+                        sync_texture(materials[m].SpecularTexUUID, materials[m].SpecularTexPath);
                     }
                 }
             }

--- a/ZEngine/ZEngine/Importers/FbxImporter.cpp
+++ b/ZEngine/ZEngine/Importers/FbxImporter.cpp
@@ -404,7 +404,41 @@ namespace ZEngine::Importers
             on_progress(context, 0.5f);
 
         if (config.Options.ImportMaterials && config.Options.ImportTextures)
+        {
             CopyTextureFiles(arena, textures, config);
+
+            // Fbx never synced texture paths into materials (pre-existing gap), and
+            // push_tex assigned throwaway random UUIDs (#755) — fix both here,
+            // matched by the original UUID before it's replaced.
+            for (size_t m = 0; m < materials.size(); ++m)
+            {
+                auto sync_texture = [&](uuids::uuid& uuid_field, Core::Containers::String& path_out) {
+                    for (size_t t = 0; t < textures.size(); ++t)
+                    {
+                        if (textures[t].TextureUUID == uuid_field && !textures[t].Path.empty())
+                        {
+                            path_out.init(arena, textures[t].Path.c_str());
+
+                            auto vfs_path = VFSPath::Parse(textures[t].Path.c_str());
+                            if (vfs_path.Succeeded() && config.VFS)
+                            {
+                                auto hash_result = Core::VFS::MetaFileIO::ComputeHash(*config.VFS, vfs_path.Value());
+                                auto meta_result = Core::VFS::MetaFileIO::GetOrCreate(*config.VFS, vfs_path.Value(), "FbxImporter", hash_result.Succeeded() ? hash_result.Value() : 0);
+                                if (meta_result.Succeeded())
+                                {
+                                    textures[t].TextureUUID = meta_result.Value().AssetUUID;
+                                    uuid_field              = meta_result.Value().AssetUUID;
+                                }
+                            }
+                            return;
+                        }
+                    }
+                };
+                sync_texture(materials[m].AlbedoTexUUID, materials[m].AlbedoTexPath);
+                sync_texture(materials[m].NormalTexUUID, materials[m].NormalTexPath);
+                sync_texture(materials[m].SpecularTexUUID, materials[m].SpecularTexPath);
+            }
+        }
 
         if (on_progress)
             on_progress(context, 0.8f);

--- a/ZEngine/ZEngine/Importers/GltfImporter.cpp
+++ b/ZEngine/ZEngine/Importers/GltfImporter.cpp
@@ -1,4 +1,5 @@
 #include <ZEngine/Core/Maths/Matrix.h>
+#include <ZEngine/Core/VFS/Meta/MetaFileIO.h>
 #include <ZEngine/Helpers/MemoryOperations.h>
 #include <ZEngine/Importers/AssetCodec.h>
 #include <ZEngine/Importers/AssetTypes.h>
@@ -746,24 +747,38 @@ namespace ZEngine::Importers
                 }
             }
 
-            // Propagate tex.Path → material.*TexPath by UUID match
+            // Propagate tex.Path → material.*TexPath by UUID match, replacing
+            // ExtractTextures' throwaway random UUID (#755) with a stable,
+            // content-hashed one.
             for (size_t m = 0; m < materials.size(); ++m)
             {
-                auto set_path = [&](const uuids::uuid& uuid, Core::Containers::String& path_out) {
+                auto sync_texture = [&](uuids::uuid& uuid_field, Core::Containers::String& path_out) {
                     for (size_t t = 0; t < textures.size(); ++t)
                     {
-                        if (textures[t].TextureUUID == uuid && !textures[t].Path.empty())
+                        if (textures[t].TextureUUID == uuid_field && !textures[t].Path.empty())
                         {
                             path_out.init(&scratch, textures[t].Path.c_str());
+
+                            auto vfs_path = Core::VFS::VFSPath::Parse(textures[t].Path.c_str());
+                            if (vfs_path.Succeeded() && config.VFS)
+                            {
+                                auto hash_result = Core::VFS::MetaFileIO::ComputeHash(*config.VFS, vfs_path.Value());
+                                auto meta_result = Core::VFS::MetaFileIO::GetOrCreate(*config.VFS, vfs_path.Value(), "GltfImporter", hash_result.Succeeded() ? hash_result.Value() : 0);
+                                if (meta_result.Succeeded())
+                                {
+                                    textures[t].TextureUUID = meta_result.Value().AssetUUID;
+                                    uuid_field              = meta_result.Value().AssetUUID;
+                                }
+                            }
                             return;
                         }
                     }
                 };
-                set_path(materials[m].AlbedoTexUUID, materials[m].AlbedoTexPath);
-                set_path(materials[m].EmissiveTexUUID, materials[m].EmissiveTexPath);
-                set_path(materials[m].NormalTexUUID, materials[m].NormalTexPath);
-                set_path(materials[m].OpacityTexUUID, materials[m].OpacityTexPath);
-                set_path(materials[m].SpecularTexUUID, materials[m].SpecularTexPath);
+                sync_texture(materials[m].AlbedoTexUUID, materials[m].AlbedoTexPath);
+                sync_texture(materials[m].EmissiveTexUUID, materials[m].EmissiveTexPath);
+                sync_texture(materials[m].NormalTexUUID, materials[m].NormalTexPath);
+                sync_texture(materials[m].OpacityTexUUID, materials[m].OpacityTexPath);
+                sync_texture(materials[m].SpecularTexUUID, materials[m].SpecularTexPath);
             }
         }
 

--- a/ZEngine/tests/Misc/VFSScanner_test.cpp
+++ b/ZEngine/tests/Misc/VFSScanner_test.cpp
@@ -1,16 +1,23 @@
 #include <ZEngine/Core/Containers/UnorderedHashMap.h>
 #include <ZEngine/Core/Memory/MemoryManager.h>
+#include <ZEngine/Core/VFS/Registry/AssetRegistry.h>
+#include <ZEngine/Core/VFS/VFSContext.h>
+#include <ZEngine/Core/VFS/VFSMemoryBackend.h>
 #include <ZEngine/Core/VFS/VFSScanner.h>
+#include <ZEngine/ZEngineDef.h>
 #include <gtest/gtest.h>
 #include <atomic>
 #include <chrono>
 #include <cstdio>
+#include <cstring>
+#include <random>
 #include <thread>
 
 using namespace ZEngine;
 using namespace ZEngine::Core::VFS;
 using namespace ZEngine::Core::Memory;
 using ZEngine::Core::Containers::Array;
+using ZEngine::Core::Containers::ArrayView;
 using ZEngine::Core::Containers::UnorderedHashMap;
 
 namespace
@@ -272,4 +279,126 @@ TEST_F(VFSScannerTest, Rescan_After_Cancel_StartsFresh)
 
     EXPECT_EQ(m_stats.FilesFound, 2u); // /proj/root.txt + /proj/sub/a.txt
     EXPECT_EQ(m_stats.DirsFound, 1u);  // /proj/sub
+}
+
+// --- #755 regression: scanning a self-describing asset with no .meta yet
+// must register it under its own embedded UUID, not an unrelated random one.
+
+namespace
+{
+    uuids::uuid MakeUUID()
+    {
+        std::random_device           rd;
+        std::mt19937                 gen(rd());
+        uuids::uuid_random_generator ugen{gen};
+        return ugen();
+    }
+
+    // Matches AssetCodec::AssetMeshFileHeader's on-disk layout: magic, version,
+    // uuid written as three separate sequential writes, tightly packed.
+    Array<uint8_t> MakeZemeshBytes(ArenaAllocator* arena, const uuids::uuid& id)
+    {
+        Array<uint8_t> bytes;
+        bytes.init(arena, 24, 24);
+        uint32_t magic   = ZEMESH_MAGIC;
+        uint32_t version = ASSET_FILE_VERSION;
+        std::memcpy(bytes.data(), &magic, sizeof(magic));
+        std::memcpy(bytes.data() + sizeof(magic), &version, sizeof(version));
+        std::memcpy(bytes.data() + sizeof(magic) + sizeof(version), &id, sizeof(id));
+        return bytes;
+    }
+} // namespace
+
+class VFSScannerMetaUUIDTest : public ::testing::Test
+{
+protected:
+    std::atomic<bool> m_completed{false};
+
+    MemoryManager     m_manager;
+    ArenaAllocator*   m_arena = nullptr;
+    VFSDirectoryCache m_cache;
+    VFSMemoryBackend  m_backend;
+    VFSContext        m_ctx;
+    AssetRegistry     m_registry;
+    VFSScanner        m_scanner;
+
+    void              SetUp() override
+    {
+        m_manager.Initialize(ZMega(16), {});
+        m_arena = &m_manager.MainArena;
+        m_cache.Initialize(m_arena);
+        m_backend.Initialize(m_arena);
+        m_ctx.Initialize(m_arena, 8);
+        ASSERT_TRUE(m_ctx.Mount(&m_backend, VFSPath::Root(), 0).Succeeded());
+        m_registry.Initialize(m_arena);
+        m_scanner.Initialize(m_arena);
+        m_scanner.SetAssetRegistry(&m_registry);
+        m_scanner.SetOnScanComplete(this, [](void* ctx, ScanStats) { static_cast<VFSScannerMetaUUIDTest*>(ctx)->m_completed.store(true); });
+    }
+
+    VFSPath P(const char* raw)
+    {
+        return VFSPath::Parse(raw).Value();
+    }
+
+    bool WaitForCompletion(int timeout_ms)
+    {
+        const auto start = std::chrono::steady_clock::now();
+        while (!m_completed.load())
+        {
+            if (std::chrono::steady_clock::now() - start > std::chrono::milliseconds(timeout_ms))
+                return false;
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        return true;
+    }
+};
+
+TEST_F(VFSScannerMetaUUIDTest, ZemeshWithNoMeta_RegistersUnderEmbeddedUUID)
+{
+    uuids::uuid    embedded = MakeUUID();
+    Array<uint8_t> bytes    = MakeZemeshBytes(m_arena, embedded);
+    ASSERT_TRUE(m_backend.WriteFile(P("/mesh.zemesh"), ArrayView<const uint8_t>(bytes.data(), bytes.size())).Succeeded());
+
+    m_scanner.Scan(&m_ctx, VFSPath::Root(), &m_cache);
+    ASSERT_TRUE(WaitForCompletion(2000));
+
+    const AssetRecord* rec = m_registry.FindByUUID(embedded);
+    ASSERT_NE(rec, nullptr) << "registry should have the mesh's own embedded UUID, not a freshly-minted random one";
+    EXPECT_EQ(rec->Type, Managers::AssetType::MESH);
+}
+
+TEST_F(VFSScannerMetaUUIDTest, ZematerialWithNoMeta_RegistersUnderEmbeddedUUID)
+{
+    uuids::uuid embedded = MakeUUID();
+    std::string json     = std::string("{\"uuid\":\"") + uuids::to_string(embedded) + "\"}";
+    ASSERT_TRUE(m_backend.WriteFile(P("/mat.zematerial"), ArrayView<const uint8_t>(reinterpret_cast<const uint8_t*>(json.data()), json.size())).Succeeded());
+
+    m_scanner.Scan(&m_ctx, VFSPath::Root(), &m_cache);
+    ASSERT_TRUE(WaitForCompletion(2000));
+
+    const AssetRecord* rec = m_registry.FindByUUID(embedded);
+    ASSERT_NE(rec, nullptr) << "registry should have the material's own embedded UUID, not a freshly-minted random one";
+    EXPECT_EQ(rec->Type, Managers::AssetType::MATERIAL);
+}
+
+TEST_F(VFSScannerMetaUUIDTest, ExistingMeta_IsNeverReplaced)
+{
+    // GetOrCreate's "never replace an existing UUID" policy must survive the
+    // new pre-seed step untouched.
+    uuids::uuid    embedded     = MakeUUID();
+    uuids::uuid    pre_existing = MakeUUID();
+    Array<uint8_t> bytes        = MakeZemeshBytes(m_arena, embedded);
+    ASSERT_TRUE(m_backend.WriteFile(P("/mesh.zemesh"), ArrayView<const uint8_t>(bytes.data(), bytes.size())).Succeeded());
+
+    MetaFileData seed = {};
+    seed.AssetUUID    = pre_existing;
+    ASSERT_TRUE(MetaFileIO::Write(m_ctx, P("/mesh.zemesh"), seed).Succeeded());
+
+    m_scanner.Scan(&m_ctx, VFSPath::Root(), &m_cache);
+    ASSERT_TRUE(WaitForCompletion(2000));
+
+    EXPECT_EQ(m_registry.FindByUUID(embedded), nullptr) << "must not have registered under the embedded UUID once a .meta already existed";
+    const AssetRecord* rec = m_registry.FindByUUID(pre_existing);
+    ASSERT_NE(rec, nullptr) << "must keep the pre-existing .meta's UUID";
 }


### PR DESCRIPTION
## Summary
- Artifact `.meta` writes now capture the mesh's own embedded UUID instead of leaving `AssetUUID` nil.
- `VFSScanner` pre-seeds a `.meta` from a `.zemesh`/`.zematerial`'s own embedded UUID on first discovery, instead of letting `MetaFileIO::GetOrCreate` mint an unrelated random one.
- Mesh-import texture UUIDs (Assimp/Fbx/Gltf) are now synced through `MetaFileIO` after `CopyTextureFiles`, so they're stable and content-hashed instead of throwaway randoms; Fbx also gains the texture-path sync into materials it was missing entirely.

Together these keep `AssetRegistry::FindByUUID` reliable after a re-scan, not just during the same-session fresh import.

## Test plan
- [x] `ZEngineTests` builds clean; `ctest -C Debug` — 557/557 pass (3 new regression tests added to `VFSScanner_test.cpp`, covering pre-seed-from-embedded-uuid and the "existing .meta is never replaced" policy).
- [x] `Obelisk` builds and links cleanly on this branch.

Fixes #755