### PR TITLE
fix(assets): stabilize mesh/material UUIDs and enable hot-reload swap on re-ingest

### DIFF
--- a/Tetragrama/Panels/AssetImporterPanel.cpp
+++ b/Tetragrama/Panels/AssetImporterPanel.cpp
@@ -747,37 +747,88 @@ namespace Tetragrama::Panels
             }
         }
 
+        // Write a .meta for every cooked material (#762) — mirrors the mesh handling
+        // below. Without this, AssimpImporter/GltfImporter/FbxImporter's material
+        // UUID stabilization (also #762) has no .meta to read on the next re-import,
+        // and every re-cook mints a brand-new, disconnected material identity.
+        {
+            auto*   ctx_engine = ZEngine::Engine::GetContext();
+            auto*   app        = self->m_layer ? reinterpret_cast<EditorPtr>(self->m_layer->CurrentApp) : nullptr;
+            cstring ws         = (app && app->Configuration) ? app->Configuration->WorkingSpacePath.c_str() : "";
+            if (ctx_engine && ctx_engine->VFS && ws[0] != '\0')
+            {
+                auto* vfs = reinterpret_cast<ZEngine::Core::VFS::IVFSContext*>(ctx_engine->VFS);
+                for (unsigned i = 0; i < outputs.size(); ++i)
+                {
+                    if (outputs[i].Type != ZEngine::Importers::AssetFileType::MATERIAL)
+                        continue;
+
+                    cstring mat_path = outputs[i].Path.c_str();
+                    auto    rel      = VFSPath::Parse(mat_path);
+                    if (!rel.Succeeded())
+                        continue;
+
+                    char native_mat_path[MAX_FILE_PATH_COUNT] = {};
+                    rel.Value().ResolveNative(ws, native_mat_path, sizeof(native_mat_path));
+
+                    ZEngine::Importers::AssetMaterial material{};
+                    ZEngine::Importers::AssetCodec::DeserializeMaterialAssetFile(&self->m_local_arena, native_mat_path, material);
+                    if (material.MaterialUUID.is_nil())
+                        continue;
+
+                    auto                             meta_result = ZEngine::Core::VFS::MetaFileIO::Read(*vfs, rel.Value());
+                    ZEngine::Core::VFS::MetaFileData meta        = meta_result.Succeeded() ? meta_result.Value() : ZEngine::Core::VFS::MetaFileData{};
+                    meta.AssetUUID                               = material.MaterialUUID;
+                    secure_strncpy(meta.SourcePath, sizeof(meta.SourcePath), self->m_path_buf, sizeof(meta.SourcePath) - 1);
+                    secure_strncpy(meta.ArtifactPath, sizeof(meta.ArtifactPath), mat_path, sizeof(meta.ArtifactPath) - 1);
+                    secure_strncpy(meta.ImporterName, sizeof(meta.ImporterName), "GltfImporter/AssimpImporter", sizeof(meta.ImporterName) - 1);
+                    ZEngine::Core::VFS::MetaFileIO::Write(*vfs, rel.Value(), meta);
+                }
+            }
+        }
+
         if (has_mesh && mesh_path)
         {
+            // mesh_path is VFS-relative (e.g. "/Assets/Meshes/test_cube.zemesh") —
+            // ReadAssetMeshFileHeader does raw filesystem I/O and needs a native path.
+            char native_mesh_path[MAX_FILE_PATH_COUNT] = {};
+            {
+                auto*   header_app = self->m_layer ? reinterpret_cast<EditorPtr>(self->m_layer->CurrentApp) : nullptr;
+                cstring header_ws  = (header_app && header_app->Configuration) ? header_app->Configuration->WorkingSpacePath.c_str() : "";
+                auto    mesh_pr    = VFSPath::Parse(mesh_path);
+                if (mesh_pr.Succeeded() && header_ws[0] != '\0')
+                    mesh_pr.Value().ResolveNative(header_ws, native_mesh_path, sizeof(native_mesh_path));
+            }
+
             // Read once, shared by the meta write below and the add-to-scene block.
             ZEngine::Importers::AssetCodec::AssetMeshFileHeader header{};
-            bool                                                has_header = ZEngine::Importers::AssetCodec::ReadAssetMeshFileHeader(mesh_path, header);
+            bool                                                has_header = ZEngine::Importers::AssetCodec::ReadAssetMeshFileHeader(native_mesh_path, header);
 
             // Write meta file (source path for re-import)
             auto*                                               ctx_engine = ZEngine::Engine::GetContext();
             if (ctx_engine && ctx_engine->VFS)
             {
-                auto*   vfs    = reinterpret_cast<ZEngine::Core::VFS::IVFSContext*>(ctx_engine->VFS);
-                auto*   app    = self->m_layer ? reinterpret_cast<EditorPtr>(self->m_layer->CurrentApp) : nullptr;
-                cstring ws     = (app && app->Configuration) ? app->Configuration->WorkingSpacePath.c_str() : "";
-                size_t  ws_len = secure_strlen(ws);
+                auto* vfs = reinterpret_cast<ZEngine::Core::VFS::IVFSContext*>(ctx_engine->VFS);
 
-                if (ws_len > 0 && strncmp(mesh_path, ws, ws_len) == 0)
+                // mesh_path (AssetImporterOutput::Path) is already a VFS-relative path
+                // (e.g. "Assets/Meshes/test_cube.zemesh") — config.OutputAssetsPath has
+                // no native workspace prefix to strip (see Editor.cpp's expand_nested:
+                // "Result is a workspace-relative sub-path ... no leading slash"). The
+                // previous strncmp-against-WorkingSpacePath check could never match,
+                // silently skipping this whole block on every import (#762).
+                auto  rel = VFSPath::Parse(mesh_path);
+                if (rel.Succeeded())
                 {
-                    auto rel = VFSPath::Parse(mesh_path + ws_len);
-                    if (rel.Succeeded())
-                    {
-                        auto                             meta_result = ZEngine::Core::VFS::MetaFileIO::Read(*vfs, rel.Value());
-                        ZEngine::Core::VFS::MetaFileData meta        = meta_result.Succeeded() ? meta_result.Value() : ZEngine::Core::VFS::MetaFileData{};
-                        // Sync to the file's own embedded UUID — otherwise a nil
-                        // AssetUUID gets locked in forever (#755).
-                        if (has_header)
-                            meta.AssetUUID = header.Id;
-                        secure_strncpy(meta.SourcePath, sizeof(meta.SourcePath), self->m_path_buf, sizeof(meta.SourcePath) - 1);
-                        secure_strncpy(meta.ArtifactPath, sizeof(meta.ArtifactPath), mesh_path, sizeof(meta.ArtifactPath) - 1);
-                        secure_strncpy(meta.ImporterName, sizeof(meta.ImporterName), "GltfImporter/AssimpImporter", sizeof(meta.ImporterName) - 1);
-                        ZEngine::Core::VFS::MetaFileIO::Write(*vfs, rel.Value(), meta);
-                    }
+                    auto                             meta_result = ZEngine::Core::VFS::MetaFileIO::Read(*vfs, rel.Value());
+                    ZEngine::Core::VFS::MetaFileData meta        = meta_result.Succeeded() ? meta_result.Value() : ZEngine::Core::VFS::MetaFileData{};
+                    // Sync to the file's own embedded UUID — otherwise a nil
+                    // AssetUUID gets locked in forever (#755).
+                    if (has_header)
+                        meta.AssetUUID = header.Id;
+                    secure_strncpy(meta.SourcePath, sizeof(meta.SourcePath), self->m_path_buf, sizeof(meta.SourcePath) - 1);
+                    secure_strncpy(meta.ArtifactPath, sizeof(meta.ArtifactPath), mesh_path, sizeof(meta.ArtifactPath) - 1);
+                    secure_strncpy(meta.ImporterName, sizeof(meta.ImporterName), "GltfImporter/AssimpImporter", sizeof(meta.ImporterName) - 1);
+                    ZEngine::Core::VFS::MetaFileIO::Write(*vfs, rel.Value(), meta);
                 }
             }
 

--- a/ZEngine/ZEngine/Core/VFS/Registry/AssetRegistry.cpp
+++ b/ZEngine/ZEngine/Core/VFS/Registry/AssetRegistry.cpp
@@ -192,6 +192,20 @@ namespace ZEngine::Core::VFS
         }
     }
 
+    void AssetRegistry::MarkStale(const uuids::uuid& uuid)
+    {
+        Helpers::Handle<AssetRecord> handle = m_index.FindByUUID(uuid);
+        if (!handle.Valid())
+            return;
+
+        m_index.SetState(handle, AssetState::Stale);
+
+        if (m_reload_cb)
+            m_reload_cb(m_reload_cb_ctx, std::span<const uuids::uuid>(&uuid, 1));
+        if (m_stale_cb)
+            m_stale_cb(m_stale_cb_ctx, uuid);
+    }
+
     void AssetRegistry::OnAssetDeleted(const Core::VFS::VFSPath& path)
     {
         Helpers::Handle<AssetRecord> handle = m_index.FindByPath(path);

--- a/ZEngine/ZEngine/Core/VFS/Registry/AssetRegistry.h
+++ b/ZEngine/ZEngine/Core/VFS/Registry/AssetRegistry.h
@@ -78,6 +78,12 @@ namespace ZEngine::Core::VFS
 
         void                   OnAssetModified(const Core::VFS::VFSPath& path);
         void                   OnAssetDeleted(const Core::VFS::VFSPath& path);
+
+        /// @brief UUID-based equivalent of OnAssetModified's stale-marking, for callers
+        ///        (e.g. AssetManager::IngestMesh re-ingesting an in-memory asset) that
+        ///        have no VFSPath to look up. No dependency cascade — fires OnStale for
+        ///        this UUID only.
+        void                   MarkStale(const uuids::uuid& uuid);
         void                   OnAssetRenamed(const Core::VFS::VFSPath& old_path, const Core::VFS::VFSPath& new_path);
 
         // Called per-file from the scanner's ScanComplete callback.

--- a/ZEngine/ZEngine/Core/VFS/VFSContext.cpp
+++ b/ZEngine/ZEngine/Core/VFS/VFSContext.cpp
@@ -110,7 +110,11 @@ namespace ZEngine::Core::VFS
             return;
         }
         m_file_watcher = new (fw_storage) VFSFileWatcher(m_platform_watcher);
-        m_file_watcher->Initialize(m_arena);
+        // Default capacity (64) is too small for a single material-heavy import —
+        // each material now also gets an explicit .meta write (#762), and a
+        // multi-material GLB (mesh + N materials + N textures) can generate more
+        // simultaneous pending debounce entries than that before any flush.
+        m_file_watcher->Initialize(m_arena, 256);
 
         const WatchHandle root_handle = m_file_watcher->Watch(m_project_root_native, /*recursive=*/true, [this](const VFSWatchEvent& ev) {
             const bool         full_rescan = (ev.Kind == WatchEventKind::Overflow);

--- a/ZEngine/ZEngine/Importers/AssimpImporter.cpp
+++ b/ZEngine/ZEngine/Importers/AssimpImporter.cpp
@@ -156,6 +156,19 @@ namespace ZEngine::Importers
             Array<AssetTexture>   textures    = {};
 
             ExtractMeshes(arena, scene, gen, mesh);
+
+            // Stabilize the mesh UUID (#762): re-importing the same destination path
+            // must keep the same identity, or a hot-reload swap can never recognize
+            // "this is an update to an existing mesh" — every re-cook would otherwise
+            // mint a fresh random UUID and look like a brand new, unrelated asset.
+            {
+                auto mesh_dir    = Core::VFS::VFSPath::Parse(config.OutputAssetsPath.c_str()).Value();
+                auto mesh_path   = mesh_dir / config.OutputAssetFile.c_str();
+                auto meta_result = Core::VFS::MetaFileIO::Read(*config.VFS, mesh_path);
+                if (meta_result.Succeeded() && !meta_result.Value().AssetUUID.is_nil())
+                    mesh.MeshUUID = meta_result.Value().AssetUUID;
+            }
+
             if (on_progress)
                 on_progress(context, 0.4f);
 
@@ -174,6 +187,24 @@ namespace ZEngine::Importers
             if (config.Options.ImportMaterials)
             {
                 ExtractMaterials(arena, scene, gen, materials, hierarchies);
+
+                // Stabilize material UUIDs (#762): re-importing the same source must
+                // keep each material's identity, or hot-reload can never recognize it
+                // as an update — every re-cook would otherwise mint a fresh random
+                // UUID. Keyed by the same (stable, name-derived) destination path
+                // SerializeMaterialAssetFile uses, so this stays in sync automatically.
+                // Runs before CreateHierachy below, which reads MaterialUUID by
+                // reference off this same materials array for each SubMesh.
+                for (size_t m = 0; m < materials.size(); ++m)
+                {
+                    auto        mat_dir      = Core::VFS::VFSPath::Parse(config.OutputMaterialPath.c_str()).Value();
+                    std::string mat_filename = fmt::format("{}{}", materials[m].Name.c_str(), ".zematerial");
+                    auto        mat_path     = mat_dir / mat_filename.c_str();
+                    auto        meta_result  = Core::VFS::MetaFileIO::Read(*config.VFS, mat_path);
+                    if (meta_result.Succeeded() && !meta_result.Value().AssetUUID.is_nil())
+                        materials[m].MaterialUUID = meta_result.Value().AssetUUID;
+                }
+
                 if (config.Options.ImportTextures)
                 {
                     ExtractTextures(arena, scene, gen, materials, textures);

--- a/ZEngine/ZEngine/Importers/FbxImporter.cpp
+++ b/ZEngine/ZEngine/Importers/FbxImporter.cpp
@@ -5,6 +5,7 @@
 #include <ZEngine/Importers/MeshOptimizer.h>
 #include <ZEngine/Logging/LoggerDefinition.h>
 #include <ZEngine/Managers/AssetManager.h>
+#include <fmt/format.h>
 #include <ufbx.h>
 #include <filesystem>
 #include <fstream>
@@ -266,6 +267,19 @@ namespace ZEngine::Importers
             total_tris += static_cast<uint32_t>(scene->meshes.data[mi]->num_triangles);
 
         mesh.MeshUUID = gen();
+
+        // Stabilize the mesh UUID (#762): re-importing the same destination path must
+        // keep the same identity, or a hot-reload swap can never recognize "this is an
+        // update to an existing mesh" — every re-cook would otherwise mint a fresh
+        // random UUID and look like a brand new, unrelated asset.
+        {
+            auto mesh_dir    = VFSPath::Parse(config.OutputAssetsPath.c_str()).Value();
+            auto mesh_path   = mesh_dir / config.OutputAssetFile.c_str();
+            auto meta_result = Core::VFS::MetaFileIO::Read(*config.VFS, mesh_path);
+            if (meta_result.Succeeded() && !meta_result.Value().AssetUUID.is_nil())
+                mesh.MeshUUID = meta_result.Value().AssetUUID;
+        }
+
         mesh.Vertices.init(scratch.Arena, (size_t) total_tris * 3 * 8);
         mesh.Indices.init(scratch.Arena, (size_t) total_tris * 3);
         mesh.SubMeshes.init(scratch.Arena, (uint32_t) scene->meshes.count);
@@ -407,6 +421,32 @@ namespace ZEngine::Importers
 
         if (on_progress)
             on_progress(context, 0.5f);
+
+        // Stabilize material UUIDs (#762): re-importing the same source must keep
+        // each material's identity, or hot-reload can never recognize it as an
+        // update. Keyed by the same (stable, name-derived) destination path
+        // SerializeMaterialAssetFile uses. Unlike Assimp/Gltf, the loop above
+        // already copied each material's original UUID into its SubMesh by value
+        // (not by reference), so matching submeshes need an explicit patch too.
+        if (config.Options.ImportMaterials)
+        {
+            for (size_t m = 0; m < materials.size(); ++m)
+            {
+                auto        mat_dir      = VFSPath::Parse(config.OutputMaterialPath.c_str()).Value();
+                std::string mat_filename = fmt::format("{}{}", materials[m].Name.c_str(), ".zematerial");
+                auto        mat_path     = mat_dir / mat_filename.c_str();
+                auto        meta_result  = Core::VFS::MetaFileIO::Read(*config.VFS, mat_path);
+                if (meta_result.Succeeded() && !meta_result.Value().AssetUUID.is_nil())
+                {
+                    uuids::uuid old_uuid      = materials[m].MaterialUUID;
+                    uuids::uuid new_uuid      = meta_result.Value().AssetUUID;
+                    materials[m].MaterialUUID = new_uuid;
+                    for (size_t s = 0; s < mesh.SubMeshes.size(); ++s)
+                        if (mesh.SubMeshes[s].MaterialUUID == old_uuid)
+                            mesh.SubMeshes[s].MaterialUUID = new_uuid;
+                }
+            }
+        }
 
         if (config.Options.ImportMaterials && config.Options.ImportTextures)
         {

--- a/ZEngine/ZEngine/Importers/GltfImporter.cpp
+++ b/ZEngine/ZEngine/Importers/GltfImporter.cpp
@@ -14,6 +14,7 @@
 #include <fastgltf/math.hpp>
 #include <fastgltf/tools.hpp>
 #include <fastgltf/types.hpp>
+#include <fmt/format.h>
 #include <uuid.h>
 #include <cstdio>
 #include <filesystem>
@@ -527,6 +528,18 @@ namespace ZEngine::Importers
         ExtractMeshes(&scratch, asset, mesh);
         mesh.MeshUUID = gen();
 
+        // Stabilize the mesh UUID (#762): re-importing the same destination path must
+        // keep the same identity, or a hot-reload swap can never recognize "this is an
+        // update to an existing mesh" — every re-cook would otherwise mint a fresh
+        // random UUID and look like a brand new, unrelated asset.
+        {
+            auto mesh_dir    = Core::VFS::VFSPath::Parse(config.OutputAssetsPath.c_str()).Value();
+            auto mesh_path   = mesh_dir / config.OutputAssetFile.c_str();
+            auto meta_result = Core::VFS::MetaFileIO::Read(*config.VFS, mesh_path);
+            if (meta_result.Succeeded() && !meta_result.Value().AssetUUID.is_nil())
+                mesh.MeshUUID = meta_result.Value().AssetUUID;
+        }
+
         // Apply per-vertex transform options
         {
             const float scale   = config.Options.UniformScale;
@@ -587,6 +600,22 @@ namespace ZEngine::Importers
         if (config.Options.ImportMaterials)
         {
             ExtractMaterials(&scratch, asset, gen, materials);
+
+            // Stabilize material UUIDs (#762): re-importing the same source must
+            // keep each material's identity, or hot-reload can never recognize it as
+            // an update. Keyed by the same (stable, name-derived) destination path
+            // SerializeMaterialAssetFile uses. Runs before BuildHierarchy below,
+            // which reads MaterialUUID by reference off this same materials array.
+            for (size_t m = 0; m < materials.size(); ++m)
+            {
+                auto        mat_dir      = Core::VFS::VFSPath::Parse(config.OutputMaterialPath.c_str()).Value();
+                std::string mat_filename = fmt::format("{}{}", materials[m].Name.c_str(), ".zematerial");
+                auto        mat_path     = mat_dir / mat_filename.c_str();
+                auto        meta_result  = Core::VFS::MetaFileIO::Read(*config.VFS, mat_path);
+                if (meta_result.Succeeded() && !meta_result.Value().AssetUUID.is_nil())
+                    materials[m].MaterialUUID = meta_result.Value().AssetUUID;
+            }
+
             if (config.Options.ImportTextures)
                 ExtractTextures(&scratch, asset, gen, textures, materials);
         }

--- a/ZEngine/ZEngine/Managers/AssetManager.cpp
+++ b/ZEngine/ZEngine/Managers/AssetManager.cpp
@@ -103,12 +103,27 @@ namespace ZEngine::Managers
         // Use MeshToHierarchySlot — populated only after data is actually ingested.
         // IsRegistered / GetAsset both give false positives because VFSScanner
         // pre-registers UUIDs with SlotHandle=0 before any mesh data exists.
-        if (s_Instance->MeshToHierarchySlot.find(mesh.MeshUUID) != nullptr)
-            return;
+        uint32_t*       existing_hier_slot = s_Instance->MeshToHierarchySlot.find(mesh.MeshUUID);
+        bool            is_reload          = existing_hier_slot != nullptr;
 
-        auto  mesh_slot = static_cast<uint32_t>(s_Instance->Meshes.size());
-        auto& m         = s_Instance->Meshes.push_use({});
-        m.MeshUUID      = mesh.MeshUUID;
+        // Hot-reload (#762): overwrite the existing slots' data in place instead of
+        // pushing new ones, so the mesh/hierarchy keep the same AssetHandle and
+        // AssetRegistry::MarkStale below can hand RenderResourceManager's OnStaleCallback
+        // a handle that already points at the fresh data.
+        uint32_t        mesh_slot          = 0;
+        AssetMesh*      mp;
+        if (is_reload)
+        {
+            mp = GetAsset<AssetMesh>(mesh.MeshUUID);
+            ZENGINE_VALIDATE_ASSERT(mp != nullptr, "IngestMesh: MeshToHierarchySlot has this UUID but the mesh record is missing")
+        }
+        else
+        {
+            mesh_slot    = static_cast<uint32_t>(s_Instance->Meshes.size());
+            mp           = &s_Instance->Meshes.push_use({});
+            mp->MeshUUID = mesh.MeshUUID;
+        }
+        AssetMesh& m = *mp;
         m.SubMeshes.init(s_Instance->Arena, mesh.SubMeshes.size());
         m.Vertices.init(s_Instance->Arena, mesh.Vertices.size(), mesh.Vertices.size());
         m.Indices.init(s_Instance->Arena, mesh.Indices.size(), mesh.Indices.size());
@@ -140,12 +155,20 @@ namespace ZEngine::Managers
             }
         }
 
-        RegisterAsset(AssetType::MESH, m.MeshUUID, mesh_slot);
+        if (!is_reload)
+            RegisterAsset(AssetType::MESH, m.MeshUUID, mesh_slot);
 
-        auto  hier_slot     = static_cast<uint32_t>(s_Instance->NodeHierarchies.size());
-        auto& h             = s_Instance->NodeHierarchies.push_use({});
-        h.NodeHierarchyUUID = hierarchy.NodeHierarchyUUID;
-        h.MeshUUID          = hierarchy.MeshUUID;
+        // Hierarchy: same in-place-overwrite treatment as the mesh above. Deliberately
+        // keep the existing NodeHierarchyUUID/MeshUUID on reload rather than the new
+        // AssetNodeHierarchy's freshly-minted one — the registry entry (and this UUID's
+        // identity) must stay stable across reloads, not just the slot index.
+        uint32_t            hier_slot = is_reload ? *existing_hier_slot : static_cast<uint32_t>(s_Instance->NodeHierarchies.size());
+        AssetNodeHierarchy& h         = is_reload ? s_Instance->NodeHierarchies[hier_slot] : s_Instance->NodeHierarchies.push_use({});
+        if (!is_reload)
+        {
+            h.NodeHierarchyUUID = hierarchy.NodeHierarchyUUID;
+            h.MeshUUID          = hierarchy.MeshUUID;
+        }
 
         h.Hierarchies.init(s_Instance->Arena, hierarchy.Hierarchies.size(), hierarchy.Hierarchies.size());
         h.LocalTransforms.init(s_Instance->Arena, hierarchy.LocalTransforms.size(), hierarchy.LocalTransforms.size());
@@ -177,14 +200,28 @@ namespace ZEngine::Managers
         for (const auto& [k, v] : hierarchy.NodeMaterials)
             h.NodeMaterials.insert(k, v);
 
-        RegisterAsset(AssetType::MESH_HIERARCHY, h.NodeHierarchyUUID, hier_slot);
-        s_Instance->MeshToHierarchySlot.insert(h.MeshUUID, hier_slot);
+        if (!is_reload)
+        {
+            RegisterAsset(AssetType::MESH_HIERARCHY, h.NodeHierarchyUUID, hier_slot);
+            s_Instance->MeshToHierarchySlot.insert(h.MeshUUID, hier_slot);
+        }
 
-        // Notify the registry that both assets are now loaded so hot-reload callbacks fire.
         if (s_Instance->Registry)
         {
-            s_Instance->Registry->SetState(m.MeshUUID, Core::VFS::AssetState::Loaded);
-            s_Instance->Registry->SetState(h.NodeHierarchyUUID, Core::VFS::AssetState::Loaded);
+            if (is_reload)
+            {
+                // SetState(Loaded) would hit RenderResourceManager's OnReady callback,
+                // which skips any UUID that already has a GPU buffer — it never reaches
+                // ScheduleSwap. MarkStale is what actually drives the hot-reload swap.
+                s_Instance->Registry->MarkStale(m.MeshUUID);
+                s_Instance->Registry->MarkStale(h.NodeHierarchyUUID);
+            }
+            else
+            {
+                // Notify the registry that both assets are now loaded so hot-reload callbacks fire.
+                s_Instance->Registry->SetState(m.MeshUUID, Core::VFS::AssetState::Loaded);
+                s_Instance->Registry->SetState(h.NodeHierarchyUUID, Core::VFS::AssetState::Loaded);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #762 (mesh hot-reload dead end), plus three more bugs that blocked the same fix from ever being reachable through the real GUI re-import workflow.

- `AssetManager::IngestMesh` silently returned early when re-ingesting an already-loaded `MeshUUID`, so a re-import could never reach the hot-reload swap path. It now overwrites the existing mesh/hierarchy slots in place and calls a new `AssetRegistry::MarkStale(uuid)` (UUID-based, no `VFSPath` needed) instead of `SetState(Loaded)` — the latter's `OnReady` callback in `RenderResourceManager` skips any UUID that already has a GPU buffer, so it never drove `ScheduleSwap`.
- `AssimpImporter`/`GltfImporter`/`FbxImporter`'s `ImportFile` (the GUI "+Import File" path) minted a brand-new random UUID on every re-cook, for both meshes and materials — there was nothing to recognize "this is an update," only "this is new." Each importer now reads the destination's existing `.meta` first and reuses its `AssetUUID` when present. `FbxImporter` needed an extra remap step since its `SubMesh.MaterialUUID` is copied by value rather than by reference.
- `AssetImporterPanel::OnImportFileComplete`'s mesh `.meta` write never actually ran: it compared a bare VFS-relative output path against a native absolute workspace path with `strncmp`, which can never match. Fixed by parsing the VFS-relative path directly. `ReadAssetMeshFileHeader` was also being handed that same VFS-relative path instead of a resolved native one, so `has_header` was silently always false. A new block now also writes a `.meta` for every cooked material — previously none were written at all.
- `VFSFileWatcher`'s debounce map capacity (default 64) was too small once every material got its own `.meta` write; a multi-material import could push the pending-entry count past the load-factor assert. Raised to 256.

## Verification

- `zEngineLib`, `ZEngineTests`, `Obelisk` all build clean (only pre-existing, unrelated warnings).
- `ctest`: 565/565 passing (same 4 pre-existing GPU-gated skips).
- Live end-to-end in Obelisk:
  - Mesh: hand-authored test cube imported, edited (3x scale), re-imported, and dragged onto the viewport — same `MeshUUID` across re-import, viewport hot-swaps to the new geometry without a restart.
  - Material: a 16-material GLB imported, then re-imported — each material's UUID confirmed identical across the re-cook, both in its `.meta` sidecar and the re-cooked `.zematerial`'s own embedded UUID field.

## Test plan

- [x] `ctest` full suite passes
- [x] Manual: import a mesh via "+Import File", edit source, re-import, confirm same `MeshUUID` and viewport hot-swap
- [x] Manual: import a multi-material glTF/GLB, re-import, confirm each material's UUID is stable across the re-cook