### PR TITLE
fix(rrm): replace AppendToGlobalBuffer with RecordStagingCopy in UploadBuffer

### DIFF
--- a/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
+++ b/ZEngine/ZEngine/Rendering/RenderResourceManager.cpp
@@ -1010,10 +1010,19 @@ namespace ZEngine::Rendering
             return {};
 
         EnsureBatchOpen(m_active_frame_index);
-        AppendToGlobalBuffer(buf, data, byte_size, 0, m_active_frame_index);
 
-        uint32_t slot_idx           = AllocGBufSlot();
-        m_gbuf_slots[slot_idx].Data = buf;
+        BufferView staging = m_device->CreateBuffer(static_cast<VkDeviceSize>(byte_size), VK_BUFFER_USAGE_TRANSFER_SRC_BIT, GpuMemoryDomain::HostStaging);
+        ZENGINE_VALIDATE_ASSERT(vmaCopyMemoryToAllocation(m_device->GpuMem.Allocator, data, staging.Allocation, 0, byte_size) == VK_SUCCESS, "RRM::UploadBuffer: staging copy failed")
+
+        StagingCopyCtx ctx{staging.Handle, buf.Handle, 0, byte_size};
+        RecordStagingCopy(m_batch_cmd->GetHandle(), &ctx);
+
+        BatchFrameState& frame = m_batch_frames[m_batch_frame_index];
+        ZENGINE_VALIDATE_ASSERT(frame.StagingCount < MAX_PENDING * 2, "RRM::UploadBuffer: batch staging overflow")
+        frame.StagingBuffers[frame.StagingCount++] = staging;
+
+        uint32_t slot_idx                          = AllocGBufSlot();
+        m_gbuf_slots[slot_idx].Data                = buf;
         return {slot_idx, m_gbuf_slots[slot_idx].Generation};
     }
 


### PR DESCRIPTION
Closes #770

## What

`UploadBuffer` was calling `AppendToGlobalBuffer(buf, ...)` which routes through `RecordGlobalBufferCopy`. That function only has `SHADER_READ` in the barrier access mask — it is designed for mesh geometry that is accessed exclusively as an SSBO via `gl_BaseVertex` indexing. Generic device-local buffers (bone matrices, particle vertex buffers) need `VERTEX_ATTRIBUTE_READ` and `INDEX_READ` as well, which `RecordStagingCopy` provides.

## Fix

Replace the `AppendToGlobalBuffer` call with the same explicit staging path that `UpdateBuffer`'s device-local branch uses:
- Allocate a host-staging buffer
- Copy CPU data into it via `vmaCopyMemoryToAllocation`
- Record a `vkCmdCopyBuffer` + full barrier via `RecordStagingCopy`
- Track the staging buffer in `m_batch_frames` for retirement

The standalone destination buffer (`buf`) is already allocated and stored correctly. Only the upload path changes.

## Test plan

- Build passes clean
- Engine runs at 120 fps, no validation errors
- No callers of `UploadBuffer` exist yet — first real caller is `SkinningUploadSystem` (Sprint 7)