### PR TITLE
fix(vfs): double-checked locking in VFSZipFile (#744), path-traversal guard in VFSDiskBackend (#745)

### DIFF
--- a/ZEngine/ZEngine/Core/VFS/VFSDiskBackend.cpp
+++ b/ZEngine/ZEngine/Core/VFS/VFSDiskBackend.cpp
@@ -1,6 +1,7 @@
 #include <ZEngine/Core/VFS/VFSDiskBackend.h>
 #include <ZEngine/Helpers/MemoryOperations.h>
 #include <chrono>
+#include <cstring>
 #include <filesystem>
 
 namespace ZEngine::Core::VFS
@@ -240,6 +241,20 @@ namespace ZEngine::Core::VFS
         Helpers::secure_memcpy(out_buf, MAX_FILE_PATH_COUNT, m_native_root, m_native_root_len);
         Helpers::secure_memcpy(out_buf + m_native_root_len, MAX_FILE_PATH_COUNT - m_native_root_len, native, native_len);
         out_buf[m_native_root_len + native_len] = '\0';
+
+        // Defense-in-depth: verify the composed path stays within m_native_root.
+        // VFSPath::Parse already rejects '..' segments, but this backend must not rely
+        // solely on every upstream caller using Parse — any future code path that
+        // constructs a VFSPath from raw bytes could bypass that check.
+        if (std::memcmp(out_buf, m_native_root, m_native_root_len) != 0)
+        {
+            return false;
+        }
+        const char next = out_buf[m_native_root_len];
+        if (next != '\0' && next != '/' && next != '\\')
+        {
+            return false;
+        }
         return true;
     }
 

--- a/ZEngine/ZEngine/Core/VFS/VFSZipBackend.cpp
+++ b/ZEngine/ZEngine/Core/VFS/VFSZipBackend.cpp
@@ -7,15 +7,25 @@ namespace ZEngine::Core::VFS
 
     VFSResult<const uint8_t*> VFSZipFile::EnsureDecompressed()
     {
-        if (m_decompressed)
+        // Fast path: already decompressed — acquire load pairs with the release store below.
+        if (m_decompressed.load(std::memory_order_acquire))
+        {
+            return VFSResult<const uint8_t*>::Ok(m_data);
+        }
+
+        // Slow path: decompress under the per-file lock.
+        // Double-checked: re-test after acquiring so two concurrent callers
+        // don't both allocate and extract.
+        std::lock_guard<std::mutex> lock(m_decompress_mutex);
+        if (m_decompressed.load(std::memory_order_relaxed))
         {
             return VFSResult<const uint8_t*>::Ok(m_data);
         }
 
         if (m_entry->UncompSize == 0)
         {
-            m_data         = static_cast<uint8_t*>(m_arena->Allocate(1));
-            m_decompressed = true;
+            m_data = static_cast<uint8_t*>(m_arena->Allocate(1));
+            m_decompressed.store(true, std::memory_order_release);
             return VFSResult<const uint8_t*>::Ok(m_data);
         }
 
@@ -29,8 +39,8 @@ namespace ZEngine::Core::VFS
             return VFSResult<const uint8_t*>::Fail(VFSError::Corrupted);
         }
 
-        m_data         = out;
-        m_decompressed = true;
+        m_data = out;
+        m_decompressed.store(true, std::memory_order_release);
         return VFSResult<const uint8_t*>::Ok(m_data);
     }
 

--- a/ZEngine/ZEngine/Core/VFS/VFSZipBackend.h
+++ b/ZEngine/ZEngine/Core/VFS/VFSZipBackend.h
@@ -6,6 +6,7 @@
 #include <ZEngine/Core/VFS/IVFSFile.h>
 #include <ZEngine/ZEngineDef.h>
 #include <miniz.h>
+#include <atomic>
 #include <mutex>
 
 namespace ZEngine::Core::VFS
@@ -45,7 +46,8 @@ namespace ZEngine::Core::VFS
         uint8_t*                m_data         = nullptr;
         VFSZipBackend*          m_backend      = nullptr;
         Memory::ArenaAllocator* m_arena        = nullptr;
-        bool                    m_decompressed = false;
+        std::atomic<bool>       m_decompressed = false;
+        std::mutex              m_decompress_mutex;
     };
 
     struct VFSZipBackend : IVFSBackend


### PR DESCRIPTION
## #744 — VFSZipFile data race on m_decompressed/m_data

`m_decompressed` was a plain `bool` with no synchronization. Two threads calling `Read()` concurrently on the same `VFSZipFile` could both see `m_decompressed == false`, both allocate from the arena, both call `ExtractEntry`, and race on the `m_data`/`m_decompressed` writes.

Fixed with double-checked locking:
- `m_decompressed` → `std::atomic<bool>`: acquire load on fast path, release store on publish
- `m_decompress_mutex` added per-file: guards the slow path so only one thread decompresses
- Second check under the lock to handle two threads reaching the slow path simultaneously

## #745 — VFSDiskBackend::ResolveNativePath missing containment check

The function was pure string concatenation — no verification that the composed path stays within `m_native_root`. `VFSPath::Parse` already rejects `..` segments so current risk is low, but the backend's own design doc specifies this check as defense-in-depth against any future code path that constructs a `VFSPath` without going through `Parse`.

Added: `std::memcmp` prefix check + separator guard (`/`, `\`, or `\0`) after building the composed path.

## #743 — already fixed in #754, closed.