### PR TITLE
fix(assets): load materials/textures when dragging a cooked mesh onto the viewport

### DIFF
--- a/Tetragrama/Panels/ViewportPanel.cpp
+++ b/Tetragrama/Panels/ViewportPanel.cpp
@@ -272,6 +272,16 @@ namespace Tetragrama::Panels
             ZEngine::Importers::AssetMesh          mesh_data{};
             ZEngine::Importers::AssetNodeHierarchy hier_data{};
             ZEngine::Importers::AssetCodec::DeserializeMeshAssetFile(scratch.Arena, native_path, mesh_data, hier_data);
+
+            // IngestMesh only loads geometry/hierarchy — ingest each submesh's material
+            // (and, transitively, its textures) first, before mesh_data is moved below.
+            for (uint32_t i = 0; i < mesh_data.SubMeshes.size(); ++i)
+            {
+                const auto& mat_uuid = mesh_data.SubMeshes[i].MaterialUUID;
+                if (!mat_uuid.is_nil())
+                    ZEngine::Managers::AssetManager::IngestMaterialFromUUID(scratch.Arena, mat_uuid);
+            }
+
             ZEngine::Managers::AssetManager::IngestMesh(std::move(mesh_data), std::move(hier_data));
             ZReleaseScratch(scratch);
         }

--- a/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp
+++ b/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp
@@ -132,7 +132,7 @@ namespace ZEngine::Applications
         }
 
         if (Device->RRM)
-            static_cast<Rendering::RenderResourceManager*>(Device->RRM)->CompleteDeferrals();
+            static_cast<Rendering::RenderResourceManager*>(Device->RRM)->CompleteDeferrals(swapchain->CurrentFrame->Index);
 
         CurrentCmdBuf = Device->CommandBufferMgr->GetCommandBuffer(Rendering::QueueType::GRAPHIC_QUEUE, swapchain->CurrentFrame->Index, RenderMainThreadIndex, 0, false);
         vkResetCommandBuffer(CurrentCmdBuf->GetHandle(), 0);
@@ -145,15 +145,15 @@ namespace ZEngine::Applications
     void AppRenderPipeline::EndFrame()
     {
         if (Device->RRM)
-            static_cast<Rendering::RenderResourceManager*>(Device->RRM)->SubmitTextureJobs();
+        {
+            auto* rrm = static_cast<Rendering::RenderResourceManager*>(Device->RRM);
+            rrm->EndFrame();
+            rrm->SubmitAsyncUploads();
+        }
         Device->CommandBufferMgr->EnqueueBuffer(CurrentCmdBuf);
         Device->CommandBufferMgr->EndEnqueuedBuffers();
 
         Device->SwapchainPtr->Present();
-
-        // RRM::EndFrame AFTER Present so swap entries drain with the correct frame counter.
-        if (Device->RRM)
-            static_cast<Rendering::RenderResourceManager*>(Device->RRM)->EndFrame(Device->SwapchainPtr->CurrentFrame->Index);
     }
 
     void AppRenderPipeline::RenderScene(Rendering::Cameras::CameraPtr camera, Rendering::Scenes::RenderScenePtr scene)

--- a/ZEngine/ZEngine/Applications/GameApplication.cpp
+++ b/ZEngine/ZEngine/Applications/GameApplication.cpp
@@ -1,6 +1,7 @@
 #include <GLFW/glfw3.h>
 #include <ZEngine/Applications/AppRenderPipeline.h>
 #include <ZEngine/Applications/GameApplication.h>
+#include <ZEngine/Core/VFS/VFSContext.h>
 #include <ZEngine/Core/VFS/VFSPath.h>
 #include <ZEngine/Engine.h>
 #include <ZEngine/Logging/LoggerDefinition.h>
@@ -23,6 +24,13 @@ namespace ZEngine::Applications
             if (Engine::GetContext()->VFS->Mount(VFSBackend, Core::VFS::VFSPath::Root(), 0).Failed())
             {
                 ZENGINE_CORE_ERROR("GameApplication: failed to mount VFSBackend")
+            }
+            else
+            {
+                // Only now is the project's own backend actually visible at "/" — the
+                // watcher set up inside Engine::Initialize only reacts to changes from
+                // here forward, so pre-existing assets need this explicit initial scan.
+                static_cast<Core::VFS::VFSContext*>(Engine::GetContext()->VFS)->ScanProject();
             }
         }
 

--- a/ZEngine/ZEngine/Core/Memory/GpuAllocator.cpp
+++ b/ZEngine/ZEngine/Core/Memory/GpuAllocator.cpp
@@ -378,7 +378,9 @@ namespace ZEngine::Core::Memory
 
         if (WritePos >= ReadPos)
         {
-            if ((offset + size) < static_cast<uint32_t>(kCapacity))
+            // <= (not <): a perfect-fit allocation landing exactly at kCapacity is valid —
+            // no need to force an unnecessary wrap attempt.
+            if ((offset + size) <= static_cast<uint32_t>(kCapacity))
             {
                 *out_vk_offset = offset;
                 WritePos       = offset + size;

--- a/ZEngine/ZEngine/Core/Memory/GpuAllocator.cpp
+++ b/ZEngine/ZEngine/Core/Memory/GpuAllocator.cpp
@@ -85,12 +85,20 @@ namespace ZEngine::Core::Memory
             }
         };
 
-        // DeviceGeometry — vertex/index/storage buffers. Fixed block size is fine here:
-        // geometry buffers don't vary in size the way textures do.
-        create_buffer_pool(GpuMemoryDomain::DeviceGeometry, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VmaAllocationCreateInfo{.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE}, GeometryBytes, 2);
+        // DeviceGeometry — vertex/index/storage buffers. blockSize=0 (auto-sized),
+        // maxBlockCount=0 (unlimited): RRM's global vertex/index buffers are each exactly
+        // 512 MB, and a fixed block exactly equal to an allocation's size can't actually
+        // fit it (same bookkeeping-headroom issue as HostStaging below — confirmed by
+        // [GPU] Pool for domain 0 exhausted firing on every single geometry allocation,
+        // not just after a block-count cap was reached).
+        create_buffer_pool(GpuMemoryDomain::DeviceGeometry, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VmaAllocationCreateInfo{.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE}, 0, 0);
 
-        // HostUniform — per-frame UBOs/SSBOs on the BAR window.
-        create_buffer_pool(GpuMemoryDomain::HostUniform, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, VmaAllocationCreateInfo{.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT, .usage = VMA_MEMORY_USAGE_AUTO}, UniformBytes, 1);
+        // HostUniform — per-frame UBOs/SSBOs on the BAR window. blockSize=0, maxBlockCount=0
+        // for the same reason as DeviceGeometry above: PerFrameUploadHeap::kCapacity alone
+        // is exactly UniformBytes, and GraphicRenderer's Transform/RenderData/Material/Light
+        // buffers plus ZUI's per-frame vertex/index buffers all share this one domain —
+        // a single fixed 1-block pool was never going to fit all of that.
+        create_buffer_pool(GpuMemoryDomain::HostUniform, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, VmaAllocationCreateInfo{.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT, .usage = VMA_MEMORY_USAGE_AUTO}, 0, 0);
 
         // HostStaging — built from the staging ring's OWN flags (AUTO_PREFER_DEVICE), not
         // AllocateBuffer's generic HostStaging branch (plain AUTO): those can resolve to

--- a/ZEngine/ZEngine/Core/VFS/VFSContext.cpp
+++ b/ZEngine/ZEngine/Core/VFS/VFSContext.cpp
@@ -207,6 +207,12 @@ namespace ZEngine::Core::VFS
         m_platform_watcher->StartThread();
     }
 
+    void VFSContext::ScanProject()
+    {
+        if (m_scanner && m_directory_cache)
+            m_scanner->Scan(this, VFSPath::Root(), m_directory_cache);
+    }
+
     void VFSContext::Tick()
     {
         if (m_file_watcher)

--- a/ZEngine/ZEngine/Core/VFS/VFSContext.cpp
+++ b/ZEngine/ZEngine/Core/VFS/VFSContext.cpp
@@ -4,6 +4,7 @@
 #include <ZEngine/Helpers/MemoryOperations.h>
 #include <ZEngine/Importers/ImportCoordinator.h>
 #include <ZEngine/Logging/LoggerDefinition.h>
+#include <cstring>
 
 #if defined(__APPLE__)
 #include <ZEngine/Core/VFS/Platform/VFSFSEventsWatcher.h>
@@ -116,10 +117,22 @@ namespace ZEngine::Core::VFS
         // simultaneous pending debounce entries than that before any flush.
         m_file_watcher->Initialize(m_arena, 256);
 
-        const WatchHandle root_handle = m_file_watcher->Watch(m_project_root_native, /*recursive=*/true, [this](const VFSWatchEvent& ev) {
+        // ev.Path/ev.OldPath are native absolute paths from the OS watcher, but every
+        // downstream consumer expects a workspace-relative VFSPath and prepends the
+        // workspace root itself — VFSPath::FromNative is just Parse, so it wouldn't strip
+        // that root. Do it here, once, instead of double-prefixing everywhere downstream.
+        auto to_relative_vfs_path = [this](cstring native) -> VFSResult<VFSPath> {
+            const size_t root_len   = Helpers::secure_strlen(m_project_root_native);
+            const size_t native_len = Helpers::secure_strlen(native);
+            if (native_len >= root_len && strncmp(native, m_project_root_native, root_len) == 0 && (native[root_len] == '\0' || native[root_len] == PLATFORM_OS_BACKSLASH))
+                return VFSPath::Parse(native[root_len] != '\0' ? native + root_len : "/");
+            return VFSPath::FromNative(native);
+        };
+
+        const WatchHandle root_handle = m_file_watcher->Watch(m_project_root_native, /*recursive=*/true, [this, to_relative_vfs_path](const VFSWatchEvent& ev) {
             const bool         full_rescan = (ev.Kind == WatchEventKind::Overflow);
 
-            VFSResult<VFSPath> path        = full_rescan ? VFSPath::FromNative(m_project_root_native) : VFSPath::FromNative(ev.Path);
+            VFSResult<VFSPath> path        = full_rescan ? to_relative_vfs_path(m_project_root_native) : to_relative_vfs_path(ev.Path);
             if (path.Failed())
                 return;
 
@@ -132,7 +145,7 @@ namespace ZEngine::Core::VFS
                 m_directory_cache->Invalidate(target);
                 if (ev.Kind == WatchEventKind::Renamed && ev.OldPath[0] != '\0')
                 {
-                    VFSResult<VFSPath> old_path = VFSPath::FromNative(ev.OldPath);
+                    VFSResult<VFSPath> old_path = to_relative_vfs_path(ev.OldPath);
                     if (old_path.Succeeded())
                         m_directory_cache->Invalidate(ev.IsDirectory ? old_path.Value() : old_path.Value().Parent());
                 }
@@ -165,7 +178,7 @@ namespace ZEngine::Core::VFS
                     case WatchEventKind::Renamed:
                         if (m_registry && ev.OldPath[0] != '\0')
                         {
-                            VFSResult<VFSPath> old_path = VFSPath::FromNative(ev.OldPath);
+                            VFSResult<VFSPath> old_path = to_relative_vfs_path(ev.OldPath);
                             if (old_path.Succeeded())
                                 m_registry->OnAssetRenamed(old_path.Value(), file_path);
                         }

--- a/ZEngine/ZEngine/Core/VFS/VFSContext.h
+++ b/ZEngine/ZEngine/Core/VFS/VFSContext.h
@@ -38,6 +38,11 @@ namespace ZEngine::Core::VFS
         // When a file is renamed:  registry->OnAssetRenamed
         void                                                    InitWatcher(const char* project_root_native, VFSDirectoryCache* cache, VFSScanner* scanner, AssetRegistry* registry = nullptr, Importers::ImportCoordinator* coordinator = nullptr);
 
+        // Scan the whole project into the registry/directory cache. Call once, after the
+        // project's own backend is mounted — InitWatcher's file watcher only reacts to
+        // changes from that point forward, it doesn't enumerate what's already on disk.
+        void                                                    ScanProject();
+
         // Pump the watcher — call once per frame from MainThreadRun.
         void                                                    Tick();
 

--- a/ZEngine/ZEngine/Core/VFS/VFSDiskBackend.cpp
+++ b/ZEngine/ZEngine/Core/VFS/VFSDiskBackend.cpp
@@ -285,7 +285,11 @@ namespace ZEngine::Core::VFS
             return VFSResult<IVFSFile*>::Fail(VFSError::PermissionDenied);
         }
 
-        void* mem = m_file_pool.Allocate();
+        void* mem;
+        {
+            std::lock_guard<std::mutex> lock(m_file_pool_mutex);
+            mem = m_file_pool.Allocate();
+        }
         if (!mem)
         {
             return VFSResult<IVFSFile*>::Fail(VFSError::OutOfMemory);
@@ -310,6 +314,7 @@ namespace ZEngine::Core::VFS
         if (file->m_handle == INVALID_HANDLE_VALUE)
         {
             file->~VFSDiskFile();
+            std::lock_guard<std::mutex> lock(m_file_pool_mutex);
             m_file_pool.Free(file);
             return VFSResult<IVFSFile*>::Fail(VFSError::NotFound);
         }
@@ -330,6 +335,7 @@ namespace ZEngine::Core::VFS
         if (file->m_fd < 0)
         {
             file->~VFSDiskFile();
+            std::lock_guard<std::mutex> lock(m_file_pool_mutex);
             m_file_pool.Free(file);
             return VFSResult<IVFSFile*>::Fail(VFSError::NotFound);
         }
@@ -349,6 +355,7 @@ namespace ZEngine::Core::VFS
             return;
         }
         file->~IVFSFile();
+        std::lock_guard<std::mutex> lock(m_file_pool_mutex);
         m_file_pool.Free(file);
     }
 

--- a/ZEngine/ZEngine/Core/VFS/VFSDiskBackend.h
+++ b/ZEngine/ZEngine/Core/VFS/VFSDiskBackend.h
@@ -4,6 +4,7 @@
 #include <ZEngine/Core/VFS/IVFSBackend.h>
 #include <ZEngine/Core/VFS/IVFSFile.h>
 #include <ZEngine/ZEngineDef.h>
+#include <mutex>
 
 #if defined(_WIN32)
 #include <Windows.h>
@@ -80,6 +81,12 @@ namespace ZEngine::Core::VFS
         VFSBackendCaps          m_caps                             = VFSBackendCaps::Read;
         Memory::ArenaAllocator* m_arena                            = nullptr;
         Memory::PoolAllocator   m_file_pool                        = {};
+        // Guards m_file_pool — VFSScanner runs ScanDirectory concurrently across ThreadPool
+        // workers (one task per subdirectory), and PoolAllocator's free-list has no internal
+        // synchronization of its own; concurrent Open/Close calls corrupt it (issue #764
+        // follow-up investigation — this manifested as unrelated-looking heap corruption
+        // crashes much later, since a corrupted free-list can hand out aliased memory).
+        std::mutex              m_file_pool_mutex                  = {};
         bool                    m_case_sensitive                   = true;
     };
 

--- a/ZEngine/ZEngine/Engine.cpp
+++ b/ZEngine/ZEngine/Engine.cpp
@@ -2,10 +2,8 @@
 #include <ZEngine/Applications/GameApplication.h>
 #include <ZEngine/Core/MainThreadScheduler.h>
 #include <ZEngine/Core/VFS/VFSContext.h>
-#include <ZEngine/Core/VFS/VFSDirectoryCache.h>
 #include <ZEngine/Core/VFS/VFSDiskBackend.h>
 #include <ZEngine/Core/VFS/VFSPath.h>
-#include <ZEngine/Core/VFS/VFSScanner.h>
 #include <ZEngine/ECS/Reflection/BuiltInComponentReflection.h>
 #include <ZEngine/ECS/Reflection/ComponentReflectionRegistry.h>
 #include <ZEngine/ECS/Systems/HierarchySystem.h>
@@ -16,12 +14,6 @@
 #include <ZEngine/Engine/FrameRateCap.h>
 #include <ZEngine/Engine/FrameTimer.h>
 #include <ZEngine/Helpers/ThreadPool.h>
-#include <ZEngine/Importers/AssimpImporter.h>
-#include <ZEngine/Importers/EnvironmentMapImporter.h>
-#include <ZEngine/Importers/FbxImporter.h>
-#include <ZEngine/Importers/GltfImporter.h>
-#include <ZEngine/Importers/ImportCoordinator.h>
-#include <ZEngine/Importers/TextureImporter.h>
 #include <ZEngine/Input/InputManager.h>
 #include <ZEngine/Logging/Logger.h>
 #include <ZEngine/Logging/LoggerDefinition.h>
@@ -39,13 +31,9 @@ using namespace std::chrono_literals;
 
 namespace ZEngine
 {
-    static std::atomic_bool                 s_request_terminate = false;
-    static std::atomic_bool                 s_close_requested   = false;
-    static EngineContextPtr                 g_engine_ctx        = nullptr;
-    static Applications::GameApplicationPtr g_app               = nullptr;
-    static std::thread                      g_render_thread     = {};
+    static EngineContextPtr g_engine_ctx = nullptr;
 
-    void                                    Engine::Initialize(Core::Memory::MemoryManager* memory, Windows::WindowConfigurationPtr window_cfg_ptr, Applications::GameApplicationPtr app)
+    void                    Engine::Initialize(Core::Memory::MemoryManager* memory, Windows::WindowConfigurationPtr window_cfg_ptr, Applications::GameApplicationPtr app)
     {
         ZENGINE_VALIDATE_ASSERT(memory != nullptr, "Engine::Initialize: memory is null — Obelisk must call MemoryManager::Initialize first")
         ZENGINE_VALIDATE_ASSERT(Logging::Logger::IsInitialized(), "Engine::Initialize: Logger not initialized — Obelisk must call Logger::Initialize first")
@@ -105,21 +93,16 @@ namespace ZEngine
         g_engine_ctx->ImportCoordinator = ZPushStructCtor(&g_engine_ctx->AssetArena, Importers::ImportCoordinator);
         g_engine_ctx->ImportCoordinator->Initialize(&g_engine_ctx->AssetArena, g_engine_ctx->VFS, Managers::AssetManager::Instance()->Registry);
 
-        static Importers::GltfImporter           s_gltf_importer;
-        static Importers::FbxImporter            s_fbx_importer;
-        static Importers::AssimpImporter         s_assimp_importer;
-        static Importers::EnvironmentMapImporter s_env_map_importer;
-        static Importers::TextureImporter        s_texture_importer;
-        s_gltf_importer.Initialize(&g_engine_ctx->ImportPipelineArena);
-        s_fbx_importer.Initialize(&g_engine_ctx->ImportPipelineArena);
-        s_assimp_importer.Initialize(&g_engine_ctx->ImportPipelineArena);
-        s_env_map_importer.Initialize(&g_engine_ctx->ImportPipelineArena);
-        s_texture_importer.Initialize(&g_engine_ctx->ImportPipelineArena);
-        g_engine_ctx->ImportCoordinator->RegisterImporter(&s_gltf_importer);
-        g_engine_ctx->ImportCoordinator->RegisterImporter(&s_fbx_importer);
-        g_engine_ctx->ImportCoordinator->RegisterImporter(&s_assimp_importer);
-        g_engine_ctx->ImportCoordinator->RegisterImporter(&s_env_map_importer);
-        g_engine_ctx->ImportCoordinator->RegisterImporter(&s_texture_importer);
+        g_engine_ctx->GltfImporter.Initialize(&g_engine_ctx->ImportPipelineArena);
+        g_engine_ctx->FbxImporter.Initialize(&g_engine_ctx->ImportPipelineArena);
+        g_engine_ctx->AssimpImporter.Initialize(&g_engine_ctx->ImportPipelineArena);
+        g_engine_ctx->EnvironmentMapImporter.Initialize(&g_engine_ctx->ImportPipelineArena);
+        g_engine_ctx->TextureImporter.Initialize(&g_engine_ctx->ImportPipelineArena);
+        g_engine_ctx->ImportCoordinator->RegisterImporter(&g_engine_ctx->GltfImporter);
+        g_engine_ctx->ImportCoordinator->RegisterImporter(&g_engine_ctx->FbxImporter);
+        g_engine_ctx->ImportCoordinator->RegisterImporter(&g_engine_ctx->AssimpImporter);
+        g_engine_ctx->ImportCoordinator->RegisterImporter(&g_engine_ctx->EnvironmentMapImporter);
+        g_engine_ctx->ImportCoordinator->RegisterImporter(&g_engine_ctx->TextureImporter);
 
         // RenderResourceManager — GPU lifetime authority, bridges asset layer and VulkanDevice
         g_engine_ctx->RenderResourceManager = ZPushStructCtor(&g_engine_ctx->AssetArena, Rendering::RenderResourceManager);
@@ -132,13 +115,11 @@ namespace ZEngine
         // Wire FileWatcher: Modified → AssetRegistry + ImportCoordinator::Enqueue(Immediate)
         if (app->WorkingSpacePath && app->WorkingSpacePath[0] != '\0')
         {
-            static Core::VFS::VFSDirectoryCache s_vfs_directory_cache;
-            static Core::VFS::VFSScanner        s_vfs_scanner;
-            s_vfs_directory_cache.Initialize(&g_engine_ctx->AssetArena);
-            s_vfs_scanner.Initialize(&g_engine_ctx->AssetArena);
-            s_vfs_scanner.SetAssetRegistry(Managers::AssetManager::Instance()->Registry);
+            g_engine_ctx->VFSDirectoryCache.Initialize(&g_engine_ctx->AssetArena);
+            g_engine_ctx->VFSScanner.Initialize(&g_engine_ctx->AssetArena);
+            g_engine_ctx->VFSScanner.SetAssetRegistry(Managers::AssetManager::Instance()->Registry);
 
-            static_cast<Core::VFS::VFSContext*>(g_engine_ctx->VFS)->InitWatcher(app->WorkingSpacePath, &s_vfs_directory_cache, &s_vfs_scanner, Managers::AssetManager::Instance()->Registry, g_engine_ctx->ImportCoordinator);
+            static_cast<Core::VFS::VFSContext*>(g_engine_ctx->VFS)->InitWatcher(app->WorkingSpacePath, &g_engine_ctx->VFSDirectoryCache, &g_engine_ctx->VFSScanner, Managers::AssetManager::Instance()->Registry, g_engine_ctx->ImportCoordinator);
         }
 
         glfwSetScrollCallback(static_cast<GLFWwindow*>(window->GetNativeWindow()), [](GLFWwindow*, double, double yoffset) {
@@ -149,7 +130,7 @@ namespace ZEngine
         Core::MainThreadScheduler::Initialize(&arena);
 
         app->CurrentWindow = g_engine_ctx->Window;
-        g_app              = app;
+        g_engine_ctx->App  = app;
 
         ZENGINE_CORE_INFO("Engine initialized")
     }
@@ -157,12 +138,12 @@ namespace ZEngine
     void Engine::Deinitialize()
     {
         // Step 1 — signal all loops to exit
-        s_request_terminate.store(true, std::memory_order_release);
+        g_engine_ctx->RequestTerminate.value.store(true, std::memory_order_release);
 
         // Step 2 — join render thread before any GPU resource is destroyed
-        if (g_render_thread.joinable())
+        if (g_engine_ctx->RenderThread.joinable())
         {
-            g_render_thread.join();
+            g_engine_ctx->RenderThread.join();
         }
 
         Core::MainThreadScheduler::Shutdown();
@@ -181,7 +162,7 @@ namespace ZEngine
         Managers::AssetManager::Shutdown();
 
         // Step 4 — destroy framebuffers, render passes, descriptor sets
-        g_app->RenderPipeline->Shutdown();
+        g_engine_ctx->App->RenderPipeline->Shutdown();
 
         // Step 12 — close VFS file handles
         if (g_engine_ctx->VFS)
@@ -219,7 +200,7 @@ namespace ZEngine
 
     void Engine::RequestClose()
     {
-        s_close_requested.store(true, std::memory_order_release);
+        g_engine_ctx->CloseRequested.value.store(true, std::memory_order_release);
     }
 
     void Engine::MainThreadRun()
@@ -232,7 +213,7 @@ namespace ZEngine
 
         ZENGINE_CORE_INFO("Engine main loop starting — FixedDT={:.4f}s MaxSteps=5", accumulator.FixedDt())
 
-        while (!s_close_requested.load(std::memory_order_acquire))
+        while (!g_engine_ctx->CloseRequested.value.load(std::memory_order_acquire))
         {
             if (!g_engine_ctx || !g_engine_ctx->Window || !g_engine_ctx->Device)
                 break;
@@ -284,10 +265,10 @@ namespace ZEngine
             Core::MainThreadScheduler::Drain();
 
             // Application update (non-ECS game logic)
-            g_app->Update(raw_dt);
+            g_engine_ctx->App->Update(raw_dt);
 
             // Render payload
-            auto     pipeline = g_app->RenderPipeline;
+            auto     pipeline = g_engine_ctx->App->RenderPipeline;
             uint32_t head     = pipeline->MailBoxBufferHead.value.load(std::memory_order_acquire);
             uint32_t next     = (head + 1) % pipeline->MaxMailBoxBufferCount;
             uint32_t tail     = pipeline->MailBoxBufferTail.value.load(std::memory_order_acquire);
@@ -305,23 +286,23 @@ namespace ZEngine
             auto& r_payload = pipeline->RenderPayloads[head];
             r_payload.RenderUIOverlay.value.store(false, std::memory_order_release);
 
-            if (g_app->EnableRenderOverlay)
+            if (g_engine_ctx->App->EnableRenderOverlay)
             {
                 pipeline->BeginOverlayFrame(raw_dt);
-                g_app->OnRenderUI();
+                g_engine_ctx->App->OnRenderUI();
                 pipeline->EndOverlayFrame();
                 r_payload.RenderUIOverlay.value.store(true, std::memory_order_release);
                 pipeline->FillOverlayPayload(r_payload);
             }
 
-            if (g_engine_ctx->Scene && g_app->CurrentScene)
+            if (g_engine_ctx->Scene && g_engine_ctx->App->CurrentScene)
             {
                 ECS::Systems::SyncHierarchy(*g_engine_ctx->Scene);
-                ECS::Systems::SyncECSToRenderScene(*g_engine_ctx->Scene, alpha, *g_app->CurrentScene);
-                ECS::Systems::SyncECSToLights(*g_engine_ctx->Scene, *g_app->CurrentScene);
+                ECS::Systems::SyncECSToRenderScene(*g_engine_ctx->Scene, alpha, *g_engine_ctx->App->CurrentScene);
+                ECS::Systems::SyncECSToLights(*g_engine_ctx->Scene, *g_engine_ctx->App->CurrentScene);
             }
 
-            g_app->PrepareScene(r_payload);
+            g_engine_ctx->App->PrepareScene(r_payload);
 
             pipeline->MailBoxBufferHead.value.store(next, std::memory_order_release);
 
@@ -354,12 +335,12 @@ namespace ZEngine
 #endif
         while (true)
         {
-            if (s_request_terminate.load(std::memory_order_acquire))
+            if (g_engine_ctx->RequestTerminate.value.load(std::memory_order_acquire))
             {
                 break;
             }
 
-            auto     pipeline = g_app->RenderPipeline;
+            auto     pipeline = g_engine_ctx->App->RenderPipeline;
 
             uint32_t tail     = pipeline->MailBoxBufferTail.value.load(std::memory_order_acquire);
             uint32_t head     = pipeline->MailBoxBufferHead.value.load(std::memory_order_acquire);
@@ -404,11 +385,11 @@ namespace ZEngine
     void Engine::Run()
     {
 
-        g_render_thread = std::thread(Engine::RenderThreadRun);
+        g_engine_ctx->RenderThread = std::thread(Engine::RenderThreadRun);
         MainThreadRun();
 
-        // OnClosing fires while all subsystems are live; Deinitialize sets s_request_terminate
-        g_app->OnClosing();
+        // OnClosing fires while all subsystems are live; Deinitialize sets RequestTerminate
+        g_engine_ctx->App->OnClosing();
 
         Deinitialize();
     }

--- a/ZEngine/ZEngine/Engine.cpp
+++ b/ZEngine/ZEngine/Engine.cpp
@@ -62,7 +62,10 @@ namespace ZEngine
             g_engine_ctx->EngineAssetsBackend.Initialize(engine_dir.c_str(), Core::VFS::VFSBackendCaps::Read | Core::VFS::VFSBackendCaps::Write | Core::VFS::VFSBackendCaps::List, &g_engine_ctx->VFSArena);
             auto mount_path = Core::VFS::VFSPath::Parse("/ZodiacEngine");
             if (mount_path.Succeeded())
-                vfs_ctx->Mount(&g_engine_ctx->EngineAssetsBackend, mount_path.Value(), -1);
+            {
+                auto res = vfs_ctx->Mount(&g_engine_ctx->EngineAssetsBackend, mount_path.Value(), -1);
+                (void) res;
+            }
         }
 
         memory->CreateBudgetedArena(memory->Budget.AssetManager, &g_engine_ctx->AssetArena);
@@ -340,10 +343,20 @@ namespace ZEngine
                 break;
             }
 
-            auto     pipeline = g_engine_ctx->App->RenderPipeline;
+            auto pipeline = g_engine_ctx->App->RenderPipeline;
 
-            uint32_t tail     = pipeline->MailBoxBufferTail.value.load(std::memory_order_acquire);
-            uint32_t head     = pipeline->MailBoxBufferHead.value.load(std::memory_order_acquire);
+            // Once the GPU device is lost (see VulkanDevice::CheckDeviceLost), continuing to
+            // call into Vulkan is undefined behaviour and has been observed to segfault inside
+            // the loader rather than return an error. Freeze the render loop instead of
+            // crashing — there is no recovery path yet, so this is a safe stop, not a resume.
+            if (pipeline->Device && pipeline->Device->IsDeviceLost.load(std::memory_order_acquire))
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                continue;
+            }
+
+            uint32_t tail = pipeline->MailBoxBufferTail.value.load(std::memory_order_acquire);
+            uint32_t head = pipeline->MailBoxBufferHead.value.load(std::memory_order_acquire);
 
             // Buffer empty
             if (tail == head)

--- a/ZEngine/ZEngine/Engine.cpp
+++ b/ZEngine/ZEngine/Engine.cpp
@@ -2,8 +2,10 @@
 #include <ZEngine/Applications/GameApplication.h>
 #include <ZEngine/Core/MainThreadScheduler.h>
 #include <ZEngine/Core/VFS/VFSContext.h>
+#include <ZEngine/Core/VFS/VFSDirectoryCache.h>
 #include <ZEngine/Core/VFS/VFSDiskBackend.h>
 #include <ZEngine/Core/VFS/VFSPath.h>
+#include <ZEngine/Core/VFS/VFSScanner.h>
 #include <ZEngine/ECS/Reflection/BuiltInComponentReflection.h>
 #include <ZEngine/ECS/Reflection/ComponentReflectionRegistry.h>
 #include <ZEngine/ECS/Systems/HierarchySystem.h>
@@ -130,7 +132,13 @@ namespace ZEngine
         // Wire FileWatcher: Modified → AssetRegistry + ImportCoordinator::Enqueue(Immediate)
         if (app->WorkingSpacePath && app->WorkingSpacePath[0] != '\0')
         {
-            static_cast<Core::VFS::VFSContext*>(g_engine_ctx->VFS)->InitWatcher(app->WorkingSpacePath, nullptr, nullptr, Managers::AssetManager::Instance()->Registry, g_engine_ctx->ImportCoordinator);
+            static Core::VFS::VFSDirectoryCache s_vfs_directory_cache;
+            static Core::VFS::VFSScanner        s_vfs_scanner;
+            s_vfs_directory_cache.Initialize(&g_engine_ctx->AssetArena);
+            s_vfs_scanner.Initialize(&g_engine_ctx->AssetArena);
+            s_vfs_scanner.SetAssetRegistry(Managers::AssetManager::Instance()->Registry);
+
+            static_cast<Core::VFS::VFSContext*>(g_engine_ctx->VFS)->InitWatcher(app->WorkingSpacePath, &s_vfs_directory_cache, &s_vfs_scanner, Managers::AssetManager::Instance()->Registry, g_engine_ctx->ImportCoordinator);
         }
 
         glfwSetScrollCallback(static_cast<GLFWwindow*>(window->GetNativeWindow()), [](GLFWwindow*, double, double yoffset) {

--- a/ZEngine/ZEngine/Engine.h
+++ b/ZEngine/ZEngine/Engine.h
@@ -2,7 +2,9 @@
 #include <ZEngine/Applications/GameApplication.h>
 #include <ZEngine/Core/Memory/MemoryManager.h>
 #include <ZEngine/Core/VFS/IVFSContext.h>
+#include <ZEngine/Core/VFS/VFSDirectoryCache.h>
 #include <ZEngine/Core/VFS/VFSDiskBackend.h>
+#include <ZEngine/Core/VFS/VFSScanner.h>
 #include <ZEngine/ECS/ActorManager.h>
 #include <ZEngine/ECS/Scene.h>
 #include <ZEngine/ECS/WorldCommands.h>
@@ -10,10 +12,17 @@
 #include <ZEngine/EngineConfiguration.h>
 #include <ZEngine/Event/EngineClosedEvent.h>
 #include <ZEngine/Hardwares/VulkanDevice.h>
+#include <ZEngine/Importers/AssimpImporter.h>
+#include <ZEngine/Importers/EnvironmentMapImporter.h>
+#include <ZEngine/Importers/FbxImporter.h>
+#include <ZEngine/Importers/GltfImporter.h>
 #include <ZEngine/Importers/ImportCoordinator.h>
+#include <ZEngine/Importers/TextureImporter.h>
 #include <ZEngine/Input/InputManager.h>
 #include <ZEngine/Rendering/RenderResourceManager.h>
 #include <ZEngine/Windows/CoreWindow.h>
+#include <ZEngine/ZEngineDef.h>
+#include <thread>
 
 namespace ZEngine
 {
@@ -22,33 +31,53 @@ namespace ZEngine
         // VFS backend for engine-owned assets (Shaders/, Settings/).
         // Mounted at VFSPath::Root() with priority -1 so the workspace backend
         // (priority 0) takes precedence for any overlapping paths.
-        Core::VFS::VFSDiskBackend         EngineAssetsBackend   = {};
+        Core::VFS::VFSDiskBackend         EngineAssetsBackend    = {};
+
+        // Project-wide directory listing cache and async tree walker — populates
+        // AssetRegistry from disk once at startup (VFSContext::ScanProject) and
+        // backs the file watcher's rescan-on-change.
+        Core::VFS::VFSDirectoryCache      VFSDirectoryCache      = {};
+        Core::VFS::VFSScanner             VFSScanner             = {};
+
+        // Import pipeline — registered with ImportCoordinator; each carves its own
+        // sub-arena from ImportPipelineArena.
+        Importers::GltfImporter           GltfImporter           = {};
+        Importers::FbxImporter            FbxImporter            = {};
+        Importers::AssimpImporter         AssimpImporter         = {};
+        Importers::EnvironmentMapImporter EnvironmentMapImporter = {};
+        Importers::TextureImporter        TextureImporter        = {};
 
         // Sub-arenas (large structs — grouped together to avoid pointer/arena interleaving)
-        Core::Memory::ArenaAllocator      VFSArena              = {};
-        Core::Memory::ArenaAllocator      AssetArena            = {};
-        Core::Memory::ArenaAllocator      InputArena            = {};
-        Core::Memory::ArenaAllocator      ECSArena              = {};
-        Core::Memory::ArenaAllocator      ImportPipelineArena   = {};
-        Core::Memory::ArenaAllocator      UIContextArena        = {};
+        Core::Memory::ArenaAllocator      VFSArena               = {};
+        Core::Memory::ArenaAllocator      AssetArena             = {};
+        Core::Memory::ArenaAllocator      InputArena             = {};
+        Core::Memory::ArenaAllocator      ECSArena               = {};
+        Core::Memory::ArenaAllocator      ImportPipelineArena    = {};
+        Core::Memory::ArenaAllocator      UIContextArena         = {};
 
         // Pointers (8 bytes each — grouped to pack cleanly)
-        Hardwares::VulkanDevicePtr        Device                = nullptr;
-        Windows::CoreWindowPtr            Window                = nullptr;
-        Core::VFS::IVFSContext*           VFS                   = nullptr;
-        Input::InputManager*              InputManager          = nullptr;
-        ECS::Scene*                       Scene                 = nullptr;
-        ECS::ActorManager*                ActorManager          = nullptr;
-        ECS::WorldCommands*               WorldCommands         = nullptr;
-        ECS::WorldTick*                   WorldTick             = nullptr;
-        Importers::ImportCoordinator*     ImportCoordinator     = nullptr;
-        Rendering::RenderResourceManager* RenderResourceManager = nullptr;
+        Hardwares::VulkanDevicePtr        Device                 = nullptr;
+        Windows::CoreWindowPtr            Window                 = nullptr;
+        Core::VFS::IVFSContext*           VFS                    = nullptr;
+        Input::InputManager*              InputManager           = nullptr;
+        ECS::Scene*                       Scene                  = nullptr;
+        ECS::ActorManager*                ActorManager           = nullptr;
+        ECS::WorldCommands*               WorldCommands          = nullptr;
+        ECS::WorldTick*                   WorldTick              = nullptr;
+        Importers::ImportCoordinator*     ImportCoordinator      = nullptr;
+        Rendering::RenderResourceManager* RenderResourceManager  = nullptr;
+        Applications::GameApplicationPtr  App                    = nullptr;
 
         // Smoothed delta time — 8-sample rolling average measured in the render thread
         // between consecutive EndFrame() calls (includes vsync wait).
         // Written by the render thread; read by the main thread for display only.
         // Plain float is sufficient: a one-frame stale read is acceptable for a counter.
-        float                             SmoothedDeltaTime     = 1.f / 60.f;
+        float                             SmoothedDeltaTime      = 1.f / 60.f;
+
+        // Render thread lifecycle — started in Run(), joined in Deinitialize().
+        std::thread                       RenderThread           = {};
+        PaddedAtomic<bool>                RequestTerminate       = {}; // signals both loops to exit
+        PaddedAtomic<bool>                CloseRequested         = {}; // MainThreadRun's own exit condition
     };
     ZDEFINE_PTR(EngineContext);
 

--- a/ZEngine/ZEngine/Hardwares/AsyncUploadQueue.cpp
+++ b/ZEngine/ZEngine/Hardwares/AsyncUploadQueue.cpp
@@ -1,0 +1,47 @@
+#include <ZEngine/Hardwares/AsyncUploadQueue.h>
+#include <ZEngine/Hardwares/VulkanDevice.h>
+#include <ZEngine/Logging/LoggerDefinition.h>
+
+namespace ZEngine::Hardwares
+{
+    void AsyncUploadQueue::Initialize(VulkanDevice* device)
+    {
+        m_device = device;
+    }
+
+    void AsyncUploadQueue::Deinitialize()
+    {
+        Clear();
+        m_device = nullptr;
+    }
+
+    void AsyncUploadQueue::Enqueue(const AsyncUploadJob& job)
+    {
+        if (!m_jobs.push(job))
+        {
+            ZENGINE_CORE_WARN("[AsyncUploadQueue] Queue full ({} jobs) — dropping upload job", CAPACITY)
+        }
+    }
+
+    void AsyncUploadQueue::SubmitAll()
+    {
+        AsyncUploadJob job;
+        while (m_jobs.pop(job))
+        {
+            // Stop draining once the device is lost rather than keep submitting every
+            // remaining job — those would just add misleading cascade errors on top of the
+            // real failure, and the device may already be unsafe to keep calling into.
+            if (!m_device->QueueSubmit(job.Buffer, job.Timeline, job.WaitFlag, job.SignalValue, job.WaitValue, job.WaitTimeline))
+                break;
+            m_device->EnqueueAsyncGPUOperation({job.WaitFlag, job.SignalValue, job.Timeline});
+        }
+    }
+
+    void AsyncUploadQueue::Clear()
+    {
+        AsyncUploadJob job;
+        while (m_jobs.pop(job))
+        {
+        }
+    }
+} // namespace ZEngine::Hardwares

--- a/ZEngine/ZEngine/Hardwares/AsyncUploadQueue.h
+++ b/ZEngine/ZEngine/Hardwares/AsyncUploadQueue.h
@@ -1,0 +1,44 @@
+#pragma once
+#include <ZEngine/Core/Containers/SPSCQueue.h>
+#include <cstdint>
+
+namespace ZEngine::Rendering::Primitives
+{
+    struct Semaphore;
+} // namespace ZEngine::Rendering::Primitives
+
+namespace ZEngine::Hardwares
+{
+    struct VulkanDevice;
+    struct CommandBuffer;
+
+    // One GPU submission tracked via a timeline semaphore instead of a CPU-blocking fence.
+    struct AsyncUploadJob
+    {
+        CommandBuffer*                    Buffer       = nullptr;
+        Rendering::Primitives::Semaphore* Timeline     = nullptr;
+        Rendering::Primitives::Semaphore* WaitTimeline = nullptr;
+        uint32_t                          WaitFlag     = 0;
+        uint64_t                          SignalValue  = 0;
+        uint64_t                          WaitValue    = UINT64_MAX;
+    };
+
+    // Submits queued GPU work and registers each job with VulkanDevice::EnqueueAsyncGPUOperation
+    // so DeviceSwapchain::Present() waits on it, without blocking the thread that recorded it.
+    // Render-thread only, single-producer/single-consumer: Enqueue in BeginFrame, SubmitAll in
+    // EndFrame, so the queue is always fully drained within the frame it was recorded in.
+    struct AsyncUploadQueue
+    {
+        static constexpr uint32_t CAPACITY = 1024;
+
+        void                      Initialize(VulkanDevice* device);
+        void                      Deinitialize();
+        void                      Enqueue(const AsyncUploadJob& job);
+        void                      SubmitAll();
+        void                      Clear();
+
+    private:
+        VulkanDevice*                                         m_device = nullptr;
+        Core::Containers::SPSCQueue<AsyncUploadJob, CAPACITY> m_jobs   = {};
+    };
+} // namespace ZEngine::Hardwares

--- a/ZEngine/ZEngine/Hardwares/CommandBufferManager.cpp
+++ b/ZEngine/ZEngine/Hardwares/CommandBufferManager.cpp
@@ -1,0 +1,250 @@
+#include <ZEngine/Hardwares/CommandBufferManager.h>
+#include <ZEngine/Hardwares/VulkanDevice.h>
+#include <ZEngine/Logging/LoggerDefinition.h>
+
+using namespace ZEngine::Rendering;
+
+namespace ZEngine::Hardwares
+{
+    void CommandBufferManager::Initialize(VulkanDevice* device, uint32_t image_count, uint8_t override_thread_count)
+    {
+        if (m_is_initialized)
+        {
+            ZENGINE_CORE_WARN("Attempted to call {}, but it has been already initialized", __FUNCTION__)
+            return;
+        }
+
+        Device                         = device;
+        TotalThreadCount               = override_thread_count > 0 ? override_thread_count : device->WorkerThreadCount;
+        TotalPoolCount                 = image_count * TotalThreadCount;
+        TotalCommandBufferCount        = TotalPoolCount * MaxBufferPerPool;
+        TotalInstantCommandBufferCount = MaxBufferPerPool * MaxBufferPerPool * TotalPoolCount; // We want to have enough instant command buffers for each pool, so we can guarantee that there will always be an instant command buffer available for each pool when needed
+
+        InstantGraphicsPools.init(Device->Arena, TotalPoolCount, TotalPoolCount);
+        InstantGraphicsCommandBuffers.init(Device->Arena, TotalInstantCommandBufferCount, TotalInstantCommandBufferCount);
+        CommandPools.init(Device->Arena, TotalPoolCount, TotalPoolCount);
+        CommandBuffers.init(Device->Arena, TotalCommandBufferCount, TotalCommandBufferCount);
+        EnqueuedCommandBuffers.init(Device->Arena, TotalCommandBufferCount, TotalCommandBufferCount);
+
+        for (uint32_t i = 0; i < TotalPoolCount; ++i)
+        {
+            InstantGraphicsPools[i] = ZPushStructCtorArgs(Device->Arena, Rendering::Pools::CommandPool, Device, QueueType::GRAPHIC_QUEUE);
+
+            for (uint32_t buf_idx = 0; buf_idx < (MaxBufferPerPool * MaxBufferPerPool); ++buf_idx)
+            {
+                uint32_t buffer_idx                       = (i * (MaxBufferPerPool * MaxBufferPerPool)) + buf_idx;
+                InstantGraphicsCommandBuffers[buffer_idx] = ZPushStructCtorArgs(Device->Arena, CommandBuffer, Device, InstantGraphicsPools[i]->Handle, InstantGraphicsPools[i]->QueueType, true);
+            }
+        }
+
+        for (uint32_t i = 0; i < TotalPoolCount; ++i)
+        {
+            CommandPools[i] = ZPushStructCtorArgs(Device->Arena, Rendering::Pools::CommandPool, Device, QueueType::GRAPHIC_QUEUE);
+            for (uint32_t buf_idx = 0; buf_idx < MaxBufferPerPool; ++buf_idx)
+            {
+                uint32_t buffer_idx        = (i * MaxBufferPerPool) + buf_idx;
+                bool     is_primary        = (buffer_idx % 2) == 0;
+                CommandBuffers[buffer_idx] = ZPushStructCtorArgs(Device->Arena, CommandBuffer, Device, CommandPools[i]->Handle, CommandPools[i]->QueueType, is_primary);
+            }
+        }
+
+        if (Device->HasSeperateTransfertQueueFamily)
+        {
+            InstantTransferPools.init(Device->Arena, TotalPoolCount, TotalPoolCount);
+            TransferCommandPools.init(Device->Arena, TotalPoolCount, TotalPoolCount);
+            TransferCommandBuffers.init(Device->Arena, TotalCommandBufferCount, TotalCommandBufferCount);
+            InstantTransferCommandBuffers.init(Device->Arena, TotalInstantCommandBufferCount, TotalInstantCommandBufferCount);
+
+            for (uint32_t i = 0; i < TotalPoolCount; ++i)
+            {
+                InstantTransferPools[i] = ZPushStructCtorArgs(Device->Arena, Rendering::Pools::CommandPool, Device, Rendering::QueueType::TRANSFER_QUEUE);
+                for (uint32_t buf_idx = 0; buf_idx < (MaxBufferPerPool * MaxBufferPerPool); ++buf_idx)
+                {
+                    uint32_t buffer_idx                       = (i * (MaxBufferPerPool * MaxBufferPerPool)) + buf_idx;
+                    InstantTransferCommandBuffers[buffer_idx] = ZPushStructCtorArgs(Device->Arena, CommandBuffer, Device, InstantTransferPools[i]->Handle, InstantTransferPools[i]->QueueType, true);
+                }
+            }
+
+            for (uint32_t i = 0; i < TotalPoolCount; ++i)
+            {
+                TransferCommandPools[i] = ZPushStructCtorArgs(Device->Arena, Rendering::Pools::CommandPool, Device, Rendering::QueueType::TRANSFER_QUEUE);
+                for (uint32_t buf_idx = 0; buf_idx < MaxBufferPerPool; ++buf_idx)
+                {
+                    uint32_t buffer_idx                = (i * MaxBufferPerPool) + buf_idx;
+                    TransferCommandBuffers[buffer_idx] = ZPushStructCtorArgs(Device->Arena, CommandBuffer, Device, TransferCommandPools[i]->Handle, TransferCommandPools[i]->QueueType, true);
+                }
+            }
+        }
+
+        m_is_initialized = true;
+    }
+
+    void CommandBufferManager::Deinitialize()
+    {
+        // Explicitly destroy each CommandPool — vkDestroyCommandPool implicitly frees
+        // all VkCommandBuffers allocated from it.  The Array::clear() that follows only
+        // zeroes the pointer list; it never invokes C++ destructors, so skipping this
+        // step leaks every VkCommandPool and VkCommandBuffer past vkDestroyDevice.
+        for (uint32_t i = 0; i < InstantGraphicsPools.size(); ++i)
+            InstantGraphicsPools[i]->~CommandPool();
+        for (uint32_t i = 0; i < CommandPools.size(); ++i)
+            CommandPools[i]->~CommandPool();
+        for (uint32_t i = 0; i < TransferCommandPools.size(); ++i)
+            TransferCommandPools[i]->~CommandPool();
+        for (uint32_t i = 0; i < InstantTransferPools.size(); ++i)
+            InstantTransferPools[i]->~CommandPool();
+
+        InstantGraphicsPools.clear();
+        InstantGraphicsCommandBuffers.clear();
+        CommandBuffers.clear();
+        TransferCommandBuffers.clear();
+        InstantTransferCommandBuffers.clear();
+        CommandPools.clear();
+        TransferCommandPools.clear();
+        InstantTransferPools.clear();
+        EnqueuedCommandBuffers.clear();
+    }
+
+    CommandBuffer* CommandBufferManager::GetCommandBuffer(Rendering::QueueType type, uint8_t frame_index, uint8_t thread_index, uint8_t buffer_per_pool_index, bool begin)
+    {
+        auto           buffer_index = ((frame_index * TotalThreadCount) + thread_index) * MaxBufferPerPool + buffer_per_pool_index;
+        CommandBuffer* buffer       = (type == Rendering::QueueType::TRANSFER_QUEUE && Device->HasSeperateTransfertQueueFamily) ? TransferCommandBuffers[buffer_index] : CommandBuffers[buffer_index];
+
+        if (begin)
+        {
+            buffer->ResetState();
+            buffer->Begin();
+        }
+        return buffer;
+    }
+
+    CommandBuffer* CommandBufferManager::GetInstantCommandBuffer(Rendering::QueueType type, uint8_t frame_index, uint8_t thread_index, uint32_t buffer_per_pool_index, bool begin)
+    {
+        // MaxBufferPerPool * MaxBufferPerPool is the total number of instant command buffers per pool
+        auto           buffer_index = ((frame_index * TotalThreadCount) + thread_index) * (MaxBufferPerPool * MaxBufferPerPool) + buffer_per_pool_index;
+        CommandBuffer* buffer       = (type == Rendering::QueueType::TRANSFER_QUEUE && Device->HasSeperateTransfertQueueFamily) ? InstantTransferCommandBuffers[buffer_index] : InstantGraphicsCommandBuffers[buffer_index];
+
+        if (begin)
+        {
+            buffer->ResetState();
+            vkResetCommandBuffer(buffer->GetHandle(), VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT);
+            buffer->Begin();
+        }
+        return buffer;
+    }
+
+    Rendering::Pools::CommandPool* CommandBufferManager::GetCommandPool(Rendering::QueueType type, uint8_t frame_index, uint8_t thread_index)
+    {
+        uint32_t pool_index = (frame_index * TotalThreadCount) + thread_index;
+        return (type == QueueType::TRANSFER_QUEUE && Device->HasSeperateTransfertQueueFamily) ? TransferCommandPools[pool_index] : CommandPools[pool_index];
+    }
+
+    Rendering::Pools::CommandPool* CommandBufferManager::GetInstantCommandPool(Rendering::QueueType type, uint8_t frame_index, uint8_t thread_index)
+    {
+        uint32_t pool_index = (frame_index * TotalThreadCount) + thread_index;
+        return (type == QueueType::TRANSFER_QUEUE && Device->HasSeperateTransfertQueueFamily) ? InstantTransferPools[pool_index] : InstantGraphicsPools[pool_index];
+    }
+
+    void CommandBufferManager::ResetPool(uint8_t frame_index, uint8_t thread_index)
+    {
+        uint32_t pool_index = (frame_index * TotalThreadCount) + thread_index;
+        vkResetCommandPool(Device->LogicalDevice, CommandPools[pool_index]->Handle, 0);
+        if (Device->HasSeperateTransfertQueueFamily)
+        {
+            vkResetCommandPool(Device->LogicalDevice, TransferCommandPools[pool_index]->Handle, 0);
+        }
+    }
+
+    void CommandBufferManager::ResetEnqueuedBufferIndex()
+    {
+        for (int i = 0; i < EnqueuedCommandBufferIndex && i < EnqueuedCommandBuffers.size(); ++i)
+        {
+            if (EnqueuedCommandBuffers[i])
+            {
+                EnqueuedCommandBuffers[i]->SetState(CommandBufferState::Pending);
+            }
+        }
+        EnqueuedCommandBufferIndex = 0u;
+    }
+
+    void CommandBufferManager::EndEnqueuedBuffers()
+    {
+        for (int i = 0; i < EnqueuedCommandBufferIndex; ++i)
+        {
+            EnqueuedCommandBuffers[i]->End();
+        }
+    }
+
+    void CommandBufferManager::EnqueueBuffer(CommandBufferPtr const buffer)
+    {
+        if (EnqueuedCommandBufferIndex < EnqueuedCommandBuffers.size())
+        {
+            EnqueuedCommandBuffers[EnqueuedCommandBufferIndex++] = buffer;
+            return;
+        }
+        ZENGINE_CORE_ERROR("[!] Enqueued Command Buffer overflow detected")
+    }
+
+    void CommandBufferManager::IncreaseBuffers()
+    {
+        // TotalPoolCount          = Device->SwapchainImageCount * TotalThreadCount;
+        // TotalCommandBufferCount = TotalPoolCount * MaxBufferPerPool;
+
+        // if (TotalCommandBufferCount > EnqueuedCommandBuffers.size())
+        // {
+        //     auto size = EnqueuedCommandBuffers.size();
+        //     for (uint32_t i = size; i < TotalCommandBufferCount; ++i)
+        //     {
+        //         EnqueuedCommandBuffers.push(nullptr);
+        //     }
+        // }
+
+        // if (TotalPoolCount > CommandPools.size())
+        // {
+        //     auto size = CommandPools.size();
+        //     for (uint32_t i = size; i < TotalCommandBufferCount; ++i)
+        //     {
+        //         CommandPools.push(ZPushStructCtorArgs(Device->Arena, Rendering::Pools::CommandPool, Device, Rendering::QueueType::GRAPHIC_QUEUE));
+        //     }
+        // }
+
+        // if (TotalCommandBufferCount > CommandBuffers.size())
+        // {
+        //     auto size = CommandBuffers.size();
+        //     for (uint32_t i = size; i < TotalCommandBufferCount; ++i)
+        //     {
+        //         int   pool_index = GetPoolFromIndex(Rendering::QueueType::GRAPHIC_QUEUE, i);
+        //         auto& pool       = CommandPools[pool_index];
+        //         CommandBuffers.push(ZPushStructCtorArgs(
+        //             Device->Arena,
+        //             CommandBuffer,
+        //             Device,
+        //             pool->Handle,
+        //             pool->QueueType,
+        //             /*(i % MaxBufferPerPool) == 0 ? false : true */ false));
+        //     }
+        // }
+
+        // if (Device->HasSeperateTransfertQueueFamily)
+        // {
+        //     auto size = TransferCommandPools.size();
+        //     for (uint32_t i = size; i < TotalCommandBufferCount; ++i)
+        //     {
+        //         TransferCommandPools.push(ZPushStructCtorArgs(Device->Arena, Rendering::Pools::CommandPool, Device, Rendering::QueueType::TRANSFER_QUEUE));
+        //     }
+
+        //     size = TransferCommandBuffers.size();
+        //     for (uint32_t i = size; i < TotalCommandBufferCount; ++i)
+        //     {
+        //         int   pool_index = GetPoolFromIndex(Rendering::QueueType::TRANSFER_QUEUE, i);
+        //         auto& pool       = TransferCommandPools[pool_index];
+        //         TransferCommandBuffers.push(ZPushStructCtorArgs(Device->Arena, CommandBuffer, Device, pool->Handle, pool->QueueType, true));
+        //     }
+        // }
+    }
+
+    bool CommandBufferManager::IsInitialized() const
+    {
+        return m_is_initialized;
+    }
+} // namespace ZEngine::Hardwares

--- a/ZEngine/ZEngine/Hardwares/CommandBufferManager.h
+++ b/ZEngine/ZEngine/Hardwares/CommandBufferManager.h
@@ -1,0 +1,53 @@
+#pragma once
+#include <ZEngine/Core/Containers/Array.h>
+#include <ZEngine/Rendering/Pools/CommandPool.h>
+#include <ZEngine/Rendering/ResourceTypes.h>
+#include <ZEngine/ZEngineDef.h>
+#include <cstdint>
+
+namespace ZEngine::Hardwares
+{
+    struct VulkanDevice;
+
+    struct CommandBuffer;
+    ZDEFINE_PTR(CommandBuffer);
+
+    struct CommandBufferManager
+    {
+        void                                                            Initialize(VulkanDevice* device, uint32_t image_count = 0, uint8_t override_thread_count = 0);
+        void                                                            Deinitialize();
+        CommandBuffer*                                                  GetCommandBuffer(Rendering::QueueType type, uint8_t frame_index, uint8_t thread_index, uint8_t buffer_per_pool_index, bool begin = true);
+        CommandBuffer*                                                  GetInstantCommandBuffer(Rendering::QueueType type, uint8_t frame_index, uint8_t thread_index, uint32_t buffer_per_pool_index, bool begin = true);
+        Rendering::Pools::CommandPool*                                  GetCommandPool(Rendering::QueueType type, uint8_t frame_index, uint8_t thread_index);
+        Rendering::Pools::CommandPool*                                  GetInstantCommandPool(Rendering::QueueType type, uint8_t frame_index, uint8_t thread_index);
+        void                                                            ResetPool(uint8_t frame_index, uint8_t thread_index);
+        void                                                            IncreaseBuffers();
+        void                                                            EnqueueBuffer(CommandBufferPtr const buffer);
+        void                                                            EndEnqueuedBuffers();
+        void                                                            ResetEnqueuedBufferIndex();
+        bool                                                            IsInitialized() const;
+
+        uint32_t                                                        TotalCommandBufferCount        = 0;
+        uint32_t                                                        TotalInstantCommandBufferCount = 0;
+        uint32_t                                                        TotalPoolCount                 = 0;
+        uint32_t                                                        TotalThreadCount               = 0;
+        uint32_t                                                        EnqueuedCommandBufferIndex     = 0;
+        const uint32_t                                                  MaxBufferPerPool               = 4;
+        VulkanDevice*                                                   Device                         = nullptr;
+
+        Core::Containers::Array<Rendering::Pools::CommandPool*>         InstantGraphicsPools           = {};
+        Core::Containers::Array<Rendering::Pools::CommandPool*>         InstantTransferPools           = {};
+        Core::Containers::Array<CommandBuffer*>                         InstantGraphicsCommandBuffers  = {};
+        Core::Containers::Array<CommandBuffer*>                         InstantTransferCommandBuffers  = {};
+
+        Core::Containers::Array<ZRawPtr(Rendering::Pools::CommandPool)> CommandPools                   = {};
+        Core::Containers::Array<ZRawPtr(Rendering::Pools::CommandPool)> TransferCommandPools           = {};
+        Core::Containers::Array<ZRawPtr(CommandBuffer)>                 CommandBuffers                 = {};
+        Core::Containers::Array<ZRawPtr(CommandBuffer)>                 TransferCommandBuffers         = {};
+        Core::Containers::Array<CommandBuffer*>                         EnqueuedCommandBuffers         = {};
+
+    private:
+        bool m_is_initialized = false;
+    };
+    ZDEFINE_PTR(CommandBufferManager);
+} // namespace ZEngine::Hardwares

--- a/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
+++ b/ZEngine/ZEngine/Hardwares/DeviceSwapchain.cpp
@@ -260,7 +260,7 @@ namespace ZEngine::Hardwares
             if (Device->RRM)
             {
                 auto* rrm = static_cast<Rendering::RenderResourceManager*>(Device->RRM);
-                rrm->ClearTextureJobs();
+                rrm->ClearAsyncUploads();
                 rrm->ResetTextureTimelines();
             }
 
@@ -319,6 +319,14 @@ namespace ZEngine::Hardwares
             return;
         }
 
+        if (Device->CheckDeviceLost(acquire_image_result, "AcquireNextImage"))
+        {
+            frame.ImageIndex = std::numeric_limits<uint32_t>::max();
+            CurrentFrame     = &frame;
+            Recreation       = RecreationState::FrameAborted;
+            return;
+        }
+
         if (PresentCompletes[image_idx]->GetState() == Rendering::Primitives::FenceState::Submitted)
         {
             PresentCompletes[image_idx]->Wait(UINT64_MAX);
@@ -342,6 +350,16 @@ namespace ZEngine::Hardwares
         {
             // OOD at acquire: semaphore not signalled, no GPU work submitted.
             IdleFrameCount.value.fetch_add(1, std::memory_order_acq_rel);
+            Device->CommandBufferMgr->ResetEnqueuedBufferIndex();
+            return;
+        }
+
+        // The device can go lost mid-frame, inside AppRenderPipeline::EndFrame's own
+        // SubmitAsyncUploads() call, before Present() runs — continuing into more Vulkan
+        // calls (including the unchecked vkGetSemaphoreCounterValue below) here would just
+        // add cascade errors on top of an already-lost device.
+        if (Device->IsDeviceLost.load(std::memory_order_acquire))
+        {
             Device->CommandBufferMgr->ResetEnqueuedBufferIndex();
             return;
         }
@@ -466,6 +484,11 @@ namespace ZEngine::Hardwares
             .pSignalSemaphores    = acquire_signal_semaphores,
         };
         VkResult r0 = vkQueueSubmit(queue.Handle, 1, &submit_0, VK_NULL_HANDLE);
+        if (Device->CheckDeviceLost(r0, "Present: acquire bridge submit"))
+        {
+            ZReleaseScratch(scratch);
+            return;
+        }
         ZENGINE_VALIDATE_ASSERT(r0 == VK_SUCCESS, "Failed to submit acquire bridge")
 
         struct TimelineAggregate
@@ -484,14 +507,18 @@ namespace ZEngine::Hardwares
         wait_values.init(scratch.Arena, 10);
         max_val_timeline_semaphores.init(scratch.Arena);
 
-        wait_semaphores.push(RenderTimeline->GetHandle());
-        wait_values.push(frame_start_value);
-        stage_flags.push(VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+        // Seed with RenderTimeline's own acquire-bridge value rather than pushing it
+        // directly — an AsyncGPUOperation can also target RenderTimeline (e.g. RRM's mesh
+        // batch upload), and pushing both separately would put the same semaphore twice
+        // in one submit's wait list with two different values.
+        max_val_timeline_semaphores.insert(RenderTimeline, {frame_start_value, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT});
 
         {
             Hardwares::AsyncGPUOperationHandle op;
             while (Device->AsyncGPUOperations.Pop(op))
             {
+                ZENGINE_CORE_TRACE("[Present] AsyncGPUOperation: timeline={} signal_value={} stage_flags={:#x}", (void*) op.Timeline->GetHandle(), op.SignalValue, op.StageFlags)
+
                 if (!max_val_timeline_semaphores.contains(op.Timeline))
                 {
                     max_val_timeline_semaphores.insert(op.Timeline, {op.SignalValue, op.StageFlags});
@@ -535,6 +562,11 @@ namespace ZEngine::Hardwares
         Device->FrameHeaps[CurrentFrame->Index].Flush(&Device->GpuMem);
 
         auto submit = vkQueueSubmit(queue.Handle, 1, &(submit_info_1), CurrentFrame->Fence->GetHandle());
+        if (Device->CheckDeviceLost(submit, "Present: render work submit"))
+        {
+            ZReleaseScratch(scratch);
+            return;
+        }
         ZENGINE_VALIDATE_ASSERT(submit == VK_SUCCESS, "Failed to submit queue")
 
         ZReleaseScratch(scratch);
@@ -566,6 +598,8 @@ namespace ZEngine::Hardwares
         };
 
         VkResult r2 = vkQueueSubmit(queue.Handle, 1, &submit2, present_complete->GetHandle());
+        if (Device->CheckDeviceLost(r2, "Present: present bridge submit"))
+            return;
         ZENGINE_VALIDATE_ASSERT(r2 == VK_SUCCESS, "Failed to submit present bridge")
 
         render_complete->SetState(Rendering::Primitives::SemaphoreState::Submitted);
@@ -586,6 +620,9 @@ namespace ZEngine::Hardwares
         VkResult present_result = vkQueuePresentKHR(queue.Handle, &present_info);
 
         IdleFrameCount.value.fetch_add(1, std::memory_order_acq_rel);
+
+        if (Device->CheckDeviceLost(present_result, "Present: vkQueuePresentKHR"))
+            return;
 
         if (present_result == VK_ERROR_OUT_OF_DATE_KHR)
         {

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
@@ -11,6 +11,7 @@
 #include <ZEngine/Windows/CoreWindow.h>
 #include <cstdlib>
 #include <filesystem>
+#include <limits>
 
 using namespace std::chrono_literals;
 using namespace ZEngine::Rendering::Primitives;
@@ -1480,12 +1481,12 @@ namespace ZEngine::Hardwares
         vkCmdPipelineBarrier(m_command_buffer, barrier_spec.SourceStageMask, barrier_spec.DestinationStageMask, 0, 0, nullptr, 0, nullptr, 1, &barrier_handle);
     }
 
-    void CommandBuffer::CopyBufferToImage(const Hardwares::BufferView& source, Hardwares::BufferImage& destination, uint32_t width, uint32_t height, uint32_t layer_count, VkImageLayout new_layout)
+    void CommandBuffer::CopyBufferToImage(const Hardwares::BufferView& source, Hardwares::BufferImage& destination, uint32_t width, uint32_t height, uint32_t layer_count, VkImageLayout new_layout, uint32_t source_offset)
     {
         ZENGINE_VALIDATE_ASSERT(m_command_buffer != nullptr, "Command buffer can't be null")
 
         VkBufferImageCopy buffer_image_copy               = {};
-        buffer_image_copy.bufferOffset                    = 0;
+        buffer_image_copy.bufferOffset                    = source_offset;
         buffer_image_copy.bufferRowLength                 = 0;
         buffer_image_copy.bufferImageHeight               = 0;
         buffer_image_copy.imageSubresource.aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -1997,8 +1998,11 @@ namespace ZEngine::Hardwares
         }
     }
 
-    BufferView VulkanDevice::WriteTextureData(CommandBufferPtr command_buf, const Rendering::Textures::TextureHandle& handle, const void* data)
+    BufferView VulkanDevice::WriteTextureData(CommandBufferPtr command_buf, const Rendering::Textures::TextureHandle& handle, const void* data, uint32_t* out_ring_offset)
     {
+        if (out_ring_offset)
+            *out_ring_offset = std::numeric_limits<uint32_t>::max();
+
         if (!handle.Valid() || !(data) || !(command_buf))
         {
             return {};
@@ -2016,8 +2020,11 @@ namespace ZEngine::Hardwares
             BufferView ring_view = {};
             ring_view.Handle     = GpuMem.Ring.Buffer;
             ring_view.Allocation = GpuMem.Ring.Allocation;
-            command_buf->CopyBufferToImage(ring_view, image_buf->GetBuffer(), resource->Width, resource->Height, resource->Specification.LayerCount, Specifications::ImageLayoutMap[VALUE_FROM_SPEC_MAP(image_buf->Layout)]);
-            // Return empty view — ring owns lifetime, caller must not free
+            command_buf->CopyBufferToImage(ring_view, image_buf->GetBuffer(), resource->Width, resource->Height, resource->Specification.LayerCount, Specifications::ImageLayoutMap[VALUE_FROM_SPEC_MAP(image_buf->Layout)], ring_offset);
+            // Ring owns lifetime, caller must not free — but must call GpuMem.Ring.Submit
+            // once it knows the timeline value this copy will signal (see out_ring_offset).
+            if (out_ring_offset)
+                *out_ring_offset = ring_offset;
             return {};
         }
 

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.cpp
@@ -1,5 +1,6 @@
 #include <ZEngine/Core/VFS/VFSPath.h>
 #include <ZEngine/Engine.h>
+#include <ZEngine/Hardwares/CommandBufferManager.h>
 #include <ZEngine/Hardwares/VulkanDevice.h>
 #include <ZEngine/Helpers/MemoryOperations.h>
 #include <ZEngine/Helpers/ThreadPool.h>
@@ -750,7 +751,7 @@ namespace ZEngine::Hardwares
         Instance                       = VK_NULL_HANDLE;
     }
 
-    void VulkanDevice::QueueSubmit(CommandBuffer* const command_buffer, Rendering::Primitives::Semaphore* const signal_semaphore, uint32_t wait_flag, uint64_t signal_value, uint64_t wait_value, Rendering::Primitives::Semaphore* const wait_semaphore)
+    bool VulkanDevice::QueueSubmit(CommandBuffer* const command_buffer, Rendering::Primitives::Semaphore* const signal_semaphore, uint32_t wait_flag, uint64_t signal_value, uint64_t wait_value, Rendering::Primitives::Semaphore* const wait_semaphore)
     {
         ZENGINE_VALIDATE_ASSERT(command_buffer->GetState() == CommandBufferState::Executable, "Command buffer must be in executable state to be submitted.")
         ZENGINE_VALIDATE_ASSERT(signal_semaphore->IsTimeline == true, "Signal semaphore must be a timeline semaphore.")
@@ -786,8 +787,12 @@ namespace ZEngine::Hardwares
             .pSignalSemaphores    = semaphores,
         };
 
-        ZENGINE_VALIDATE_ASSERT(vkQueueSubmit(GetQueue(command_buffer->QueueType).Handle, 1, &submit_info, VK_NULL_HANDLE) == VK_SUCCESS, "Failed to submit queue")
+        VkResult submit_result = vkQueueSubmit(GetQueue(command_buffer->QueueType).Handle, 1, &submit_info, VK_NULL_HANDLE);
+        if (CheckDeviceLost(submit_result, "QueueSubmit (timeline)"))
+            return false;
+        ZENGINE_VALIDATE_ASSERT(submit_result == VK_SUCCESS, "Failed to submit queue")
         command_buffer->SetState(CommandBufferState::Pending);
+        return true;
     }
 
     bool VulkanDevice::QueueSubmit(const VkPipelineStageFlags wait_stage_flag, CommandBuffer* command_buffer, Rendering::Primitives::Semaphore* const signal_semaphore, Rendering::Primitives::Fence* const fence)
@@ -820,7 +825,10 @@ namespace ZEngine::Hardwares
             //clang-format on
         };
 
-        ZENGINE_VALIDATE_ASSERT(vkQueueSubmit(GetQueue(command_buffer->QueueType).Handle, 1, &submit_info, fence ? fence->GetHandle() : VK_NULL_HANDLE) == VK_SUCCESS, "Failed to submit queue")
+        VkResult submit_result = vkQueueSubmit(GetQueue(command_buffer->QueueType).Handle, 1, &submit_info, fence ? fence->GetHandle() : VK_NULL_HANDLE);
+        if (CheckDeviceLost(submit_result, "QueueSubmit (fence)"))
+            return false;
+        ZENGINE_VALIDATE_ASSERT(submit_result == VK_SUCCESS, "Failed to submit queue")
         command_buffer->SetState(CommandBufferState::Pending);
 
         if (fence)
@@ -887,6 +895,18 @@ namespace ZEngine::Hardwares
     {
         QueueWait(Rendering::QueueType::TRANSFER_QUEUE);
         QueueWait(Rendering::QueueType::GRAPHIC_QUEUE);
+    }
+
+    bool VulkanDevice::CheckDeviceLost(VkResult result, const char* where)
+    {
+        if (result != VK_ERROR_DEVICE_LOST)
+            return false;
+
+        if (!IsDeviceLost.exchange(true, std::memory_order_acq_rel))
+        {
+            ZENGINE_CORE_CRITICAL("[GPU] VK_ERROR_DEVICE_LOST detected in {} — halting further Vulkan submission", where)
+        }
+        return true;
     }
 
     VKAPI_ATTR VkBool32 VKAPI_CALL VulkanDevice::__debugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageType, const VkDebugUtilsMessengerCallbackDataEXT* pCallbackData, void* pUserData)
@@ -1576,251 +1596,6 @@ namespace ZEngine::Hardwares
 
         ZReleaseScratch(scratch);
     }
-
-    void CommandBufferManager::Initialize(VulkanDevice* device, uint32_t image_count, uint8_t override_thread_count)
-    {
-        if (m_is_initialized)
-        {
-            ZENGINE_CORE_WARN("Attempted to call {}, but it has been already initialized", __FUNCTION__)
-            return;
-        }
-
-        Device                         = device;
-        TotalThreadCount               = override_thread_count > 0 ? override_thread_count : device->WorkerThreadCount;
-        TotalPoolCount                 = image_count * TotalThreadCount;
-        TotalCommandBufferCount        = TotalPoolCount * MaxBufferPerPool;
-        TotalInstantCommandBufferCount = MaxBufferPerPool * MaxBufferPerPool * TotalPoolCount; // We want to have enough instant command buffers for each pool, so we can guarantee that there will always be an instant command buffer available for each pool when needed
-
-        InstantGraphicsPools.init(Device->Arena, TotalPoolCount, TotalPoolCount);
-        InstantGraphicsCommandBuffers.init(Device->Arena, TotalInstantCommandBufferCount, TotalInstantCommandBufferCount);
-        CommandPools.init(Device->Arena, TotalPoolCount, TotalPoolCount);
-        CommandBuffers.init(Device->Arena, TotalCommandBufferCount, TotalCommandBufferCount);
-        EnqueuedCommandBuffers.init(Device->Arena, TotalCommandBufferCount, TotalCommandBufferCount);
-
-        for (uint32_t i = 0; i < TotalPoolCount; ++i)
-        {
-            InstantGraphicsPools[i] = ZPushStructCtorArgs(Device->Arena, Rendering::Pools::CommandPool, Device, QueueType::GRAPHIC_QUEUE);
-
-            for (uint32_t buf_idx = 0; buf_idx < (MaxBufferPerPool * MaxBufferPerPool); ++buf_idx)
-            {
-                uint32_t buffer_idx                       = (i * (MaxBufferPerPool * MaxBufferPerPool)) + buf_idx;
-                InstantGraphicsCommandBuffers[buffer_idx] = ZPushStructCtorArgs(Device->Arena, CommandBuffer, Device, InstantGraphicsPools[i]->Handle, InstantGraphicsPools[i]->QueueType, true);
-            }
-        }
-
-        for (uint32_t i = 0; i < TotalPoolCount; ++i)
-        {
-            CommandPools[i] = ZPushStructCtorArgs(Device->Arena, Rendering::Pools::CommandPool, Device, QueueType::GRAPHIC_QUEUE);
-            for (uint32_t buf_idx = 0; buf_idx < MaxBufferPerPool; ++buf_idx)
-            {
-                uint32_t buffer_idx        = (i * MaxBufferPerPool) + buf_idx;
-                bool     is_primary        = (buffer_idx % 2) == 0;
-                CommandBuffers[buffer_idx] = ZPushStructCtorArgs(Device->Arena, CommandBuffer, Device, CommandPools[i]->Handle, CommandPools[i]->QueueType, is_primary);
-            }
-        }
-
-        if (Device->HasSeperateTransfertQueueFamily)
-        {
-            InstantTransferPools.init(Device->Arena, TotalPoolCount, TotalPoolCount);
-            TransferCommandPools.init(Device->Arena, TotalPoolCount, TotalPoolCount);
-            TransferCommandBuffers.init(Device->Arena, TotalCommandBufferCount, TotalCommandBufferCount);
-            InstantTransferCommandBuffers.init(Device->Arena, TotalInstantCommandBufferCount, TotalInstantCommandBufferCount);
-
-            for (uint32_t i = 0; i < TotalPoolCount; ++i)
-            {
-                InstantTransferPools[i] = ZPushStructCtorArgs(Device->Arena, Rendering::Pools::CommandPool, Device, Rendering::QueueType::TRANSFER_QUEUE);
-                for (uint32_t buf_idx = 0; buf_idx < (MaxBufferPerPool * MaxBufferPerPool); ++buf_idx)
-                {
-                    uint32_t buffer_idx                       = (i * (MaxBufferPerPool * MaxBufferPerPool)) + buf_idx;
-                    InstantTransferCommandBuffers[buffer_idx] = ZPushStructCtorArgs(Device->Arena, CommandBuffer, Device, InstantTransferPools[i]->Handle, InstantTransferPools[i]->QueueType, true);
-                }
-            }
-
-            for (uint32_t i = 0; i < TotalPoolCount; ++i)
-            {
-                TransferCommandPools[i] = ZPushStructCtorArgs(Device->Arena, Rendering::Pools::CommandPool, Device, Rendering::QueueType::TRANSFER_QUEUE);
-                for (uint32_t buf_idx = 0; buf_idx < MaxBufferPerPool; ++buf_idx)
-                {
-                    uint32_t buffer_idx                = (i * MaxBufferPerPool) + buf_idx;
-                    TransferCommandBuffers[buffer_idx] = ZPushStructCtorArgs(Device->Arena, CommandBuffer, Device, TransferCommandPools[i]->Handle, TransferCommandPools[i]->QueueType, true);
-                }
-            }
-        }
-
-        m_is_initialized = true;
-    }
-
-    void CommandBufferManager::Deinitialize()
-    {
-        // Explicitly destroy each CommandPool — vkDestroyCommandPool implicitly frees
-        // all VkCommandBuffers allocated from it.  The Array::clear() that follows only
-        // zeroes the pointer list; it never invokes C++ destructors, so skipping this
-        // step leaks every VkCommandPool and VkCommandBuffer past vkDestroyDevice.
-        for (uint32_t i = 0; i < InstantGraphicsPools.size(); ++i)
-            InstantGraphicsPools[i]->~CommandPool();
-        for (uint32_t i = 0; i < CommandPools.size(); ++i)
-            CommandPools[i]->~CommandPool();
-        for (uint32_t i = 0; i < TransferCommandPools.size(); ++i)
-            TransferCommandPools[i]->~CommandPool();
-        for (uint32_t i = 0; i < InstantTransferPools.size(); ++i)
-            InstantTransferPools[i]->~CommandPool();
-
-        InstantGraphicsPools.clear();
-        InstantGraphicsCommandBuffers.clear();
-        CommandBuffers.clear();
-        TransferCommandBuffers.clear();
-        InstantTransferCommandBuffers.clear();
-        CommandPools.clear();
-        TransferCommandPools.clear();
-        InstantTransferPools.clear();
-        EnqueuedCommandBuffers.clear();
-    }
-
-    CommandBuffer* CommandBufferManager::GetCommandBuffer(Rendering::QueueType type, uint8_t frame_index, uint8_t thread_index, uint8_t buffer_per_pool_index, bool begin)
-    {
-        auto           buffer_index = ((frame_index * TotalThreadCount) + thread_index) * MaxBufferPerPool + buffer_per_pool_index;
-        CommandBuffer* buffer       = (type == Rendering::QueueType::TRANSFER_QUEUE && Device->HasSeperateTransfertQueueFamily) ? TransferCommandBuffers[buffer_index] : CommandBuffers[buffer_index];
-
-        if (begin)
-        {
-            buffer->ResetState();
-            buffer->Begin();
-        }
-        return buffer;
-    }
-
-    CommandBuffer* CommandBufferManager::GetInstantCommandBuffer(Rendering::QueueType type, uint8_t frame_index, uint8_t thread_index, uint32_t buffer_per_pool_index, bool begin)
-    {
-        // MaxBufferPerPool * MaxBufferPerPool is the total number of instant command buffers per pool
-        auto           buffer_index = ((frame_index * TotalThreadCount) + thread_index) * (MaxBufferPerPool * MaxBufferPerPool) + buffer_per_pool_index;
-        CommandBuffer* buffer       = (type == Rendering::QueueType::TRANSFER_QUEUE && Device->HasSeperateTransfertQueueFamily) ? InstantTransferCommandBuffers[buffer_index] : InstantGraphicsCommandBuffers[buffer_index];
-
-        if (begin)
-        {
-            buffer->ResetState();
-            vkResetCommandBuffer(buffer->GetHandle(), VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT);
-            buffer->Begin();
-        }
-        return buffer;
-    }
-
-    Rendering::Pools::CommandPool* CommandBufferManager::GetCommandPool(Rendering::QueueType type, uint8_t frame_index, uint8_t thread_index)
-    {
-        uint32_t pool_index = (frame_index * TotalThreadCount) + thread_index;
-        return (type == QueueType::TRANSFER_QUEUE && Device->HasSeperateTransfertQueueFamily) ? TransferCommandPools[pool_index] : CommandPools[pool_index];
-    }
-
-    Rendering::Pools::CommandPool* CommandBufferManager::GetInstantCommandPool(Rendering::QueueType type, uint8_t frame_index, uint8_t thread_index)
-    {
-        uint32_t pool_index = (frame_index * TotalThreadCount) + thread_index;
-        return (type == QueueType::TRANSFER_QUEUE && Device->HasSeperateTransfertQueueFamily) ? InstantTransferPools[pool_index] : InstantGraphicsPools[pool_index];
-    }
-
-    void CommandBufferManager::ResetPool(uint8_t frame_index, uint8_t thread_index)
-    {
-        uint32_t pool_index = (frame_index * TotalThreadCount) + thread_index;
-        vkResetCommandPool(Device->LogicalDevice, CommandPools[pool_index]->Handle, 0);
-        if (Device->HasSeperateTransfertQueueFamily)
-        {
-            vkResetCommandPool(Device->LogicalDevice, TransferCommandPools[pool_index]->Handle, 0);
-        }
-    }
-
-    void CommandBufferManager::ResetEnqueuedBufferIndex()
-    {
-        for (int i = 0; i < EnqueuedCommandBufferIndex && i < EnqueuedCommandBuffers.size(); ++i)
-        {
-            if (EnqueuedCommandBuffers[i])
-            {
-                EnqueuedCommandBuffers[i]->SetState(CommandBufferState::Pending);
-            }
-        }
-        EnqueuedCommandBufferIndex = 0u;
-    }
-
-    void CommandBufferManager::EndEnqueuedBuffers()
-    {
-        for (int i = 0; i < EnqueuedCommandBufferIndex; ++i)
-        {
-            EnqueuedCommandBuffers[i]->End();
-        }
-    }
-
-    void CommandBufferManager::EnqueueBuffer(CommandBufferPtr const buffer)
-    {
-        if (EnqueuedCommandBufferIndex < EnqueuedCommandBuffers.size())
-        {
-            EnqueuedCommandBuffers[EnqueuedCommandBufferIndex++] = buffer;
-            return;
-        }
-        ZENGINE_CORE_ERROR("[!] Enqueued Command Buffer overflow detected")
-    }
-
-    void CommandBufferManager::IncreaseBuffers()
-    {
-        // TotalPoolCount          = Device->SwapchainImageCount * TotalThreadCount;
-        // TotalCommandBufferCount = TotalPoolCount * MaxBufferPerPool;
-
-        // if (TotalCommandBufferCount > EnqueuedCommandBuffers.size())
-        // {
-        //     auto size = EnqueuedCommandBuffers.size();
-        //     for (uint32_t i = size; i < TotalCommandBufferCount; ++i)
-        //     {
-        //         EnqueuedCommandBuffers.push(nullptr);
-        //     }
-        // }
-
-        // if (TotalPoolCount > CommandPools.size())
-        // {
-        //     auto size = CommandPools.size();
-        //     for (uint32_t i = size; i < TotalCommandBufferCount; ++i)
-        //     {
-        //         CommandPools.push(ZPushStructCtorArgs(Device->Arena, Rendering::Pools::CommandPool, Device, Rendering::QueueType::GRAPHIC_QUEUE));
-        //     }
-        // }
-
-        // if (TotalCommandBufferCount > CommandBuffers.size())
-        // {
-        //     auto size = CommandBuffers.size();
-        //     for (uint32_t i = size; i < TotalCommandBufferCount; ++i)
-        //     {
-        //         int   pool_index = GetPoolFromIndex(Rendering::QueueType::GRAPHIC_QUEUE, i);
-        //         auto& pool       = CommandPools[pool_index];
-        //         CommandBuffers.push(ZPushStructCtorArgs(
-        //             Device->Arena,
-        //             CommandBuffer,
-        //             Device,
-        //             pool->Handle,
-        //             pool->QueueType,
-        //             /*(i % MaxBufferPerPool) == 0 ? false : true */ false));
-        //     }
-        // }
-
-        // if (Device->HasSeperateTransfertQueueFamily)
-        // {
-        //     auto size = TransferCommandPools.size();
-        //     for (uint32_t i = size; i < TotalCommandBufferCount; ++i)
-        //     {
-        //         TransferCommandPools.push(ZPushStructCtorArgs(Device->Arena, Rendering::Pools::CommandPool, Device, Rendering::QueueType::TRANSFER_QUEUE));
-        //     }
-
-        //     size = TransferCommandBuffers.size();
-        //     for (uint32_t i = size; i < TotalCommandBufferCount; ++i)
-        //     {
-        //         int   pool_index = GetPoolFromIndex(Rendering::QueueType::TRANSFER_QUEUE, i);
-        //         auto& pool       = TransferCommandPools[pool_index];
-        //         TransferCommandBuffers.push(ZPushStructCtorArgs(Device->Arena, CommandBuffer, Device, pool->Handle, pool->QueueType, true));
-        //     }
-        // }
-    }
-
-    bool CommandBufferManager::IsInitialized() const
-    {
-        return m_is_initialized;
-    }
-
-
-
 
     void ImageBuffer::Construct(Hardwares::VulkanDevice* device)
     {

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.h
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.h
@@ -4,6 +4,7 @@
 #include <ZEngine/Core/Containers/SPSCQueue.h>
 #include <ZEngine/Core/Memory/GpuAllocator.h>
 #include <ZEngine/Rendering/RenderHandle.h>
+#include <ZEngine/Hardwares/CommandBufferManager.h>
 #include <ZEngine/Hardwares/DeferredFreeQueue.h>
 #include <ZEngine/Hardwares/DeviceSwapchain.h>
 #include <ZEngine/Hardwares/PerFrameUploadHeap.h>
@@ -27,6 +28,7 @@
 #include <unordered_set>
 #include <limits>
 #include <cstdint>
+#include <atomic>
 // clang-format on
 
 namespace ZEngine::Windows
@@ -57,7 +59,6 @@ namespace ZEngine::Hardwares
     using Core::Memory::GpuMemoryDomain;
 
     struct WriteDescriptorSetRequestKey;
-    struct CommandBufferManager;
     struct AsyncGPUOperation;
     struct AsyncGPUOperationHandle;
     /*
@@ -181,47 +182,6 @@ namespace ZEngine::Hardwares
 
     ZDEFINE_PTR(CommandBuffer);
 
-    struct CommandBufferManager
-    {
-        struct InstantCommandBufferInfo;
-
-        void                                                            Initialize(VulkanDevice* device, uint32_t image_count = 0, uint8_t override_thread_count = 0);
-        void                                                            Deinitialize();
-        CommandBuffer*                                                  GetCommandBuffer(Rendering::QueueType type, uint8_t frame_index, uint8_t thread_index, uint8_t buffer_per_pool_index, bool begin = true);
-        CommandBuffer*                                                  GetInstantCommandBuffer(Rendering::QueueType type, uint8_t frame_index, uint8_t thread_index, uint32_t buffer_per_pool_index, bool begin = true);
-        Rendering::Pools::CommandPool*                                  GetCommandPool(Rendering::QueueType type, uint8_t frame_index, uint8_t thread_index);
-        Rendering::Pools::CommandPool*                                  GetInstantCommandPool(Rendering::QueueType type, uint8_t frame_index, uint8_t thread_index);
-        void                                                            ResetPool(uint8_t frame_index, uint8_t thread_index);
-        void                                                            IncreaseBuffers();
-        void                                                            EnqueueBuffer(CommandBufferPtr const buffer);
-        void                                                            EndEnqueuedBuffers();
-        void                                                            ResetEnqueuedBufferIndex();
-        bool                                                            IsInitialized() const;
-
-        uint32_t                                                        TotalCommandBufferCount        = 0;
-        uint32_t                                                        TotalInstantCommandBufferCount = 0;
-        uint32_t                                                        TotalPoolCount                 = 0;
-        uint32_t                                                        TotalThreadCount               = 0;
-        uint32_t                                                        EnqueuedCommandBufferIndex     = 0;
-        const uint32_t                                                  MaxBufferPerPool               = 4;
-        VulkanDevice*                                                   Device                         = nullptr;
-
-        Core::Containers::Array<Rendering::Pools::CommandPool*>         InstantGraphicsPools           = {};
-        Core::Containers::Array<Rendering::Pools::CommandPool*>         InstantTransferPools           = {};
-        Core::Containers::Array<CommandBuffer*>                         InstantGraphicsCommandBuffers  = {};
-        Core::Containers::Array<CommandBuffer*>                         InstantTransferCommandBuffers  = {};
-
-        Core::Containers::Array<ZRawPtr(Rendering::Pools::CommandPool)> CommandPools                   = {};
-        Core::Containers::Array<ZRawPtr(Rendering::Pools::CommandPool)> TransferCommandPools           = {};
-        Core::Containers::Array<ZRawPtr(CommandBuffer)>                 CommandBuffers                 = {};
-        Core::Containers::Array<ZRawPtr(CommandBuffer)>                 TransferCommandBuffers         = {};
-        Core::Containers::Array<CommandBuffer*>                         EnqueuedCommandBuffers         = {};
-
-    private:
-        bool m_is_initialized = false;
-    };
-    ZDEFINE_PTR(CommandBufferManager);
-
     struct WriteDescriptorSetRequestKey
     {
         uint32_t        Binding = 0;
@@ -262,6 +222,11 @@ namespace ZEngine::Hardwares
         bool                                                                                                                         PhysicalDeviceSupportSampledImageBindless   = false;
         bool                                                                                                                         PhysicalDeviceSupportStorageBufferBindless  = false;
         bool                                                                                                                         PhysicalDeviceSupportTimelineSemaphore      = false;
+        // Sticky, set once VK_ERROR_DEVICE_LOST is observed on any queue/swapchain call —
+        // see CheckDeviceLost. The render loop checks this and stops issuing further Vulkan
+        // calls: once a device is lost, continuing to call into it is undefined behaviour and
+        // has been observed to segfault inside the Vulkan loader rather than return cleanly.
+        std::atomic_bool                                                                                                             IsDeviceLost                                = false;
         const char*                                                                                                                  ApplicationName                             = "Tetragrama";
         const char*                                                                                                                  EngineName                                  = "ZEngine";
         uint32_t                                                                                                                     WorkerThreadCount                           = 1;
@@ -315,8 +280,13 @@ namespace ZEngine::Hardwares
         void                                                                                                                         Initialize(ZEngine::Core::Memory::ArenaAllocator* arena, Windows::CoreWindow* const window, uint32_t worker_thread_count);
         void                                                                                                                         Deinitialize();
         void                                                                                                                         Dispose();
-        void                                                                                                                         QueueSubmit(CommandBuffer* const command_buffer, Rendering::Primitives::Semaphore* const signal_semaphore, uint32_t wait_flag, uint64_t signal_value, uint64_t wait_value, Rendering::Primitives::Semaphore* const wait_timeline);
+        bool                                                                                                                         QueueSubmit(CommandBuffer* const command_buffer, Rendering::Primitives::Semaphore* const signal_semaphore, uint32_t wait_flag, uint64_t signal_value, uint64_t wait_value, Rendering::Primitives::Semaphore* const wait_timeline);
         bool                                                                                                                         QueueSubmit(const VkPipelineStageFlags wait_stage_flag, CommandBuffer* const command_buffer, Rendering::Primitives::Semaphore* const signal_semaphore = nullptr, Rendering::Primitives::Fence* const fence = nullptr);
+        /// @brief If result is VK_ERROR_DEVICE_LOST, sets IsDeviceLost (logging once, on the
+        ///        first caller to observe it) and returns true so the caller can bail out
+        ///        instead of asserting or continuing to submit to a dead device.
+        /// @param where Short description of the call site, for the one-time log line.
+        bool                                                                                                                         CheckDeviceLost(VkResult result, const char* where);
         void                                                                                                                         EnqueueAsyncGPUOperation(const AsyncGPUOperationHandle& handle);
         QueueView                                                                                                                    GetQueue(Rendering::QueueType type);
         void                                                                                                                         QueueWait(Rendering::QueueType type);

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.h
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.h
@@ -161,7 +161,7 @@ namespace ZEngine::Hardwares
         void                              DrawIndexed(uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance);
         void                              Draw(uint32_t vertex_count, uint32_t instance_count, uint32_t first_index, uint32_t first_instance);
         void                              TransitionImageLayout(const Rendering::Primitives::ImageMemoryBarrier& image_barrier);
-        void                              CopyBufferToImage(const Hardwares::BufferView& source, Hardwares::BufferImage& destination, uint32_t width, uint32_t height, uint32_t layer_count, VkImageLayout new_layout);
+        void                              CopyBufferToImage(const Hardwares::BufferView& source, Hardwares::BufferImage& destination, uint32_t width, uint32_t height, uint32_t layer_count, VkImageLayout new_layout, uint32_t source_offset = 0);
         void                              BindVertexBuffer(const Core::Memory::BufferView& buffer);
         void                              BindIndexBuffer(const Core::Memory::BufferView& buffer, VkIndexType type);
         void                              SetScissor(uint32_t w, uint32_t h, int32_t x = 0, int32_t y = 0);
@@ -348,7 +348,15 @@ namespace ZEngine::Hardwares
         /// @brief Timeline-gated disposal. Render-thread only.
         void                                            DestroyTexture(const Rendering::Textures::TextureHandle& handle);
 
-        BufferView                                      WriteTextureData(CommandBufferPtr command_buf, const Rendering::Textures::TextureHandle& handle, const void* data);
+        /// @brief Copies data into the texture's backing image via the ring buffer when it
+        ///        fits, else a one-shot staging buffer (returned so the caller can free it
+        ///        once the copy's GPU work retires).
+        /// @param out_ring_offset When non-null, set to the ring's byte offset if the ring
+        ///        path was used (UINT32_MAX otherwise) — the caller must then call
+        ///        GpuMem.Ring.Submit(offset, size, signal_value) once it knows the timeline
+        ///        value the enqueued copy will signal, or this region is never marked safe
+        ///        to reclaim and a later allocation can overwrite it before the GPU reads it.
+        BufferView                                      WriteTextureData(CommandBufferPtr command_buf, const Rendering::Textures::TextureHandle& handle, const void* data, uint32_t* out_ring_offset = nullptr);
 
         Rendering::Renderers::RenderPasses::RenderPass* CreateRenderPass(Rendering::Specifications::RenderPassSpecification spec);
 

--- a/ZEngine/ZEngine/Helpers/ThreadPool.h
+++ b/ZEngine/ZEngine/Helpers/ThreadPool.h
@@ -102,14 +102,6 @@ namespace ZEngine::Helpers
             task();
         }
 
-        /// @brief Register a per-worker init callback.
-        ///        Called exactly once per worker at the start of its task loop.
-        ///        If called after workers have started (the typical case — RRM
-        ///        initialises after the pool is constructed), all idle workers
-        ///        are woken via notify_one so they pick up the callback immediately.
-        ///        The callback runs before any queued tasks on each worker thread.
-        /// @param fn  Callback — fn(ctx, worker_idx). Must be thread-safe.
-        /// @param ctx Caller context forwarded to fn.
         void InitClosureSlab(Core::Memory::ArenaAllocator* arena, size_t bytes)
         {
             m_closure_slab.Init(arena, bytes);
@@ -120,6 +112,13 @@ namespace ZEngine::Helpers
             return m_closure_slab.Pool ? &m_closure_slab : nullptr;
         }
 
+        /// @brief Register a per-worker init callback.
+        ///        Each worker runs this at most once, the next time it reaches the top
+        ///        of its loop — whether that's before its first task (registered early)
+        ///        or after being woken by notify_one below (the typical case — RRM
+        ///        initialises after the pool is already running).
+        /// @param fn  Callback — fn(ctx, worker_idx). Must be thread-safe.
+        /// @param ctx Caller context forwarded to fn.
         void RegisterWorkerInit(WorkerInitFn fn, void* ctx)
         {
             m_init_ctx.value.store(ctx, std::memory_order_relaxed);
@@ -157,15 +156,28 @@ namespace ZEngine::Helpers
 
         void                       WorkerRun(size_t idx)
         {
-            // Call per-worker init callback if registered (e.g. set t_worker_slab).
-            // Runs before the first task — guaranteed by RegisterWorkerInit waking the worker.
-            WorkerInitFn init = m_init_fn.value.load(std::memory_order_acquire);
-            if (init)
-                init(m_init_ctx.value.load(std::memory_order_relaxed), idx);
+            // Re-checked every time this worker reaches the top of its loop, not just
+            // once before entering it — RegisterWorkerInit is normally called after the
+            // pool's workers are already running and idle-waiting in cv.wait below;
+            // notify_one wakes the wait but does NOT resume execution back at a one-time
+            // pre-loop check, so a "run once before the loop" version of this never
+            // actually ran the callback on any real worker. last_init dedupes so a plain
+            // task-arrival wake (no new registration) doesn't re-run the same callback.
+            WorkerInitFn last_init       = nullptr;
+            auto         run_init_if_new = [&] {
+                WorkerInitFn init = m_init_fn.value.load(std::memory_order_acquire);
+                if (init && init != last_init)
+                {
+                    init(m_init_ctx.value.load(std::memory_order_relaxed), idx);
+                    last_init = init;
+                }
+            };
 
             Worker& w = m_workers[idx];
             while (!m_cancellation.value.load(std::memory_order_acquire))
             {
+                run_init_if_new();
+
                 Task task;
                 while (w.queue.pop(task))
                     task();

--- a/ZEngine/ZEngine/Importers/TextureImporter.cpp
+++ b/ZEngine/ZEngine/Importers/TextureImporter.cpp
@@ -24,9 +24,14 @@ namespace ZEngine::Importers
     {
         (void) ctx;
 
-        // Resolve to native path — stbi_info works on the filesystem, not the VFS.
-        char native[MAX_FILE_PATH_COUNT] = {};
-        path.ToNative(native, sizeof(native));
+        // path is workspace-relative — ToNative alone only swaps separators and would
+        // leave the workspace root missing, so resolve it like every other importer.
+        char        native[MAX_FILE_PATH_COUNT] = {};
+        const char* working_space               = Managers::AssetManager::Instance() ? Managers::AssetManager::Instance()->CurrentWorkingSpacePath : "";
+        if (working_space && working_space[0] != '\0')
+            path.ResolveNative(working_space, native, sizeof(native));
+        else
+            path.ToNative(native, sizeof(native));
 
         int w = 0, h = 0, ch = 0;
         if (!stbi_info(native, &w, &h, &ch))

--- a/ZEngine/ZEngine/Managers/AssetManager.cpp
+++ b/ZEngine/ZEngine/Managers/AssetManager.cpp
@@ -263,7 +263,7 @@ namespace ZEngine::Managers
             char full_path[MAX_FILE_PATH_COUNT] = {};
             snprintf(full_path, sizeof(full_path), "%s%c%s", s_Instance->CurrentWorkingSpacePath, PLATFORM_OS_BACKSLASH, new_tex.Path.c_str());
             auto* rrm      = static_cast<Rendering::RenderResourceManager*>(s_Instance->Device->RRM);
-            new_tex.Handle = rrm->SubmitTextureFile(0, 0, full_path);
+            new_tex.Handle = rrm->SubmitTextureFile(full_path);
             if (!new_tex.Handle.Valid())
             {
                 ZENGINE_VALIDATE_ASSERT(s_Instance->FallbackTextureHandle.Valid(), "FallbackTextureHandle not initialized — InitFallbackTexture must be called before ingesting assets")

--- a/ZEngine/ZEngine/Managers/AssetManager.cpp
+++ b/ZEngine/ZEngine/Managers/AssetManager.cpp
@@ -60,7 +60,16 @@ namespace ZEngine::Managers
 
         static Core::VFS::AssetRegistry s_registry;
         s_registry.Initialize(s_Instance->Arena);
-        s_Instance->Registry = &s_registry;
+        s_Instance->Registry                  = &s_registry;
+
+        // Reserve slot 0 as an intentional fallback material: AppRenderPipeline defaults
+        // an unresolved submesh to index 0, so without this it would silently alias
+        // whichever real material happens to be ingested first.
+        Importers::AssetMaterial fallback_mat = {};
+        s_Instance->Materials.push(fallback_mat);
+        Rendering::Meshes::MeshMaterial fallback_gpu = {};
+        fallback_gpu.AlbedoColor                     = Rendering::gpuvec4(1.0f, 0.078f, 0.576f, 1.0f); // matches FallbackTextureHandle's (255, 20, 147)
+        s_Instance->GPUMeshMaterials.push(fallback_gpu);
     }
 
     void AssetManager::InitFallbackTexture()
@@ -315,6 +324,27 @@ namespace ZEngine::Managers
         gpu_mat.NormalMap                        = ResolveTextureMapIndex(mat.NormalTexUUID, mat.NormalTexPath);
         gpu_mat.OpacityMap                       = ResolveTextureMapIndex(mat.OpacityTexUUID, mat.OpacityTexPath);
         gpu_mat.SpecularMap                      = ResolveTextureMapIndex(mat.SpecularTexUUID, mat.SpecularTexPath);
+    }
+
+    void AssetManager::IngestMaterialFromUUID(Core::Memory::ArenaAllocator* scratch, const uuids::uuid& material_uuid)
+    {
+        if (!s_Instance || !s_Instance->Registry || !scratch || material_uuid.is_nil())
+            return;
+        // Same dedup key IngestMaterial uses — no-op if already ingested.
+        if (s_Instance->UUIDToMaterialSlot.find(material_uuid) != nullptr)
+            return;
+
+        auto* rec = s_Instance->Registry->FindByUUID(material_uuid);
+        if (!rec)
+            return;
+
+        char native[MAX_FILE_PATH_COUNT] = {};
+        rec->Path.ResolveNative(s_Instance->CurrentWorkingSpacePath, native, sizeof(native));
+
+        Importers::AssetMaterial mat = {};
+        Importers::AssetCodec::DeserializeMaterialAssetFile(scratch, native, mat);
+        if (!mat.MaterialUUID.is_nil())
+            IngestMaterial(std::move(mat)); // transitively ingests each referenced texture map
     }
 
     uint32_t AssetManager::ResolveTextureMapIndex(const uuids::uuid& id, const Core::Containers::String& path)

--- a/ZEngine/ZEngine/Managers/AssetManager.h
+++ b/ZEngine/ZEngine/Managers/AssetManager.h
@@ -88,6 +88,11 @@ namespace ZEngine::Managers
         static void                                                                         IngestTextures(Core::Containers::Array<Importers::AssetTexture>&& textures);
         static void                                                                         IngestMaterial(Importers::AssetMaterial&& material);
 
+        /// @brief Single-UUID counterpart to ReloadFromDisk's material block — resolves,
+        ///        deserializes, and ingests one material (and its textures) by UUID.
+        ///        No-op if uuid is nil, unregistered, or already ingested.
+        static void                                                                         IngestMaterialFromUUID(Core::Memory::ArenaAllocator* scratch, const uuids::uuid& material_uuid);
+
         /// @brief Thread-safe lookup of a texture's current handle by UUID.
         static Rendering::Textures::TextureHandle                                           FindTextureHandle(const uuids::uuid& uuid);
 
@@ -160,7 +165,9 @@ namespace ZEngine::Managers
         if (!Instance()->Registry)
             return nullptr;
         const auto* rec = Instance()->Registry->FindByUUID(id);
-        if (!rec)
+        // VFSScanner pre-registers every .zematerial UUID with SlotHandle=0 before any
+        // ingest happens — IsLoaded() tells a real ingest apart from that placeholder.
+        if (!rec || !rec->IsLoaded())
             return nullptr;
         return GetAsset<Importers::AssetMaterial, AssetHandle>(rec->SlotHandle);
     }

--- a/ZEngine/ZEngine/Rendering/Pools/CommandPool.h
+++ b/ZEngine/ZEngine/Rendering/Pools/CommandPool.h
@@ -11,7 +11,7 @@ namespace ZEngine::Hardwares
 
 namespace ZEngine::Rendering::Pools
 {
-    struct CommandPool : public Helpers::RefCounted
+    struct CommandPool
     {
         Hardwares::VulkanDevice* Device = nullptr;
 

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
@@ -128,7 +128,7 @@ namespace ZEngine::Rendering
         m_batch_timeline     = ZPushStructCtorArgs(m_device->Arena, Rendering::Primitives::Semaphore, m_device, true);
         m_batch_frames.init(m_device->Arena, frame_count, frame_count);
         for (uint32_t i = 0; i < frame_count; ++i)
-            m_batch_frames[i] = {};
+            m_batch_frames[i] = BatchFrameState{};
 
         // RenderThread-only, single thread slot — cycles through BufferedFrameCount distinct
         // command buffers instead of resetting and resubmitting the same one every call (see

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
@@ -34,6 +34,7 @@
 #include <stb/stb_image_write.h>
 #include <cstring>
 #include <filesystem>
+#include <limits>
 #include <set>
 
 using namespace ZEngine::Core::Memory;
@@ -912,22 +913,29 @@ namespace ZEngine::Rendering
             to_transfer.SourceQueueFamily                = m_device->TransferFamilyIndex;
             to_transfer.DestinationQueueFamily           = m_device->TransferFamilyIndex;
             transfer_cmd->TransitionImageLayout(ImageMemoryBarrier{to_transfer});
-            img_buf->Layout                                  = to_transfer.NewLayout;
+            img_buf->Layout             = to_transfer.NewLayout;
 
-            BufferView                      transfer_staging = m_device->WriteTextureData(transfer_cmd, handle, data);
+            uint32_t   ring_offset      = 0;
+            BufferView transfer_staging = m_device->WriteTextureData(transfer_cmd, handle, data, &ring_offset);
+            // Ring chunks retire against RenderTimeline (see VulkanDevice::TickMemory),
+            // not m_tex_transfer_timelines — the frame's own submission is on the same
+            // queue, after this one, so it's a safe (if slightly conservative) proxy for
+            // "the transfer copy has definitely finished reading the ring by then".
+            if (ring_offset != std::numeric_limits<uint32_t>::max())
+                m_device->GpuMem.Ring.Submit(ring_offset, static_cast<uint32_t>(texture->BufferSize), m_device->SwapchainPtr->RenderTimelineNextValue);
 
-            ImageMemoryBarrierSpecification release          = {};
-            release.ImageHandle                              = buffer_handle;
-            release.OldLayout                                = ImageLayout::TRANSFER_DST_OPTIMAL;
-            release.NewLayout                                = (img_buf_aspect & VK_IMAGE_ASPECT_DEPTH_BIT) ? ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL : ImageLayout::SHADER_READ_ONLY_OPTIMAL;
-            release.ImageAspectMask                          = VkImageAspectFlagBits(img_buf_aspect);
-            release.SourceAccessMask                         = VK_ACCESS_TRANSFER_WRITE_BIT;
-            release.DestinationAccessMask                    = VK_ACCESS_NONE;
-            release.SourceStageMask                          = VK_PIPELINE_STAGE_TRANSFER_BIT;
-            release.DestinationStageMask                     = (img_buf_aspect & VK_IMAGE_ASPECT_DEPTH_BIT) ? VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT : VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-            release.LayerCount                               = texture->Specification.LayerCount;
-            release.SourceQueueFamily                        = m_device->TransferFamilyIndex;
-            release.DestinationQueueFamily                   = m_device->GraphicFamilyIndex;
+            ImageMemoryBarrierSpecification release = {};
+            release.ImageHandle                     = buffer_handle;
+            release.OldLayout                       = ImageLayout::TRANSFER_DST_OPTIMAL;
+            release.NewLayout                       = (img_buf_aspect & VK_IMAGE_ASPECT_DEPTH_BIT) ? ImageLayout::DEPTH_STENCIL_ATTACHMENT_OPTIMAL : ImageLayout::SHADER_READ_ONLY_OPTIMAL;
+            release.ImageAspectMask                 = VkImageAspectFlagBits(img_buf_aspect);
+            release.SourceAccessMask                = VK_ACCESS_TRANSFER_WRITE_BIT;
+            release.DestinationAccessMask           = VK_ACCESS_NONE;
+            release.SourceStageMask                 = VK_PIPELINE_STAGE_TRANSFER_BIT;
+            release.DestinationStageMask            = (img_buf_aspect & VK_IMAGE_ASPECT_DEPTH_BIT) ? VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT : VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+            release.LayerCount                      = texture->Specification.LayerCount;
+            release.SourceQueueFamily               = m_device->TransferFamilyIndex;
+            release.DestinationQueueFamily          = m_device->GraphicFamilyIndex;
             transfer_cmd->TransitionImageLayout(ImageMemoryBarrier{release});
             img_buf->Layout = release.NewLayout;
             transfer_cmd->End();
@@ -988,9 +996,14 @@ namespace ZEngine::Rendering
             to_transfer.SourceQueueFamily               = m_device->GraphicFamilyIndex;
             to_transfer.DestinationQueueFamily          = m_device->GraphicFamilyIndex;
             cmd->TransitionImageLayout(ImageMemoryBarrier{to_transfer});
-            img_buf->Layout                          = to_transfer.NewLayout;
+            img_buf->Layout        = to_transfer.NewLayout;
 
-            BufferView                      staging  = m_device->WriteTextureData(cmd, handle, data);
+            uint32_t   ring_offset = 0;
+            BufferView staging     = m_device->WriteTextureData(cmd, handle, data, &ring_offset);
+            // See the separate-transfer-queue branch above for why RenderTimelineNextValue
+            // (not signal_value/m_tex_timelines) is the correct retirement marker here.
+            if (ring_offset != std::numeric_limits<uint32_t>::max())
+                m_device->GpuMem.Ring.Submit(ring_offset, static_cast<uint32_t>(texture->BufferSize), m_device->SwapchainPtr->RenderTimelineNextValue);
 
             ImageMemoryBarrierSpecification to_final = {};
             to_final.ImageHandle                     = buffer_handle;
@@ -1067,8 +1080,9 @@ namespace ZEngine::Rendering
         vkResetCommandBuffer(cmd->GetHandle(), 0);
         cmd->Begin();
         cmd->TransitionImageLayout(ImageMemoryBarrier{to_transfer});
-        img_buf->Layout    = to_transfer.NewLayout;
-        BufferView staging = m_device->WriteTextureData(cmd, handle, pixels);
+        img_buf->Layout        = to_transfer.NewLayout;
+        uint32_t   ring_offset = 0;
+        BufferView staging     = m_device->WriteTextureData(cmd, handle, pixels, &ring_offset);
         cmd->TransitionImageLayout(ImageMemoryBarrier{to_final});
         img_buf->Layout = to_final.NewLayout;
         cmd->End();
@@ -1084,6 +1098,11 @@ namespace ZEngine::Rendering
         vkQueueSubmit(gfx_queue, 1, &submit, m_upload_fence);
         vkWaitForFences(m_device->LogicalDevice, 1, &m_upload_fence, VK_TRUE, UINT64_MAX);
         cmd->ResetState();
+
+        // Fence wait above already blocked until the GPU finished reading the ring, so
+        // this chunk is retroactively safe — 0 always satisfies Drain's <= completed_value.
+        if (ring_offset != std::numeric_limits<uint32_t>::max())
+            m_device->GpuMem.Ring.Submit(ring_offset, static_cast<uint32_t>(texture->BufferSize), 0);
 
         if (staging)
             m_device->GpuMem.FreeBuffer(staging);
@@ -1455,7 +1474,6 @@ namespace ZEngine::Rendering
                 pixels = static_cast<uint8_t*>(slab->Alloc(bytes));
                 Helpers::secure_memmove(pixels, bytes, buffer.data(), bytes);
             }
-
             TextureDeferral deferral;
             deferral.Pixels    = pixels;
             deferral.ByteSize  = bytes;

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
@@ -120,19 +120,24 @@ namespace ZEngine::Rendering
 
     void RenderResourceManager::InitUploadPool()
     {
-        // Create fences pre-signaled so vkWaitForFences before the first submit returns immediately.
-        VkFenceCreateInfo fence_ci{VK_STRUCTURE_TYPE_FENCE_CREATE_INFO, nullptr, VK_FENCE_CREATE_SIGNALED_BIT};
+        // Pre-signaled so the first Wait() before a submit returns immediately.
+        uint32_t frame_count = m_device->SwapchainPtr->BufferredFrameCount;
+        m_sync_upload_fence  = ZPushStructCtorArgs(m_device->Arena, Rendering::Primitives::Fence, m_device, true);
 
-        m_upload_pool = ZPushStructCtorArgs(m_device->Arena, Rendering::Pools::CommandPool, m_device, QueueType::GRAPHIC_QUEUE);
-        m_upload_cmd  = ZPushStructCtorArgs(m_device->Arena, CommandBuffer, m_device, m_upload_pool->Handle, QueueType::GRAPHIC_QUEUE, true);
-        vkCreateFence(m_device->LogicalDevice, &fence_ci, nullptr, &m_upload_fence);
+        // LastSignal == 0 means "never used yet" for a given frame index.
+        m_batch_timeline     = ZPushStructCtorArgs(m_device->Arena, Rendering::Primitives::Semaphore, m_device, true);
+        m_batch_frames.init(m_device->Arena, frame_count, frame_count);
+        for (uint32_t i = 0; i < frame_count; ++i)
+            m_batch_frames[i] = {};
 
-        if (m_device->HasSeperateTransfertQueueFamily)
-        {
-            m_transfer_pool = ZPushStructCtorArgs(m_device->Arena, Rendering::Pools::CommandPool, m_device, QueueType::TRANSFER_QUEUE);
-            m_transfer_cmd  = ZPushStructCtorArgs(m_device->Arena, CommandBuffer, m_device, m_transfer_pool->Handle, QueueType::TRANSFER_QUEUE, true);
-            vkCreateFence(m_device->LogicalDevice, &fence_ci, nullptr, &m_transfer_fence);
-        }
+        // RenderThread-only, single thread slot — cycles through BufferedFrameCount distinct
+        // command buffers instead of resetting and resubmitting the same one every call (see
+        // issue #764 follow-up: reusing a single command buffer across many upload cycles was
+        // suspected as a factor in an otherwise-unexplained GPU stall).
+        m_upload_cmd_mgr = ZPushStructCtor(m_device->Arena, CommandBufferManager);
+        m_upload_cmd_mgr->Initialize(m_device, m_device->SwapchainPtr->BufferredFrameCount, 1);
+
+        m_async_uploads.Initialize(m_device);
     }
 
     void RenderResourceManager::Shutdown()
@@ -151,38 +156,23 @@ namespace ZEngine::Rendering
             m_upload_slabs[i].Shutdown();
         m_upload_slab_count = 0;
 
-        // Free command buffers before destroying their parent pools, then destroy pools.
         // Arena-allocated objects have no automatic destructor — explicit calls are required.
-        if (m_upload_cmd)
+        if (m_upload_cmd_mgr)
         {
-            m_upload_cmd->Free();
-            m_upload_cmd = nullptr;
+            m_upload_cmd_mgr->Deinitialize();
+            m_upload_cmd_mgr = nullptr;
         }
-        if (m_upload_pool)
+        m_async_uploads.Deinitialize();
+        if (m_sync_upload_fence)
         {
-            m_upload_pool->~CommandPool();
-            m_upload_pool = nullptr;
+            m_sync_upload_fence->~Fence();
+            m_sync_upload_fence = nullptr;
         }
-        if (m_transfer_cmd)
+        if (m_batch_timeline)
         {
-            m_transfer_cmd->Free();
-            m_transfer_cmd = nullptr;
+            m_batch_timeline->~Semaphore();
+            m_batch_timeline = nullptr;
         }
-        if (m_transfer_pool)
-        {
-            m_transfer_pool->~CommandPool();
-            m_transfer_pool = nullptr;
-        }
-
-        auto destroy_fence = [&](VkFence& fence) {
-            if (fence != VK_NULL_HANDLE)
-            {
-                vkDestroyFence(m_device->LogicalDevice, fence, nullptr);
-                fence = VK_NULL_HANDLE;
-            }
-        };
-        destroy_fence(m_upload_fence);
-        destroy_fence(m_transfer_fence);
 
         // Free all live buffer slots
         if (m_global_vertex_buf)
@@ -202,15 +192,18 @@ namespace ZEngine::Rendering
 
     void RenderResourceManager::BeginFrame(uint32_t frame_index)
     {
+        m_active_frame_index = static_cast<uint8_t>(frame_index);
+        RetireBatchStagings();
         FlushPendingUploads(frame_index);
         FlushPendingSwaps(frame_index);
         FlushPendingTextureReloads();
         FlushPendingTextureReleases();
     }
 
-    void RenderResourceManager::EndFrame(uint32_t frame_index)
+    void RenderResourceManager::EndFrame()
     {
-        m_current_frame = frame_index + 1;
+        if (m_batch_mode)
+            EndBatchUpload();
     }
 
     void RenderResourceManager::FlushPendingSwaps(uint32_t frame_index)
@@ -227,6 +220,9 @@ namespace ZEngine::Rendering
         {
             return;
         }
+
+        // Idempotent — no-op if FlushPendingUploads already opened the batch this frame.
+        EnsureBatchOpen(static_cast<uint8_t>(frame_index));
 
         for (uint32_t i = 0; i < count; ++i)
         {
@@ -255,12 +251,96 @@ namespace ZEngine::Rendering
         }
     }
 
-    static void RecordAndSubmit(VkDevice device, CommandBuffer* cmd, VkFence fence, VkQueue queue, std::function<void(VkCommandBuffer)> record_fn, VkSemaphore wait_semaphore = VK_NULL_HANDLE, uint64_t wait_value = 0)
+    // Contexts + C-style record callbacks for RecordAndSubmit (no std::function — matches the
+    // rest of the engine's zero-heap-alloc convention for hot-path callbacks, see ThreadPool's
+    // TaskFn).
+    struct GlobalBufferCopyCtx
+    {
+        VkBuffer     SrcBuffer;
+        VkBuffer     DstBuffer;
+        VkDeviceSize DstOffset;
+        size_t       ByteSize;
+    };
+
+    static void RecordGlobalBufferCopy(VkCommandBuffer cmd, void* ctx_ptr)
+    {
+        auto*        ctx = static_cast<GlobalBufferCopyCtx*>(ctx_ptr);
+        VkBufferCopy region{.srcOffset = 0, .dstOffset = ctx->DstOffset, .size = ctx->ByteSize};
+        vkCmdCopyBuffer(cmd, ctx->SrcBuffer, ctx->DstBuffer, 1, &region);
+
+        VkBufferMemoryBarrier barrier{VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER};
+        barrier.srcAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
+        barrier.dstAccessMask       = VK_ACCESS_SHADER_READ_BIT;
+        barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barrier.buffer              = ctx->DstBuffer;
+        barrier.offset              = ctx->DstOffset;
+        barrier.size                = ctx->ByteSize;
+        vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, nullptr, 1, &barrier, 0, nullptr);
+    }
+
+    struct RingCopyCtx
+    {
+        VkBuffer     SrcBuffer;
+        VkBuffer     DstBuffer;
+        uint32_t     RingOffset;
+        VkDeviceSize DstOffset;
+        size_t       ByteSize;
+    };
+
+    static void RecordRingCopy(VkCommandBuffer cmd, void* ctx_ptr)
+    {
+        auto*        ctx = static_cast<RingCopyCtx*>(ctx_ptr);
+        VkBufferCopy region{.srcOffset = ctx->RingOffset, .dstOffset = ctx->DstOffset, .size = ctx->ByteSize};
+        vkCmdCopyBuffer(cmd, ctx->SrcBuffer, ctx->DstBuffer, 1, &region);
+
+        VkBufferMemoryBarrier barrier{VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER};
+        barrier.srcAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
+        barrier.dstAccessMask       = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT | VK_ACCESS_INDEX_READ_BIT;
+        barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barrier.buffer              = ctx->DstBuffer;
+        barrier.offset              = ctx->DstOffset;
+        barrier.size                = ctx->ByteSize;
+        vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_VERTEX_INPUT_BIT | VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, nullptr, 1, &barrier, 0, nullptr);
+    }
+
+    struct StagingCopyCtx
+    {
+        VkBuffer     SrcBuffer;
+        VkBuffer     DstBuffer;
+        VkDeviceSize DstOffset;
+        size_t       ByteSize;
+    };
+
+    static void RecordStagingCopy(VkCommandBuffer cmd, void* ctx_ptr)
+    {
+        auto*        ctx = static_cast<StagingCopyCtx*>(ctx_ptr);
+        VkBufferCopy region{.srcOffset = 0, .dstOffset = ctx->DstOffset, .size = ctx->ByteSize};
+        vkCmdCopyBuffer(cmd, ctx->SrcBuffer, ctx->DstBuffer, 1, &region);
+
+        // Same fallback destinations as RecordRingCopy (generic SSBOs, ZUI vertex/index
+        // buffers), so the same access/stage transition. Previously relied on the caller
+        // fully blocking on a fence before returning — harmless then, but once this runs
+        // as part of a deferred batch, the cross-submission consumer needs an explicit
+        // barrier, not just ordering.
+        VkBufferMemoryBarrier barrier{VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER};
+        barrier.srcAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
+        barrier.dstAccessMask       = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT | VK_ACCESS_INDEX_READ_BIT;
+        barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barrier.buffer              = ctx->DstBuffer;
+        barrier.offset              = ctx->DstOffset;
+        barrier.size                = ctx->ByteSize;
+        vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_VERTEX_INPUT_BIT | VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, nullptr, 1, &barrier, 0, nullptr);
+    }
+
+    static void RecordAndSubmit(CommandBuffer* cmd, Rendering::Primitives::Fence* fence, VkQueue queue, void (*record_fn)(VkCommandBuffer, void*), void* record_ctx, VkSemaphore wait_semaphore = VK_NULL_HANDLE, uint64_t wait_value = 0)
     {
         cmd->ResetState();
         vkResetCommandBuffer(cmd->GetHandle(), 0);
         cmd->Begin();
-        record_fn(cmd->GetHandle());
+        record_fn(cmd->GetHandle(), record_ctx);
         cmd->End();
 
         VkTimelineSemaphoreSubmitInfo timeline_wait{VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO};
@@ -283,10 +363,10 @@ namespace ZEngine::Rendering
         }
 
         // Wait before reset — fence may be in-flight under MoltenVK async completion.
-        vkWaitForFences(device, 1, &fence, VK_TRUE, UINT64_MAX);
-        vkResetFences(device, 1, &fence);
-        vkQueueSubmit(queue, 1, &submit, fence);
-        vkWaitForFences(device, 1, &fence, VK_TRUE, UINT64_MAX);
+        fence->Wait(UINT64_MAX);
+        fence->Reset();
+        vkQueueSubmit(queue, 1, &submit, fence->GetHandle());
+        fence->Wait(UINT64_MAX);
         cmd->ResetState();
     }
 
@@ -309,8 +389,13 @@ namespace ZEngine::Rendering
         ZENGINE_VALIDATE_ASSERT(m_vtx_cursor + vtx_bytes <= GLOBAL_VTX_CAPACITY, "RRM::RegisterBuiltinGeometry: global vertex buffer out of space")
         ZENGINE_VALIDATE_ASSERT(m_idx_cursor + idx_bytes <= GLOBAL_IDX_CAPACITY, "RRM::RegisterBuiltinGeometry: global index buffer out of space")
 
-        AppendToGlobalBuffer(m_global_vertex_buf, vtx_data, vtx_bytes, m_vtx_cursor, 0);
-        AppendToGlobalBuffer(m_global_index_buf, idx_data, idx_bytes, m_idx_cursor, 0);
+        // Called pre-render-thread (single-threaded init) — the batch this opens simply
+        // stays open, unclosed, until the first real frame's RRM::EndFrame, at which point
+        // any mesh uploads from that same first frame join it too. Safe: frame_index here
+        // is just "which reusable slot", decoupled from the swapchain's own frame index.
+        EnsureBatchOpen(static_cast<uint8_t>(m_active_frame_index));
+        AppendToGlobalBuffer(m_global_vertex_buf, vtx_data, vtx_bytes, m_vtx_cursor, m_active_frame_index);
+        AppendToGlobalBuffer(m_global_index_buf, idx_data, idx_bytes, m_idx_cursor, m_active_frame_index);
 
         out_vtx_offset  = static_cast<uint32_t>(m_vtx_cursor / (8 * sizeof(float)));
         out_idx_offset  = static_cast<uint32_t>(m_idx_cursor / sizeof(uint32_t));
@@ -337,30 +422,82 @@ namespace ZEngine::Rendering
         m_uuid_to_buffer_count = 0;
     }
 
-    void RenderResourceManager::BeginBatchUpload()
+    void RenderResourceManager::RetireBatchStagings()
     {
-        vkWaitForFences(m_device->LogicalDevice, 1, &m_upload_fence, VK_TRUE, UINT64_MAX);
-        vkResetFences(m_device->LogicalDevice, 1, &m_upload_fence);
-        m_upload_cmd->ResetState();
-        vkResetCommandBuffer(m_upload_cmd->GetHandle(), 0);
-        m_upload_cmd->Begin();
-        m_batch_mode          = true;
-        m_batch_staging_count = 0;
+        uint64_t completed = 0;
+        vkGetSemaphoreCounterValue(m_device->LogicalDevice, m_batch_timeline->GetHandle(), &completed);
+        for (uint32_t i = 0; i < m_batch_frames.size(); ++i)
+        {
+            BatchFrameState& frame = m_batch_frames[i];
+            if (frame.LastSignal == 0 || frame.LastSignal > completed || frame.StagingCount == 0)
+                continue;
+            for (uint32_t j = 0; j < frame.StagingCount; ++j)
+                m_device->GpuMem.FreeBuffer(frame.StagingBuffers[j]);
+            frame.StagingCount = 0;
+        }
+    }
+
+    void RenderResourceManager::EnsureBatchOpen(uint8_t frame_index)
+    {
+        if (!m_batch_mode)
+            BeginBatchUpload(frame_index);
+    }
+
+    void RenderResourceManager::BeginBatchUpload(uint8_t frame_index)
+    {
+        m_batch_frame_index    = frame_index;
+        // Instant buffer, not the regular pool's slot 0 — that slot is shared by
+        // synchronous callers (AppendToGlobalBuffer's non-batch branch, UpdateBuffer) that
+        // submit and block before returning; this buffer's submission is deferred instead.
+        m_batch_cmd            = m_upload_cmd_mgr->GetInstantCommandBuffer(QueueType::GRAPHIC_QUEUE, frame_index, 0, 0, false);
+
+        BatchFrameState& frame = m_batch_frames[frame_index];
+
+        // Wait for this frame index's buffer to be free of its last use before recording
+        // into it again. Almost always a no-op — BufferedFrameCount frames have already
+        // passed by the time this frame index comes back around.
+        if (frame.LastSignal != 0)
+            m_batch_timeline->Wait(frame.LastSignal, UINT64_MAX);
+
+        // Guaranteed-safe fallback free, in case RetireBatchStagings' poll hasn't caught up
+        // yet — the wait above proves this frame index's previous batch is done either way.
+        for (uint32_t i = 0; i < frame.StagingCount; ++i)
+            m_device->GpuMem.FreeBuffer(frame.StagingBuffers[i]);
+        frame.StagingCount = 0;
+
+        m_batch_cmd->ResetState();
+        vkResetCommandBuffer(m_batch_cmd->GetHandle(), 0);
+        m_batch_cmd->Begin();
+        m_batch_mode = true;
     }
 
     void RenderResourceManager::EndBatchUpload()
     {
-        m_upload_cmd->End();
-        VkCommandBuffer cmd_handle = m_upload_cmd->GetHandle();
-        VkQueue         gfx_queue  = m_device->GetQueue(QueueType::GRAPHIC_QUEUE).Handle;
-        VkSubmitInfo    submit{VK_STRUCTURE_TYPE_SUBMIT_INFO, nullptr, 0, nullptr, nullptr, 1, &cmd_handle, 0, nullptr};
-        vkQueueSubmit(gfx_queue, 1, &submit, m_upload_fence);
-        vkWaitForFences(m_device->LogicalDevice, 1, &m_upload_fence, VK_TRUE, UINT64_MAX);
-        m_upload_cmd->ResetState();
-        for (uint32_t i = 0; i < m_batch_staging_count; ++i)
-            m_device->GpuMem.FreeBuffer(m_batch_stagings[i]);
-        m_batch_staging_count = 0;
-        m_batch_mode          = false;
+        m_batch_cmd->End();
+
+        // Submission is deferred to SubmitAsyncUploads (AppRenderPipeline::EndFrame) instead
+        // of submitted-and-blocked-on here, so a mesh drop never stalls the render thread.
+        // Signals m_batch_timeline — a dedicated semaphore with exactly one writer (this
+        // function) — rather than DeviceSwapchain::RenderTimeline, which Present() also
+        // drives independently; sharing it produced a timeline value Intel's Windows driver
+        // treats as non-monotonic.
+        uint64_t signal_value                          = ++m_batch_next_value;
+        m_batch_frames[m_batch_frame_index].LastSignal = signal_value;
+
+        Hardwares::AsyncUploadJob job;
+        job.Buffer      = m_batch_cmd;
+        job.Timeline    = m_batch_timeline;
+        job.SignalValue = signal_value;
+        // Stages that actually consume the global vertex/index buffers, matching
+        // RecordGlobalBufferCopy's own barrier — so Present() waits at the right point.
+        job.WaitFlag    = VK_PIPELINE_STAGE_VERTEX_INPUT_BIT | VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+        m_async_uploads.Enqueue(job);
+
+        // Left in m_batch_frames[m_batch_frame_index] for RetireBatchStagings (or the next
+        // BeginBatchUpload for this same frame index) to free once m_batch_timeline proves
+        // this copy has completed.
+        m_batch_mode = false;
+        m_batch_cmd  = nullptr;
     }
 
     void RenderResourceManager::AppendToGlobalBuffer(BufferView& global_buf, const void* data, size_t byte_size, VkDeviceSize byte_offset, uint32_t frame_index)
@@ -369,35 +506,16 @@ namespace ZEngine::Rendering
         ZENGINE_VALIDATE_ASSERT(staging, "RRM::AppendToGlobalBuffer: staging alloc failed")
         ZENGINE_VALIDATE_ASSERT(vmaCopyMemoryToAllocation(m_device->GpuMem.Allocator, data, staging.Allocation, 0, byte_size) == VK_SUCCESS, "RRM::AppendToGlobalBuffer: staging copy failed")
 
-        auto record = [&](VkCommandBuffer cmd) {
-            VkBufferCopy region{.srcOffset = 0, .dstOffset = byte_offset, .size = byte_size};
-            vkCmdCopyBuffer(cmd, staging.Handle, global_buf.Handle, 1, &region);
+        GlobalBufferCopyCtx ctx{staging.Handle, global_buf.Handle, byte_offset, byte_size};
 
-            VkBufferMemoryBarrier barrier{VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER};
-            barrier.srcAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
-            barrier.dstAccessMask       = VK_ACCESS_SHADER_READ_BIT;
-            barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            barrier.buffer              = global_buf.Handle;
-            barrier.offset              = byte_offset;
-            barrier.size                = byte_size;
-            vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, nullptr, 1, &barrier, 0, nullptr);
-        };
-
-        if (m_batch_mode)
-        {
-            record(m_upload_cmd->GetHandle());
-            ZENGINE_VALIDATE_ASSERT(m_batch_staging_count < MAX_PENDING * 2, "RRM::AppendToGlobalBuffer: batch staging overflow")
-            m_batch_stagings[m_batch_staging_count++] = staging;
-        }
-        else
-        {
-            VkSemaphore render_timeline = m_device->SwapchainPtr ? m_device->SwapchainPtr->RenderTimeline->GetHandle() : VK_NULL_HANDLE;
-            uint64_t    render_value    = m_device->SwapchainPtr ? m_device->SwapchainPtr->RenderTimelineNextValue : 0;
-            VkQueue     gfx_queue       = m_device->GetQueue(QueueType::GRAPHIC_QUEUE).Handle;
-            RecordAndSubmit(m_device->LogicalDevice, m_upload_cmd, m_upload_fence, gfx_queue, record, render_timeline, render_value);
-            m_device->GpuMem.FreeBuffer(staging);
-        }
+        // Every caller (FlushPendingUploads, FlushPendingSwaps, RegisterBuiltinGeometry)
+        // calls EnsureBatchOpen first — there is no longer a synchronous fallback path.
+        ZENGINE_VALIDATE_ASSERT(m_batch_mode, "RRM::AppendToGlobalBuffer: called without an open batch — call EnsureBatchOpen first")
+        ZENGINE_VALIDATE_ASSERT(static_cast<uint8_t>(frame_index) == m_batch_frame_index, "RRM::AppendToGlobalBuffer: frame_index does not match the currently open batch")
+        RecordGlobalBufferCopy(m_batch_cmd->GetHandle(), &ctx);
+        BatchFrameState& frame = m_batch_frames[m_batch_frame_index];
+        ZENGINE_VALIDATE_ASSERT(frame.StagingCount < MAX_PENDING * 2, "RRM::AppendToGlobalBuffer: batch staging overflow")
+        frame.StagingBuffers[frame.StagingCount++] = staging;
     }
 
     RenderResourceManager::MeshSlot RenderResourceManager::AppendMeshData(AssetHandle asset, uint32_t frame_index)
@@ -407,6 +525,16 @@ namespace ZEngine::Rendering
         {
             return {};
         }
+
+        static constexpr uint32_t FLOATS_PER_DRAW_VERTEX = 8;                                      // x,y,z, nx,ny,nz, u,v
+        static constexpr uint32_t DRAW_VERTEX_BYTES      = FLOATS_PER_DRAW_VERTEX * sizeof(float); // 32
+
+        // Every downstream offset/count in this function assumes Vertices.size() is a whole
+        // number of DrawVertex elements — if that ever drifts, m_vtx_cursor stops being
+        // vertex-aligned and silently corrupts the GPU-side read offset for every mesh
+        // appended afterward. Enforced only by importer convention, not by any other check,
+        // so assert it here rather than let it corrupt the buffer quietly.
+        ZENGINE_VALIDATE_ASSERT(mesh->Vertices.size() % FLOATS_PER_DRAW_VERTEX == 0, "RRM::AppendMeshData: Vertices.size() is not a whole number of DrawVertex elements")
 
         size_t vert_bytes = mesh->Vertices.size() * sizeof(float);
         size_t idx_bytes  = mesh->Indices.size() * sizeof(uint32_t);
@@ -420,16 +548,13 @@ namespace ZEngine::Rendering
         AppendToGlobalBuffer(m_global_vertex_buf, mesh->Vertices.data(), vert_bytes, m_vtx_cursor, frame_index);
         AppendToGlobalBuffer(m_global_index_buf, mesh->Indices.data(), idx_bytes, m_idx_cursor, frame_index);
 
-        static constexpr uint32_t FLOATS_PER_DRAW_VERTEX  = 8;                                      // x,y,z, nx,ny,nz, u,v
-        static constexpr uint32_t DRAW_VERTEX_BYTES       = FLOATS_PER_DRAW_VERTEX * sizeof(float); // 32
+        uint32_t vtx_elem_offset  = static_cast<uint32_t>(m_vtx_cursor / DRAW_VERTEX_BYTES); // DrawVertex[] index
+        uint32_t idx_elem_offset  = static_cast<uint32_t>(m_idx_cursor / sizeof(uint32_t));  // uint32[] index
+        uint32_t vtx_elem_count   = static_cast<uint32_t>(mesh->Vertices.size() / FLOATS_PER_DRAW_VERTEX);
+        uint32_t idx_elem_count   = static_cast<uint32_t>(mesh->Indices.size());
 
-        uint32_t                  vtx_elem_offset         = static_cast<uint32_t>(m_vtx_cursor / DRAW_VERTEX_BYTES); // DrawVertex[] index
-        uint32_t                  idx_elem_offset         = static_cast<uint32_t>(m_idx_cursor / sizeof(uint32_t));  // uint32[] index
-        uint32_t                  vtx_elem_count          = static_cast<uint32_t>(mesh->Vertices.size() / FLOATS_PER_DRAW_VERTEX);
-        uint32_t                  idx_elem_count          = static_cast<uint32_t>(mesh->Indices.size());
-
-        m_vtx_cursor                                     += vert_bytes;
-        m_idx_cursor                                     += idx_bytes;
+        m_vtx_cursor             += vert_bytes;
+        m_idx_cursor             += idx_bytes;
 
         ZENGINE_LOG_RENDER_INFO("[RRM] Uploaded mesh: {} verts ({} bytes), {} indices ({} bytes) — vtx@{} idx@{}", vtx_elem_count, vert_bytes, idx_elem_count, idx_bytes, vtx_elem_offset, idx_elem_offset)
 
@@ -466,8 +591,9 @@ namespace ZEngine::Rendering
         if (count == 0)
             return;
 
-        // Batch all mesh uploads into one GPU command buffer submission
-        BeginBatchUpload();
+        // Joins this frame's deferred batch (opened here if nothing else has yet) — closed
+        // once, by RRM::EndFrame, after everything else that might also join it this frame.
+        EnsureBatchOpen(static_cast<uint8_t>(frame_index));
         for (uint32_t i = 0; i < count; ++i)
         {
             BufferHandle h = DoUploadMesh(local[i].Asset, frame_index);
@@ -482,7 +608,6 @@ namespace ZEngine::Rendering
                 ZENGINE_CORE_ERROR("[RRM] Mesh upload failed for asset handle {}", local[i].Asset)
             }
         }
-        EndBatchUpload();
     }
 
     void RenderResourceManager::UpdateBuffer(BufferView& dst, const void* data, size_t byte_size, uint32_t dst_offset)
@@ -502,57 +627,46 @@ namespace ZEngine::Rendering
             return;
         }
 
-        // DEVICE_LOCAL — Ring staging → dedicated command buffer → vkQueueSubmit → fence wait.
-        uint32_t       ring_offset = 0;
-        void*          ring_ptr    = m_device->GpuMem.Ring.Allocate(static_cast<uint32_t>(byte_size), 4, &ring_offset);
-
-        VkQueue        gfx_queue   = m_device->GetQueue(QueueType::GRAPHIC_QUEUE).Handle;
-        CommandBuffer* upload_cmd  = m_upload_cmd;
+        // DEVICE_LOCAL. Two sub-cases with different lifecycles:
+        uint32_t ring_offset = 0;
+        void*    ring_ptr    = m_device->GpuMem.Ring.Allocate(static_cast<uint32_t>(byte_size), 4, &ring_offset);
 
         if (ring_ptr)
         {
+            // Ring path stays synchronous, deliberately not deferred: GpuAllocator::Ring's
+            // retirement (Ring::Drain, driven by VulkanDevice::TickMemory) tracks every
+            // chunk in one FIFO compared against RenderTimeline's completed value alone.
+            // Stamping a chunk with m_batch_timeline's (future, not-yet-reached) signal
+            // value instead would compare it against the wrong counter — the chunk could
+            // be reclaimed before the deferred copy on m_batch_timeline ever executes.
+            // Fixing that needs Ring to track more than one semaphore, which is out of
+            // scope here — so this sub-case keeps the fence-blocking model, just repointed
+            // at m_sync_upload_fence.
             secure_memmove(ring_ptr, byte_size, data, byte_size);
 
-            VkBuffer src_buf = m_device->GpuMem.Ring.Buffer;
-            RecordAndSubmit(m_device->LogicalDevice, upload_cmd, m_upload_fence, gfx_queue, [&](VkCommandBuffer cmd) {
-                VkBufferCopy region{.srcOffset = ring_offset, .dstOffset = dst_offset, .size = byte_size};
-                vkCmdCopyBuffer(cmd, src_buf, dst.Handle, 1, &region);
+            VkQueue        gfx_queue  = m_device->GetQueue(QueueType::GRAPHIC_QUEUE).Handle;
+            CommandBuffer* upload_cmd = m_upload_cmd_mgr->GetCommandBuffer(QueueType::GRAPHIC_QUEUE, m_active_frame_index, 0, 0, false);
+            RingCopyCtx    ctx{m_device->GpuMem.Ring.Buffer, dst.Handle, ring_offset, dst_offset, byte_size};
+            RecordAndSubmit(upload_cmd, m_sync_upload_fence, gfx_queue, RecordRingCopy, &ctx);
 
-                VkBufferMemoryBarrier barrier{VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER};
-                barrier.srcAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
-                barrier.dstAccessMask       = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT | VK_ACCESS_INDEX_READ_BIT;
-                barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-                barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-                barrier.buffer              = dst.Handle;
-                barrier.offset              = dst_offset;
-                barrier.size                = byte_size;
-                vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_VERTEX_INPUT_BIT | VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, nullptr, 1, &barrier, 0, nullptr);
-            });
-
-            m_device->GpuMem.Ring.Submit(ring_offset, static_cast<uint32_t>(byte_size), 0);
+            m_device->GpuMem.Ring.Submit(ring_offset, static_cast<uint32_t>(byte_size), m_device->SwapchainPtr->RenderTimelineNextValue);
         }
         else
         {
+            // Staging path joins this frame's deferred batch — no GpuAllocator::Ring
+            // involvement, so no cross-semaphore retirement hazard.
+            EnsureBatchOpen(m_active_frame_index);
+
             BufferView staging = m_device->CreateBuffer(static_cast<VkDeviceSize>(byte_size), VK_BUFFER_USAGE_TRANSFER_SRC_BIT, GpuMemoryDomain::HostStaging);
             ZENGINE_VALIDATE_ASSERT(vmaCopyMemoryToAllocation(m_device->GpuMem.Allocator, data, staging.Allocation, 0, byte_size) == VK_SUCCESS, "RRM::UpdateBuffer: staging copy failed")
 
-            VkBuffer stg_buf = staging.Handle;
-            RecordAndSubmit(m_device->LogicalDevice, upload_cmd, m_upload_fence, gfx_queue, [&](VkCommandBuffer cmd) {
-                VkBufferCopy region{.srcOffset = 0, .dstOffset = dst_offset, .size = byte_size};
-                vkCmdCopyBuffer(cmd, stg_buf, dst.Handle, 1, &region);
-            });
+            StagingCopyCtx ctx{staging.Handle, dst.Handle, dst_offset, byte_size};
+            RecordStagingCopy(m_batch_cmd->GetHandle(), &ctx);
 
-            DeferredFreeEntry e;
-            e.EntryKind     = DeferredFreeEntry::Kind::Buffer;
-            e.TimelineValue = m_device->SwapchainPtr->RenderTimelineNextValue;
-            e.Data.Buffer   = staging;
-            m_device->DeferFree(e);
+            BatchFrameState& frame = m_batch_frames[m_batch_frame_index];
+            ZENGINE_VALIDATE_ASSERT(frame.StagingCount < MAX_PENDING * 2, "RRM::UpdateBuffer: batch staging overflow")
+            frame.StagingBuffers[frame.StagingCount++] = staging;
         }
-    }
-
-    BufferHandle RenderResourceManager::UploadMesh(AssetHandle asset)
-    {
-        return DoUploadMesh(asset, m_current_frame);
     }
 
     void RenderResourceManager::ScheduleSwap(BufferHandle old_handle, AssetHandle new_asset)
@@ -763,7 +877,8 @@ namespace ZEngine::Rendering
         if (!buf)
             return {};
 
-        AppendToGlobalBuffer(buf, data, byte_size, 0, 0);
+        EnsureBatchOpen(m_active_frame_index);
+        AppendToGlobalBuffer(buf, data, byte_size, 0, m_active_frame_index);
 
         uint32_t slot_idx           = AllocGBufSlot();
         m_gbuf_slots[slot_idx].Data = buf;
@@ -789,6 +904,7 @@ namespace ZEngine::Rendering
         m_tex_next_values.init(m_device->Arena, total_pool_count, total_pool_count);
         m_tex_retire_values.init(m_device->Arena, total_pool_count, total_pool_count);
         m_tex_retire_staging.init(m_device->Arena, total_pool_count, total_pool_count);
+        m_tex_deferral_retry.init(m_device->Arena, MAX_DEFERRAL_RETRY);
 
         for (uint32_t i = 0; i < total_pool_count; ++i)
         {
@@ -895,7 +1011,7 @@ namespace ZEngine::Rendering
             if (i >= GEOMETRY_UPLOAD_SLOT)
             {
                 ZENGINE_CORE_WARN("[RRM] UploadTextureBuffer: no free transfer slot — upload deferred")
-                return handle;
+                return {};
             }
 
             auto                            transfer_cmd = m_device->CommandBufferMgr->GetInstantCommandBuffer(QueueType::TRANSFER_QUEUE, frame_index, thread_index, i);
@@ -945,7 +1061,7 @@ namespace ZEngine::Rendering
             if (transfer_staging)
                 m_tex_transfer_staging[pool_index][i] = transfer_staging;
 
-            m_tex_job_queue.Enqueue({transfer_cmd, m_tex_transfer_timelines[pool_index], nullptr, VK_PIPELINE_STAGE_TRANSFER_BIT, transfer_val, UINT64_MAX});
+            m_async_uploads.Enqueue({transfer_cmd, m_tex_transfer_timelines[pool_index], nullptr, VK_PIPELINE_STAGE_TRANSFER_BIT, transfer_val, UINT64_MAX});
 
             uint32_t acquire_slot  = 0;
             auto&    retire_values = m_tex_retire_values[pool_index];
@@ -953,7 +1069,15 @@ namespace ZEngine::Rendering
                 if (retire_values[acquire_slot] == 0)
                     break;
             if (acquire_slot >= GEOMETRY_UPLOAD_SLOT)
+            {
+                // Unlike the two early returns above, the transfer-queue copy has already
+                // been recorded and enqueued by this point (img_buf->Layout mutated) — this
+                // call cannot be safely retried from scratch, so it's treated as done rather
+                // than deferred (the texture just stays transfer-owned until a future upload
+                // call for the same handle happens to find a free acquire slot).
+                ZENGINE_CORE_WARN("[RRM] UploadTextureBuffer: no free acquire slot — texture left transfer-owned")
                 return handle;
+            }
 
             auto                            acquire_cmd  = m_device->CommandBufferMgr->GetInstantCommandBuffer(QueueType::GRAPHIC_QUEUE, frame_index, thread_index, acquire_slot);
             ImageMemoryBarrierSpecification acquire_spec = release;
@@ -966,7 +1090,7 @@ namespace ZEngine::Rendering
 
             uint64_t graphics_val       = m_tex_next_values[pool_index].fetch_add(1, std::memory_order_acq_rel);
             retire_values[acquire_slot] = graphics_val;
-            m_tex_job_queue.Enqueue({acquire_cmd, m_tex_timelines[pool_index], m_tex_transfer_timelines[pool_index], (uint32_t) release.DestinationStageMask, graphics_val, transfer_val});
+            m_async_uploads.Enqueue({acquire_cmd, m_tex_timelines[pool_index], m_tex_transfer_timelines[pool_index], (uint32_t) release.DestinationStageMask, graphics_val, transfer_val});
         }
         else
         {
@@ -978,7 +1102,7 @@ namespace ZEngine::Rendering
             if (i >= GEOMETRY_UPLOAD_SLOT)
             {
                 ZENGINE_CORE_WARN("[RRM] UploadTextureBuffer: no free graphics slot — upload deferred")
-                return handle;
+                return {};
             }
 
             auto                            cmd         = m_device->CommandBufferMgr->GetInstantCommandBuffer(QueueType::GRAPHIC_QUEUE, frame_index, thread_index, i);
@@ -1024,7 +1148,7 @@ namespace ZEngine::Rendering
             retire_values[i]      = signal_value;
             if (staging)
                 m_tex_retire_staging[pool_index][i] = staging;
-            m_tex_job_queue.Enqueue({cmd, m_tex_timelines[pool_index], nullptr, (uint32_t) to_final.DestinationStageMask, signal_value, UINT64_MAX});
+            m_async_uploads.Enqueue({cmd, m_tex_timelines[pool_index], nullptr, (uint32_t) to_final.DestinationStageMask, signal_value, UINT64_MAX});
             img_buf->Layout = to_final.NewLayout;
         }
         return handle;
@@ -1075,7 +1199,10 @@ namespace ZEngine::Rendering
         to_final.SourceQueueFamily                    = m_device->GraphicFamilyIndex;
         to_final.DestinationQueueFamily               = m_device->GraphicFamilyIndex;
 
-        auto* cmd                                     = m_upload_cmd;
+        auto*                         cmd             = m_upload_cmd_mgr->GetCommandBuffer(QueueType::GRAPHIC_QUEUE, m_active_frame_index, 0, 0, false);
+        Rendering::Primitives::Fence* fence           = m_sync_upload_fence;
+        fence->Wait(UINT64_MAX);
+        fence->Reset();
         cmd->ResetState();
         vkResetCommandBuffer(cmd->GetHandle(), 0);
         cmd->Begin();
@@ -1093,19 +1220,23 @@ namespace ZEngine::Rendering
         submit.commandBufferCount = 1;
         submit.pCommandBuffers    = &raw;
 
-        vkWaitForFences(m_device->LogicalDevice, 1, &m_upload_fence, VK_TRUE, UINT64_MAX);
-        vkResetFences(m_device->LogicalDevice, 1, &m_upload_fence);
-        vkQueueSubmit(gfx_queue, 1, &submit, m_upload_fence);
-        vkWaitForFences(m_device->LogicalDevice, 1, &m_upload_fence, VK_TRUE, UINT64_MAX);
+        vkQueueSubmit(gfx_queue, 1, &submit, fence->GetHandle());
+        fence->Wait(UINT64_MAX);
         cmd->ResetState();
 
-        // Fence wait above already blocked until the GPU finished reading the ring, so
-        // this chunk is retroactively safe — 0 always satisfies Drain's <= completed_value.
+        // Gated on the render timeline's own progress rather than marked safe at value 0 —
+        // the fence wait above is not trustworthy proof of completion once any command
+        // buffer on the queue has already timed out (issue #764 follow-up investigation).
         if (ring_offset != std::numeric_limits<uint32_t>::max())
-            m_device->GpuMem.Ring.Submit(ring_offset, static_cast<uint32_t>(texture->BufferSize), 0);
+            m_device->GpuMem.Ring.Submit(ring_offset, static_cast<uint32_t>(texture->BufferSize), m_device->SwapchainPtr->RenderTimelineNextValue);
 
         if (staging)
-            m_device->GpuMem.FreeBuffer(staging);
+        {
+            DeferredFreeEntry e;
+            e.EntryKind   = DeferredFreeEntry::Kind::Buffer;
+            e.Data.Buffer = staging;
+            m_device->DeferFree(e);
+        }
 
         return handle;
     }
@@ -1115,30 +1246,34 @@ namespace ZEngine::Rendering
         m_tex_deferral_queue.Emplace(std::forward<TextureDeferral>(deferral));
     }
 
-    void RenderResourceManager::CompleteDeferrals()
+    void RenderResourceManager::CompleteDeferrals(uint8_t frame_index)
     {
+        // Deferrals that found no free upload slot this pass are collected here and
+        // requeued after the loop — retried next frame instead of freeing pixel data
+        // that was never actually copied to the GPU, and instead of spinning in place
+        // waiting for a slot that won't free up within this same call.
+        m_tex_deferral_retry.clear();
         while (!m_tex_deferral_queue.Empty())
         {
             TextureDeferral d = {};
             m_tex_deferral_queue.Pop(d);
-            UploadTextureBuffer(d.FrameIdx, d.ThreadIdx, d.TexHandle, d.Pixels);
+            auto result = UploadTextureBuffer(frame_index, 0, d.TexHandle, d.Pixels);
+            if (!result.Valid())
+            {
+                m_tex_deferral_retry.push(std::move(d));
+                continue;
+            }
             // Free slab-owned pixels after upload. Nullptr = borrowed pointer, skip.
             if (d.Slab && d.Pixels)
                 d.Slab->Free(d.Pixels);
         }
+        for (auto& d : m_tex_deferral_retry)
+            m_tex_deferral_queue.Emplace(std::move(d));
     }
 
-    void RenderResourceManager::SubmitTextureJobs()
+    void RenderResourceManager::SubmitAsyncUploads()
     {
-        while (!m_tex_job_queue.Empty())
-        {
-            TextureTimelineJob job;
-            if (m_tex_job_queue.Pop(job))
-            {
-                m_device->QueueSubmit(job.Buffer, job.Timeline, job.WaitFlag, job.SignalValue, job.WaitValue, job.WaitTimeline);
-                m_device->EnqueueAsyncGPUOperation({job.WaitFlag, job.SignalValue, job.Timeline});
-            }
-        }
+        m_async_uploads.SubmitAll();
     }
 
     void RenderResourceManager::RetireTextureSlots(uint8_t frame_index, uint8_t thread_index)
@@ -1187,9 +1322,9 @@ namespace ZEngine::Rendering
         }
     }
 
-    void RenderResourceManager::ClearTextureJobs()
+    void RenderResourceManager::ClearAsyncUploads()
     {
-        m_tex_job_queue.Clear();
+        m_async_uploads.Clear();
         m_device->AsyncGPUOperations.Clear();
     }
 
@@ -1222,7 +1357,7 @@ namespace ZEngine::Rendering
     Rendering::Textures::TextureHandle RenderResourceManager::IngestTexture(const uuids::uuid& uuid, const char* absolute_path, Rendering::Textures::TextureHandle existing)
     {
         ZENGINE_LOG_RENDER_INFO("[RRM] {} texture {} from {}", existing.Valid() ? "Reloading" : "Ingesting", uuids::to_string(uuid), absolute_path)
-        return SubmitTextureFile(0, 0, absolute_path, existing);
+        return SubmitTextureFile(absolute_path, existing);
     }
 
     void RenderResourceManager::ScheduleTextureReload(const uuids::uuid& uuid)
@@ -1306,7 +1441,7 @@ namespace ZEngine::Rendering
             m_device->DestroyTexture(local[i]);
     }
 
-    Rendering::Textures::TextureHandle RenderResourceManager::SubmitTextureFile(uint8_t frame_index, uint8_t thread_index, const char* filename, Rendering::Textures::TextureHandle existing)
+    Rendering::Textures::TextureHandle RenderResourceManager::SubmitTextureFile(const char* filename, Rendering::Textures::TextureHandle existing)
     {
         using namespace Rendering::Specifications;
 
@@ -1374,10 +1509,9 @@ namespace ZEngine::Rendering
         std::string                        captured_filename = abs_filename;
         std::string                        captured_ext      = file_ext;
         TextureSpecification               captured_spec     = spec;
-        uint8_t                            fi = frame_index, ti = thread_index;
-        Rendering::Textures::TextureHandle captured_handle = tex_handle;
+        Rendering::Textures::TextureHandle captured_handle   = tex_handle;
 
-        Helpers::ThreadPoolHelper::Submit([this, captured_filename, captured_ext, captured_spec, fi, ti, captured_handle]() mutable {
+        Helpers::ThreadPoolHelper::Submit([this, captured_filename, captured_ext, captured_spec, captured_handle]() mutable {
             std::vector<uint8_t> buffer;
 
             if (captured_spec.IsCubemap)
@@ -1478,8 +1612,6 @@ namespace ZEngine::Rendering
             deferral.Pixels    = pixels;
             deferral.ByteSize  = bytes;
             deferral.Slab      = slab;
-            deferral.FrameIdx  = fi;
-            deferral.ThreadIdx = ti;
             deferral.TexHandle = captured_handle;
             EnqueueTextureDeferral(std::move(deferral));
             m_device->RequestDescriptorUpdate(captured_handle);
@@ -1508,7 +1640,7 @@ namespace ZEngine::Rendering
             stbi_write_png(kFallbackPath, W, H, 4, pixels, W * 4);
         }
 
-        return SubmitTextureFile(0, 0, kFallbackPath);
+        return SubmitTextureFile(kFallbackPath);
     }
 
 } // namespace ZEngine::Rendering

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
@@ -335,7 +335,7 @@ namespace ZEngine::Rendering
         vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_VERTEX_INPUT_BIT | VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, nullptr, 1, &barrier, 0, nullptr);
     }
 
-    static void RecordAndSubmit(CommandBuffer* cmd, Rendering::Primitives::Fence* fence, VkQueue queue, void (*record_fn)(VkCommandBuffer, void*), void* record_ctx, VkSemaphore wait_semaphore = VK_NULL_HANDLE, uint64_t wait_value = 0)
+    static void RecordAndSubmit(CommandBuffer* cmd, Rendering::Primitives::Fence* fence, VkQueue queue, void (*record_fn)(VkCommandBuffer, void*), void* record_ctx)
     {
         cmd->ResetState();
         vkResetCommandBuffer(cmd->GetHandle(), 0);
@@ -343,24 +343,10 @@ namespace ZEngine::Rendering
         record_fn(cmd->GetHandle(), record_ctx);
         cmd->End();
 
-        VkTimelineSemaphoreSubmitInfo timeline_wait{VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO};
-        VkPipelineStageFlags          wait_stage = VK_PIPELINE_STAGE_TRANSFER_BIT;
-
-        VkCommandBuffer               raw        = cmd->GetHandle();
-        VkSubmitInfo                  submit{VK_STRUCTURE_TYPE_SUBMIT_INFO};
+        VkCommandBuffer raw = cmd->GetHandle();
+        VkSubmitInfo    submit{VK_STRUCTURE_TYPE_SUBMIT_INFO};
         submit.commandBufferCount = 1;
         submit.pCommandBuffers    = &raw;
-
-        if (wait_semaphore != VK_NULL_HANDLE && wait_value > 0)
-        {
-            timeline_wait.waitSemaphoreValueCount   = 1;
-            timeline_wait.pWaitSemaphoreValues      = &wait_value;
-            timeline_wait.signalSemaphoreValueCount = 0;
-            submit.pNext                            = &timeline_wait;
-            submit.waitSemaphoreCount               = 1;
-            submit.pWaitSemaphores                  = &wait_semaphore;
-            submit.pWaitDstStageMask                = &wait_stage;
-        }
 
         // Wait before reset — fence may be in-flight under MoltenVK async completion.
         fence->Wait(UINT64_MAX);
@@ -446,8 +432,8 @@ namespace ZEngine::Rendering
     void RenderResourceManager::BeginBatchUpload(uint8_t frame_index)
     {
         m_batch_frame_index    = frame_index;
-        // Instant buffer, not the regular pool's slot 0 — that slot is shared by
-        // synchronous callers (AppendToGlobalBuffer's non-batch branch, UpdateBuffer) that
+        // Instant buffer, not the regular pool's slot 0 — that slot is shared by the two
+        // remaining synchronous callers (UpdateBuffer's ring path, UploadFontAtlas), which
         // submit and block before returning; this buffer's submission is deferred instead.
         m_batch_cmd            = m_upload_cmd_mgr->GetInstantCommandBuffer(QueueType::GRAPHIC_QUEUE, frame_index, 0, 0, false);
 

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.h
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.h
@@ -4,6 +4,8 @@
 #include <ZEngine/Core/Memory/TLSFSlab.h>
 #include <ZEngine/Core/VFS/Registry/AssetRegistry.h>
 #include <ZEngine/Core/VFS/VFSError.h>
+#include <ZEngine/Hardwares/AsyncUploadQueue.h>
+#include <ZEngine/Hardwares/CommandBufferManager.h>
 #include <ZEngine/Hardwares/DeferredFreeQueue.h>
 #include <ZEngine/Helpers/ThreadPool.h>
 #include <ZEngine/Helpers/ThreadSafeQueue.h>
@@ -22,6 +24,11 @@ namespace ZEngine::Hardwares
     struct CommandBuffer;
 } // namespace ZEngine::Hardwares
 
+namespace ZEngine::Rendering::Primitives
+{
+    struct Fence;
+} // namespace ZEngine::Rendering::Primitives
+
 namespace ZEngine::Rendering
 {
     // RenderResourceManager — single authority over GPU buffer/image lifetime.
@@ -32,7 +39,7 @@ namespace ZEngine::Rendering
     //
     // THREAD SAFETY:
     //   Initialize / Shutdown       — main thread, once at startup/teardown
-    //   BeginFrame / EndFrame       — render thread only
+    //   BeginFrame                  — render thread only
     //   OnAssetReady callback       — asset/import thread; mesh only (protected by m_pending_mutex)
     //   OnAssetStale callback       — asset/import thread; mesh only, ScheduleSwap protected
     //                                 by m_pending_swap_mutex. Textures are triggered via
@@ -65,18 +72,9 @@ namespace ZEngine::Rendering
         /// @param frame_index Current swapchain frame index (0 .. FRAMES_IN_FLIGHT-1).
         void                                BeginFrame(uint32_t frame_index);
 
-        /// @brief Per-frame render-thread exit point.
-        /// @details Advances the internal frame counter. Called by AppRenderPipeline after
-        ///          command buffer submission.
-        /// @param frame_index Current swapchain frame index (0 .. FRAMES_IN_FLIGHT-1).
-        void                                EndFrame(uint32_t frame_index);
-
-        /// @brief Upload a mesh asset to the packed global vertex and index buffers.
-        /// @details Thread-safe: enqueues a pending upload consumed by BeginFrame.
-        ///          Vertices and indices are appended at the current watermark cursor.
-        /// @param asset_handle Handle to a fully imported MeshAsset in the AssetManager.
-        /// @return A valid BufferHandle on success; invalid if the asset is null or upload fails.
-        BufferHandle                        UploadMesh(Managers::AssetHandle asset_handle);
+        /// @brief Closes this frame's deferred upload batch, if anything joined it.
+        /// @details Called by AppRenderPipeline::EndFrame, before SubmitAsyncUploads.
+        void                                EndFrame();
 
         /// @brief Ingest a texture file, uploading (existing invalid) or reloading it in
         ///        place (existing valid) under the same handle.
@@ -102,16 +100,16 @@ namespace ZEngine::Rendering
 
         /// @brief Upload raw RGBA pixel data to an existing TextureHandle via the timeline path.
         /// @details Records a staging copy into an instant command buffer and enqueues the
-        ///          submission to the timeline job queue. Actual GPU submission drains in
-        ///          SubmitTextureJobs(). For font atlas upload prefer UploadFontAtlas.
+        ///          submission to the async upload queue. Actual GPU submission drains in
+        ///          SubmitAsyncUploads(). For font atlas upload prefer UploadFontAtlas.
         /// @param frame_index  Render frame index used to select the per-frame command pool.
         /// @param thread_index Thread index within the pool.
         /// @param handle       Pre-allocated TextureHandle whose VkImage will receive the data.
-        /// @param data         RGBA pixel data; must remain valid until SubmitTextureJobs runs.
+        /// @param data         RGBA pixel data; must remain valid until SubmitAsyncUploads runs.
         /// @return The same handle on success; invalid handle if no free upload slot.
         Rendering::Textures::TextureHandle  UploadTextureBuffer(uint8_t frame_index, uint8_t thread_index, const Rendering::Textures::TextureHandle& handle, unsigned char* data);
 
-        // Upload the ImGui font atlas synchronously using m_upload_cmd/m_upload_fence.
+        // Upload the ZUI font atlas synchronously using m_upload_cmd_mgr/m_sync_upload_fence.
         // Blocks until the GPU copy is complete so the texture is ready before the first
         // frame renders. Caller must enqueue the returned handle to
         // TextureHandleToUpdates for bindless descriptor registration.
@@ -119,13 +117,14 @@ namespace ZEngine::Rendering
 
         /// @brief Decode a texture file on the thread pool and upload it, async.
         /// @details When existing is valid, reconstructs that handle in place instead of
-        ///          allocating a new one (used by IngestTexture's reimport path).
-        /// @param frame_index  Render frame index.
-        /// @param thread_index Thread index within the per-frame pool.
+        ///          allocating a new one (used by IngestTexture's reimport path). The actual
+        ///          upload happens later in CompleteDeferrals, against whichever frame is
+        ///          current at that time — decode latency on the thread pool means a frame
+        ///          index captured here would be stale by the time the upload runs.
         /// @param filename     Absolute path to the image file on disk.
         /// @param existing     Handle to reconstruct in place; invalid to allocate a new one.
         /// @return A valid TextureHandle that will become readable once the upload drains.
-        Rendering::Textures::TextureHandle  SubmitTextureFile(uint8_t frame_index, uint8_t thread_index, const char* filename, Rendering::Textures::TextureHandle existing = {});
+        Rendering::Textures::TextureHandle  SubmitTextureFile(const char* filename, Rendering::Textures::TextureHandle existing = {});
 
         /// @brief Return the (255, 20, 147) fallback TextureHandle for missing textures, creating it on first call.
         Rendering::Textures::TextureHandle  GetOrCreateFallbackTexture();
@@ -141,8 +140,6 @@ namespace ZEngine::Rendering
             size_t                             ByteSize  = 0;       ///< Size of Pixels in bytes.
             Core::Memory::TLSFSlab*            Slab      = nullptr; ///< Owning slab; nullptr = borrowed pointer.
             Rendering::Textures::TextureHandle TexHandle = {};
-            uint8_t                            FrameIdx  = 0;
-            uint8_t                            ThreadIdx = 0;
         };
 
         /// @brief Enqueue a texture upload deferral for processing in the next BeginFrame.
@@ -150,13 +147,17 @@ namespace ZEngine::Rendering
         void                            EnqueueTextureDeferral(TextureDeferral&& deferral);
 
         /// @brief Drain all pending texture deferrals by dispatching UploadTextureBuffer.
-        /// @details Called from AppRenderPipeline::BeginFrame. Processes every entry in
-        ///          m_tex_deferral_queue and submits the underlying staging copies.
-        void                            CompleteDeferrals();
+        /// @details Called from AppRenderPipeline::BeginFrame, against the frame that's
+        ///          current at the time each deferral actually drains (not when it was
+        ///          enqueued — decode latency on the thread pool means those can be frames
+        ///          apart). Deferrals that find no free upload slot are retried next frame.
+        /// @param frame_index Render frame index to upload against.
+        void                            CompleteDeferrals(uint8_t frame_index);
 
-        /// @brief Submit all pending timeline semaphore jobs to the GPU graphics queue.
-        /// @details Called from AppRenderPipeline::EndFrame. Processes m_tex_job_queue.
-        void                            SubmitTextureJobs();
+        /// @brief Submit all pending async upload jobs (texture uploads and mesh batch
+        ///        uploads) to the GPU graphics queue.
+        /// @details Called from AppRenderPipeline::EndFrame. Processes m_async_uploads.
+        void                            SubmitAsyncUploads();
 
         /// @brief Retire command buffers whose timeline fence has been signalled.
         /// @details Frees staging buffers associated with completed texture uploads for the
@@ -165,9 +166,9 @@ namespace ZEngine::Rendering
         /// @param thread_index Thread index within the per-frame pool.
         void                            RetireTextureSlots(uint8_t frame_index, uint8_t thread_index);
 
-        /// @brief Cancel all queued timeline jobs without submitting them.
+        /// @brief Cancel all queued async upload jobs without submitting them.
         /// @details Called on swapchain resize or recreate to discard stale uploads.
-        void                            ClearTextureJobs();
+        void                            ClearAsyncUploads();
 
         /// @brief Reset all texture timeline semaphore counters after a swapchain recreate.
         /// @details Re-initialises per-pool signal values and retire arrays to zero.
@@ -190,7 +191,7 @@ namespace ZEngine::Rendering
         ///          underlying VmaAllocation is freed after FRAMES_IN_FLIGHT frames via the
         ///          deferred-free queue. For mesh handles the slot is invalidated only — the
         ///          packed global buffer is append-only and reclaimed on shutdown.
-        /// @param handle Handle returned by UploadMesh or UploadBuffer.
+        /// @param handle Handle returned by the mesh upload path or UploadBuffer.
         void                            Release(BufferHandle handle);
 
         /// @brief Look up a generic device-local buffer by handle.
@@ -227,7 +228,7 @@ namespace ZEngine::Rendering
         }
 
         /// @brief Query the element-count offsets for a mesh in the global geometry buffers.
-        /// @param handle     BufferHandle returned by UploadMesh.
+        /// @param handle     BufferHandle returned by the mesh upload path.
         /// @param vtx_offset Out: index of the first DrawVertex element in the global VB.
         /// @param idx_offset Out: index of the first uint32 element in the global IB.
         /// @return true if the handle is valid and the offsets were written; false otherwise.
@@ -257,7 +258,7 @@ namespace ZEngine::Rendering
         /// @brief Release the geometry slot for a mesh and unregister its UUID.
         /// @details Frees the MeshSlot so it can be reused by a future upload.
         ///          The VB/IB bytes are not reclaimed (append-only buffer) but the
-        ///          slot index becomes available for the next UploadMesh call.
+        ///          slot index becomes available for the next mesh upload.
         ///          No-op if the UUID is not registered.
         /// @param uuid Asset UUID of the mesh to release.
         void         ReleaseMeshGeometry(const uuids::uuid& uuid);
@@ -380,8 +381,16 @@ namespace ZEngine::Rendering
         void                           FlushPendingTextureReleases();
 
         // Batch upload helpers — render-thread only
-        void                           BeginBatchUpload();
+        void                           BeginBatchUpload(uint8_t frame_index);
         void                           EndBatchUpload();
+        /// @brief Open the batch if it isn't already open this frame. Idempotent — every
+        ///        join point (mesh uploads, hot-reload swaps, UpdateBuffer's staging path,
+        ///        builtin geometry registration) calls this before recording, so only the
+        ///        first one actually opens it.
+        void                           EnsureBatchOpen(uint8_t frame_index);
+        /// @brief Free any frame index's batch staging buffers once m_batch_timeline has
+        ///        reached their stored signal value. Called once per frame from BeginFrame.
+        void                           RetireBatchStagings();
         void                           ResetGeometryBuffersInternal();
 
         void                           InitUploadPool();
@@ -463,38 +472,57 @@ namespace ZEngine::Rendering
         std::mutex                         m_pending_texture_release_mutex;
 
         // Geometry compaction request — set by asset thread, executed on render thread
-        std::atomic<bool>                  m_pending_reset                   = false;
+        std::atomic<bool>                  m_pending_reset      = false;
 
-        // Batch upload state — render-thread only, no locking needed
-        bool                               m_batch_mode                      = false;
-        Core::Memory::BufferView           m_batch_stagings[MAX_PENDING * 2] = {};
-        uint32_t                           m_batch_staging_count             = 0;
+        // Batch upload state — render-thread only, no locking needed.
+        bool                               m_batch_mode         = false;
+        Hardwares::CommandBuffer*          m_batch_cmd          = nullptr;
+        uint8_t                            m_batch_frame_index  = 0;
 
-        uint32_t                           m_current_frame                   = 0;
+        // Set at the top of BeginFrame(frame_index) — lets upload paths that aren't already
+        // threaded through a frame_index parameter (UpdateBuffer, UploadFontAtlas) still pick
+        // the correct per-frame command buffer from m_upload_cmd_mgr below.
+        uint8_t                            m_active_frame_index = 0;
 
-        // Dedicated command pools for geometry uploads — isolated from the swapchain
-        // timeline semaphore chain. Geometry uploads must not share the graphics queue
-        // submission path with Present; a private pool + fence ensures safe isolation.
-        Rendering::Pools::CommandPool*     m_upload_pool                     = nullptr;
-        Hardwares::CommandBuffer*          m_upload_cmd                      = nullptr;
-        VkFence                            m_upload_fence                    = VK_NULL_HANDLE;
-        Rendering::Pools::CommandPool*     m_transfer_pool                   = nullptr;
-        Hardwares::CommandBuffer*          m_transfer_cmd                    = nullptr;
-        VkFence                            m_transfer_fence                  = VK_NULL_HANDLE;
+        // Dedicated command buffer manager for geometry/font-atlas uploads, separate from
+        // Device->CommandBufferMgr. Regular pool slot 0 serves the two remaining
+        // synchronous callers (UploadFontAtlas, UpdateBuffer's ring path); the instant
+        // pool serves BeginBatchUpload/EndBatchUpload, whose submission is deferred to
+        // SubmitAsyncUploads instead of blocked on.
+        Hardwares::CommandBufferManagerPtr m_upload_cmd_mgr     = {};
+        // The only two remaining synchronous, fence-blocking uploads (UploadFontAtlas,
+        // UpdateBuffer's ring path — see their comments for why they can't join the
+        // deferred batch) are both render-thread-only and always fully block before
+        // returning, so one shared fence is enough: neither can ever be "in flight" when
+        // the other starts.
+        Rendering::Primitives::Fence*      m_sync_upload_fence  = nullptr;
+
+        // Dedicated timeline semaphore for the mesh batch upload path — intentionally NOT
+        // DeviceSwapchain::RenderTimeline. RenderTimeline is Present()'s own frame-pacing
+        // primitive (it increments RenderTimelineNextValue twice per frame internally);
+        // having RRM also drive it from EndBatchUpload produced a timeline value Intel's
+        // Windows driver treats as non-monotonic. A fully separate semaphore/counter with
+        // exactly one writer (EndBatchUpload) makes that class of interleaving impossible
+        // by construction.
+        Rendering::Primitives::Semaphore*  m_batch_timeline     = nullptr;
+        uint64_t                           m_batch_next_value   = 0;
+
+        // Per-frame-index batch state: the m_batch_timeline value last signalled for that
+        // frame index's batch, and the staging buffers still owned by it. Retired
+        // proactively every frame by RetireBatchStagings once m_batch_timeline reaches
+        // LastSignal, with BeginBatchUpload's own reuse-wait as a guaranteed fallback.
+        // Self-contained — no DeferFree/RenderTimeline dependency.
+        struct BatchFrameState
+        {
+            uint64_t                 LastSignal                      = 0;
+            Core::Memory::BufferView StagingBuffers[MAX_PENDING * 2] = {};
+            uint32_t                 StagingCount                    = 0;
+        };
+        Core::Containers::Array<BatchFrameState>                                   m_batch_frames             = {};
 
         // Upper bound for texture timeline slot search — keeps textures out of the
         // geometry slots and caps the retire loop to the same range.
-        static constexpr uint32_t          GEOMETRY_UPLOAD_SLOT              = 15;
-
-        struct TextureTimelineJob
-        {
-            Hardwares::CommandBuffer*         Buffer       = nullptr;
-            Rendering::Primitives::Semaphore* Timeline     = nullptr;
-            Rendering::Primitives::Semaphore* WaitTimeline = nullptr;
-            uint32_t                          WaitFlag     = 0;
-            uint64_t                          SignalValue  = 0;
-            uint64_t                          WaitValue    = UINT64_MAX;
-        };
+        static constexpr uint32_t                                                  GEOMETRY_UPLOAD_SLOT       = 15;
 
         uint32_t                                                                   m_tex_total_cmd_count      = 0;
         Core::Containers::Array<std::atomic_uint64_t>                              m_tex_next_values          = {};
@@ -505,8 +533,14 @@ namespace ZEngine::Rendering
         Core::Containers::Array<Core::Containers::Array<uint64_t>>                 m_tex_transfer_retire      = {};
         Core::Containers::Array<Core::Containers::Array<Core::Memory::BufferView>> m_tex_retire_staging       = {};
         Core::Containers::Array<Core::Containers::Array<Core::Memory::BufferView>> m_tex_transfer_staging     = {};
-        Helpers::ThreadSafeQueue<TextureTimelineJob>                               m_tex_job_queue            = {};
+        Hardwares::AsyncUploadQueue                                                m_async_uploads            = {};
         Helpers::ThreadSafeQueue<TextureDeferral>                                  m_tex_deferral_queue       = {};
+
+        // Scratch buffer for deferrals that find no free upload slot during a
+        // CompleteDeferrals pass — arena-backed, fixed capacity, reused every frame via
+        // clear() so retrying a full deferral queue never allocates on the hot path.
+        static constexpr uint32_t                                                  MAX_DEFERRAL_RETRY         = 8192;
+        Core::Containers::Array<TextureDeferral>                                   m_tex_deferral_retry       = {};
 
         void                                                                       InitTextureTimelines();
         void                                                                       ShutdownTextureTimelines();

--- a/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.cpp
@@ -133,7 +133,7 @@ namespace ZEngine::Rendering::Renderers
         {
             auto* rrm = ZEngine::Engine::GetContext()->RenderResourceManager;
             if (rrm)
-                m_env_map = rrm->SubmitTextureFile(0, 0, EnvMapPath);
+                m_env_map = rrm->SubmitTextureFile(EnvMapPath);
         }
 
         res_builder->ReadDepth(RendererResourceName::FrameDepthRenderTargetName);


### PR DESCRIPTION
## Summary

Fixes #764 (the drag-drop material/texture loading gap). Dragging an already-cooked `.zemesh` from the Content Browser onto the viewport (`ViewportPanel::SpawnDroppedMesh`) only ever loaded geometry and hierarchy via `IngestMesh` — it never resolved or ingested the mesh's referenced materials or their textures. If none of a mesh's materials happened to already be resident from an earlier import this session, the dropped mesh rendered with whatever material happened to occupy slot 0 in `AssetManager::Materials` — an arbitrary, unrelated material, not the correct one.

## Changes

- `AssetManager::IngestMaterialFromUUID` (new) — single-UUID counterpart to the existing (previously uncalled) `ReloadFromDisk`'s material block: resolve the UUID via the registry, deserialize its `.zematerial`, and ingest it (which transitively ingests its textures). `SpawnDroppedMesh` now calls this for every submesh's `MaterialUUID` before the mesh data is moved into `IngestMesh`.
- Reserved slot 0 in `Materials`/`GPUMeshMaterials` as an intentional magenta fallback material, created once at `AssetManager::Initialize`. `AppRenderPipeline`'s render-time material lookup already defaulted an unresolved submesh to index 0 — without a reserved slot, that meant aliasing to whichever real material happened to be ingested first, silently rendering the wrong material instead of a recognizable "unresolved" signal.
- `GetAsset<AssetMaterial, uuid>` now checks `AssetRecord::IsLoaded()`, not just non-null — closes a related false-positive where `VFSScanner` pre-registers every `.zematerial` UUID with `SlotHandle=0` before any ingest happens, so the old check returned `Materials[0]` for any UUID that was scanned but never actually ingested.

Live-verifying the above surfaced two more, unrelated pre-existing bugs in the file-watcher path that made every freshly-imported texture fail to resolve:

- `VFSPath::FromNative` (used by `VFSContext`'s file-watcher callback) is just `Parse` — no notion of the project root, so a native watch-event path came out still fully absolute, then got double-prefixed by every downstream consumer (registry, `ImportCoordinator`'s importers) that expects a workspace-relative path. Fixed by stripping the project root before parsing.
- `TextureImporter::Import` used `path.ToNative()` (bare separator swap) instead of `ResolveNative(workspace_root, ...)` for its own file probe — only "worked" by accident while the path above was wrongly absolute. Fixed to resolve against the workspace root like every other importer's native probe.

**Then, live-testing the fix further surfaced a fourth, even more fundamental bug**: `VFSContext::InitWatcher` was always called with `cache=nullptr, scanner=nullptr`, so `VFSScanner` was never actually constructed anywhere in the live engine — not even the reactive rescan-on-file-change ever ran. The only way an asset's UUID ever reached `AssetRegistry` was a fresh import that same session; anything cooked in a *previous* session and never touched since was invisible to any UUID-based lookup, including the new `IngestMaterialFromUUID` above. Fixed by:
- Constructing a real `VFSScanner` + `VFSDirectoryCache` in `Engine::Initialize` and wiring the scanner to the registry.
- New `VFSContext::ScanProject()`, called once from `GameApplication::Initialize` right after the project's own VFS backend is actually mounted at `/` (mounting happens *after* `Engine::Initialize` returns, so scanning any earlier hit an empty mount table and silently registered nothing).

## Known follow-up (tracked in #764, not fixed here)

Even with all of the above fixed and verified via direct live process inspection — mesh geometry, material, and texture data are now provably 100% correct end-to-end (confirmed live: the exact submesh UUID resolves through the registry to a `Loaded` record with a valid slot, a real bindless texture index, and the correct color multiplier) — the dropped mesh still renders with the reserved fallback (magenta) color instead of its real texture. This is no longer explainable by any CPU-side/asset-identity issue; it's isolated to something between "correct material buffer contents" and "final sampled pixel," most likely a genuine GPU/Vulkan-level issue (buffer visibility timing, descriptor staleness, or similar) that needs a frame capture (RenderDoc/GFXReconstruct, layers already loaded) to pin down rather than further static/CPU-side inspection. A GPU device-loss timeout was also observed once during this testing, of unclear relation.

## Verification

- `zEngineLib`, `Tetragrama`, `ZEngineTests`, `Obelisk` all build clean.
- `ctest`: 565/565 passing (same 4 pre-existing GPU-gated skips), after every commit in this branch.
- Live in Obelisk: dragging a cooked mesh now correctly ingests and resolves all of its materials, even without a fresh re-import this session (verified via direct process memory inspection — a 16-material character mesh's material now resolves to a `Loaded` registry record with correct GPU data, where before the scanner fix it returned `nullptr`).

## Test plan

- [x] `ctest` full suite passes
- [x] Manual: drag a cooked `.zemesh` with multiple materials onto the viewport in a fresh editor session (no re-import), confirm every submesh's material UUID resolves to a `Loaded` record (verified via lldb memory inspection)
- [ ] Manual: once #764's remaining GPU-level issue is resolved, visually confirm the dropped mesh renders with its correct textures