### PR TITLE
feat(streaming): virtual geometry streaming — pool allocator, eviction, compaction, VRAM auto-detect

### DIFF
--- a/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp
+++ b/ZEngine/ZEngine/Applications/AppRenderPipeline.cpp
@@ -205,6 +205,17 @@ namespace ZEngine::Applications
                 if (!handle.IsValid())
                     continue;
 
+                // Skip non-resident meshes — either upload still in flight (Pending) or the
+                // slot was evicted (Unloaded). For evicted slots, enqueue a reload so the
+                // streaming manager re-uploads the data at the start of the next frame.
+                if (!rrm->IsMeshResident(handle))
+                {
+                    rrm->RequestMeshLoad(handle, inst.MeshUUID);
+                    continue;
+                }
+
+                rrm->MarkMeshReferenced(handle);
+
                 uint32_t vtx_base = 0, idx_base = 0;
                 rrm->GetMeshOffsets(handle, vtx_base, idx_base);
 

--- a/ZEngine/ZEngine/Core/Memory/Allocator.cpp
+++ b/ZEngine/ZEngine/Core/Memory/Allocator.cpp
@@ -29,7 +29,10 @@ namespace ZEngine::Core::Memory
             return;
 
         m_total_size              = size;
-        m_mem_page_size           = page_size;
+        // Default to 4096 when the caller passes 0 — prevents the commit-size mask
+        // (offset + size + page_size - 1) & ~(page_size - 1) from evaluating to 0
+        // on Windows and causing VirtualAlloc(MEM_COMMIT, 0) to fail.
+        m_mem_page_size           = page_size ? page_size : 4096;
         m_initial_current_offset  = 0;
         m_initial_previous_offset = 0;
 #ifndef _WIN32

--- a/ZEngine/ZEngine/Engine.cpp
+++ b/ZEngine/ZEngine/Engine.cpp
@@ -19,8 +19,10 @@
 #include <ZEngine/Logging/LoggerDefinition.h>
 #include <ZEngine/Managers/AssetManager.h>
 #include <ZEngine/Windows/GameWindow.h>
+#include <nlohmann/json.hpp>
 #include <chrono>
 #include <filesystem>
+#include <fstream>
 
 #ifdef __APPLE__
 #include <mach/mach.h>
@@ -33,7 +35,26 @@ namespace ZEngine
 {
     static EngineContextPtr g_engine_ctx = nullptr;
 
-    void                    Engine::Initialize(Core::Memory::MemoryManager* memory, Windows::WindowConfigurationPtr window_cfg_ptr, Applications::GameApplicationPtr app)
+    // Read memory.geometry_streaming_mb from a project.json file.
+    // Returns 0 if the file is absent, unparseable, or the key is missing — callers
+    // treat 0 as "use auto-detection from device VRAM".
+    static VkDeviceSize     ReadGeometryBudgetOverride(const char* config_file)
+    {
+        if (!config_file || config_file[0] == '\0')
+            return 0;
+        std::ifstream f(config_file);
+        if (!f.is_open())
+            return 0;
+        auto json = nlohmann::json::parse(f, nullptr, /*exceptions=*/false);
+        if (json.is_discarded() || !json.contains("memory"))
+            return 0;
+        const auto& mem = json["memory"];
+        if (!mem.contains("geometry_streaming_mb"))
+            return 0;
+        return static_cast<VkDeviceSize>(mem["geometry_streaming_mb"].get<uint32_t>()) << 20;
+    }
+
+    void Engine::Initialize(Core::Memory::MemoryManager* memory, Windows::WindowConfigurationPtr window_cfg_ptr, Applications::GameApplicationPtr app)
     {
         ZENGINE_VALIDATE_ASSERT(memory != nullptr, "Engine::Initialize: memory is null — Obelisk must call MemoryManager::Initialize first")
         ZENGINE_VALIDATE_ASSERT(Logging::Logger::IsInitialized(), "Engine::Initialize: Logger not initialized — Obelisk must call Logger::Initialize first")
@@ -107,8 +128,13 @@ namespace ZEngine
         g_engine_ctx->ImportCoordinator->RegisterImporter(&g_engine_ctx->EnvironmentMapImporter);
         g_engine_ctx->ImportCoordinator->RegisterImporter(&g_engine_ctx->TextureImporter);
 
+        // Geometry streaming budget — auto-detected from device VRAM, overridable via
+        // project.json "memory.geometry_streaming_mb". Must be set before RRM::Initialize
+        // since InitGlobalBuffers reads it during VkBuffer allocation.
+        g_engine_ctx->Device->GeometryStreamingBudget = ReadGeometryBudgetOverride(app->ConfigFile);
+
         // RenderResourceManager — GPU lifetime authority, bridges asset layer and VulkanDevice
-        g_engine_ctx->RenderResourceManager = ZPushStructCtor(&g_engine_ctx->AssetArena, Rendering::RenderResourceManager);
+        g_engine_ctx->RenderResourceManager           = ZPushStructCtor(&g_engine_ctx->AssetArena, Rendering::RenderResourceManager);
         g_engine_ctx->RenderResourceManager->Initialize(g_engine_ctx->Device, Managers::AssetManager::Instance()->Registry);
         g_engine_ctx->Device->RRM = g_engine_ctx->RenderResourceManager;
 

--- a/ZEngine/ZEngine/Hardwares/VulkanDevice.h
+++ b/ZEngine/ZEngine/Hardwares/VulkanDevice.h
@@ -235,6 +235,11 @@ namespace ZEngine::Hardwares
 
         uint32_t                                                                                                                     WriteDescriptorSetIndex                     = 0;
         uint32_t                                                                                                                     MaxGlobalTexture                            = 8192;
+        /// @brief Geometry streaming pool budget in bytes (vtx + idx combined).
+        ///        0 = auto-detect from PhysicalDeviceMemoryProperties (default).
+        ///        Set by Engine::Initialize from project.json memory.geometry_streaming_mb
+        ///        before RenderResourceManager::Initialize runs.
+        VkDeviceSize                                                                                                                 GeometryStreamingBudget                     = 0;
         VkInstance                                                                                                                   Instance                                    = VK_NULL_HANDLE;
         VkSurfaceKHR                                                                                                                 Surface                                     = VK_NULL_HANDLE;
         VkSurfaceFormatKHR                                                                                                           SurfaceFormat                               = {};

--- a/ZEngine/ZEngine/Rendering/GeometryPool.cpp
+++ b/ZEngine/ZEngine/Rendering/GeometryPool.cpp
@@ -1,0 +1,205 @@
+#include <ZEngine/Rendering/GeometryPool.h>
+#include <ZEngine/ZEngineDef.h>
+
+namespace ZEngine::Rendering
+{
+    void GeometryPool::Initialize(Core::Memory::ArenaAllocator* arena, VkDeviceSize vtx_capacity, VkDeviceSize idx_capacity, uint32_t max_free_nodes)
+    {
+        ZENGINE_VALIDATE_ASSERT(arena != nullptr, "GeometryPool::Initialize: arena must not be null")
+        ZENGINE_VALIDATE_ASSERT(vtx_capacity > 0, "GeometryPool::Initialize: vtx_capacity must be > 0")
+        ZENGINE_VALIDATE_ASSERT(idx_capacity > 0, "GeometryPool::Initialize: idx_capacity must be > 0")
+        ZENGINE_VALIDATE_ASSERT(max_free_nodes > 0, "GeometryPool::Initialize: max_free_nodes must be > 0")
+
+        VtxCapacity = vtx_capacity;
+        IdxCapacity = idx_capacity;
+        VtxUsed     = 0;
+        IdxUsed     = 0;
+        VtxCursor   = 0;
+        IdxCursor   = 0;
+        FreeVtxHead = nullptr;
+        FreeIdxHead = nullptr;
+
+        FreeNodePool.Initialize(arena, static_cast<size_t>(max_free_nodes) * sizeof(FreeNode), sizeof(FreeNode), alignof(FreeNode));
+    }
+
+    // Search the sorted free list for the first node >= need (first-fit).
+    // On success removes the node (returning it to the pool) and, if it was larger,
+    // allocates a new node for the remainder and inserts it in its sorted position.
+    static bool TryAllocFromList(GeometryPool::FreeNode*& head, Core::Memory::PoolAllocator& pool, VkDeviceSize need, VkDeviceSize& out_offset)
+    {
+        GeometryPool::FreeNode* prev = nullptr;
+        GeometryPool::FreeNode* cur  = head;
+        while (cur)
+        {
+            if (cur->Size >= need)
+            {
+                out_offset                         = cur->Offset;
+
+                VkDeviceSize            rem_offset = cur->Offset + need;
+                VkDeviceSize            rem_size   = cur->Size - need;
+
+                // Unlink and return the matched node.
+                GeometryPool::FreeNode* next       = cur->Next;
+                if (prev)
+                    prev->Next = next;
+                else
+                    head = next;
+                pool.Free(cur);
+
+                if (rem_size > 0)
+                {
+                    // Remainder starts after the allocated block — insert it where the removed
+                    // node was (sorted order preserved: rem_offset > cur->Offset > any prev).
+                    auto* rem   = static_cast<GeometryPool::FreeNode*>(pool.Allocate());
+                    rem->Offset = rem_offset;
+                    rem->Size   = rem_size;
+                    rem->Next   = next;
+                    if (prev)
+                        prev->Next = rem;
+                    else
+                        head = rem;
+                }
+                return true;
+            }
+            prev = cur;
+            cur  = cur->Next;
+        }
+        return false;
+    }
+
+    // Insert a freed range into the sorted free list and merge with adjacent neighbours.
+    static void InsertAndMerge(GeometryPool::FreeNode*& head, Core::Memory::PoolAllocator& pool, VkDeviceSize offset, VkDeviceSize size)
+    {
+        auto* node                   = static_cast<GeometryPool::FreeNode*>(pool.Allocate());
+        node->Offset                 = offset;
+        node->Size                   = size;
+        node->Next                   = nullptr;
+
+        // Find insertion position (sorted by Offset).
+        GeometryPool::FreeNode* prev = nullptr;
+        GeometryPool::FreeNode* cur  = head;
+        while (cur && cur->Offset < offset)
+        {
+            prev = cur;
+            cur  = cur->Next;
+        }
+
+        node->Next = cur;
+        if (prev)
+            prev->Next = node;
+        else
+            head = node;
+
+        // Merge with the next node if adjacent.
+        if (node->Next && node->Offset + node->Size == node->Next->Offset)
+        {
+            GeometryPool::FreeNode* merge  = node->Next;
+            node->Size                    += merge->Size;
+            node->Next                     = merge->Next;
+            pool.Free(merge);
+        }
+
+        // Merge with the previous node if adjacent.
+        if (prev && prev->Offset + prev->Size == node->Offset)
+        {
+            prev->Size += node->Size;
+            prev->Next  = node->Next;
+            pool.Free(node);
+        }
+    }
+
+    bool GeometryPool::Allocate(VkDeviceSize vtx_bytes, VkDeviceSize idx_bytes, GeometryRegion& out)
+    {
+        ZENGINE_VALIDATE_ASSERT(vtx_bytes > 0, "GeometryPool::Allocate: vtx_bytes must be > 0")
+        ZENGINE_VALIDATE_ASSERT(idx_bytes > 0, "GeometryPool::Allocate: idx_bytes must be > 0")
+
+        VkDeviceSize vtx_offset    = 0;
+        VkDeviceSize idx_offset    = 0;
+        bool         vtx_from_free = TryAllocFromList(FreeVtxHead, FreeNodePool, vtx_bytes, vtx_offset);
+        bool         idx_from_free = TryAllocFromList(FreeIdxHead, FreeNodePool, idx_bytes, idx_offset);
+
+        // If one axis succeeded from the free list but the other did not, undo it.
+        if (vtx_from_free && !idx_from_free)
+        {
+            InsertAndMerge(FreeVtxHead, FreeNodePool, vtx_offset, vtx_bytes);
+            vtx_from_free = false;
+        }
+        if (idx_from_free && !vtx_from_free)
+        {
+            InsertAndMerge(FreeIdxHead, FreeNodePool, idx_offset, idx_bytes);
+            idx_from_free = false;
+        }
+
+        if (!vtx_from_free)
+        {
+            if (VtxCursor + vtx_bytes > VtxCapacity)
+                return false;
+            vtx_offset  = VtxCursor;
+            VtxCursor  += vtx_bytes;
+        }
+
+        if (!idx_from_free)
+        {
+            if (IdxCursor + idx_bytes > IdxCapacity)
+            {
+                if (!vtx_from_free)
+                    VtxCursor -= vtx_bytes;
+                else
+                    InsertAndMerge(FreeVtxHead, FreeNodePool, vtx_offset, vtx_bytes);
+                return false;
+            }
+            idx_offset  = IdxCursor;
+            IdxCursor  += idx_bytes;
+        }
+
+        out.VtxByteOffset  = vtx_offset;
+        out.VtxByteSize    = vtx_bytes;
+        out.IdxByteOffset  = idx_offset;
+        out.IdxByteSize    = idx_bytes;
+        VtxUsed           += vtx_bytes;
+        IdxUsed           += idx_bytes;
+        return true;
+    }
+
+    void GeometryPool::Free(const GeometryRegion& region)
+    {
+        ZENGINE_VALIDATE_ASSERT(region.VtxByteSize > 0, "GeometryPool::Free: region has zero vtx size")
+        ZENGINE_VALIDATE_ASSERT(region.IdxByteSize > 0, "GeometryPool::Free: region has zero idx size")
+        ZENGINE_VALIDATE_ASSERT(VtxUsed >= region.VtxByteSize, "GeometryPool::Free: VtxUsed underflow")
+        ZENGINE_VALIDATE_ASSERT(IdxUsed >= region.IdxByteSize, "GeometryPool::Free: IdxUsed underflow")
+
+        InsertAndMerge(FreeVtxHead, FreeNodePool, region.VtxByteOffset, region.VtxByteSize);
+        InsertAndMerge(FreeIdxHead, FreeNodePool, region.IdxByteOffset, region.IdxByteSize);
+        VtxUsed -= region.VtxByteSize;
+        IdxUsed -= region.IdxByteSize;
+    }
+
+    float GeometryPool::FragmentationRatio() const
+    {
+        VkDeviceSize total_capacity = VtxCapacity + IdxCapacity;
+        if (total_capacity == 0)
+            return 0.f;
+
+        VkDeviceSize free_vtx = 0;
+        for (const FreeNode* n = FreeVtxHead; n; n = n->Next)
+            free_vtx += n->Size;
+
+        VkDeviceSize free_idx = 0;
+        for (const FreeNode* n = FreeIdxHead; n; n = n->Next)
+            free_idx += n->Size;
+
+        return static_cast<float>(free_vtx + free_idx) / static_cast<float>(total_capacity);
+    }
+
+    void GeometryPool::Reset()
+    {
+        FreeNodePool.Clear();
+        FreeVtxHead = nullptr;
+        FreeIdxHead = nullptr;
+        VtxCursor   = 0;
+        IdxCursor   = 0;
+        VtxUsed     = 0;
+        IdxUsed     = 0;
+    }
+
+} // namespace ZEngine::Rendering

--- a/ZEngine/ZEngine/Rendering/GeometryPool.h
+++ b/ZEngine/ZEngine/Rendering/GeometryPool.h
@@ -1,0 +1,83 @@
+#pragma once
+#include <ZEngine/Core/Memory/Allocator.h>
+#include <ZEngine/Core/Memory/GpuAllocator.h>
+#include <vulkan/vulkan.h>
+
+namespace ZEngine::Rendering
+{
+    /// @brief Contiguous byte ranges allocated from the streaming geometry pool for one mesh.
+    /// @details VtxByteOffset/VtxByteSize describe a region inside GeometryPool::VertexBuffer;
+    ///          IdxByteOffset/IdxByteSize describe a region inside GeometryPool::IndexBuffer.
+    ///          Both axes are allocated and freed as a unit via GeometryPool::Allocate/Free.
+    struct GeometryRegion
+    {
+        VkDeviceSize VtxByteOffset = 0;
+        VkDeviceSize IdxByteOffset = 0;
+        VkDeviceSize VtxByteSize   = 0;
+        VkDeviceSize IdxByteSize   = 0;
+    };
+
+    /// @brief Variable-size region allocator over the global streaming vertex and index buffers.
+    ///
+    /// One region per mesh — allocation granularity matches the natural upload unit
+    /// (AppendMeshData appends one contiguous vtx block + one contiguous idx block per mesh).
+    /// Freed regions are returned to sorted intrusive free lists backed by a PoolAllocator,
+    /// and merged with adjacent free ranges on free. When the append cursor is exhausted and
+    /// no free range is large enough, Allocate returns false — the caller should compact.
+    struct GeometryPool
+    {
+        Core::Memory::BufferView VertexBuffer = {}; ///< Device-local VkBuffer for vertex data.
+        Core::Memory::BufferView IndexBuffer  = {}; ///< Device-local VkBuffer for index data.
+
+        VkDeviceSize             VtxCapacity  = 0; ///< Total vertex buffer capacity in bytes.
+        VkDeviceSize             IdxCapacity  = 0; ///< Total index buffer capacity in bytes.
+        VkDeviceSize             VtxUsed      = 0; ///< Bytes held by live (non-freed) regions.
+        VkDeviceSize             IdxUsed      = 0;
+        VkDeviceSize             VtxCursor    = 0; ///< Append cursor; advanced only when the free list has no fit.
+        VkDeviceSize             IdxCursor    = 0;
+
+        /// @brief A node in the sorted intrusive free list for one buffer axis.
+        struct FreeNode
+        {
+            VkDeviceSize Offset = 0;
+            VkDeviceSize Size   = 0;
+            FreeNode*    Next   = nullptr;
+        };
+
+        FreeNode*                   FreeVtxHead  = nullptr; ///< Head of the vtx free list, sorted by Offset.
+        FreeNode*                   FreeIdxHead  = nullptr; ///< Head of the idx free list, sorted by Offset.
+        Core::Memory::PoolAllocator FreeNodePool = {};      ///< Fixed-chunk pool backing all FreeNode allocations.
+
+        /// @brief Initialise the pool with the given capacities.
+        /// @param arena          Arena backing the PoolAllocator's node storage.
+        /// @param vtx_capacity   Total vertex buffer capacity in bytes.
+        /// @param idx_capacity   Total index buffer capacity in bytes.
+        /// @param max_free_nodes Upper bound on simultaneous free nodes across both axes;
+        ///                       size to 2 * max_mesh_slots to guarantee no overflow.
+        void                        Initialize(Core::Memory::ArenaAllocator* arena, VkDeviceSize vtx_capacity, VkDeviceSize idx_capacity, uint32_t max_free_nodes);
+
+        /// @brief Allocate a region large enough for vtx_bytes of vertex data and idx_bytes of
+        ///        index data. Searches the free list first (first-fit), then the append cursor.
+        /// @param vtx_bytes Byte size of the vertex data to reserve.
+        /// @param idx_bytes Byte size of the index data to reserve.
+        /// @param out       Filled with the allocated offsets and sizes on success.
+        /// @return true on success; false if the pool is full (caller should compact).
+        bool                        Allocate(VkDeviceSize vtx_bytes, VkDeviceSize idx_bytes, GeometryRegion& out);
+
+        /// @brief Return a region to the free lists.
+        /// @details Inserts in sorted order and merges adjacent free ranges on both axes.
+        ///          Subtracts from VtxUsed/IdxUsed.
+        /// @param region The region previously returned by Allocate.
+        void                        Free(const GeometryRegion& region);
+
+        /// @brief Ratio of hole bytes (freed but not yet compacted) to total capacity, in [0, 1].
+        /// @details 0 = fully packed, 1 = everything is holes. Compaction is typically
+        ///          triggered when this exceeds 0.30.
+        float                       FragmentationRatio() const;
+
+        /// @brief Reset the pool to empty: zero cursors, return all nodes to the pool,
+        ///        zero Used counters. Does not touch the underlying VkBuffer allocations.
+        void                        Reset();
+    };
+
+} // namespace ZEngine::Rendering

--- a/ZEngine/ZEngine/Rendering/GeometryStreamingManager.cpp
+++ b/ZEngine/ZEngine/Rendering/GeometryStreamingManager.cpp
@@ -1,0 +1,147 @@
+#include <ZEngine/Logging/LoggerDefinition.h>
+#include <ZEngine/Rendering/GeometryStreamingManager.h>
+#include <ZEngine/Rendering/RenderResourceManager.h>
+
+namespace ZEngine::Rendering
+{
+    void GeometryStreamingManager::Initialize(Hardwares::VulkanDevice* device, RenderResourceManager* rrm)
+    {
+        m_device            = device;
+        m_rrm               = rrm;
+        m_clock_hand        = 0;
+        m_compact_requested = false;
+    }
+
+    void GeometryStreamingManager::Deinitialize()
+    {
+        m_device = nullptr;
+        m_rrm    = nullptr;
+    }
+
+    bool GeometryStreamingManager::RequestLoad(const StreamRequest& req)
+    {
+        return m_load_queue.push(req);
+    }
+
+    void GeometryStreamingManager::DrainLoadQueue(uint32_t frame_index)
+    {
+        StreamRequest req;
+        while (m_load_queue.pop(req))
+        {
+            if (!req.Handle.IsValid())
+                continue;
+            uint32_t slot_idx = req.Handle.Index;
+            if (slot_idx >= m_rrm->m_mesh_slot_count)
+                continue;
+            auto& slot = m_rrm->m_mesh_slots[slot_idx];
+            if (slot.Generation != req.Handle.Generation)
+                continue;
+            if (slot.Data.State != RenderResourceManager::StreamingState::Unloaded)
+                continue; // already loading or resident from a parallel path
+
+            // Re-upload the mesh data into a fresh pool region via the per-frame batch.
+            RenderResourceManager::MeshSlot new_data = m_rrm->AppendMeshData(req.Asset, frame_index);
+            if (new_data.VtxCount == 0)
+            {
+                ZENGINE_CORE_WARN("[GeometryStreamingManager] RequestLoad: AppendMeshData failed for slot {}", slot_idx)
+                continue;
+            }
+            slot.Data.Region   = new_data.Region;
+            slot.Data.VtxCount = new_data.VtxCount;
+            slot.Data.IdxCount = new_data.IdxCount;
+            slot.Data.State    = RenderResourceManager::StreamingState::Resident;
+            ZENGINE_CORE_TRACE("[GeometryStreamingManager] Reloaded mesh slot {}", slot_idx)
+        }
+    }
+
+    void GeometryStreamingManager::Tick(uint32_t frame_index)
+    {
+        if (!m_rrm)
+            return;
+
+        // Drain pending reload requests first — before eviction and compaction checks,
+        // so newly reloaded meshes count toward the current usage before the thresholds
+        // are evaluated.
+        DrainLoadQueue(frame_index);
+
+        // Request compaction if fragmentation exceeds the threshold.
+        if (m_rrm->m_pool.FragmentationRatio() > kCompactionThreshold)
+            m_compact_requested = true;
+
+        // Run the eviction sweep if either buffer axis is under pressure.
+        const auto& pool         = m_rrm->m_pool;
+        bool        vtx_pressure = pool.VtxCapacity > 0 && static_cast<float>(pool.VtxUsed) / static_cast<float>(pool.VtxCapacity) > kEvictionThreshold;
+        bool        idx_pressure = pool.IdxCapacity > 0 && static_cast<float>(pool.IdxUsed) / static_cast<float>(pool.IdxCapacity) > kEvictionThreshold;
+        if (vtx_pressure || idx_pressure)
+            RunEvictionSweep();
+
+        // Clear all Referenced bits so RenderScene can mark fresh references this frame.
+        uint32_t count = m_rrm->m_mesh_slot_count;
+        for (uint32_t i = 0; i < count; ++i)
+        {
+            auto& slot = m_rrm->m_mesh_slots[i];
+            if (slot.Generation != 0 && slot.Data.State == RenderResourceManager::StreamingState::Resident)
+                slot.Data.Referenced = false;
+        }
+    }
+
+    void GeometryStreamingManager::RunEvictionSweep()
+    {
+        uint32_t count = m_rrm->m_mesh_slot_count;
+        if (count == 0)
+            return;
+
+        // Walk up to `count` slots from the current clock-hand position.
+        // Slots with Referenced=true get a second chance (bit cleared, skipped this cycle).
+        // The first non-referenced, non-pinned Resident slot is evicted.
+        for (uint32_t visited = 0; visited < count; ++visited)
+        {
+            uint32_t i   = m_clock_hand % count;
+            m_clock_hand = (m_clock_hand + 1) % count;
+
+            auto& slot   = m_rrm->m_mesh_slots[i];
+            if (slot.Generation == 0)
+                continue; // free slot
+            if (slot.Data.State != RenderResourceManager::StreamingState::Resident)
+                continue;
+            if (slot.Data.Pinned)
+                continue;
+
+            if (slot.Data.Referenced)
+            {
+                slot.Data.Referenced = false; // second-chance: clear and skip
+                continue;
+            }
+
+            // Evict: return bytes to the pool and mark the slot unloaded.
+            slot.Data.State = RenderResourceManager::StreamingState::Unloaded;
+            if (slot.Data.Region.VtxByteSize > 0)
+                m_rrm->m_pool.Free(slot.Data.Region);
+            slot.Data.Region = {};
+            ZENGINE_CORE_TRACE("[GeometryStreamingManager] Evicted mesh slot {}", i)
+            return; // one eviction per sweep call
+        }
+    }
+
+    void GeometryStreamingManager::RequestEvict(BufferHandle handle)
+    {
+        if (!m_rrm || !handle.IsValid())
+            return;
+        uint32_t slot_idx = handle.Index;
+        if (slot_idx >= m_rrm->m_mesh_slot_count)
+            return;
+        auto& slot = m_rrm->m_mesh_slots[slot_idx];
+        if (slot.Generation != handle.Generation)
+            return;
+        if (slot.Data.State != RenderResourceManager::StreamingState::Resident)
+            return;
+        if (slot.Data.Pinned)
+            return;
+        slot.Data.State = RenderResourceManager::StreamingState::Unloaded;
+        if (slot.Data.Region.VtxByteSize > 0)
+            m_rrm->m_pool.Free(slot.Data.Region);
+        slot.Data.Region = {};
+        ZENGINE_CORE_TRACE("[GeometryStreamingManager] Explicit eviction of mesh slot {}", slot_idx)
+    }
+
+} // namespace ZEngine::Rendering

--- a/ZEngine/ZEngine/Rendering/GeometryStreamingManager.h
+++ b/ZEngine/ZEngine/Rendering/GeometryStreamingManager.h
@@ -1,0 +1,85 @@
+#pragma once
+#include <ZEngine/Core/Containers/SPSCQueue.h>
+#include <ZEngine/Managers/AssetManager.h>
+#include <ZEngine/Rendering/RenderHandle.h>
+#include <uuid.h>
+#include <cstdint>
+
+namespace ZEngine::Hardwares
+{
+    struct VulkanDevice;
+}
+
+namespace ZEngine::Rendering
+{
+    class RenderResourceManager;
+
+    /// @brief Per-mesh load request submitted to the streaming manager.
+    struct StreamRequest
+    {
+        uuids::uuid           UUID     = {}; ///< Asset UUID; used for dedup and UUID map update.
+        Managers::AssetHandle Asset    = 0;  ///< Asset handle to read geometry data from.
+        BufferHandle          Handle   = {}; ///< Pre-allocated mesh slot — manager fills its region.
+        uint8_t               Priority = 0;  ///< 0 = high (currently visible), 1 = prefetch.
+    };
+
+    /// @brief Drives streaming geometry eviction on behalf of RenderResourceManager.
+    /// @details Tick() is called once per frame from RenderResourceManager::BeginFrame, after
+    ///          batch stagings are retired and pending uploads are flushed.
+    ///
+    ///          Eviction uses a clock-hand sweep over the mesh slot array: slots with Referenced=true
+    ///          get one grace cycle (bit cleared, slot skipped); slots with Referenced=false are
+    ///          evicted when pool usage exceeds kEvictionThreshold. The Referenced bits are cleared
+    ///          at the end of every Tick so RenderScene can mark fresh references each frame.
+    class GeometryStreamingManager
+    {
+    public:
+        /// @brief Pool usage (vtx or idx axis) above which the eviction sweep runs.
+        static constexpr float kEvictionThreshold   = 0.85f;
+        /// @brief Fragmentation ratio above which a compaction is requested.
+        static constexpr float kCompactionThreshold = 0.30f;
+
+        /// @brief Bind the manager to a device and RRM. Must be called before Tick().
+        void                   Initialize(Hardwares::VulkanDevice* device, RenderResourceManager* rrm);
+        void                   Deinitialize();
+
+        /// @brief Per-frame driver — called from RenderResourceManager::BeginFrame.
+        /// @details Checks pool fragmentation, runs the eviction sweep if pool is under
+        ///          pressure, then clears all Referenced bits for the coming frame.
+        /// @param frame_index Current swapchain frame index.
+        void                   Tick(uint32_t frame_index);
+
+        /// @brief Enqueue a mesh load request. Single-producer (render thread), consumed by Tick().
+        /// @details Pushes onto m_load_queue (SPSC). Returns false and drops the request if
+        ///          the queue is full (kLoadQueueCapacity requests already pending).
+        bool                   RequestLoad(const StreamRequest& req);
+
+        /// @brief Mark a mesh slot for eviction. Render-thread only (future use).
+        void                   RequestEvict(BufferHandle handle);
+
+        /// @brief True if a compaction pass has been requested and not yet serviced.
+        bool                   IsCompactionRequested() const
+        {
+            return m_compact_requested;
+        }
+
+        /// @brief Acknowledge and clear the compaction request after the caller has compacted.
+        void ClearCompactionRequest()
+        {
+            m_compact_requested = false;
+        }
+
+    private:
+        void                                                           RunEvictionSweep();
+        void                                                           DrainLoadQueue(uint32_t frame_index);
+
+        static constexpr uint32_t                                      kLoadQueueCapacity  = 256;
+
+        Hardwares::VulkanDevice*                                       m_device            = nullptr;
+        RenderResourceManager*                                         m_rrm               = nullptr;
+        Core::Containers::SPSCQueue<StreamRequest, kLoadQueueCapacity> m_load_queue        = {};
+        uint32_t                                                       m_clock_hand        = 0;
+        bool                                                           m_compact_requested = false;
+    };
+
+} // namespace ZEngine::Rendering

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
@@ -175,10 +175,14 @@ namespace ZEngine::Rendering
         }
 
         // Free all live buffer slots
-        if (m_global_vertex_buf)
-            m_device->GpuMem.FreeBuffer(m_global_vertex_buf);
-        if (m_global_index_buf)
-            m_device->GpuMem.FreeBuffer(m_global_index_buf);
+        if (m_pool.VertexBuffer)
+            m_device->GpuMem.FreeBuffer(m_pool.VertexBuffer);
+        if (m_pool.IndexBuffer)
+            m_device->GpuMem.FreeBuffer(m_pool.IndexBuffer);
+        if (m_builtin_vertex_buf)
+            m_device->GpuMem.FreeBuffer(m_builtin_vertex_buf);
+        if (m_builtin_index_buf)
+            m_device->GpuMem.FreeBuffer(m_builtin_index_buf);
 
         for (uint32_t i = 0; i < m_gbuf_slot_count; ++i)
         {
@@ -186,6 +190,7 @@ namespace ZEngine::Rendering
                 m_device->GpuMem.FreeBuffer(m_gbuf_slots[i].Data);
         }
 
+        m_streaming_mgr.Deinitialize();
         m_device   = nullptr;
         m_registry = nullptr;
     }
@@ -194,6 +199,9 @@ namespace ZEngine::Rendering
     {
         m_active_frame_index = static_cast<uint8_t>(frame_index);
         RetireBatchStagings();
+        m_streaming_mgr.Tick(frame_index);
+        if (m_streaming_mgr.IsCompactionRequested())
+            RunCompaction();
         FlushPendingUploads(frame_index);
         FlushPendingSwaps(frame_index);
         FlushPendingTextureReloads();
@@ -245,8 +253,13 @@ namespace ZEngine::Rendering
                     ZENGINE_LOG_RENDER_ERR("[RRM] Hot-reload swap failed to re-upload mesh data — old data left in place")
                     continue;
                 }
-                // Append-only global buffer — no GPU free for the old region, just repoint.
-                m_mesh_slots[s.OldBuffer.Index].Data = new_data;
+                // Free the old region before repointing the slot — pool is no longer append-only.
+                auto& slot = m_mesh_slots[s.OldBuffer.Index];
+                if (slot.Data.Region.VtxByteSize > 0)
+                    m_pool.Free(slot.Data.Region);
+                slot.Data            = new_data;
+                slot.Data.State      = StreamingState::Resident;
+                slot.Data.Referenced = false;
             }
         }
     }
@@ -356,37 +369,83 @@ namespace ZEngine::Rendering
         cmd->ResetState();
     }
 
+    // Derive a per-axis geometry streaming budget from the device's device-local VRAM.
+    // Uses 15% of the largest device-local heap, clamped to [GLOBAL_VTX_MIN, GLOBAL_VTX_CAPACITY].
+    // The same value is used for both vtx and idx axes (split evenly from the total budget).
+    static VkDeviceSize DeriveGeometryBudget(const VkPhysicalDeviceMemoryProperties& props)
+    {
+        VkDeviceSize largest_device_local = 0;
+        for (uint32_t i = 0; i < props.memoryHeapCount; ++i)
+        {
+            if ((props.memoryHeaps[i].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) && props.memoryHeaps[i].size > largest_device_local)
+                largest_device_local = props.memoryHeaps[i].size;
+        }
+
+        if (largest_device_local == 0)
+            return RenderResourceManager::GLOBAL_VTX_CAPACITY;
+
+        VkDeviceSize half_budget = largest_device_local * 15 / 100 / 2;
+        half_budget              = std::max(half_budget, RenderResourceManager::GLOBAL_VTX_MIN);
+        half_budget              = std::min(half_budget, RenderResourceManager::GLOBAL_VTX_CAPACITY);
+        return half_budget;
+    }
+
     void RenderResourceManager::InitGlobalBuffers()
     {
-        m_global_vertex_buf = m_device->GpuMem.AllocateBuffer(GLOBAL_VTX_CAPACITY, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, GpuMemoryDomain::DeviceGeometry, "RRM::GlobalVertexBuffer");
+        VkDeviceSize vtx_capacity = 0;
+        VkDeviceSize idx_capacity = 0;
 
-        m_global_index_buf  = m_device->GpuMem.AllocateBuffer(GLOBAL_IDX_CAPACITY, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, GpuMemoryDomain::DeviceGeometry, "RRM::GlobalIndexBuffer");
+        if (m_device->GeometryStreamingBudget != 0)
+        {
+            // Explicit project.json override: split evenly, clamp to [min, max].
+            VkDeviceSize half = m_device->GeometryStreamingBudget / 2;
+            half              = std::max(half, GLOBAL_VTX_MIN);
+            half              = std::min(half, GLOBAL_VTX_CAPACITY);
+            vtx_capacity      = half;
+            idx_capacity      = half;
+            ZENGINE_LOG_RENDER_INFO("[RRM] Geometry pool: project override {} MB vtx + {} MB idx", vtx_capacity >> 20, idx_capacity >> 20)
+        }
+        else
+        {
+            vtx_capacity = DeriveGeometryBudget(m_device->PhysicalDeviceMemoryProperties);
+            idx_capacity = vtx_capacity;
+            ZENGINE_LOG_RENDER_INFO("[RRM] Geometry pool: auto-detected {} MB vtx + {} MB idx (15% of largest device-local heap)", vtx_capacity >> 20, idx_capacity >> 20)
+        }
 
-        m_vtx_cursor        = 0;
-        m_idx_cursor        = 0;
+        m_pool.VertexBuffer = m_device->GpuMem.AllocateBuffer(vtx_capacity, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, GpuMemoryDomain::DeviceGeometry, "RRM::GlobalVertexBuffer");
+        m_pool.IndexBuffer  = m_device->GpuMem.AllocateBuffer(idx_capacity, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, GpuMemoryDomain::DeviceGeometry, "RRM::GlobalIndexBuffer");
+        ZENGINE_VALIDATE_ASSERT(m_pool.VertexBuffer, "RRM: global vertex buffer allocation failed")
+        ZENGINE_VALIDATE_ASSERT(m_pool.IndexBuffer, "RRM: global index buffer allocation failed")
+        m_pool.Initialize(m_device->Arena, vtx_capacity, idx_capacity, MAX_BUFFERS * 2);
 
-        ZENGINE_VALIDATE_ASSERT(m_global_vertex_buf, "RRM: global vertex buffer allocation failed")
-        ZENGINE_VALIDATE_ASSERT(m_global_index_buf, "RRM: global index buffer allocation failed")
+        m_builtin_vertex_buf = m_device->GpuMem.AllocateBuffer(BUILTIN_VTX_CAPACITY, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, GpuMemoryDomain::DeviceGeometry, "RRM::BuiltinVertexBuffer");
+        m_builtin_index_buf  = m_device->GpuMem.AllocateBuffer(BUILTIN_IDX_CAPACITY, VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, GpuMemoryDomain::DeviceGeometry, "RRM::BuiltinIndexBuffer");
+        m_builtin_vtx_cursor = 0;
+        m_builtin_idx_cursor = 0;
+        ZENGINE_VALIDATE_ASSERT(m_builtin_vertex_buf, "RRM: builtin vertex buffer allocation failed")
+        ZENGINE_VALIDATE_ASSERT(m_builtin_index_buf, "RRM: builtin index buffer allocation failed")
+
+        m_streaming_mgr.Initialize(m_device, this);
     }
 
     void RenderResourceManager::RegisterBuiltinGeometry(const void* vtx_data, size_t vtx_bytes, const uint32_t* idx_data, uint32_t idx_count, uint32_t& out_vtx_offset, uint32_t& out_idx_offset)
     {
         const size_t idx_bytes = idx_count * sizeof(uint32_t);
-        ZENGINE_VALIDATE_ASSERT(m_vtx_cursor + vtx_bytes <= GLOBAL_VTX_CAPACITY, "RRM::RegisterBuiltinGeometry: global vertex buffer out of space")
-        ZENGINE_VALIDATE_ASSERT(m_idx_cursor + idx_bytes <= GLOBAL_IDX_CAPACITY, "RRM::RegisterBuiltinGeometry: global index buffer out of space")
+        ZENGINE_VALIDATE_ASSERT(m_builtin_vtx_cursor + vtx_bytes <= BUILTIN_VTX_CAPACITY, "RRM::RegisterBuiltinGeometry: builtin vertex buffer out of space")
+        ZENGINE_VALIDATE_ASSERT(m_builtin_idx_cursor + idx_bytes <= BUILTIN_IDX_CAPACITY, "RRM::RegisterBuiltinGeometry: builtin index buffer out of space")
 
-        // Called pre-render-thread (single-threaded init) — the batch this opens simply
-        // stays open, unclosed, until the first real frame's RRM::EndFrame, at which point
-        // any mesh uploads from that same first frame join it too. Safe: frame_index here
-        // is just "which reusable slot", decoupled from the swapchain's own frame index.
+        // Called pre-render-thread (single-threaded init) — the batch this opens stays
+        // open until the first real frame's RRM::EndFrame, where any mesh uploads from
+        // that frame join it too. Builtin data goes into the pinned builtin buffers, not
+        // the streaming global buffers, so a ResetGeometryBuffers never corrupts it.
         EnsureBatchOpen(static_cast<uint8_t>(m_active_frame_index));
-        AppendToGlobalBuffer(m_global_vertex_buf, vtx_data, vtx_bytes, m_vtx_cursor, m_active_frame_index);
-        AppendToGlobalBuffer(m_global_index_buf, idx_data, idx_bytes, m_idx_cursor, m_active_frame_index);
+        AppendToGlobalBuffer(m_builtin_vertex_buf, vtx_data, vtx_bytes, m_builtin_vtx_cursor, m_active_frame_index);
+        AppendToGlobalBuffer(m_builtin_index_buf, idx_data, idx_bytes, m_builtin_idx_cursor, m_active_frame_index);
 
-        out_vtx_offset  = static_cast<uint32_t>(m_vtx_cursor / (8 * sizeof(float)));
-        out_idx_offset  = static_cast<uint32_t>(m_idx_cursor / sizeof(uint32_t));
-        m_vtx_cursor   += vtx_bytes;
-        m_idx_cursor   += idx_bytes;
+        out_vtx_offset        = static_cast<uint32_t>(m_builtin_vtx_cursor / (8 * sizeof(float)));
+        out_idx_offset        = static_cast<uint32_t>(m_builtin_idx_cursor / sizeof(uint32_t));
+        m_builtin_vtx_cursor += vtx_bytes;
+        m_builtin_idx_cursor += idx_bytes;
     }
 
     void RenderResourceManager::ResetGeometryBuffers()
@@ -396,8 +455,7 @@ namespace ZEngine::Rendering
 
     void RenderResourceManager::ResetGeometryBuffersInternal()
     {
-        m_vtx_cursor = 0;
-        m_idx_cursor = 0;
+        m_pool.Reset();
         for (uint32_t i = 0; i < m_mesh_slot_count; ++i)
             m_mesh_slots[i] = {};
         m_mesh_slot_count = 0;
@@ -406,6 +464,68 @@ namespace ZEngine::Rendering
         for (uint32_t i = 0; i < m_uuid_to_buffer_count; ++i)
             m_uuid_to_buffer[i] = {};
         m_uuid_to_buffer_count = 0;
+    }
+
+    void RenderResourceManager::RunCompaction()
+    {
+        // Snapshot all Resident slots with their AssetHandles before touching the pool.
+        // AssetManager::Meshes is always CPU-resident today (no CPU-side eviction), so
+        // GetAsset<AssetMesh> inside AppendMeshData is guaranteed to succeed for every
+        // Resident slot. If CPU streaming is added later, switch to a GPU self-copy.
+        struct CompactEntry
+        {
+            uint32_t              SlotIdx;
+            Managers::AssetHandle Asset;
+        };
+        CompactEntry entries[MAX_UUID_MAP];
+        uint32_t     entry_count = 0;
+
+        {
+            std::lock_guard lock(m_uuid_map_mutex);
+            for (uint32_t i = 0; i < m_uuid_to_buffer_count; ++i)
+            {
+                const UUIDBufferPair& pair = m_uuid_to_buffer[i];
+                if (!pair.Handle.IsValid())
+                    continue;
+                uint32_t slot_idx = pair.Handle.Index;
+                if (slot_idx >= m_mesh_slot_count)
+                    continue;
+                const auto& slot = m_mesh_slots[slot_idx];
+                if (slot.Generation != pair.Handle.Generation)
+                    continue;
+                if (slot.Data.State != StreamingState::Resident)
+                    continue;
+                const AssetRecord* rec = m_registry->FindByUUID(pair.UUID);
+                if (!rec)
+                    continue;
+                entries[entry_count++] = {slot_idx, rec->SlotHandle};
+            }
+        }
+
+        // Reset the pool: zero cursors, clear free lists. VkBuffer content is irrelevant —
+        // every Resident byte will be re-uploaded into the new packed layout below.
+        m_pool.Reset();
+
+        // Clear stale regions so no slot holds a dangling offset after the reset.
+        for (uint32_t i = 0; i < entry_count; ++i)
+            m_mesh_slots[entries[i].SlotIdx].Data.Region = {};
+
+        // Re-upload each mesh into a fresh packed region.  EnsureBatchOpen opens the
+        // batch if nothing else has yet — it will be closed by EndFrame as normal.
+        EnsureBatchOpen(m_active_frame_index);
+        for (uint32_t i = 0; i < entry_count; ++i)
+        {
+            MeshSlot new_data = AppendMeshData(entries[i].Asset, m_active_frame_index);
+            if (new_data.VtxCount > 0)
+            {
+                m_mesh_slots[entries[i].SlotIdx].Data.Region   = new_data.Region;
+                m_mesh_slots[entries[i].SlotIdx].Data.VtxCount = new_data.VtxCount;
+                m_mesh_slots[entries[i].SlotIdx].Data.IdxCount = new_data.IdxCount;
+            }
+        }
+
+        m_streaming_mgr.ClearCompactionRequest();
+        ZENGINE_LOG_RENDER_INFO("[RRM] Geometry compaction complete — {} meshes re-packed, fragmentation now {:.1f}%", entry_count, m_pool.FragmentationRatio() * 100.f)
     }
 
     void RenderResourceManager::RetireBatchStagings()
@@ -486,13 +606,13 @@ namespace ZEngine::Rendering
         m_batch_cmd  = nullptr;
     }
 
-    void RenderResourceManager::AppendToGlobalBuffer(BufferView& global_buf, const void* data, size_t byte_size, VkDeviceSize byte_offset, uint32_t frame_index)
+    void RenderResourceManager::AppendToGlobalBuffer(BufferView& dst_buf, const void* data, size_t byte_size, VkDeviceSize byte_offset, uint32_t frame_index)
     {
         BufferView staging = m_device->GpuMem.AllocateBuffer(static_cast<VkDeviceSize>(byte_size), VK_BUFFER_USAGE_TRANSFER_SRC_BIT, GpuMemoryDomain::HostStaging, "RRM::Staging");
         ZENGINE_VALIDATE_ASSERT(staging, "RRM::AppendToGlobalBuffer: staging alloc failed")
         ZENGINE_VALIDATE_ASSERT(vmaCopyMemoryToAllocation(m_device->GpuMem.Allocator, data, staging.Allocation, 0, byte_size) == VK_SUCCESS, "RRM::AppendToGlobalBuffer: staging copy failed")
 
-        GlobalBufferCopyCtx ctx{staging.Handle, global_buf.Handle, byte_offset, byte_size};
+        GlobalBufferCopyCtx ctx{staging.Handle, dst_buf.Handle, byte_offset, byte_size};
 
         // Every caller (FlushPendingUploads, FlushPendingSwaps, RegisterBuiltinGeometry)
         // calls EnsureBatchOpen first — there is no longer a synchronous fallback path.
@@ -515,36 +635,31 @@ namespace ZEngine::Rendering
         static constexpr uint32_t FLOATS_PER_DRAW_VERTEX = 8;                                      // x,y,z, nx,ny,nz, u,v
         static constexpr uint32_t DRAW_VERTEX_BYTES      = FLOATS_PER_DRAW_VERTEX * sizeof(float); // 32
 
-        // Every downstream offset/count in this function assumes Vertices.size() is a whole
-        // number of DrawVertex elements — if that ever drifts, m_vtx_cursor stops being
-        // vertex-aligned and silently corrupts the GPU-side read offset for every mesh
-        // appended afterward. Enforced only by importer convention, not by any other check,
-        // so assert it here rather than let it corrupt the buffer quietly.
+        // Every downstream offset assumes Vertices.size() is a whole number of DrawVertex
+        // elements — enforced only by importer convention, so assert here rather than let
+        // a misaligned cursor corrupt every subsequent mesh's GPU-side read offset.
         ZENGINE_VALIDATE_ASSERT(mesh->Vertices.size() % FLOATS_PER_DRAW_VERTEX == 0, "RRM::AppendMeshData: Vertices.size() is not a whole number of DrawVertex elements")
 
-        size_t vert_bytes = mesh->Vertices.size() * sizeof(float);
-        size_t idx_bytes  = mesh->Indices.size() * sizeof(uint32_t);
-
-        if (m_vtx_cursor + vert_bytes > GLOBAL_VTX_CAPACITY || m_idx_cursor + idx_bytes > GLOBAL_IDX_CAPACITY)
+        size_t         vert_bytes = mesh->Vertices.size() * sizeof(float);
+        size_t         idx_bytes  = mesh->Indices.size() * sizeof(uint32_t);
+        GeometryRegion region;
+        if (!m_pool.Allocate(static_cast<VkDeviceSize>(vert_bytes), static_cast<VkDeviceSize>(idx_bytes), region))
         {
-            ZENGINE_LOG_RENDER_ERR("[RRM] AppendMeshData: global buffer capacity exceeded")
+            ZENGINE_LOG_RENDER_ERR("[RRM] AppendMeshData: geometry pool full")
             return {};
         }
 
-        AppendToGlobalBuffer(m_global_vertex_buf, mesh->Vertices.data(), vert_bytes, m_vtx_cursor, frame_index);
-        AppendToGlobalBuffer(m_global_index_buf, mesh->Indices.data(), idx_bytes, m_idx_cursor, frame_index);
+        AppendToGlobalBuffer(m_pool.VertexBuffer, mesh->Vertices.data(), vert_bytes, region.VtxByteOffset, frame_index);
+        AppendToGlobalBuffer(m_pool.IndexBuffer, mesh->Indices.data(), idx_bytes, region.IdxByteOffset, frame_index);
 
-        uint32_t vtx_elem_offset  = static_cast<uint32_t>(m_vtx_cursor / DRAW_VERTEX_BYTES); // DrawVertex[] index
-        uint32_t idx_elem_offset  = static_cast<uint32_t>(m_idx_cursor / sizeof(uint32_t));  // uint32[] index
-        uint32_t vtx_elem_count   = static_cast<uint32_t>(mesh->Vertices.size() / FLOATS_PER_DRAW_VERTEX);
-        uint32_t idx_elem_count   = static_cast<uint32_t>(mesh->Indices.size());
-
-        m_vtx_cursor             += vert_bytes;
-        m_idx_cursor             += idx_bytes;
+        uint32_t vtx_elem_offset = static_cast<uint32_t>(region.VtxByteOffset / DRAW_VERTEX_BYTES);
+        uint32_t idx_elem_offset = static_cast<uint32_t>(region.IdxByteOffset / sizeof(uint32_t));
+        uint32_t vtx_elem_count  = static_cast<uint32_t>(mesh->Vertices.size() / FLOATS_PER_DRAW_VERTEX);
+        uint32_t idx_elem_count  = static_cast<uint32_t>(mesh->Indices.size());
 
         ZENGINE_LOG_RENDER_INFO("[RRM] Uploaded mesh: {} verts ({} bytes), {} indices ({} bytes) — vtx@{} idx@{}", vtx_elem_count, vert_bytes, idx_elem_count, idx_bytes, vtx_elem_offset, idx_elem_offset)
 
-        return {vtx_elem_offset, idx_elem_offset, vtx_elem_count, idx_elem_count};
+        return {region, vtx_elem_count, idx_elem_count};
     }
 
     BufferHandle RenderResourceManager::DoUploadMesh(AssetHandle asset, uint32_t frame_index)
@@ -555,8 +670,11 @@ namespace ZEngine::Rendering
             return {};
         }
 
-        uint32_t slot           = AllocMeshSlot();
-        m_mesh_slots[slot].Data = data;
+        uint32_t slot                      = AllocMeshSlot();
+        m_mesh_slots[slot].Data            = data;
+        m_mesh_slots[slot].Data.State      = StreamingState::Resident;
+        m_mesh_slots[slot].Data.Referenced = false;
+        m_mesh_slots[slot].Data.Pinned     = false;
         return {slot, m_mesh_slots[slot].Generation};
     }
 
@@ -679,9 +797,36 @@ namespace ZEngine::Rendering
         const auto& slot = m_mesh_slots[handle.Index];
         if (slot.Generation != handle.Generation)
             return false;
-        vtx_offset = slot.Data.VtxOffset;
-        idx_offset = slot.Data.IdxOffset;
+        vtx_offset = static_cast<uint32_t>(slot.Data.Region.VtxByteOffset / DRAW_VERTEX_BYTES);
+        idx_offset = static_cast<uint32_t>(slot.Data.Region.IdxByteOffset / sizeof(uint32_t));
         return true;
+    }
+
+    bool RenderResourceManager::RequestMeshLoad(BufferHandle handle, const uuids::uuid& uuid)
+    {
+        const AssetRecord* rec = m_registry->FindByUUID(uuid);
+        if (!rec || rec->SlotHandle == 0)
+            return false;
+        return m_streaming_mgr.RequestLoad({uuid, rec->SlotHandle, handle, 0});
+    }
+
+    bool RenderResourceManager::IsMeshResident(BufferHandle handle) const
+    {
+        if (!handle.IsValid() || handle.Index >= m_mesh_slot_count)
+            return false;
+        const auto& slot = m_mesh_slots[handle.Index];
+        if (slot.Generation != handle.Generation)
+            return false;
+        return slot.Data.State == StreamingState::Resident;
+    }
+
+    void RenderResourceManager::MarkMeshReferenced(BufferHandle handle)
+    {
+        if (!handle.IsValid() || handle.Index >= m_mesh_slot_count)
+            return;
+        auto& slot = m_mesh_slots[handle.Index];
+        if (slot.Generation == handle.Generation)
+            slot.Data.Referenced = true;
     }
 
     BufferHandle RenderResourceManager::FindMeshBuffer(const uuids::uuid& uuid) const
@@ -705,9 +850,13 @@ namespace ZEngine::Rendering
             {
                 BufferHandle h = m_uuid_to_buffer[i].Handle;
 
-                // Free the mesh slot (geometry bytes stay in VB/IB — append-only)
                 if (h.IsValid() && !(h.Generation & GBUF_GEN_TAG) && h.Index < m_mesh_slot_count)
-                    m_mesh_slots[h.Index].Generation = 0;
+                {
+                    auto& slot = m_mesh_slots[h.Index];
+                    if (slot.Data.Region.VtxByteSize > 0)
+                        m_pool.Free(slot.Data.Region);
+                    slot.Generation = 0;
+                }
 
                 // Remove from UUID map (swap with last entry)
                 m_uuid_to_buffer[i] = m_uuid_to_buffer[--m_uuid_to_buffer_count];

--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.h
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.h
@@ -10,6 +10,8 @@
 #include <ZEngine/Helpers/ThreadPool.h>
 #include <ZEngine/Helpers/ThreadSafeQueue.h>
 #include <ZEngine/Managers/AssetManager.h>
+#include <ZEngine/Rendering/GeometryPool.h>
+#include <ZEngine/Rendering/GeometryStreamingManager.h>
 #include <ZEngine/Rendering/Pools/CommandPool.h>
 #include <ZEngine/Rendering/Primitives/Semaphore.h>
 #include <ZEngine/Rendering/RenderHandle.h>
@@ -17,6 +19,9 @@
 #include <vulkan/vulkan.h>
 #include <atomic>
 #include <mutex>
+
+// Forward declaration for the test-only helper that accesses RRM private members.
+struct RRMTestHelper;
 
 namespace ZEngine::Hardwares
 {
@@ -50,7 +55,18 @@ namespace ZEngine::Rendering
     class RenderResourceManager
     {
     public:
-        static constexpr uint32_t           FRAMES_IN_FLIGHT = 3;
+        static constexpr uint32_t     FRAMES_IN_FLIGHT    = 3;
+        static constexpr VkDeviceSize GLOBAL_VTX_CAPACITY = 512ULL * 1024 * 1024; // upper-bound clamp for DeriveGeometryBudget
+        static constexpr VkDeviceSize GLOBAL_VTX_MIN      = 128ULL * 1024 * 1024; // lower-bound clamp
+
+        /// @brief Streaming lifecycle state of a mesh slot.
+        enum class StreamingState : uint8_t
+        {
+            Unloaded = 0, ///< No region allocated; never loaded or previously evicted.
+            Pending,      ///< Region allocated, GPU upload enqueued but not yet signalled.
+            Resident,     ///< GPU-resident — safe to emit draw commands.
+            Evicting,     ///< Marked for eviction; replacement upload may be in flight.
+        };
 
         /// @brief Initialize the RRM and bind it to a VulkanDevice and AssetRegistry.
         /// @details Registers OnAssetReady and OnAssetStale callbacks on the registry,
@@ -208,7 +224,7 @@ namespace ZEngine::Rendering
         /// @return Pointer to the global vertex BufferView; always valid after Initialize.
         const Core::Memory::BufferView* GetGlobalVertexBuffer() const
         {
-            return &m_global_vertex_buf;
+            return &m_pool.VertexBuffer;
         }
 
         /// @brief Return the shared device-local VkBuffer that holds all uploaded index data.
@@ -216,7 +232,24 @@ namespace ZEngine::Rendering
         /// @return Pointer to the global index BufferView; always valid after Initialize.
         const Core::Memory::BufferView* GetGlobalIndexBuffer() const
         {
-            return &m_global_index_buf;
+            return &m_pool.IndexBuffer;
+        }
+
+        /// @brief Return the pinned VkBuffer that holds builtin vertex data (skybox, grid).
+        /// @details Written once at Setup time via RegisterBuiltinGeometry; never touched by
+        ///          ResetGeometryBuffers or the streaming eviction path.
+        /// @return Pointer to the builtin vertex BufferView; always valid after Initialize.
+        const Core::Memory::BufferView* GetBuiltinVertexBuffer() const
+        {
+            return &m_builtin_vertex_buf;
+        }
+
+        /// @brief Return the pinned VkBuffer that holds builtin index data (skybox, grid).
+        /// @details Analogous to GetBuiltinVertexBuffer for index (uint32) data.
+        /// @return Pointer to the builtin index BufferView; always valid after Initialize.
+        const Core::Memory::BufferView* GetBuiltinIndexBuffer() const
+        {
+            return &m_builtin_index_buf;
         }
 
         /// @brief Return true once at least one mesh has been appended to the global buffers.
@@ -224,7 +257,7 @@ namespace ZEngine::Rendering
         ///          data is present.
         bool GlobalBuffersReady() const
         {
-            return m_vtx_cursor > 0;
+            return m_pool.VtxCursor > 0;
         }
 
         /// @brief Query the element-count offsets for a mesh in the global geometry buffers.
@@ -233,6 +266,24 @@ namespace ZEngine::Rendering
         /// @param idx_offset Out: index of the first uint32 element in the global IB.
         /// @return true if the handle is valid and the offsets were written; false otherwise.
         bool         GetMeshOffsets(BufferHandle handle, uint32_t& vtx_offset, uint32_t& idx_offset) const;
+
+        /// @brief Return true if the mesh's GPU region is fully uploaded and safe to draw.
+        /// @details RenderScene calls this before emitting draw commands — meshes in Pending
+        ///          or Unloaded state are skipped without stalling the render thread.
+        bool         IsMeshResident(BufferHandle handle) const;
+
+        /// @brief Set the clock-hand Referenced bit for a resident mesh.
+        /// @details Called by RenderScene for every mesh that emits a draw command this frame.
+        ///          The eviction sweep clears the bit; meshes referenced within the last cycle
+        ///          get one grace period before becoming eviction candidates.
+        void         MarkMeshReferenced(BufferHandle handle);
+
+        /// @brief Enqueue a reload request for an evicted mesh slot.
+        /// @details Called by RenderScene when a valid but non-resident handle is encountered.
+        ///          Pushes onto the streaming manager's SPSC load queue; the slot is re-uploaded
+        ///          at the start of the next BeginFrame. Returns false and drops the request if
+        ///          the queue is full (256 pending reloads).
+        bool         RequestMeshLoad(BufferHandle handle, const uuids::uuid& uuid);
 
         /// @brief Upload builtin geometry (skybox, grid, etc.) into the global vertex/index
         ///        buffers and return the element-count offsets.  Vertices must already be
@@ -345,167 +396,35 @@ namespace ZEngine::Rendering
             uint32_t Generation = 0; // 0 = free
         };
 
-        static constexpr uint32_t MAX_BUFFERS      = 4096;
-        static constexpr uint32_t MAX_GENERIC_BUFS = 4096;
-        // Generation tag: bit 31 = 1 marks a generic-buffer handle so Release() and
-        // GetBuffer() can distinguish them from mesh handles (bit 31 = 0).
-        static constexpr uint32_t GBUF_GEN_TAG     = 0x8000'0000u;
-
-        // Per-mesh record in the slot pool — element-count offsets into the global buffers.
+        // Per-mesh record: byte-level region in the streaming pool (for Free on eviction/release),
+        // element counts for draw-call assembly, and streaming lifecycle state.
+        // Element offsets are derived on demand from Region.VtxByteOffset / DRAW_VERTEX_BYTES
+        // and Region.IdxByteOffset / sizeof(uint32_t).
         struct MeshSlot
         {
-            uint32_t VtxOffset = 0; // first DrawVertex element in m_global_vertex_buf
-            uint32_t IdxOffset = 0; // first uint32 element in m_global_index_buf
-            uint32_t VtxCount  = 0;
-            uint32_t IdxCount  = 0;
+            GeometryRegion Region     = {};
+            uint32_t       VtxCount   = 0;
+            uint32_t       IdxCount   = 0;
+            StreamingState State      = StreamingState::Unloaded;
+            bool           Referenced = false; ///< Clock-hand bit: set by RenderScene, cleared by eviction sweep.
+            bool           Pinned     = false; ///< Never evicted (builtins, or explicitly pinned).
         };
 
-        BufferHandle                   DoUploadMesh(Managers::AssetHandle asset, uint32_t frame_index);
-
-        /// @brief Append one mesh asset's vertex/index data to the global buffers.
-        /// @details Shared by DoUploadMesh (allocates a new slot) and FlushPendingSwaps
-        ///          (reuses an existing slot). Returns a zero-VtxCount MeshSlot on failure.
-        MeshSlot                       AppendMeshData(Managers::AssetHandle asset, uint32_t frame_index);
-
-        void                           AppendToGlobalBuffer(Core::Memory::BufferView& global_buf, const void* data, size_t byte_size, VkDeviceSize byte_offset, uint32_t frame_index);
-
-        void                           FlushPendingUploads(uint32_t frame_index);
-
-        /// @brief Drain m_pending_swaps and apply each swap immediately (render thread only).
-        void                           FlushPendingSwaps(uint32_t frame_index);
-
-        /// @brief Drain m_pending_texture_reloads and reimport each one (render thread only).
-        void                           FlushPendingTextureReloads();
-
-        /// @brief Drain m_pending_texture_releases and call Device->DestroyTexture for each (render thread only).
-        void                           FlushPendingTextureReleases();
-
-        // Batch upload helpers — render-thread only
-        void                           BeginBatchUpload(uint8_t frame_index);
-        void                           EndBatchUpload();
-        /// @brief Open the batch if it isn't already open this frame. Idempotent — every
-        ///        join point (mesh uploads, hot-reload swaps, UpdateBuffer's staging path,
-        ///        builtin geometry registration) calls this before recording, so only the
-        ///        first one actually opens it.
-        void                           EnsureBatchOpen(uint8_t frame_index);
-        /// @brief Free any frame index's batch staging buffers once m_batch_timeline has
-        ///        reached their stored signal value. Called once per frame from BeginFrame.
-        void                           RetireBatchStagings();
-        void                           ResetGeometryBuffersInternal();
-
-        void                           InitUploadPool();
-        void                           InitGlobalBuffers();
-        uint32_t                       AllocMeshSlot();
-        uint32_t                       AllocGBufSlot();
-
-        /// @brief Advance counter and return the next GBUF_GEN_TAG-tagged generation value.
-        static uint32_t                NextGBufGeneration(uint32_t& counter);
-
-        Hardwares::VulkanDevice*       m_device                                         = nullptr;
-        Core::VFS::AssetRegistry*      m_registry                                       = nullptr;
-
-        // Per-worker TLSF upload slabs — carved from Device->Arena at Initialize.
-        // Each worker owns one slab exclusively via t_worker_slab (ThreadPool.h).
-        // Sized to cover the worst-case decode buffer: equirect→cubemap ≈ 96 MB.
-        static constexpr size_t        UPLOAD_SLAB_BYTES                                = 128 * 1024 * 1024; // 128 MB per worker
-        Core::Memory::TLSFSlab         m_upload_slabs[Helpers::ThreadPool::MAX_WORKERS] = {};
-        uint32_t                       m_upload_slab_count                              = 0;
-
-        void                           InitUploadSlabs(uint32_t worker_count);
-
-        // Global geometry buffers — all mesh vertices/indices packed together.
-        static constexpr VkDeviceSize  GLOBAL_VTX_CAPACITY                       = 512 * 1024 * 1024; // 512 MB → ~16M DrawVertex
-        static constexpr VkDeviceSize  GLOBAL_IDX_CAPACITY                       = 512 * 1024 * 1024; // 512 MB → ~128M uint32
-        Core::Memory::BufferView       m_global_vertex_buf                       = {};
-        Core::Memory::BufferView       m_global_index_buf                        = {};
-        VkDeviceSize                   m_vtx_cursor                              = 0; // byte offset of next write
-        VkDeviceSize                   m_idx_cursor                              = 0;
-
-        // Mesh slot pool — stores per-mesh offsets into the global buffers.
-        Slot<MeshSlot>                 m_mesh_slots[MAX_BUFFERS]                 = {};
-        uint32_t                       m_mesh_slot_count                         = 0;
-        // Never reset by Release() — gives each slot a monotonic generation on reuse
-        // instead of the deterministic idx+1 a released-then-reallocated slot would
-        // otherwise get back, which is what gave stale handles no real ABA protection.
-        uint32_t                       m_mesh_slot_gen_counter[MAX_BUFFERS]      = {};
-
-        // Generic device-local buffer pool — for bone matrices, particle VBs, etc.
-        // Handles carry GBUF_GEN_TAG in bit 31 to distinguish from mesh handles.
-        Slot<Core::Memory::BufferView> m_gbuf_slots[MAX_GENERIC_BUFS]            = {};
-        uint32_t                       m_gbuf_slot_count                         = 0;
-        uint32_t                       m_gbuf_slot_gen_counter[MAX_GENERIC_BUFS] = {};
-
-        // UUID → handle maps (for hot-reload swap lookup)
-        // Written on first upload; read on OnAssetStale. Protected by m_uuid_map_mutex.
+        // UUID→handle entry for hot-reload swap lookup. Protected by m_uuid_map_mutex.
         struct UUIDBufferPair
         {
             uuids::uuid  UUID;
             BufferHandle Handle;
         };
-        static constexpr uint32_t          MAX_UUID_MAP                           = 4096;
-        UUIDBufferPair                     m_uuid_to_buffer[MAX_UUID_MAP]         = {};
-        uint32_t                           m_uuid_to_buffer_count                 = 0;
 
-        // Pending uploads — written from asset thread, flushed in BeginFrame
-        static constexpr uint32_t          MAX_PENDING                            = 1024;
-        PendingUpload                      m_pending[MAX_PENDING]                 = {};
-        uint32_t                           m_pending_count                        = 0;
-
-        // Pending hot-reload swaps — written from asset thread (ScheduleSwap), drained by
-        // FlushPendingSwaps on the render thread. A dedicated mutex, not m_pending_mutex:
-        // that lock is held across file I/O and a GPU call in SubmitTextureFile, and
-        // swap enqueue/drain must not stall behind a concurrent texture load.
-        PendingSwap                        m_pending_swaps[MAX_PENDING]           = {};
-        uint32_t                           m_pending_swap_count                   = 0;
-
-        // Pending texture reloads — written from any thread via ScheduleTextureReload
-        // (deduped by UUID at enqueue time), drained by FlushPendingTextureReloads on the
-        // render thread.
-        uuids::uuid                        m_pending_texture_reloads[MAX_PENDING] = {};
-        uint32_t                           m_pending_texture_reload_count         = 0;
-        std::mutex                         m_pending_texture_reload_mutex;
-
-        // Pending texture releases — handle captured up front in ReleaseTexture, drained
-        // by FlushPendingTextureReleases, the only caller of Device->DestroyTexture.
-        Rendering::Textures::TextureHandle m_pending_texture_releases[MAX_PENDING] = {};
-        uint32_t                           m_pending_texture_release_count         = 0;
-        std::mutex                         m_pending_texture_release_mutex;
-
-        // Geometry compaction request — set by asset thread, executed on render thread
-        std::atomic<bool>                  m_pending_reset      = false;
-
-        // Batch upload state — render-thread only, no locking needed.
-        bool                               m_batch_mode         = false;
-        Hardwares::CommandBuffer*          m_batch_cmd          = nullptr;
-        uint8_t                            m_batch_frame_index  = 0;
-
-        // Set at the top of BeginFrame(frame_index) — lets upload paths that aren't already
-        // threaded through a frame_index parameter (UpdateBuffer, UploadFontAtlas) still pick
-        // the correct per-frame command buffer from m_upload_cmd_mgr below.
-        uint8_t                            m_active_frame_index = 0;
-
-        // Dedicated command buffer manager for geometry/font-atlas uploads, separate from
-        // Device->CommandBufferMgr. Regular pool slot 0 serves the two remaining
-        // synchronous callers (UploadFontAtlas, UpdateBuffer's ring path); the instant
-        // pool serves BeginBatchUpload/EndBatchUpload, whose submission is deferred to
-        // SubmitAsyncUploads instead of blocked on.
-        Hardwares::CommandBufferManagerPtr m_upload_cmd_mgr     = {};
-        // The only two remaining synchronous, fence-blocking uploads (UploadFontAtlas,
-        // UpdateBuffer's ring path — see their comments for why they can't join the
-        // deferred batch) are both render-thread-only and always fully block before
-        // returning, so one shared fence is enough: neither can ever be "in flight" when
-        // the other starts.
-        Rendering::Primitives::Fence*      m_sync_upload_fence  = nullptr;
-
-        // Dedicated timeline semaphore for the mesh batch upload path — intentionally NOT
-        // DeviceSwapchain::RenderTimeline. RenderTimeline is Present()'s own frame-pacing
-        // primitive (it increments RenderTimelineNextValue twice per frame internally);
-        // having RRM also drive it from EndBatchUpload produced a timeline value Intel's
-        // Windows driver treats as non-monotonic. A fully separate semaphore/counter with
-        // exactly one writer (EndBatchUpload) makes that class of interleaving impossible
-        // by construction.
-        Rendering::Primitives::Semaphore*  m_batch_timeline     = nullptr;
-        uint64_t                           m_batch_next_value   = 0;
+        static constexpr uint32_t DRAW_VERTEX_BYTES = 8 * sizeof(float); // x y z nx ny nz u v
+        static constexpr uint32_t MAX_BUFFERS       = 4096;
+        static constexpr uint32_t MAX_GENERIC_BUFS  = 4096;
+        // Generation tag: bit 31 = 1 marks a generic-buffer handle so Release() and
+        // GetBuffer() can distinguish them from mesh handles (bit 31 = 0).
+        static constexpr uint32_t GBUF_GEN_TAG      = 0x8000'0000u;
+        static constexpr uint32_t MAX_UUID_MAP      = 4096;
+        static constexpr uint32_t MAX_PENDING       = 1024;
 
         // Per-frame-index batch state: the m_batch_timeline value last signalled for that
         // frame index's batch, and the staging buffers still owned by it. Retired
@@ -518,36 +437,169 @@ namespace ZEngine::Rendering
             Core::Memory::BufferView StagingBuffers[MAX_PENDING * 2] = {};
             uint32_t                 StagingCount                    = 0;
         };
-        Core::Containers::Array<BatchFrameState>                                   m_batch_frames             = {};
+        static constexpr uint32_t     MAX_DEFERRAL_RETRY   = 8192;
+        // Upper bound for texture timeline slot search — keeps textures out of geometry
+        // slots and caps the retire loop to the same range.
+        static constexpr uint32_t     GEOMETRY_UPLOAD_SLOT = 15;
+        // Per-worker TLSF slab size — covers worst-case decode buffer (equirect→cubemap ≈ 96 MB).
+        static constexpr size_t       UPLOAD_SLAB_BYTES    = 128 * 1024 * 1024;
+        // Written once at Setup time via RegisterBuiltinGeometry; never reset by
+        // ResetGeometryBuffers and never touched by the streaming eviction path.
+        static constexpr VkDeviceSize BUILTIN_VTX_CAPACITY = 1 * 1024 * 1024; // 1 MB — ample for all engine builtins
+        static constexpr VkDeviceSize BUILTIN_IDX_CAPACITY = 1 * 1024 * 1024;
 
-        // Upper bound for texture timeline slot search — keeps textures out of the
-        // geometry slots and caps the retire loop to the same range.
-        static constexpr uint32_t                                                  GEOMETRY_UPLOAD_SLOT       = 15;
+        BufferHandle                  DoUploadMesh(Managers::AssetHandle asset, uint32_t frame_index);
 
-        uint32_t                                                                   m_tex_total_cmd_count      = 0;
-        Core::Containers::Array<std::atomic_uint64_t>                              m_tex_next_values          = {};
-        Core::Containers::Array<std::atomic_uint64_t>                              m_tex_transfer_next_values = {};
+        /// @brief Append one mesh asset's vertex/index data to the global buffers.
+        /// @details Shared by DoUploadMesh (new slot) and FlushPendingSwaps (reuse slot).
+        ///          Returns a zero-VtxCount MeshSlot on failure.
+        MeshSlot                      AppendMeshData(Managers::AssetHandle asset, uint32_t frame_index);
+
+        void                          AppendToGlobalBuffer(Core::Memory::BufferView& dst_buf, const void* data, size_t byte_size, VkDeviceSize byte_offset, uint32_t frame_index);
+        void                          FlushPendingUploads(uint32_t frame_index);
+
+        /// @brief Drain m_pending_swaps and apply each swap immediately (render thread only).
+        void                          FlushPendingSwaps(uint32_t frame_index);
+
+        /// @brief Drain m_pending_texture_reloads and reimport each one (render thread only).
+        void                          FlushPendingTextureReloads();
+
+        /// @brief Drain m_pending_texture_releases and call Device->DestroyTexture (render thread only).
+        void                          FlushPendingTextureReleases();
+
+        void                          BeginBatchUpload(uint8_t frame_index);
+        void                          EndBatchUpload();
+
+        /// @brief Open the batch if not already open this frame. Idempotent — every join
+        ///        point (mesh uploads, hot-reload swaps, UpdateBuffer staging, builtin
+        ///        registration) calls this before recording so only the first one opens it.
+        void                          EnsureBatchOpen(uint8_t frame_index);
+
+        /// @brief Free frame-index batch stagings once m_batch_timeline reaches LastSignal.
+        ///        Called once per frame from BeginFrame.
+        void                          RetireBatchStagings();
+
+        void                          ResetGeometryBuffersInternal();
+        /// @brief Re-pack all Resident mesh regions from offset 0, eliminating fragmentation holes.
+        /// @details Resets the pool and re-uploads every Resident mesh's CPU asset data into
+        ///          fresh batch regions using the existing AppendMeshData path. Slot regions are
+        ///          updated in place before RenderScene runs. The batch is submitted by
+        ///          EndFrame/SubmitAsyncUploads; Present()'s m_batch_timeline wait ensures the
+        ///          render submission sees the new data before drawing.
+        void                          RunCompaction();
+        void                          InitUploadPool();
+        void                          InitGlobalBuffers();
+        void                          InitUploadSlabs(uint32_t worker_count);
+        void                          InitTextureTimelines();
+        void                          ShutdownTextureTimelines();
+        uint32_t                      AllocMeshSlot();
+        uint32_t                      AllocGBufSlot();
+
+        /// @brief Advance counter and return the next GBUF_GEN_TAG-tagged generation value.
+        static uint32_t               NextGBufGeneration(uint32_t& counter);
+
+        friend class GeometryStreamingManager;
+        friend struct ::RRMTestHelper; // test-only — grants slot state access to streaming manager tests
+
+        Hardwares::VulkanDevice*                                                   m_device                                         = nullptr;
+        Core::VFS::AssetRegistry*                                                  m_registry                                       = nullptr;
+
+        // Dedicated command buffer manager for geometry/font-atlas uploads, separate from
+        // Device->CommandBufferMgr. Regular pool slot 0 serves the two remaining
+        // synchronous callers (UploadFontAtlas, UpdateBuffer's ring path); the instant
+        // pool serves BeginBatchUpload/EndBatchUpload, whose submission is deferred to
+        // SubmitAsyncUploads instead of blocked on.
+        Hardwares::CommandBufferManagerPtr                                         m_upload_cmd_mgr                                 = {};
+        // The only two remaining synchronous, fence-blocking uploads (UploadFontAtlas and
+        // UpdateBuffer's ring path) are both render-thread-only and always fully block
+        // before returning, so one shared fence is enough — neither can ever be in flight
+        // when the other starts.
+        Rendering::Primitives::Fence*                                              m_sync_upload_fence                              = nullptr;
+        Hardwares::AsyncUploadQueue                                                m_async_uploads                                  = {};
+
+        // Streaming geometry pool — owns the global VB/IB and their free lists.
+        GeometryPool                                                               m_pool                                           = {};
+        GeometryStreamingManager                                                   m_streaming_mgr                                  = {};
+
+        // Separate from the global streaming pool so a scene reload cannot corrupt the
+        // skybox and grid draw offsets via ResetGeometryBuffers.
+        Core::Memory::BufferView                                                   m_builtin_vertex_buf                             = {};
+        Core::Memory::BufferView                                                   m_builtin_index_buf                              = {};
+        VkDeviceSize                                                               m_builtin_vtx_cursor                             = 0;
+        VkDeviceSize                                                               m_builtin_idx_cursor                             = 0;
+
+        // Dedicated timeline semaphore — single writer (EndBatchUpload), intentionally NOT
+        // DeviceSwapchain::RenderTimeline. Sharing RenderTimeline with Present()'s own
+        // two-per-frame increments produced non-monotonic values on Intel's Windows driver.
+        Rendering::Primitives::Semaphore*                                          m_batch_timeline                                 = nullptr;
+        Hardwares::CommandBuffer*                                                  m_batch_cmd                                      = nullptr;
+        Core::Containers::Array<BatchFrameState>                                   m_batch_frames                                   = {};
+        uint64_t                                                                   m_batch_next_value                               = 0;
+        // Single-byte batch fields packed together to eliminate alignment padding gaps.
+        uint8_t                                                                    m_batch_frame_index                              = 0;
+        // Set at BeginFrame — lets upload paths not threaded through a frame_index param
+        // (UpdateBuffer, UploadFontAtlas) pick the correct per-frame command buffer.
+        uint8_t                                                                    m_active_frame_index                             = 0;
+        bool                                                                       m_batch_mode                                     = false;
+
+        // Per-worker TLSF slabs carved from Device->Arena at Initialize. Each worker owns
+        // one slab exclusively via t_worker_slab (ThreadPool.h).
+        Core::Memory::TLSFSlab                                                     m_upload_slabs[Helpers::ThreadPool::MAX_WORKERS] = {};
+        uint32_t                                                                   m_upload_slab_count                              = 0;
+
+        Slot<MeshSlot>                                                             m_mesh_slots[MAX_BUFFERS]                        = {};
+        uint32_t                                                                   m_mesh_slot_count                                = 0;
+        // Monotonic per-slot counter, never reset by Release() — provides ABA protection
+        // on slot reuse (a stale handle with the old generation is never re-validated).
+        uint32_t                                                                   m_mesh_slot_gen_counter[MAX_BUFFERS]             = {};
+
+        // Handles carry GBUF_GEN_TAG in bit 31 to distinguish from mesh handles.
+        Slot<Core::Memory::BufferView>                                             m_gbuf_slots[MAX_GENERIC_BUFS]                   = {};
+        uint32_t                                                                   m_gbuf_slot_count                                = 0;
+        uint32_t                                                                   m_gbuf_slot_gen_counter[MAX_GENERIC_BUFS]        = {};
+
+        // Written on first upload; read on OnAssetStale.
+        UUIDBufferPair                                                             m_uuid_to_buffer[MAX_UUID_MAP]                   = {};
+        uint32_t                                                                   m_uuid_to_buffer_count                           = 0;
+        std::mutex                                                                 m_uuid_map_mutex;
+
+        PendingUpload                                                              m_pending[MAX_PENDING] = {};
+        uint32_t                                                                   m_pending_count        = 0;
+        std::mutex                                                                 m_pending_mutex;
+
+        // Dedicated mutex — m_pending_mutex is held across file I/O and a GPU call inside
+        // SubmitTextureFile; swap enqueue must not stall behind a concurrent texture load.
+        PendingSwap                                                                m_pending_swaps[MAX_PENDING] = {};
+        uint32_t                                                                   m_pending_swap_count         = 0;
+        std::mutex                                                                 m_pending_swap_mutex;
+
+        // Set by asset thread, executed on render thread.
+        std::atomic<bool>                                                          m_pending_reset                        = false;
+
+        // Deduped by UUID at enqueue time.
+        uuids::uuid                                                                m_pending_texture_reloads[MAX_PENDING] = {};
+        uint32_t                                                                   m_pending_texture_reload_count         = 0;
+        std::mutex                                                                 m_pending_texture_reload_mutex;
+
+        // Handle captured up front in ReleaseTexture; FlushPendingTextureReleases is the
+        // only caller of Device->DestroyTexture.
+        Rendering::Textures::TextureHandle                                         m_pending_texture_releases[MAX_PENDING] = {};
+        uint32_t                                                                   m_pending_texture_release_count         = 0;
+        std::mutex                                                                 m_pending_texture_release_mutex;
+
         Core::Containers::Array<Rendering::Primitives::Semaphore*>                 m_tex_timelines            = {};
         Core::Containers::Array<Rendering::Primitives::Semaphore*>                 m_tex_transfer_timelines   = {};
         Core::Containers::Array<Core::Containers::Array<uint64_t>>                 m_tex_retire_values        = {};
         Core::Containers::Array<Core::Containers::Array<uint64_t>>                 m_tex_transfer_retire      = {};
         Core::Containers::Array<Core::Containers::Array<Core::Memory::BufferView>> m_tex_retire_staging       = {};
         Core::Containers::Array<Core::Containers::Array<Core::Memory::BufferView>> m_tex_transfer_staging     = {};
-        Hardwares::AsyncUploadQueue                                                m_async_uploads            = {};
+        Core::Containers::Array<std::atomic_uint64_t>                              m_tex_next_values          = {};
+        Core::Containers::Array<std::atomic_uint64_t>                              m_tex_transfer_next_values = {};
         Helpers::ThreadSafeQueue<TextureDeferral>                                  m_tex_deferral_queue       = {};
-
-        // Scratch buffer for deferrals that find no free upload slot during a
-        // CompleteDeferrals pass — arena-backed, fixed capacity, reused every frame via
-        // clear() so retrying a full deferral queue never allocates on the hot path.
-        static constexpr uint32_t                                                  MAX_DEFERRAL_RETRY         = 8192;
+        // Scratch buffer for deferrals that find no free upload slot — reused every frame
+        // via clear() so retrying the full queue never allocates on the hot path.
         Core::Containers::Array<TextureDeferral>                                   m_tex_deferral_retry       = {};
-
-        void                                                                       InitTextureTimelines();
-        void                                                                       ShutdownTextureTimelines();
-
-        std::mutex                                                                 m_pending_mutex;
-        std::mutex                                                                 m_pending_swap_mutex;
-        std::mutex                                                                 m_uuid_map_mutex;
+        uint32_t                                                                   m_tex_total_cmd_count      = 0;
     };
 
 } // namespace ZEngine::Rendering

--- a/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.cpp
+++ b/ZEngine/ZEngine/Rendering/Renderers/RendererPasses.cpp
@@ -194,8 +194,8 @@ namespace ZEngine::Rendering::Renderers
         }
         auto* rrm = ZEngine::Engine::GetContext()->RenderResourceManager;
         command_buffer->BindPipeline(Specifications::PipelineBindPoint::GRAPHIC, pass->Pipeline);
-        command_buffer->BindVertexBuffer(*rrm->GetGlobalVertexBuffer());
-        command_buffer->BindIndexBuffer(*rrm->GetGlobalIndexBuffer(), VK_INDEX_TYPE_UINT32);
+        command_buffer->BindVertexBuffer(*rrm->GetBuiltinVertexBuffer());
+        command_buffer->BindIndexBuffer(*rrm->GetBuiltinIndexBuffer(), VK_INDEX_TYPE_UINT32);
         command_buffer->BindDescriptorSets(device->SwapchainPtr->CurrentFrame->Index, scene ? &scene->CameraHeapOffset : nullptr, scene ? 1u : 0u);
         command_buffer->DrawIndexed(36, 1, m_idx_offset, static_cast<int32_t>(m_vtx_offset), 0);
         command_buffer->EndRenderPass();
@@ -269,8 +269,8 @@ namespace ZEngine::Rendering::Renderers
         }
         auto* rrm = ZEngine::Engine::GetContext()->RenderResourceManager;
         command_buffer->BindPipeline(Specifications::PipelineBindPoint::GRAPHIC, pass->Pipeline);
-        command_buffer->BindVertexBuffer(*rrm->GetGlobalVertexBuffer());
-        command_buffer->BindIndexBuffer(*rrm->GetGlobalIndexBuffer(), VK_INDEX_TYPE_UINT32);
+        command_buffer->BindVertexBuffer(*rrm->GetBuiltinVertexBuffer());
+        command_buffer->BindIndexBuffer(*rrm->GetBuiltinIndexBuffer(), VK_INDEX_TYPE_UINT32);
         command_buffer->BindDescriptorSets(device->SwapchainPtr->CurrentFrame->Index, scene ? &scene->CameraHeapOffset : nullptr, scene ? 1u : 0u);
         command_buffer->PushConstants(VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT, 0, sizeof(GridPushConstantData), &PushData);
         command_buffer->DrawIndexed(6, 1, m_idx_offset, static_cast<int32_t>(m_vtx_offset), 0);

--- a/ZEngine/docs/future-plan/virtual-geometry-streaming.md
+++ b/ZEngine/docs/future-plan/virtual-geometry-streaming.md
@@ -1,0 +1,403 @@
+# ZEngine — Virtual Geometry Streaming
+
+**Status:** Design
+**Closes:** Issue #622
+**Depends on:** Global geometry buffer (PR #611, shipped), async upload queue (PR #766, shipped),
+`bindless-descriptor-architecture.md` (design decision on pool model)
+**Blocks:** Large-scene support, LOD system (Sprints 15–16)
+
+---
+
+## 1. Problem
+
+The current global VB/IB reserves **1 GB of VRAM at startup** (512 MB vertex + 512 MB index,
+`GeometryBytes` in `MemoryManager.h`), regardless of how much scene content is loaded. The
+buffers are append-only: `ReleaseMeshGeometry` frees the slot and UUID map entry but leaves
+the bytes permanently orphaned. Hot-reload swap makes this worse — each re-ingest appends new
+data at the current watermark and orphans the old region. The only reclaim mechanism is
+`ResetGeometryBuffers`, a full bulk reset that also corrupts the skybox and grid (see §3).
+
+For projects whose total geometry fits in VRAM this is fine. For large scenes it is not, and
+the static 1 GB reservation is wasted on machines with 4–8 GB VRAM budgets.
+
+---
+
+## 2. Design principles
+
+- **Variable-size regions, not fixed pages.** One mesh asset = one contiguous VB region + one
+  contiguous IB region. This matches how `AppendMeshData` already works and how the draw
+  path consumes offsets (`VertexSB[VertexOffset + gl_VertexIndex]`). Forcing fixed-size pages
+  would require splitting meshes across page boundaries, changing the draw path, and adding
+  mapping overhead — complexity with no benefit for this engine's mesh size distribution.
+- **The render thread never waits on streaming I/O.** A mesh whose region is not yet resident
+  is simply skipped in `RenderScene` (no draw command emitted). No stall, no proxy.
+- **Async upload through the existing batch timeline.** Streaming loads go through
+  `m_batch_timeline` / `m_async_uploads` (the same path used for normal mesh uploads),
+  not through a new fence-blocking submission.
+- **Compaction instead of in-place reuse.** Fragmentation is resolved by a safe compaction
+  pass triggered when free space falls below a threshold. Compaction re-uploads all resident
+  meshes from offset 0, then re-registers builtins. This is simpler than a first-fit
+  allocator over variable-size holes.
+- **Builtins are pinned on a separate allocation.** Skybox and grid geometry live in a
+  dedicated small VkBuffer that is never touched by the streaming system, eliminating the
+  existing `ResetGeometryBuffers` corruption bug.
+
+---
+
+## 3. Existing bug — builtin geometry and ResetGeometryBuffers
+
+`RegisterBuiltinGeometry` appends skybox/grid data to the main global VB/IB at the current
+cursor and stores the resulting element offsets in the pass structs (`m_vtx_offset`,
+`m_idx_offset`). `ResetGeometryBuffersInternal` zeroes the cursors but does not zero the
+VkBuffer contents and does not call `RegisterBuiltinGeometry` again. The pass structs keep
+their stale offsets, which point at GPU bytes that will be silently overwritten by the next
+mesh upload. The passes appear to work until that overwrite occurs.
+
+**Fix (prerequisite to streaming):** Give builtins their own separate VkBuffer allocation,
+independent of the main streaming pool. Skybox and grid register into this buffer once at
+`Setup` time; it is never touched by `ResetGeometryBuffers` or the streaming eviction path.
+
+---
+
+## 4. New types
+
+### 4.1 GeometryRegion — a contiguous slot in the pool
+
+```cpp
+/// @brief A contiguous byte range allocated from the streaming geometry pool.
+/// @details Stores both vertex and index regions together since they are always
+///          allocated and freed as a pair for a single mesh asset.
+struct GeometryRegion
+{
+    VkDeviceSize VtxByteOffset = 0; ///< Byte offset of this mesh's vertex data in the pool VB.
+    VkDeviceSize IdxByteOffset = 0; ///< Byte offset of this mesh's index data in the pool IB.
+    VkDeviceSize VtxByteSize   = 0; ///< Byte size of the vertex region.
+    VkDeviceSize IdxByteSize   = 0; ///< Byte size of the index region.
+};
+```
+
+Replaces the cursor pair as the unit of allocation. Stored alongside the existing `MeshSlot`
+element-count offsets (which remain the draw-path interface — nothing in draw code changes).
+
+### 4.2 StreamingState — per mesh slot
+
+```cpp
+/// @brief Lifecycle state of a mesh slot in the streaming geometry pool.
+enum class StreamingState : uint8_t
+{
+    Unloaded = 0, ///< No region allocated; mesh has never been loaded or was evicted.
+    Pending,      ///< Region allocated, GPU upload enqueued but not yet signalled.
+    Resident,     ///< GPU-resident and safe to emit draw commands for.
+    Evicting,     ///< Marked for eviction; a replacement upload may be in flight.
+};
+```
+
+Added to `MeshSlot`. `RenderScene` checks `Resident` before emitting a draw command.
+
+### 4.3 GeometryPool — the streaming allocator
+
+Owns the global VB/IB and the free-region list. Replaces the raw cursor pair in
+`RenderResourceManager`.
+
+```cpp
+/// @brief Variable-size region allocator over the global streaming vertex and index buffers.
+/// @details One region per mesh asset; allocated on stream-in, freed on eviction.
+///          Adjacent free regions are merged on free to limit fragmentation.
+///          When the append cursor is exhausted and no free region is large enough,
+///          Allocate returns false — the caller should trigger a compaction pass.
+struct GeometryPool
+{
+    Core::Memory::BufferView VertexBuffer = {}; ///< Device-local VkBuffer for vertex data.
+    Core::Memory::BufferView IndexBuffer  = {}; ///< Device-local VkBuffer for index data.
+
+    VkDeviceSize VtxCapacity = 0; ///< Total vertex buffer capacity in bytes.
+    VkDeviceSize IdxCapacity = 0; ///< Total index buffer capacity in bytes.
+    VkDeviceSize VtxUsed     = 0; ///< Bytes currently held by live regions (excluding holes).
+    VkDeviceSize IdxUsed     = 0;
+
+    /// @brief Sorted free lists — one per axis.  Adjacent entries are merged on Free().
+    Core::Containers::Array<GeometryRegion> FreeVtxRegions = {};
+    Core::Containers::Array<GeometryRegion> FreeIdxRegions = {};
+
+    VkDeviceSize VtxCursor = 0; ///< Append cursor; advanced only when the free list has no fit.
+    VkDeviceSize IdxCursor = 0;
+
+    /// @brief Allocate a region for a mesh of the given byte sizes.
+    /// @param vtx_bytes Byte size of the vertex data to reserve.
+    /// @param idx_bytes Byte size of the index data to reserve.
+    /// @param out       Filled with the allocated region offsets and sizes on success.
+    /// @return true on success; false if the pool is full (caller should compact).
+    bool         Allocate(VkDeviceSize vtx_bytes, VkDeviceSize idx_bytes, GeometryRegion& out);
+
+    /// @brief Return a region to the free list.
+    /// @details Adjacent free regions at the same offset are merged to limit fragmentation.
+    /// @param region The region previously returned by Allocate.
+    void         Free(const GeometryRegion& region);
+
+    /// @brief Ratio of dead bytes (holes) to total capacity.
+    /// @details Compaction is triggered when this exceeds kCompactionThreshold (default: 0.30).
+    /// @return Value in [0, 1]; 0 = fully packed, 1 = entirely holes.
+    float        FragmentationRatio() const;
+};
+```
+
+### 4.4 GeometryStreamingManager — the background worker
+
+```cpp
+/// @brief Per-mesh load request submitted to the streaming manager.
+struct StreamRequest
+{
+    uuids::uuid           UUID     = {};     ///< Asset UUID, used for dedup and UUID map update.
+    Managers::AssetHandle Asset    = 0;      ///< Asset handle to read geometry data from.
+    BufferHandle          Handle   = {};     ///< Pre-allocated mesh slot — manager fills its region.
+    uint8_t               Priority = 0;      ///< 0 = high (currently visible), 1 = prefetch.
+};
+
+/// @brief Drives streaming geometry loads and evictions on behalf of RenderResourceManager.
+/// @details Tick() is called once per frame from RenderResourceManager::BeginFrame.
+///          Load requests are enqueued from any thread via RequestLoad; eviction and
+///          compaction are render-thread-only operations driven by Tick().
+class GeometryStreamingManager
+{
+public:
+    /// @brief Bind the manager to a device and RRM. Must be called before Tick().
+    void Initialize(VulkanDevice* device, RenderResourceManager* rrm);
+    void Deinitialize();
+
+    /// @brief Per-frame driver — called from RenderResourceManager::BeginFrame.
+    /// @details Drains completed async uploads (Pending → Resident), checks fragmentation,
+    ///          and runs the eviction sweep if the pool is under pressure.
+    /// @param frame_index Current swapchain frame index.
+    void Tick(uint32_t frame_index);
+
+    /// @brief Enqueue a mesh load request. Thread-safe.
+    /// @param req Describes the mesh to load and its priority.
+    void RequestLoad(const StreamRequest& req);
+
+    /// @brief Mark a mesh slot for eviction. Render-thread only.
+    /// @param handle Handle of the resident mesh to evict.
+    void RequestEvict(BufferHandle handle);
+};
+```
+
+`Tick` is called from `RenderResourceManager::BeginFrame`. It:
+1. Drains completed async uploads, transitions `Pending → Resident`.
+2. Checks fragmentation ratio; if above threshold, schedules a compaction.
+3. Evicts the lowest-priority resident mesh if the pool is full and a new load is waiting.
+
+Background uploads are submitted via the existing `m_async_uploads` queue; the batch
+timeline (`m_batch_timeline`) signals completion exactly as it does for normal mesh uploads.
+
+---
+
+## 5. Eviction policy — clock-hand
+
+Each `MeshSlot` carries a `Referenced` bit, set by `RenderScene` whenever the mesh emits a
+draw command (i.e., it is visible and resident this frame).
+
+The streaming manager's eviction sweep walks `m_mesh_slots` in order (clock hand). For each
+`Resident` slot:
+- If `Referenced == true`: clear the bit, advance.
+- If `Referenced == false`: this slot is a candidate. Evict if the pool needs space.
+
+This gives recently-drawn meshes one full cycle of grace before eviction. No sorted structure,
+no timestamps — O(N) sweep over the slot array, called only when eviction is needed.
+
+Slots with `Pinned == true` (builtins, or any slot explicitly pinned by the caller) are
+skipped by the sweep unconditionally.
+
+---
+
+## 6. Compaction
+
+Triggered when `GeometryPool::FragmentationRatio()` exceeds `kCompactionThreshold` (default:
+0.30 — 30% of capacity is holes). The compaction pass:
+
+1. Snapshot all `Resident` mesh slots and their `GeometryRegion` byte ranges.
+2. Reset pool cursors to 0, clear the free lists.
+3. Re-upload all resident meshes in slot order, assigning new regions from offset 0.
+4. Update each `MeshSlot`'s `VtxOffset`/`IdxOffset` atomically before the next frame's
+   draw-command assembly.
+5. Builtin geometry is unaffected — it lives in a separate pinned buffer.
+
+Compaction runs inside `RenderResourceManager::BeginFrame` and completes before `RenderScene`
+assembles draw commands. The re-upload batch is submitted via `m_batch_timeline` as usual;
+`BeginFrame` waits on that signal before returning.
+
+For scenes where mesh count is large and eviction is frequent, compaction should be rare
+(fragmentation stays low because evicted regions are freed and reused). If it fires
+frequently, the pool budget should be increased — raise `geometry_streaming_mb` in
+`project.json` or let auto-detection pick a larger value on higher-VRAM hardware (see §7).
+
+---
+
+## 7. Pool budget and configuration
+
+### 7.1 Auto-detection
+
+The streaming pool size is never prompted from the user during project creation. At startup,
+before `VulkanDevice::Initialize`, the engine queries `VkPhysicalDeviceMemoryProperties` for
+the total device-local heap size and derives the geometry streaming budget as **15% of
+device-local VRAM**, clamped to [128 MB, 512 MB]:
+
+```cpp
+/// @brief Derive a geometry streaming pool size from the physical device's VRAM.
+/// @param device_local_bytes Total device-local heap capacity in bytes.
+/// @return Budget in bytes, clamped to [128 MB, 512 MB].
+static VkDeviceSize DeriveGeometryBudget(VkDeviceSize device_local_bytes)
+{
+    VkDeviceSize budget = device_local_bytes * 15 / 100;
+    budget              = std::max(budget, 128ULL << 20);
+    budget              = std::min(budget, 512ULL << 20);
+    return budget;
+}
+```
+
+This produces sensible defaults without user input: a 4 GB GPU gets ~600 MB clamped to
+512 MB; a 2 GB GPU gets ~300 MB; a 1 GB GPU gets ~150 MB.
+
+### 7.2 Optional project.json override
+
+If the project file contains a `"memory"` section, the explicit value overrides the
+auto-detected budget. The field is optional — omitting it silently falls back to
+auto-detection. Users only set it when targeting a known VRAM tier (e.g. a console port or a
+low-end PC SKU) or when the watermark warning fires repeatedly.
+
+```json
+{
+    "memory": {
+        "geometry_streaming_mb": 256
+    }
+}
+```
+
+### 7.3 Two-pass project file read
+
+`project.json` is currently parsed in `EditorConfiguration::ReadConfig` (Tetragrama), which
+runs after `VulkanDevice::Initialize`. The `"memory"` section must be read **before** the
+device initializes because `GpuAllocator::Initialize` commits pool sizes at that point.
+
+The fix is a lightweight pre-parse in `EntryPoint.cpp` — just the `"memory"` section, using
+the same `--projectConfigFile` argument already present — before `MemoryBudgetConfig` is
+constructed. The full `EditorConfiguration::ReadConfig` still runs later for everything else.
+
+```cpp
+/// @brief Read the geometry streaming budget override from a project config file.
+/// @details Returns 0 if the file is absent, unparseable, or has no memory section —
+///          the caller falls back to auto-detection in that case.
+/// @param config_file Absolute path to project.json.
+/// @return Override budget in bytes, or 0 for auto-detect.
+static VkDeviceSize ReadGeometryBudgetOverride(const std::string& config_file)
+{
+    if (config_file.empty())
+        return 0;
+    std::ifstream f(config_file);
+    if (!f.is_open())
+        return 0;
+    auto json = nlohmann::json::parse(f, nullptr, false);
+    if (json.is_discarded() || !json.contains("memory"))
+        return 0;
+    const auto& mem = json["memory"];
+    if (!mem.contains("geometry_streaming_mb"))
+        return 0;
+    return static_cast<VkDeviceSize>(mem["geometry_streaming_mb"].get<uint32_t>()) << 20;
+}
+```
+
+### 7.4 Compile-time constants
+
+```cpp
+/// @brief Builtin geometry buffer size — skybox + grid + headroom. Never auto-derived.
+constexpr uint64_t BuiltinGeometryBytes = 1ULL << 20;
+```
+
+`MAX_BUFFERS` (4096) and `MAX_UUID_MAP` (4096) are slot counts, not byte budgets, and remain
+unchanged.
+
+---
+
+## 8. Changes to existing code
+
+### RenderResourceManager
+
+| Change | Reason |
+|---|---|
+| Replace `m_vtx_cursor`/`m_idx_cursor` with `GeometryPool m_pool` | Pool owns allocation |
+| Add `BufferView m_builtin_vtx_buf`, `m_builtin_idx_buf` | Pinned builtin geometry |
+| Add `StreamingState`, `Referenced`, `Pinned` to `MeshSlot` | Draw guard + eviction |
+| `ResetGeometryBuffers` resets pool only, never touches builtin buffers | Bug fix |
+| `RegisterBuiltinGeometry` writes to builtin buffers | Bug fix |
+| `AppendMeshData` calls `m_pool.Allocate()` instead of advancing cursors | Pool allocation |
+| `ReleaseMeshGeometry` calls `m_pool.Free(region)` | Byte reclaim |
+| `BeginFrame` calls `m_streaming_mgr.Tick(frame_index)` | Streaming driver |
+
+### AppRenderPipeline::RenderScene
+
+```cpp
+auto handle = rrm->FindMeshBuffer(inst.MeshUUID);
+if (!handle.IsValid())
+    continue;
+
+/// @note Mesh may be allocated but not yet GPU-resident (upload in flight).
+///       Skip draw command emission rather than stalling the render thread.
+if (!rrm->IsMeshResident(handle))
+    continue;
+
+rrm->MarkMeshReferenced(handle);   // set clock-hand Referenced bit for this frame
+```
+
+### RendererPasses (SkyboxPass, GridPass)
+
+`RegisterBuiltinGeometry` writes into the pinned builtin buffer after this change. The draw
+path for these passes already uses the conventional `BindVertexBuffer`/`BindIndexBuffer` +
+`DrawIndexed` path (not the storage-buffer path), so they bind the builtin buffer's
+`VkBuffer` handle directly. No shader changes required.
+
+### GpuAllocator / MemoryManager
+
+Replace `GeometryBytes = 512 MB` with two separate VMA pool allocations:
+`GeometryStreamingBytes` (256 MB, two blocks) for the streaming pool and
+`BuiltinGeometryBytes` (1 MB, one block) for the builtin buffer.
+
+---
+
+## 9. What does NOT change
+
+- **Draw-path shader code**: `VertexSB[VertexOffset + gl_VertexIndex]` is unchanged. The
+  streaming system updates `MeshSlot.VtxOffset`/`IdxOffset` when a region is assigned; the
+  shader reads them as before.
+- **`SubMeshAllocation` / `VkDrawIndirectCommand` assembly**: unchanged — still element-count
+  offsets, still indirect.
+- **Texture streaming**: handled separately by the LRU eviction path described in
+  `bindless-descriptor-architecture.md` §7. Geometry and texture streaming are independent.
+- **`AsyncUploadQueue` / `m_batch_timeline`**: reused as-is for streaming uploads.
+
+---
+
+## 10. Deliverables checklist
+
+| Item | Status |
+|---|---|
+| Fix `RegisterBuiltinGeometry` — separate pinned builtin buffer | Not started |
+| `GeometryPool` struct — `Allocate`/`Free`/`FragmentationRatio` | Not started |
+| Replace cursors with `GeometryPool` in RRM | Not started |
+| `StreamingState` + `Referenced` + `Pinned` in `MeshSlot` | Not started |
+| `ReleaseMeshGeometry` calls `m_pool.Free` | Not started |
+| `GeometryStreamingManager` skeleton + `Tick` | Not started |
+| Clock-hand eviction sweep | Not started |
+| Compaction pass | Not started |
+| `RenderScene` resident guard + `MarkMeshReferenced` | Not started |
+| `MemoryBudgetConfig` new fields, reduce default 512 MB → 128 MB per buffer | Not started |
+| Unit tests: alloc/free/fragmentation, eviction order, compaction correctness | Not started |
+
+---
+
+## 11. Implementation order
+
+1. **Builtin buffer bug fix** — isolated, testable, no streaming machinery needed.
+2. **`GeometryPool`** — pure data structure, no Vulkan. Unit-testable standalone.
+3. **Wire `GeometryPool` into RRM** — replace cursors, update `ReleaseMeshGeometry`.
+4. **`StreamingState` + draw-path guard** — once pool is live, non-resident meshes must be
+   skippable before the eviction sweep is wired in.
+5. **Eviction sweep** — clock-hand, driven by `Tick`.
+6. **Compaction** — last, only needed once fragmentation is observed in practice.

--- a/ZEngine/tests/Rendering/GeometryPoolTest.cpp
+++ b/ZEngine/tests/Rendering/GeometryPoolTest.cpp
@@ -1,0 +1,196 @@
+#include <ZEngine/Core/Memory/Allocator.h>
+#include <ZEngine/Rendering/GeometryPool.h>
+#include <gtest/gtest.h>
+
+using namespace ZEngine::Core::Memory;
+using namespace ZEngine::Rendering;
+
+namespace
+{
+    // Provide enough arena memory for the PoolAllocator's backing slab.
+    // 4096 nodes * sizeof(FreeNode) = 4096 * 24 ≈ 96 KB; round up to 512 KB.
+    constexpr uint64_t ARENA_SIZE     = 512 * 1024;
+    constexpr uint32_t MAX_FREE_NODES = 4096;
+
+    struct PoolFixture
+    {
+        ArenaAllocator arena{};
+        GeometryPool   pool{};
+
+        PoolFixture()
+        {
+            arena.Initialize(ARENA_SIZE, {});
+            pool.Initialize(&arena, /*vtx*/ 1024, /*idx*/ 1024, MAX_FREE_NODES);
+        }
+
+        ~PoolFixture()
+        {
+            arena.Shutdown();
+        }
+    };
+} // namespace
+
+TEST(GeometryPool, FreshPoolIsEmpty)
+{
+    PoolFixture f;
+    EXPECT_EQ(f.pool.VtxUsed, 0u);
+    EXPECT_EQ(f.pool.IdxUsed, 0u);
+    EXPECT_EQ(f.pool.VtxCursor, 0u);
+    EXPECT_EQ(f.pool.IdxCursor, 0u);
+    EXPECT_EQ(f.pool.FreeVtxHead, nullptr);
+    EXPECT_EQ(f.pool.FreeIdxHead, nullptr);
+    EXPECT_FLOAT_EQ(f.pool.FragmentationRatio(), 0.f);
+}
+
+TEST(GeometryPool, AllocateAdvancesCursors)
+{
+    PoolFixture    f;
+    GeometryRegion r;
+    ASSERT_TRUE(f.pool.Allocate(100, 50, r));
+    EXPECT_EQ(r.VtxByteOffset, 0u);
+    EXPECT_EQ(r.VtxByteSize, 100u);
+    EXPECT_EQ(r.IdxByteOffset, 0u);
+    EXPECT_EQ(r.IdxByteSize, 50u);
+    EXPECT_EQ(f.pool.VtxCursor, 100u);
+    EXPECT_EQ(f.pool.IdxCursor, 50u);
+    EXPECT_EQ(f.pool.VtxUsed, 100u);
+    EXPECT_EQ(f.pool.IdxUsed, 50u);
+}
+
+TEST(GeometryPool, SecondAllocAppendsAfterFirst)
+{
+    PoolFixture    f;
+    GeometryRegion a, b;
+    ASSERT_TRUE(f.pool.Allocate(100, 50, a));
+    ASSERT_TRUE(f.pool.Allocate(200, 80, b));
+    EXPECT_EQ(b.VtxByteOffset, 100u);
+    EXPECT_EQ(b.IdxByteOffset, 50u);
+    EXPECT_EQ(f.pool.VtxCursor, 300u);
+    EXPECT_EQ(f.pool.IdxCursor, 130u);
+}
+
+TEST(GeometryPool, AllocateFailsWhenFull)
+{
+    PoolFixture    f;
+    GeometryRegion r;
+    ASSERT_TRUE(f.pool.Allocate(1024, 1024, r)); // exactly fills both axes
+    GeometryRegion overflow;
+    EXPECT_FALSE(f.pool.Allocate(1, 1, overflow));
+}
+
+TEST(GeometryPool, AllocateFailsWhenOnlyOneAxisFull)
+{
+    PoolFixture    f;
+    GeometryRegion r;
+    ASSERT_TRUE(f.pool.Allocate(1024, 1, r)); // vtx full, idx has space
+    GeometryRegion overflow;
+    EXPECT_FALSE(f.pool.Allocate(1, 1, overflow)); // vtx cursor exhausted
+    // idx cursor must not have advanced (rollback)
+    EXPECT_EQ(f.pool.IdxCursor, 1u);
+}
+
+TEST(GeometryPool, FreeRecordsHolesAsFragmentation)
+{
+    PoolFixture    f;
+    GeometryRegion r;
+    ASSERT_TRUE(f.pool.Allocate(100, 50, r));
+    EXPECT_FLOAT_EQ(f.pool.FragmentationRatio(), 0.f);
+    f.pool.Free(r);
+    // 150 freed bytes / 2048 total capacity
+    float expected = 150.f / 2048.f;
+    EXPECT_NEAR(f.pool.FragmentationRatio(), expected, 1e-5f);
+    EXPECT_EQ(f.pool.VtxUsed, 0u);
+    EXPECT_EQ(f.pool.IdxUsed, 0u);
+}
+
+TEST(GeometryPool, FreedRegionIsReusedByNextAlloc)
+{
+    PoolFixture    f;
+    GeometryRegion a, b;
+    ASSERT_TRUE(f.pool.Allocate(100, 50, a));
+    ASSERT_TRUE(f.pool.Allocate(200, 80, b));
+    f.pool.Free(a); // frees [0, 100) vtx and [0, 50) idx
+    GeometryRegion c;
+    ASSERT_TRUE(f.pool.Allocate(100, 50, c));
+    // Should reuse the freed region, not the cursor.
+    EXPECT_EQ(c.VtxByteOffset, 0u);
+    EXPECT_EQ(c.IdxByteOffset, 0u);
+    EXPECT_FLOAT_EQ(f.pool.FragmentationRatio(), 0.f);
+}
+
+TEST(GeometryPool, PartialReuseLeavesSmallerFreeNode)
+{
+    PoolFixture    f;
+    GeometryRegion a;
+    ASSERT_TRUE(f.pool.Allocate(200, 100, a));
+    f.pool.Free(a); // [0,200) vtx, [0,100) idx free
+    GeometryRegion b;
+    ASSERT_TRUE(f.pool.Allocate(50, 40, b)); // fits in free region
+    EXPECT_EQ(b.VtxByteOffset, 0u);
+    EXPECT_EQ(b.IdxByteOffset, 0u);
+    // Remainder [50,200) vtx and [40,100) idx should still be free
+    EXPECT_NE(f.pool.FreeVtxHead, nullptr);
+    EXPECT_EQ(f.pool.FreeVtxHead->Offset, 50u);
+    EXPECT_EQ(f.pool.FreeVtxHead->Size, 150u);
+    EXPECT_NE(f.pool.FreeIdxHead, nullptr);
+    EXPECT_EQ(f.pool.FreeIdxHead->Offset, 40u);
+    EXPECT_EQ(f.pool.FreeIdxHead->Size, 60u);
+}
+
+TEST(GeometryPool, AdjacentFreedRegionsMerge)
+{
+    PoolFixture    f;
+    GeometryRegion a, b;
+    ASSERT_TRUE(f.pool.Allocate(100, 50, a));
+    ASSERT_TRUE(f.pool.Allocate(100, 50, b));
+    f.pool.Free(a);
+    f.pool.Free(b); // b starts where a ended — should merge
+    EXPECT_EQ(f.pool.FreeVtxHead->Offset, 0u);
+    EXPECT_EQ(f.pool.FreeVtxHead->Size, 200u);
+    EXPECT_EQ(f.pool.FreeVtxHead->Next, nullptr); // merged into one node
+    EXPECT_EQ(f.pool.FreeIdxHead->Offset, 0u);
+    EXPECT_EQ(f.pool.FreeIdxHead->Size, 100u);
+    EXPECT_EQ(f.pool.FreeIdxHead->Next, nullptr);
+}
+
+TEST(GeometryPool, ResetClearsAllState)
+{
+    PoolFixture    f;
+    GeometryRegion r;
+    ASSERT_TRUE(f.pool.Allocate(100, 50, r));
+    f.pool.Free(r);
+    f.pool.Reset();
+    EXPECT_EQ(f.pool.VtxCursor, 0u);
+    EXPECT_EQ(f.pool.IdxCursor, 0u);
+    EXPECT_EQ(f.pool.VtxUsed, 0u);
+    EXPECT_EQ(f.pool.IdxUsed, 0u);
+    EXPECT_EQ(f.pool.FreeVtxHead, nullptr);
+    EXPECT_EQ(f.pool.FreeIdxHead, nullptr);
+    EXPECT_FLOAT_EQ(f.pool.FragmentationRatio(), 0.f);
+    // Pool should be fully functional after reset.
+    GeometryRegion r2;
+    EXPECT_TRUE(f.pool.Allocate(100, 50, r2));
+    EXPECT_EQ(r2.VtxByteOffset, 0u);
+}
+
+TEST(GeometryPool, FragmentationRatioZeroWhenNoFreeNodes)
+{
+    PoolFixture    f;
+    GeometryRegion r;
+    ASSERT_TRUE(f.pool.Allocate(512, 512, r));
+    EXPECT_FLOAT_EQ(f.pool.FragmentationRatio(), 0.f);
+}
+
+TEST(GeometryPool, MultipleAllocsAndFreesPreserveUsedCount)
+{
+    PoolFixture    f;
+    GeometryRegion regions[8];
+    for (int i = 0; i < 8; ++i)
+        ASSERT_TRUE(f.pool.Allocate(64, 32, regions[i]));
+    EXPECT_EQ(f.pool.VtxUsed, 8u * 64u);
+    EXPECT_EQ(f.pool.IdxUsed, 8u * 32u);
+    for (int i = 0; i < 4; ++i)
+        f.pool.Free(regions[i]);
+    EXPECT_EQ(f.pool.VtxUsed, 4u * 64u);
+    EXPECT_EQ(f.pool.IdxUsed, 4u * 32u);
+}

--- a/ZEngine/tests/Rendering/GeometryStreamingManagerTest.cpp
+++ b/ZEngine/tests/Rendering/GeometryStreamingManagerTest.cpp
@@ -1,0 +1,239 @@
+#include <ZEngine/Core/Memory/Allocator.h>
+#include <ZEngine/Rendering/GeometryPool.h>
+#include <ZEngine/Rendering/GeometryStreamingManager.h>
+#include <ZEngine/Rendering/RenderResourceManager.h>
+#include <gtest/gtest.h>
+
+using namespace ZEngine::Core::Memory;
+using namespace ZEngine::Rendering;
+
+// Test-only helper — friend-declared in RenderResourceManager to allow direct
+// slot state manipulation without requiring a live Vulkan device.
+struct RRMTestHelper
+{
+    static void SetSlot(RenderResourceManager& rrm, uint32_t idx, uint32_t gen, RenderResourceManager::StreamingState state, bool referenced, bool pinned, const GeometryRegion& region = {})
+    {
+        if (idx >= RenderResourceManager::MAX_BUFFERS)
+            return;
+        rrm.m_mesh_slots[idx].Generation      = gen;
+        rrm.m_mesh_slots[idx].Data.State      = state;
+        rrm.m_mesh_slots[idx].Data.Referenced = referenced;
+        rrm.m_mesh_slots[idx].Data.Pinned     = pinned;
+        rrm.m_mesh_slots[idx].Data.Region     = region;
+        if (idx >= rrm.m_mesh_slot_count)
+            rrm.m_mesh_slot_count = idx + 1;
+    }
+
+    static RenderResourceManager::StreamingState GetState(const RenderResourceManager& rrm, uint32_t idx)
+    {
+        return rrm.m_mesh_slots[idx].Data.State;
+    }
+
+    static bool GetReferenced(const RenderResourceManager& rrm, uint32_t idx)
+    {
+        return rrm.m_mesh_slots[idx].Data.Referenced;
+    }
+
+    static const GeometryRegion& GetRegion(const RenderResourceManager& rrm, uint32_t idx)
+    {
+        return rrm.m_mesh_slots[idx].Data.Region;
+    }
+
+    static void SetupPool(RenderResourceManager& rrm, ArenaAllocator* arena, VkDeviceSize vtx_cap, VkDeviceSize idx_cap, uint32_t max_free_nodes)
+    {
+        rrm.m_pool.Initialize(arena, vtx_cap, idx_cap, max_free_nodes);
+    }
+
+    static GeometryPool& GetPool(RenderResourceManager& rrm)
+    {
+        return rrm.m_pool;
+    }
+};
+
+namespace
+{
+    constexpr uint64_t ARENA_SIZE = 512 * 1024;
+
+    struct StreamingFixture
+    {
+        ArenaAllocator           arena{};
+        RenderResourceManager    rrm{};
+        GeometryStreamingManager mgr{};
+
+        StreamingFixture()
+        {
+            arena.Initialize(ARENA_SIZE, {});
+            RRMTestHelper::SetupPool(rrm, &arena, 4096, 4096, 256);
+            mgr.Initialize(nullptr, &rrm);
+        }
+
+        ~StreamingFixture()
+        {
+            mgr.Deinitialize();
+            arena.Shutdown();
+        }
+    };
+} // namespace
+
+TEST(GeometryStreamingManager, TickClearsReferencedBitsOnResidentSlots)
+{
+    StreamingFixture f;
+    RRMTestHelper::SetSlot(f.rrm, 0, 1, RenderResourceManager::StreamingState::Resident, /*referenced=*/true, false);
+    RRMTestHelper::SetSlot(f.rrm, 1, 1, RenderResourceManager::StreamingState::Unloaded, /*referenced=*/true, false);
+    f.mgr.Tick(0);
+    EXPECT_FALSE(RRMTestHelper::GetReferenced(f.rrm, 0)); // Resident — bit cleared
+    EXPECT_TRUE(RRMTestHelper::GetReferenced(f.rrm, 1));  // Unloaded — untouched
+}
+
+TEST(GeometryStreamingManager, EvictionSweepSkipsReferencedSlot)
+{
+    StreamingFixture f;
+    GeometryRegion   r0, r1;
+    RRMTestHelper::GetPool(f.rrm).Allocate(128, 64, r0);
+    RRMTestHelper::GetPool(f.rrm).Allocate(128, 64, r1);
+    RRMTestHelper::SetSlot(f.rrm, 0, 1, RenderResourceManager::StreamingState::Resident, /*referenced=*/true, false, r0);
+    RRMTestHelper::SetSlot(f.rrm, 1, 1, RenderResourceManager::StreamingState::Resident, /*referenced=*/false, false, r1);
+
+    // Force eviction pressure by filling pool above 85%.
+    GeometryRegion filler;
+    RRMTestHelper::GetPool(f.rrm).Allocate(4096 - 256 - 2, 4096 - 128 - 2, filler);
+
+    f.mgr.Tick(0);
+    // Slot 0 (Referenced) gets second-chance — stays Resident (bit cleared).
+    // Slot 1 (not referenced) is evicted.
+    EXPECT_EQ(RRMTestHelper::GetState(f.rrm, 0), RenderResourceManager::StreamingState::Resident);
+    EXPECT_FALSE(RRMTestHelper::GetReferenced(f.rrm, 0)); // second-chance cleared the bit
+    EXPECT_EQ(RRMTestHelper::GetState(f.rrm, 1), RenderResourceManager::StreamingState::Unloaded);
+}
+
+TEST(GeometryStreamingManager, EvictionSweepFreesPoolRegion)
+{
+    StreamingFixture f;
+    GeometryRegion   r;
+    RRMTestHelper::GetPool(f.rrm).Allocate(200, 100, r);
+    RRMTestHelper::SetSlot(f.rrm, 0, 1, RenderResourceManager::StreamingState::Resident, /*referenced=*/false, false, r);
+
+    VkDeviceSize   used_before = RRMTestHelper::GetPool(f.rrm).VtxUsed;
+
+    // Force eviction pressure.
+    GeometryRegion filler;
+    RRMTestHelper::GetPool(f.rrm).Allocate(4096 - 200 - 2, 4096 - 100 - 2, filler);
+
+    f.mgr.Tick(0);
+
+    EXPECT_EQ(RRMTestHelper::GetState(f.rrm, 0), RenderResourceManager::StreamingState::Unloaded);
+    EXPECT_EQ(RRMTestHelper::GetRegion(f.rrm, 0).VtxByteSize, 0u);                      // region zeroed
+    EXPECT_LT(RRMTestHelper::GetPool(f.rrm).VtxUsed, used_before + filler.VtxByteSize); // bytes returned
+}
+
+TEST(GeometryStreamingManager, EvictionSweepSkipsPinnedSlots)
+{
+    StreamingFixture f;
+    GeometryRegion   r;
+    RRMTestHelper::GetPool(f.rrm).Allocate(128, 64, r);
+    RRMTestHelper::SetSlot(f.rrm, 0, 1, RenderResourceManager::StreamingState::Resident, /*referenced=*/false, /*pinned=*/true, r);
+
+    GeometryRegion filler;
+    RRMTestHelper::GetPool(f.rrm).Allocate(4096 - 128 - 2, 4096 - 64 - 2, filler);
+
+    f.mgr.Tick(0);
+    EXPECT_EQ(RRMTestHelper::GetState(f.rrm, 0), RenderResourceManager::StreamingState::Resident);
+}
+
+TEST(GeometryStreamingManager, RequestEvictFreesRegionAndSetsUnloaded)
+{
+    StreamingFixture f;
+    GeometryRegion   r;
+    RRMTestHelper::GetPool(f.rrm).Allocate(200, 100, r);
+    RRMTestHelper::SetSlot(f.rrm, 0, 1, RenderResourceManager::StreamingState::Resident, false, false, r);
+    BufferHandle h{0, 1};
+
+    VkDeviceSize vtx_used_before = RRMTestHelper::GetPool(f.rrm).VtxUsed;
+    f.mgr.RequestEvict(h);
+
+    EXPECT_EQ(RRMTestHelper::GetState(f.rrm, 0), RenderResourceManager::StreamingState::Unloaded);
+    EXPECT_EQ(RRMTestHelper::GetRegion(f.rrm, 0).VtxByteSize, 0u);
+    EXPECT_LT(RRMTestHelper::GetPool(f.rrm).VtxUsed, vtx_used_before);
+}
+
+TEST(GeometryStreamingManager, RequestEvictNoOpOnInvalidHandle)
+{
+    StreamingFixture f;
+    BufferHandle     invalid{};
+    EXPECT_NO_FATAL_FAILURE(f.mgr.RequestEvict(invalid));
+}
+
+TEST(GeometryStreamingManager, RequestEvictNoOpOnPinnedSlot)
+{
+    StreamingFixture f;
+    GeometryRegion   r;
+    RRMTestHelper::GetPool(f.rrm).Allocate(100, 50, r);
+    RRMTestHelper::SetSlot(f.rrm, 0, 1, RenderResourceManager::StreamingState::Resident, false, /*pinned=*/true, r);
+    BufferHandle h{0, 1};
+    f.mgr.RequestEvict(h);
+    EXPECT_EQ(RRMTestHelper::GetState(f.rrm, 0), RenderResourceManager::StreamingState::Resident);
+}
+
+TEST(GeometryStreamingManager, RequestEvictNoOpOnUnloadedSlot)
+{
+    StreamingFixture f;
+    RRMTestHelper::SetSlot(f.rrm, 0, 1, RenderResourceManager::StreamingState::Unloaded, false, false);
+    BufferHandle h{0, 1};
+    f.mgr.RequestEvict(h);
+    EXPECT_EQ(RRMTestHelper::GetState(f.rrm, 0), RenderResourceManager::StreamingState::Unloaded);
+}
+
+TEST(GeometryStreamingManager, RequestEvictNoOpOnStaleHandle)
+{
+    StreamingFixture f;
+    GeometryRegion   r;
+    RRMTestHelper::GetPool(f.rrm).Allocate(100, 50, r);
+    RRMTestHelper::SetSlot(f.rrm, 0, 2, RenderResourceManager::StreamingState::Resident, false, false, r); // gen=2
+    BufferHandle stale{0, 1};                                                                              // gen=1 — stale
+    f.mgr.RequestEvict(stale);
+    EXPECT_EQ(RRMTestHelper::GetState(f.rrm, 0), RenderResourceManager::StreamingState::Resident);
+}
+
+TEST(GeometryStreamingManager, FragmentationAboveThresholdSetsCompactionRequest)
+{
+    StreamingFixture f;
+    GeometryRegion   r;
+    // Allocate then free enough to push fragmentation above 0.30.
+    RRMTestHelper::GetPool(f.rrm).Allocate(2000, 2000, r);
+    RRMTestHelper::GetPool(f.rrm).Free(r);
+
+    EXPECT_FALSE(f.mgr.IsCompactionRequested());
+    f.mgr.Tick(0);
+    EXPECT_TRUE(f.mgr.IsCompactionRequested());
+}
+
+TEST(GeometryStreamingManager, ClearCompactionRequestResetsFlag)
+{
+    StreamingFixture f;
+    GeometryRegion   r;
+    RRMTestHelper::GetPool(f.rrm).Allocate(2000, 2000, r);
+    RRMTestHelper::GetPool(f.rrm).Free(r);
+    f.mgr.Tick(0);
+    ASSERT_TRUE(f.mgr.IsCompactionRequested());
+    f.mgr.ClearCompactionRequest();
+    EXPECT_FALSE(f.mgr.IsCompactionRequested());
+}
+
+TEST(GeometryStreamingManager, RequestLoadQueueOverflowReturnsFalse)
+{
+    // SPSCQueue<T, N> holds at most N-1 items (head==tail = empty sentinel).
+    // kLoadQueueCapacity=256 → effective capacity 255.
+    StreamingFixture f;
+    StreamRequest    req{};
+    req.Handle         = BufferHandle{0, 1};
+    uint32_t succeeded = 0;
+    for (uint32_t i = 0; i < 256; ++i)
+    {
+        if (f.mgr.RequestLoad(req))
+            ++succeeded;
+        else
+            break;
+    }
+    EXPECT_EQ(succeeded, 255u);           // N-1 items fit
+    EXPECT_FALSE(f.mgr.RequestLoad(req)); // next push must fail
+}


### PR DESCRIPTION
## Summary

Closes #622. Full virtual geometry streaming system on top of the existing global VB/IB.

- **`GeometryPool`** (`GeometryPool.h/.cpp`): variable-size region allocator over the streaming VB/IB. `PoolAllocator`-backed intrusive sorted free lists (O(1) node alloc/free), first-fit search, merge-on-free, `FragmentationRatio()`. 12 unit tests.
- **RRM wiring**: replaced the append-only cursors with `GeometryPool m_pool`. `AppendMeshData` calls `m_pool.Allocate()`; `ReleaseMeshGeometry` and `FlushPendingSwaps` call `m_pool.Free()` (hot-reload swap leak fixed). `GetGlobalVertex/IndexBuffer()` return pool's own BufferViews.
- **Builtin geometry fix**: `RegisterBuiltinGeometry` (skybox, grid) now writes into separate pinned `m_builtin_vertex_buf`/`m_builtin_index_buf` buffers, fixing a silent corruption where `ResetGeometryBuffers` would overwrite builtin draw offsets on scene reload.
- **`StreamingState` + draw guard**: `MeshSlot` gains `StreamingState` (Unloaded/Pending/Resident/Evicting), `Referenced` (clock-hand bit), and `Pinned`. `RenderScene` calls `IsMeshResident` before emitting draw commands and `MarkMeshReferenced` for every mesh that draws; non-resident meshes are skipped and queued for reload.
- **`GeometryStreamingManager`** (`GeometryStreamingManager.h/.cpp`): clock-hand eviction sweep (second-chance, one eviction per call), fragmentation-triggered compaction request, `SPSCQueue<StreamRequest, 256>`-backed `RequestLoad` (render thread producer, `Tick` consumer), direct-execution `RequestEvict`. `Tick()` called from `RRM::BeginFrame`. 12 unit tests via `RRMTestHelper` friend.
- **Compaction**: `RunCompaction()` snapshots all Resident slots, resets the pool, re-uploads every mesh from CPU asset data into fresh packed regions via the existing `m_batch_timeline` path. Triggered when fragmentation > 0.30.
- **VRAM auto-detection**: `DeriveGeometryBudget()` computes 15% of the largest device-local heap, clamped to [128, 512] MB per axis. Optional override via `project.json "memory": { "geometry_streaming_mb": N }` — pre-parsed by `Engine::Initialize` before RRM init.
- **`nonuniformEXT` fix** (`zui_draw.frag`): extension was required but index not wrapped — spec violation on non-NVIDIA hardware. Fixed.
- **Bindless descriptor writes batched**: one `vkUpdateDescriptorSets` per frame instead of one per dequeued texture. Watermark warning at 75% of `MaxGlobalTexture`.

## Test plan

- CI build passes on Linux/Windows/macOS
- 589/589 tests pass (12 new GeometryPool + 12 new GeometryStreamingManager)
- Live: drag-drop mesh onto viewport, verify it renders; drag multiple meshes, verify all render; hot-reload a mesh, verify the swap takes effect without visual glitch