### PR TITLE
fix(importers): route ImportFile scratch allocations through each importer's own Arena

### DIFF
--- a/ZEngine/ZEngine/Importers/AssimpImporter.cpp
+++ b/ZEngine/ZEngine/Importers/AssimpImporter.cpp
@@ -103,6 +103,13 @@ namespace ZEngine::Importers
 
     void AssimpImporter::ImportFile(const char* filename, const AssetCodec::ImportConfiguration& cfg, Core::Memory::ArenaAllocator* arena, void* context, ImportCompleteCallback on_complete, ImportProgressCallback on_progress, ImportErrorCallback on_error, ImportLogCallback on_log)
     {
+        // The caller's arena is sized only for a few short path strings (#760) — carve a
+        // scratch sub-arena from this importer's own, generously-sized private Arena
+        // instead, matching the pattern Import() already uses for hot-reload.
+        Core::Memory::ArenaAllocator scratch{};
+        Arena.CreateSubArena(ZMega(64), &scratch);
+        arena                                  = &scratch;
+
         AssetCodec::ImportConfiguration config = {};
         config.OutputWorkingSpacePath.init(arena, cfg.OutputWorkingSpacePath.c_str());
         config.OutputTextureFilesPath.init(arena, cfg.OutputTextureFilesPath.c_str());

--- a/ZEngine/ZEngine/Importers/FbxImporter.cpp
+++ b/ZEngine/ZEngine/Importers/FbxImporter.cpp
@@ -214,6 +214,11 @@ namespace ZEngine::Importers
 
     void FbxImporter::ImportFile(const char* filename, const AssetCodec::ImportConfiguration& cfg, Core::Memory::ArenaAllocator* arena, void* context, ImportCompleteCallback on_complete, ImportProgressCallback on_progress, ImportErrorCallback on_error, ImportLogCallback on_log)
     {
+        // The caller's arena is sized only for a few short path strings (#760) — route
+        // everything through this importer's own, generously-sized private Arena instead.
+        Arena.Clear();
+        arena                                  = &Arena;
+
         AssetCodec::ImportConfiguration config = {};
         config.OutputWorkingSpacePath.init(arena, cfg.OutputWorkingSpacePath.c_str());
         config.OutputTextureFilesPath.init(arena, cfg.OutputTextureFilesPath.c_str());

--- a/ZEngine/ZEngine/Importers/GltfImporter.cpp
+++ b/ZEngine/ZEngine/Importers/GltfImporter.cpp
@@ -466,6 +466,16 @@ namespace ZEngine::Importers
 
     void GltfImporter::ImportFile(const char* filename, const AssetCodec::ImportConfiguration& cfg, Core::Memory::ArenaAllocator* arena, void* context, ImportCompleteCallback on_complete, ImportProgressCallback on_progress, ImportErrorCallback on_error, ImportLogCallback on_log)
     {
+        // The caller's arena is sized only for a few short path strings (#760) — carve a
+        // scratch sub-arena from this importer's own, generously-sized private Arena
+        // instead, matching the pattern Import() already uses for hot-reload. Declared
+        // once here (rather than down at the old ExtractMeshes call site) so the config
+        // copy below and the final serialized outputs share the same backing memory
+        // instead of each getting an independent, aliasing CreateSubArena carve-out.
+        Core::Memory::ArenaAllocator scratch{};
+        Arena.CreateSubArena(ZMega(32), &scratch);
+        arena                                  = &scratch;
+
         // Build arena-allocated config copy (same pattern as AssimpImporter::ImportFile)
         AssetCodec::ImportConfiguration config = {};
         config.OutputWorkingSpacePath.init(arena, cfg.OutputWorkingSpacePath.c_str());
@@ -503,10 +513,7 @@ namespace ZEngine::Importers
         if (on_progress)
             on_progress(context, 0.3f);
 
-        fastgltf::Asset&             asset = result.get();
-
-        Core::Memory::ArenaAllocator scratch{};
-        Arena.CreateSubArena(ZMega(32), &scratch);
+        fastgltf::Asset&      asset = result.get();
 
         std::random_device    rd;
         std::mt19937          gen_mt(rd());


### PR DESCRIPTION
## Summary
- `AssetImporterPanel::m_local_arena` is a 64KB arena sized for a handful of path strings, but `StartImport()` also handed it to `AssimpImporter`/`GltfImporter`/`FbxImporter::ImportFile` as the scratch arena for node-hierarchy, mesh, material, and texture data — guaranteed to exhaust it on any real import (two `Array<Mat4f>` alone need ~384KB).
- When exhausted, the arena's OOM assert doesn't halt execution without a debugger attached, so `Array::reserve()` silently left `m_capacity` inconsistent with a null `m_data`, crashing on the very next `push()`.
- Each importer already carves its own generously-sized private `Arena` at `Initialize()` (128MB / 64MB / 512MB for Assimp/Gltf/Fbx) and already uses it for the file-watcher hot-reload path (`Import()`) — `ImportFile()` just wasn't using it. Routed `ImportFile()` through the same private `Arena` instead, matching each importer's own existing scratch-arena convention (`GltfImporter` already declared a `scratch` sub-arena partway through — relocated it to the top so the config-string copy and the final serialized outputs share it too, instead of each getting an independent, aliasing carve-out).

## Root cause, confirmed live with lldb
Reproduced by importing a minimal hand-written 8-vertex `.obj` through the Importer panel — crashed 100% of the time before this fix:
```
* thread #7, stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #1: Array<Mat4<float>>::push(...) at Array.h:206:28
    frame #2: AddNode(...) at IAssetImporter.cpp:15:35
    frame #3: AssimpImporter::TraverseNode(...) at AssimpImporter.cpp:513:40
    frame #4: AssimpImporter::CreateHierachy(...) at AssimpImporter.cpp:508:9
    frame #5: AssimpImporter::ImportFile(filename="/private/tmp/test_cube.obj", arena=0x...) at AssimpImporter.cpp:210:13
    frame #6: AssetImporterPanel::StartImport()::$_2::operator()() at AssetImporterPanel.cpp:660
```
After the fix, the same file imports cleanly with no crash.

## Test plan
- [x] `ZEngineTests` builds and passes via `ctest` — 565/565 (100%), no regressions
- [x] Manually reproduced the crash pre-fix (lldb-attached, live backtrace above) and confirmed it's gone post-fix, importing the exact same file that crashed every time before

Fixes #760